### PR TITLE
test: L1モジュールのユニットテスト拡充 (13→74件)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,11 @@ def tmp_output_dir(tmp_path: Path) -> Path:
     output = tmp_path / "output"
     output.mkdir()
     return output
+
+
+@pytest.fixture
+def fake_video(tmp_path: Path) -> Path:
+    """Create a zero-byte .mp4 file that passes CLI validation."""
+    video = tmp_path / "test_video.mp4"
+    video.write_bytes(b"")
+    return video

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,19 @@
 """Tests for CLI entry point."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 from typer.testing import CliRunner
 
 from allaganeye.cli import app
+from allaganeye.exceptions import DetectionError, VideoProcessingError
 
 runner = CliRunner()
+
+MODULE = "allaganeye.commands.split_matches.run_split"
+
+
+# --- Basic tests ---
 
 
 def test_version():
@@ -45,6 +54,9 @@ def test_split_unsupported_format(tmp_path):
     )
 
 
+# --- Validation tests (exit code 5) ---
+
+
 def test_split_negative_sample_interval(tmp_path):
     fake_file = tmp_path / "video.mp4"
     fake_file.write_bytes(b"\x00")
@@ -71,5 +83,198 @@ def test_split_blackout_threshold_over_255(tmp_path):
 def test_split_negative_min_match_duration(tmp_path):
     fake_file = tmp_path / "video.mp4"
     fake_file.write_bytes(b"\x00")
-    result = runner.invoke(app, ["split", str(fake_file), "--min-match-duration", "-1"])
+    result = runner.invoke(
+        app, ["split", str(fake_file), "--min-match-duration", "-1"]
+    )
     assert result.exit_code == 5
+
+
+# --- Option tests ---
+
+
+@patch(MODULE)
+def test_split_default_options(mock_run_split, fake_video):
+    """Default options produce expected SplitConfig values."""
+    result = runner.invoke(app, ["split", str(fake_video)])
+
+    assert result.exit_code == 0
+    mock_run_split.assert_called_once()
+    _, kwargs = mock_run_split.call_args
+    config = mock_run_split.call_args[0][1]
+    assert config.output_dir == Path("./output")
+    assert config.sample_interval == 1.0
+    assert config.blackout_threshold == 15.0
+    assert config.min_match_duration == 300.0
+    assert config.dry_run is False
+    assert kwargs["verbose"] is False
+
+
+@patch(MODULE)
+def test_split_output_dir_option(mock_run_split, fake_video, tmp_path):
+    """Short -o option sets output_dir."""
+    out = tmp_path / "custom"
+    result = runner.invoke(app, ["split", str(fake_video), "-o", str(out)])
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.output_dir == out
+
+
+@patch(MODULE)
+def test_split_output_dir_long_form(mock_run_split, fake_video, tmp_path):
+    """Long --output-dir option sets output_dir."""
+    out = tmp_path / "custom"
+    result = runner.invoke(app, ["split", str(fake_video), "--output-dir", str(out)])
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.output_dir == out
+
+
+@patch(MODULE)
+def test_split_sample_interval(mock_run_split, fake_video):
+    """--sample-interval option is forwarded to config."""
+    result = runner.invoke(
+        app, ["split", str(fake_video), "--sample-interval", "2.5"]
+    )
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.sample_interval == 2.5
+
+
+@patch(MODULE)
+def test_split_blackout_threshold(mock_run_split, fake_video):
+    """--blackout-threshold option is forwarded to config."""
+    result = runner.invoke(
+        app, ["split", str(fake_video), "--blackout-threshold", "20.0"]
+    )
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.blackout_threshold == 20.0
+
+
+@patch(MODULE)
+def test_split_min_match_duration(mock_run_split, fake_video):
+    """--min-match-duration option is forwarded to config."""
+    result = runner.invoke(
+        app, ["split", str(fake_video), "--min-match-duration", "120"]
+    )
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.min_match_duration == 120.0
+
+
+@patch(MODULE)
+def test_split_dry_run(mock_run_split, fake_video):
+    """--dry-run flag sets config.dry_run=True."""
+    result = runner.invoke(app, ["split", str(fake_video), "--dry-run"])
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.dry_run is True
+
+
+@patch(MODULE)
+def test_split_verbose_short(mock_run_split, fake_video):
+    """-v flag sets verbose=True."""
+    result = runner.invoke(app, ["split", str(fake_video), "-v"])
+
+    assert result.exit_code == 0
+    assert mock_run_split.call_args[1]["verbose"] is True
+
+
+@patch(MODULE)
+def test_split_verbose_long(mock_run_split, fake_video):
+    """--verbose flag sets verbose=True."""
+    result = runner.invoke(app, ["split", str(fake_video), "--verbose"])
+
+    assert result.exit_code == 0
+    assert mock_run_split.call_args[1]["verbose"] is True
+
+
+@patch(MODULE)
+def test_split_all_options_combined(mock_run_split, fake_video, tmp_path):
+    """All options combined are correctly forwarded."""
+    out = tmp_path / "all"
+    result = runner.invoke(
+        app,
+        [
+            "split",
+            str(fake_video),
+            "-o",
+            str(out),
+            "--sample-interval",
+            "0.5",
+            "--blackout-threshold",
+            "25.0",
+            "--min-match-duration",
+            "60",
+            "--dry-run",
+            "-v",
+        ],
+    )
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.output_dir == out
+    assert config.sample_interval == 0.5
+    assert config.blackout_threshold == 25.0
+    assert config.min_match_duration == 60.0
+    assert config.dry_run is True
+    assert mock_run_split.call_args[1]["verbose"] is True
+
+
+# --- Error exit code tests ---
+
+
+@patch(MODULE)
+def test_split_processing_error_exit_code(mock_run_split, fake_video):
+    """VideoProcessingError produces exit code 3."""
+    mock_run_split.side_effect = VideoProcessingError("ffmpeg failed")
+
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 3
+
+
+@patch(MODULE)
+def test_split_detection_error_exit_code(mock_run_split, fake_video):
+    """DetectionError produces exit code 4."""
+    mock_run_split.side_effect = DetectionError("No boundaries found")
+
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 4
+
+
+@patch(MODULE)
+def test_split_unexpected_error_exit_code(mock_run_split, fake_video):
+    """Unexpected RuntimeError produces exit code 1."""
+    mock_run_split.side_effect = RuntimeError("unexpected")
+
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 1
+
+
+# --- Extension support tests ---
+
+
+@patch(MODULE)
+def test_split_mkv_extension(mock_run_split, tmp_path):
+    """MKV files are accepted."""
+    video = tmp_path / "recording.mkv"
+    video.write_bytes(b"")
+    result = runner.invoke(app, ["split", str(video)])
+    assert result.exit_code == 0
+    mock_run_split.assert_called_once()
+
+
+@patch(MODULE)
+def test_split_avi_extension(mock_run_split, tmp_path):
+    """AVI files are accepted."""
+    video = tmp_path / "recording.avi"
+    video.write_bytes(b"")
+    result = runner.invoke(app, ["split", str(video)])
+    assert result.exit_code == 0
+    mock_run_split.assert_called_once()

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -10,6 +10,70 @@ from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import _extract_segments, detect_match_boundaries
 
 
+# --- Helpers ---
+
+
+def _make_frame(brightness: int) -> np.ndarray:
+    """Create a 2x2 BGR frame with uniform brightness."""
+    return np.full((2, 2, 3), brightness, dtype=np.uint8)
+
+
+def _make_capture_mock(
+    *,
+    is_opened: bool = True,
+    fps: float = 30.0,
+    frame_count: int = 9000,
+    frames: dict[int, np.ndarray] | None = None,
+    default_brightness: int = 128,
+) -> MagicMock:
+    """Create a mock cv2.VideoCapture with configurable behavior.
+
+    Args:
+        frames: dict mapping frame index to numpy frame.
+            Missing indices use default_brightness.
+    """
+    cap = MagicMock()
+    cap.isOpened.return_value = is_opened
+
+    def get_prop(prop_id):
+        import cv2
+
+        if prop_id == cv2.CAP_PROP_FPS:
+            return fps
+        if prop_id == cv2.CAP_PROP_FRAME_COUNT:
+            return frame_count
+        return 0.0
+
+    cap.get.side_effect = get_prop
+
+    current_frame = [0]
+
+    def set_pos(prop_id, value):
+        current_frame[0] = int(value)
+
+    cap.set.side_effect = set_pos
+
+    if frames is None:
+        frames = {}
+
+    def read():
+        idx = current_frame[0]
+        if idx >= frame_count:
+            return False, None
+        if idx in frames:
+            return True, frames[idx]
+        return True, _make_frame(default_brightness)
+
+    cap.read.side_effect = read
+
+    return cap
+
+
+# ============================================================
+# TestExtractSegments
+# ============================================================
+
+
 class TestExtractSegments:
     """Unit tests for segment extraction logic (no video files needed)."""
 
@@ -95,35 +159,232 @@ class TestExtractSegments:
         assert result[1]["start"] == 604.0
 
 
+# ============================================================
+# TestDetectMatchBoundaries
+# ============================================================
+
+
 class TestDetectMatchBoundaries:
-    """Tests for detect_match_boundaries with mocked OpenCV."""
+    """Tests for detect_match_boundaries() with mocked cv2.VideoCapture."""
 
-    def _make_mock_cap(self, fps=30.0, total_frames=3600, read_failures=None):
-        """Create a mock VideoCapture that returns bright frames."""
-        cap = MagicMock()
-        cap.isOpened.return_value = True
-        cap.get.side_effect = lambda prop: {
-            5: fps,  # CAP_PROP_FPS
-            7: float(total_frames),  # CAP_PROP_FRAME_COUNT
-        }.get(prop, 0.0)
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_video_cannot_open(self, mock_vc_class):
+        """VideoCapture open failure raises VideoProcessingError."""
+        mock_vc_class.return_value = _make_capture_mock(is_opened=False)
 
-        bright_frame = np.full((100, 100, 3), 128, dtype=np.uint8)
-        failure_positions = set(read_failures or [])
-        call_count = {"n": 0}
+        with pytest.raises(VideoProcessingError, match="Cannot open video"):
+            detect_match_boundaries(Path("test.mp4"))
 
-        def mock_read():
-            pos = call_count["n"]
-            call_count["n"] += 1
-            if pos in failure_positions:
-                return False, None
-            return True, bright_frame.copy()
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_fps_zero(self, mock_vc_class):
+        """fps=0 raises VideoProcessingError."""
+        mock_vc_class.return_value = _make_capture_mock(fps=0.0, frame_count=9000)
 
-        cap.read.side_effect = mock_read
-        return cap
+        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
+            detect_match_boundaries(Path("test.mp4"))
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_frame_count_zero(self, mock_vc_class):
+        """frame_count=0 raises VideoProcessingError."""
+        mock_vc_class.return_value = _make_capture_mock(fps=30.0, frame_count=0)
+
+        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
+            detect_match_boundaries(Path("test.mp4"))
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_negative_fps(self, mock_vc_class):
+        """Negative fps raises VideoProcessingError."""
+        mock_vc_class.return_value = _make_capture_mock(fps=-1.0, frame_count=9000)
+
+        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
+            detect_match_boundaries(Path("test.mp4"))
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_all_bright_frames(self, mock_vc_class):
+        """All bright frames → single segment covering full duration."""
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=30.0,
+            frame_count=9000,
+            default_brightness=128,
+        )
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            min_match_duration=100.0,
+        )
+        assert len(result) == 1
+        assert result[0]["start"] == 0.0
+        assert result[0]["end"] == pytest.approx(300.0)
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_all_black_frames(self, mock_vc_class):
+        """All black frames → no segments (entire video is blackout)."""
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=30.0,
+            frame_count=9000,
+            default_brightness=5,
+        )
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            min_match_duration=100.0,
+        )
+        assert len(result) == 0
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_blackout_in_middle(self, mock_vc_class):
+        """Blackout in middle splits video into two segments."""
+        fps = 30.0
+        total_frames = 54000  # 1800s
+
+        black_frames = {}
+        for sec in range(598, 603):
+            frame_idx = int(sec * fps)
+            black_frames[frame_idx] = _make_frame(5)
+
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=fps,
+            frame_count=total_frames,
+            frames=black_frames,
+            default_brightness=128,
+        )
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            sample_interval=1.0,
+            min_match_duration=300.0,
+        )
+        assert len(result) == 2
+        assert result[0]["start"] == 0.0
+        assert result[1]["end"] == pytest.approx(1800.0)
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_sample_interval_respected(self, mock_vc_class):
+        """frame_step = fps * sample_interval determines sampling stride."""
+        fps = 30.0
+        total_frames = 9000  # 300s
+        cap = _make_capture_mock(
+            fps=fps, frame_count=total_frames, default_brightness=128
+        )
+        mock_vc_class.return_value = cap
+
+        detect_match_boundaries(
+            Path("test.mp4"),
+            sample_interval=2.0,
+            min_match_duration=100.0,
+        )
+
+        # frame_step = 30 * 2.0 = 60, frames sampled: 0, 60, 120, ...
+        set_calls = list(cap.set.call_args_list)
+        frame_indices = [int(c[0][1]) for c in set_calls]
+        if len(frame_indices) > 1:
+            strides = [
+                frame_indices[i + 1] - frame_indices[i]
+                for i in range(len(frame_indices) - 1)
+            ]
+            assert all(s == 60 for s in strides)
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_sample_interval_very_small(self, mock_vc_class):
+        """Very small sample_interval clamps frame_step to 1."""
+        fps = 30.0
+        total_frames = 90  # 3s, small for speed
+        cap = _make_capture_mock(
+            fps=fps, frame_count=total_frames, default_brightness=128
+        )
+        mock_vc_class.return_value = cap
+
+        detect_match_boundaries(
+            Path("test.mp4"),
+            sample_interval=0.01,
+            min_match_duration=1.0,
+        )
+
+        # frame_step = int(30 * 0.01) = 0 → clamped to 1
+        set_calls = list(cap.set.call_args_list)
+        frame_indices = [int(c[0][1]) for c in set_calls]
+        if len(frame_indices) > 1:
+            strides = [
+                frame_indices[i + 1] - frame_indices[i]
+                for i in range(len(frame_indices) - 1)
+            ]
+            assert all(s == 1 for s in strides)
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_custom_threshold(self, mock_vc_class):
+        """Brightness 20 with threshold 15 → not blackout → 1 segment."""
+        fps = 30.0
+        total_frames = 9000  # 300s
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=fps,
+            frame_count=total_frames,
+            default_brightness=20,
+        )
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=100.0,
+        )
+        assert len(result) == 1
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_custom_threshold_blackout(self, mock_vc_class):
+        """Higher threshold makes same brightness frames count as blackout."""
+        fps = 30.0
+        total_frames = 9000
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=fps,
+            frame_count=total_frames,
+            default_brightness=20,
+        )
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            blackout_threshold=25.0,
+            min_match_duration=100.0,
+        )
+        assert len(result) == 0
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_custom_min_duration(self, mock_vc_class):
+        """min_match_duration filters short segments."""
+        fps = 30.0
+        total_frames = 54000  # 1800s
+
+        # Blackout at 200s → segments: 0-200s (200s) and ~200-1800s (1600s)
+        black_frames = {}
+        for sec in range(198, 203):
+            black_frames[int(sec * fps)] = _make_frame(5)
+
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=fps,
+            frame_count=total_frames,
+            frames=black_frames,
+            default_brightness=128,
+        )
+
+        # min_match_duration=300 → only the long segment
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            min_match_duration=300.0,
+        )
+        assert len(result) == 1
+        assert result[0]["start"] > 100.0  # the second (long) segment
 
     @patch("allaganeye.video.detector.cv2")
     def test_consecutive_read_failures_raises(self, mock_cv2):
-        cap = self._make_mock_cap(read_failures={0, 1, 2})
+        """3 consecutive read failures raise VideoProcessingError."""
+        cap = MagicMock()
+        cap.isOpened.return_value = True
+        cap.get.side_effect = lambda prop: {
+            5: 30.0,  # CAP_PROP_FPS
+            7: 3600.0,  # CAP_PROP_FRAME_COUNT
+        }.get(prop, 0.0)
+
+        # Every read fails
+        cap.read.return_value = (False, None)
+
         mock_cv2.VideoCapture.return_value = cap
         mock_cv2.CAP_PROP_FPS = 5
         mock_cv2.CAP_PROP_FRAME_COUNT = 7
@@ -132,11 +393,22 @@ class TestDetectMatchBoundaries:
         with pytest.raises(VideoProcessingError, match="consecutive"):
             detect_match_boundaries(Path("test.mp4"), min_match_duration=1.0)
 
-    @patch("allaganeye.video.detector.cv2")
-    def test_open_failure_raises(self, mock_cv2):
-        cap = MagicMock()
-        cap.isOpened.return_value = False
-        mock_cv2.VideoCapture.return_value = cap
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_release_called_on_success(self, mock_vc_class):
+        """cap.release() is called after successful processing."""
+        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
+        mock_vc_class.return_value = cap
 
-        with pytest.raises(VideoProcessingError, match="Cannot open"):
+        detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
+        cap.release.assert_called_once()
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_release_called_on_property_error(self, mock_vc_class):
+        """cap.release() is called even when fps/frame_count error occurs."""
+        cap = _make_capture_mock(fps=0.0, frame_count=9000)
+        mock_vc_class.return_value = cap
+
+        with pytest.raises(VideoProcessingError):
             detect_match_boundaries(Path("test.mp4"))
+
+        cap.release.assert_called_once()

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,12 +1,16 @@
 """Tests for video probe module."""
 
 import json
+import subprocess
 from unittest.mock import patch
 
 import pytest
 
+from allaganeye.exceptions import InputFileError, VideoProcessingError
 from allaganeye.video.probe import _parse_frame_rate, probe_video
-from allaganeye.exceptions import VideoProcessingError
+
+
+# --- Existing test ---
 
 
 def test_probe_nonexistent_file(tmp_path):
@@ -39,26 +43,51 @@ def test_parse_frame_rate_invalid(rate_str):
     assert _parse_frame_rate(rate_str) == 0.0
 
 
-# --- fps fallback tests ---
+# --- Helpers ---
 
 
-def _make_ffprobe_output(r_frame_rate="30/1", avg_frame_rate="30/1"):
-    """Build a fake ffprobe JSON output."""
-    return json.dumps(
-        {
-            "streams": [
-                {
-                    "codec_type": "video",
-                    "codec_name": "h264",
-                    "width": 1920,
-                    "height": 1080,
-                    "r_frame_rate": r_frame_rate,
-                    "avg_frame_rate": avg_frame_rate,
-                }
-            ],
-            "format": {"duration": "600.0"},
-        }
+def _make_ffprobe_output(r_frame_rate="30/1", avg_frame_rate="30/1", **overrides):
+    """Build a fake ffprobe JSON output.
+
+    Args:
+        r_frame_rate: Value for r_frame_rate field.
+        avg_frame_rate: Value for avg_frame_rate field.
+        **overrides: Override keys in the video stream or format dict.
+            Supported: duration, width, height, codec_name, audio_codec,
+            include_audio, include_video.
+    """
+    duration = overrides.get("duration", "600.0")
+    width = overrides.get("width", 1920)
+    height = overrides.get("height", 1080)
+    codec_name = overrides.get("codec_name", "h264")
+    audio_codec = overrides.get("audio_codec", "aac")
+    include_audio = overrides.get("include_audio", True)
+    include_video = overrides.get("include_video", True)
+
+    streams = []
+    if include_video:
+        streams.append(
+            {
+                "codec_type": "video",
+                "codec_name": codec_name,
+                "width": width,
+                "height": height,
+                "r_frame_rate": r_frame_rate,
+                "avg_frame_rate": avg_frame_rate,
+            }
+        )
+    if include_audio:
+        streams.append({"codec_type": "audio", "codec_name": audio_codec})
+    return json.dumps({"streams": streams, "format": {"duration": duration}})
+
+
+def _mock_result(stdout="", returncode=0):
+    return subprocess.CompletedProcess(
+        args=["ffprobe"], returncode=returncode, stdout=stdout, stderr=""
     )
+
+
+# --- fps fallback tests ---
 
 
 @patch("allaganeye.video.probe.subprocess.run")
@@ -95,3 +124,220 @@ def test_probe_fps_error_when_both_fail(mock_run, tmp_path):
     )
     with pytest.raises(VideoProcessingError, match="Cannot determine video frame rate"):
         probe_video(video)
+
+
+# --- Normal cases ---
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_normal_mp4(mock_run, tmp_path):
+    """Normal ffprobe output is parsed correctly."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=_make_ffprobe_output(duration="1800.5")
+    )
+
+    result = probe_video(video)
+
+    assert result["duration"] == 1800.5
+    assert result["width"] == 1920
+    assert result["height"] == 1080
+    assert result["fps"] == 30.0
+    assert result["codec"] == "h264"
+    assert result["audio_codec"] == "aac"
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_fractional_fps(mock_run, tmp_path):
+    """Fractional fps (e.g., 60000/1001) is parsed correctly."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=_make_ffprobe_output(
+            r_frame_rate="60000/1001", avg_frame_rate="60000/1001"
+        )
+    )
+
+    result = probe_video(video)
+    assert result["fps"] == pytest.approx(59.94, rel=1e-2)
+
+
+# --- FPS edge cases (both r_frame_rate and avg_frame_rate must fail) ---
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_fps_zero_denominator(mock_run, tmp_path):
+    """Zero denominator in both frame rate fields raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=_make_ffprobe_output(r_frame_rate="30/0", avg_frame_rate="0/0")
+    )
+
+    with pytest.raises(VideoProcessingError, match="Cannot determine video frame rate"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_fps_non_numeric(mock_run, tmp_path):
+    """Non-numeric fps in both fields raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=_make_ffprobe_output(r_frame_rate="abc/def", avg_frame_rate="N/A")
+    )
+
+    with pytest.raises(VideoProcessingError, match="Cannot determine video frame rate"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_fps_missing_key(mock_run, tmp_path):
+    """Missing r_frame_rate falls back to avg_frame_rate; both empty raises error."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    data = {
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "avg_frame_rate": "",
+            }
+        ],
+        "format": {"duration": "600.0"},
+    }
+    mock_run.return_value = _mock_result(stdout=json.dumps(data))
+
+    with pytest.raises(VideoProcessingError, match="Cannot determine video frame rate"):
+        probe_video(video)
+
+
+# --- Stream handling ---
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_no_audio_stream(mock_run, tmp_path):
+    """Video without audio stream returns audio_codec=None."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=_make_ffprobe_output(include_audio=False)
+    )
+
+    result = probe_video(video)
+    assert result["audio_codec"] is None
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_no_video_stream(mock_run, tmp_path):
+    """File with no video stream raises InputFileError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=_make_ffprobe_output(include_video=False)
+    )
+
+    with pytest.raises(InputFileError, match="No video stream"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_empty_streams(mock_run, tmp_path):
+    """Empty streams list raises InputFileError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=json.dumps({"streams": [], "format": {"duration": "600.0"}})
+    )
+
+    with pytest.raises(InputFileError, match="No video stream"):
+        probe_video(video)
+
+
+# --- Error cases ---
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_invalid_json(mock_run, tmp_path):
+    """Invalid JSON from ffprobe raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(stdout="not valid json {{{")
+
+    with pytest.raises(VideoProcessingError, match="invalid JSON"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_subprocess_failure(mock_run, tmp_path):
+    """ffprobe CalledProcessError raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.side_effect = subprocess.CalledProcessError(1, "ffprobe", stderr="error")
+
+    with pytest.raises(VideoProcessingError, match="ffprobe failed"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_ffprobe_not_found(mock_run, tmp_path):
+    """Missing ffprobe raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.side_effect = FileNotFoundError()
+
+    with pytest.raises(VideoProcessingError, match="ffprobe not found"):
+        probe_video(video)
+
+
+# --- Missing metadata ---
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_missing_duration(mock_run, tmp_path):
+    """Missing duration in format defaults to 0.0."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    data = {
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "r_frame_rate": "30/1",
+                "avg_frame_rate": "30/1",
+            }
+        ],
+        "format": {},
+    }
+    mock_run.return_value = _mock_result(stdout=json.dumps(data))
+
+    result = probe_video(video)
+    assert result["duration"] == 0.0
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_missing_dimensions(mock_run, tmp_path):
+    """Missing width/height defaults to 0."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    data = {
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "r_frame_rate": "30/1",
+                "avg_frame_rate": "30/1",
+            }
+        ],
+        "format": {"duration": "600.0"},
+    }
+    mock_run.return_value = _mock_result(stdout=json.dumps(data))
+
+    result = probe_video(video)
+    assert result["width"] == 0
+    assert result["height"] == 0

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1,12 +1,38 @@
 """Tests for split_matches pipeline orchestration."""
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from allaganeye.commands.split_matches import run_split
 from allaganeye.config import SplitConfig
-from allaganeye.exceptions import AllaganEyeError, DetectionError
+from allaganeye.exceptions import AllaganEyeError, DetectionError, VideoProcessingError
+
+# Standard mock return values
+PROBE_RESULT = {
+    "duration": 1800.0,
+    "width": 1920,
+    "height": 1080,
+    "fps": 30.0,
+    "codec": "h264",
+    "audio_codec": "aac",
+}
+
+BOUNDARIES = [
+    {"start": 0.0, "end": 600.0},
+    {"start": 610.0, "end": 1200.0},
+]
+
+MODULE = "allaganeye.commands.split_matches"
+
+
+def _output_files(output_dir: Path) -> list[Path]:
+    return [output_dir / "match_001.mp4", output_dir / "match_002.mp4"]
+
+
+# --- Fixtures ---
 
 
 @pytest.fixture
@@ -18,24 +44,12 @@ def config(tmp_path):
 def mock_pipeline():
     """Mock probe/detect/split for pipeline tests."""
     with (
-        patch("allaganeye.commands.split_matches.probe_video") as mock_probe,
-        patch(
-            "allaganeye.commands.split_matches.detect_match_boundaries"
-        ) as mock_detect,
-        patch("allaganeye.commands.split_matches.split_video") as mock_split,
+        patch(f"{MODULE}.probe_video") as mock_probe,
+        patch(f"{MODULE}.detect_match_boundaries") as mock_detect,
+        patch(f"{MODULE}.split_video") as mock_split,
     ):
-        mock_probe.return_value = {
-            "duration": 1200.0,
-            "width": 1920,
-            "height": 1080,
-            "fps": 30.0,
-            "codec": "h264",
-            "audio_codec": "aac",
-        }
-        mock_detect.return_value = [
-            {"start": 0.0, "end": 600.0},
-            {"start": 610.0, "end": 1200.0},
-        ]
+        mock_probe.return_value = PROBE_RESULT
+        mock_detect.return_value = BOUNDARIES
         mock_split.return_value = [
             Path("output/match_001.mp4"),
             Path("output/match_002.mp4"),
@@ -43,46 +57,237 @@ def mock_pipeline():
         yield mock_probe, mock_detect, mock_split
 
 
+# --- Pipeline happy path ---
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_happy_path(mock_probe, mock_detect, mock_split, tmp_path):
+    """Full pipeline calls probe, detect, split in order and writes metadata."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    video = Path("input.mp4")
+
+    run_split(video, config)
+
+    mock_probe.assert_called_once_with(video)
+    mock_detect.assert_called_once_with(
+        video,
+        sample_interval=config.sample_interval,
+        blackout_threshold=config.blackout_threshold,
+        min_match_duration=config.min_match_duration,
+    )
+    mock_split.assert_called_once_with(video, BOUNDARIES, tmp_path)
+    assert (tmp_path / "metadata.json").exists()
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_metadata_json_content(mock_probe, mock_detect, mock_split, tmp_path):
+    """metadata.json contains correct structure and values."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+
+    data = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    assert data["source"] == "input.mp4"
+    assert data["source_duration"] == 1800.0
+    assert len(data["matches"]) == 2
+    m1 = data["matches"][0]
+    assert m1["index"] == 1
+    assert m1["start_time"] == 0.0
+    assert m1["end_time"] == 600.0
+    assert m1["duration"] == 600.0
+    assert "match_001" in m1["output_file"]
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_output_dir_created(mock_probe, mock_detect, mock_split, tmp_path):
+    """Output directory is created if it doesn't exist."""
+    output = tmp_path / "subdir" / "output"
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = [output / "match_001.mp4", output / "match_002.mp4"]
+    config = SplitConfig(output_dir=output, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+
+    assert output.is_dir()
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_dry_run(mock_probe, mock_detect, mock_split, tmp_path):
+    """Dry-run mode skips split and metadata writing."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    config = SplitConfig(output_dir=tmp_path, dry_run=True, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+
+    mock_probe.assert_called_once()
+    mock_detect.assert_called_once()
+    mock_split.assert_not_called()
+    assert not (tmp_path / "metadata.json").exists()
+
+
+# --- Detection empty ---
+
+
+def test_pipeline_no_boundaries():
+    """Zero boundaries raises DetectionError."""
+    with (
+        patch(f"{MODULE}.probe_video") as mock_probe,
+        patch(f"{MODULE}.detect_match_boundaries") as mock_detect,
+    ):
+        mock_probe.return_value = PROBE_RESULT
+        mock_detect.return_value = []
+        config = SplitConfig(min_match_duration=60.0)
+
+        with pytest.raises(DetectionError, match="No match boundaries detected"):
+            run_split(Path("input.mp4"), config)
+
+
+# --- Error propagation ---
+
+
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_probe_failure(mock_probe):
+    """Probe failure propagates VideoProcessingError."""
+    mock_probe.side_effect = VideoProcessingError("ffprobe failed")
+    config = SplitConfig(min_match_duration=60.0)
+
+    with pytest.raises(VideoProcessingError, match="ffprobe failed"):
+        run_split(Path("input.mp4"), config)
+
+
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_detect_failure(mock_probe, mock_detect):
+    """Detection failure propagates VideoProcessingError."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.side_effect = VideoProcessingError("Cannot open video")
+    config = SplitConfig(min_match_duration=60.0)
+
+    with pytest.raises(VideoProcessingError, match="Cannot open video"):
+        run_split(Path("input.mp4"), config)
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_split_failure(mock_probe, mock_detect, mock_split, tmp_path):
+    """Split failure propagates VideoProcessingError."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.side_effect = VideoProcessingError("ffmpeg failed")
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    with pytest.raises(VideoProcessingError, match="ffmpeg failed"):
+        run_split(Path("input.mp4"), config)
+
+
+# --- Error handling (from PR #34) ---
+
+
 class TestMkdirError:
     def test_mkdir_permission_error(self, config, mock_pipeline):
-        from allaganeye.commands.split_matches import run_split
-
         with patch.object(
             Path, "mkdir", side_effect=PermissionError("Permission denied")
         ):
-            with pytest.raises(AllaganEyeError, match="Cannot create output directory"):
+            with pytest.raises(
+                AllaganEyeError, match="Cannot create output directory"
+            ):
                 run_split(Path("video.mp4"), config)
 
 
 class TestMetadataWriteError:
     def test_write_text_oserror(self, tmp_path, mock_pipeline):
-        config = SplitConfig(output_dir=tmp_path / "output", min_match_duration=60.0)
-
-        from allaganeye.commands.split_matches import run_split
+        cfg = SplitConfig(output_dir=tmp_path / "output", min_match_duration=60.0)
 
         with patch.object(Path, "write_text", side_effect=OSError("Disk full")):
             with pytest.raises(AllaganEyeError, match="Cannot write metadata"):
-                run_split(Path("video.mp4"), config)
+                run_split(Path("video.mp4"), cfg)
 
 
-class TestDetectionEmpty:
-    def test_no_boundaries_raises(self, config):
-        from allaganeye.commands.split_matches import run_split
+# --- Verbose output ---
 
-        with (
-            patch("allaganeye.commands.split_matches.probe_video") as mock_probe,
-            patch(
-                "allaganeye.commands.split_matches.detect_match_boundaries"
-            ) as mock_detect,
-        ):
-            mock_probe.return_value = {
-                "duration": 1200.0,
-                "width": 1920,
-                "height": 1080,
-                "fps": 30.0,
-                "codec": "h264",
-                "audio_codec": "aac",
-            }
-            mock_detect.return_value = []
-            with pytest.raises(DetectionError):
-                run_split(Path("video.mp4"), config)
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_verbose_output(mock_probe, mock_detect, mock_split, tmp_path, capsys):
+    """Verbose mode prints probe info and match details."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+
+    output = capsys.readouterr().out
+    assert "Probing:" in output
+    assert "Duration:" in output
+    assert "Detecting match boundaries" in output
+    assert "Match 1:" in output
+    assert "Match 2:" in output
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_non_verbose_output(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Non-verbose mode prints summary but not details."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=False)
+
+    output = capsys.readouterr().out
+    assert "Detected 2 match(es)" in output
+    assert "Probing:" not in output
+    assert "Match 1:" not in output
+
+
+# --- Config forwarding ---
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_config_params_forwarded(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """Non-default config values are forwarded to detect_match_boundaries."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(
+        output_dir=tmp_path,
+        sample_interval=2.0,
+        blackout_threshold=20.0,
+        min_match_duration=120.0,
+    )
+
+    run_split(Path("input.mp4"), config)
+
+    mock_detect.assert_called_once_with(
+        Path("input.mp4"),
+        sample_interval=2.0,
+        blackout_threshold=20.0,
+        min_match_duration=120.0,
+    )

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,5 +1,6 @@
 """Tests for video splitter module."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -9,12 +10,18 @@ from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.splitter import _ffmpeg_split, split_video
 
 
+# --- Existing test ---
+
+
 def test_split_nonexistent_file(tmp_path):
     """Splitting a nonexistent file raises VideoProcessingError."""
     fake = tmp_path / "nonexistent.mp4"
     boundaries = [{"start": 0.0, "end": 10.0}]
     with pytest.raises(VideoProcessingError):
         split_video(fake, boundaries, tmp_path)
+
+
+# --- _ffmpeg_split command verification ---
 
 
 class TestFfmpegSplitCommand:
@@ -58,3 +65,105 @@ class TestFfmpegSplitCommand:
         ss_idx = args.index("-ss")
         ss_value = float(args[ss_idx + 1])
         assert ss_value == pytest.approx(120.5)
+
+
+# --- split_video normal cases ---
+
+
+@patch("allaganeye.video.splitter.subprocess.run")
+def test_split_single_boundary(mock_run, tmp_path):
+    """Single boundary produces one output file."""
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["ffmpeg"], returncode=0, stdout="", stderr=""
+    )
+    video = tmp_path / "input.mp4"
+    boundaries = [{"start": 10.0, "end": 300.0}]
+
+    result = split_video(video, boundaries, tmp_path)
+
+    assert len(result) == 1
+    assert result[0] == tmp_path / "match_001.mp4"
+    assert mock_run.call_count == 1
+
+
+@patch("allaganeye.video.splitter.subprocess.run")
+def test_split_multiple_boundaries(mock_run, tmp_path):
+    """Multiple boundaries produce correctly numbered files."""
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["ffmpeg"], returncode=0, stdout="", stderr=""
+    )
+    video = tmp_path / "input.mp4"
+    boundaries = [
+        {"start": 0.0, "end": 600.0},
+        {"start": 610.0, "end": 1200.0},
+        {"start": 1210.0, "end": 1800.0},
+    ]
+
+    result = split_video(video, boundaries, tmp_path)
+
+    assert len(result) == 3
+    assert result[0].name == "match_001.mp4"
+    assert result[1].name == "match_002.mp4"
+    assert result[2].name == "match_003.mp4"
+    assert mock_run.call_count == 3
+
+
+@patch("allaganeye.video.splitter.subprocess.run")
+def test_split_empty_boundaries(mock_run, tmp_path):
+    """Empty boundaries list returns empty list without calling ffmpeg."""
+    video = tmp_path / "input.mp4"
+
+    result = split_video(video, [], tmp_path)
+
+    assert result == []
+    mock_run.assert_not_called()
+
+
+# --- Error cases ---
+
+
+@patch("allaganeye.video.splitter.subprocess.run")
+def test_split_ffmpeg_returns_nonzero(mock_run, tmp_path):
+    """FFmpeg non-zero exit raises VideoProcessingError."""
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["ffmpeg"], returncode=1, stdout="", stderr="encoding failed"
+    )
+    video = tmp_path / "input.mp4"
+    boundaries = [{"start": 0.0, "end": 300.0}]
+
+    with pytest.raises(VideoProcessingError, match="ffmpeg split failed"):
+        split_video(video, boundaries, tmp_path)
+
+
+@patch("allaganeye.video.splitter.subprocess.run")
+def test_split_ffmpeg_not_found(mock_run, tmp_path):
+    """Missing ffmpeg raises VideoProcessingError."""
+    mock_run.side_effect = FileNotFoundError()
+    video = tmp_path / "input.mp4"
+    boundaries = [{"start": 0.0, "end": 300.0}]
+
+    with pytest.raises(VideoProcessingError, match="ffmpeg not found"):
+        split_video(video, boundaries, tmp_path)
+
+
+@patch("allaganeye.video.splitter.subprocess.run")
+def test_split_partial_failure(mock_run, tmp_path):
+    """Partial failure: first split succeeds, second fails, error propagates."""
+    success = subprocess.CompletedProcess(
+        args=["ffmpeg"], returncode=0, stdout="", stderr=""
+    )
+    failure = subprocess.CompletedProcess(
+        args=["ffmpeg"], returncode=1, stdout="", stderr="disk full"
+    )
+    mock_run.side_effect = [success, failure]
+    video = tmp_path / "input.mp4"
+    boundaries = [
+        {"start": 0.0, "end": 600.0},
+        {"start": 610.0, "end": 1200.0},
+    ]
+
+    with pytest.raises(VideoProcessingError, match="ffmpeg split failed"):
+        split_video(video, boundaries, tmp_path)
+
+    # First call succeeded, second failed
+    assert mock_run.call_count == 2


### PR DESCRIPTION
## Summary

L1モジュール全体のユニットテストを大幅に拡充。develop-0.1.0（PR #25, #34 マージ後）にリベース済み。

- probe.py: ffprobe JSON パース正常系、FPS パース（分数・0除算・非数値 → VideoProcessingError）、avg_frame_rate フォールバック、ストリーム欠損、subprocess 失敗
- splitter.py: split_video の単一/複数境界分割、ファイル命名、空境界リスト、部分失敗。_ffmpeg_split の引数順序検証（既存テストと統合）
- detector.py: cv2.VideoCapture モックによる detect_match_boundaries() テスト — 明暗フレーム、サンプリング間隔、閾値変更、連続 read 失敗、release() 確認
- split_matches.py: probe→detect→split パイプライン、metadata.json 内容検証、dry-run、エラー伝播、mkdir/write エラー、verbose 出力
- cli.py: 全オプション (--output-dir, --sample-interval, --blackout-threshold, --min-match-duration, --dry-run, -v)、ConfigValidationError (exit 5)、exit code 検証、拡張子サポート

全テストはモックベースで外部ツール不要、0.72s で 104 件通過。

関連 Issue: #10, #11, #12, #13

## Test plan

- [x] `pytest -v` — 104/104 passed (0.72s)
- [x] `ruff check .` — All checks passed
- [ ] lead-engineer によるコードレビュー

## 関連 Issue (コードレビュー中に起票)

- #18 split_video() の部分失敗時に出力済みファイルが残る
- #19 detect_match_boundaries() で VideoCapture オープン失敗時に release() が呼ばれない
- #20 metadata.json 書き込み失敗時のエラーハンドリングがない

🤖 Generated with [Claude Code](https://claude.com/claude-code)