### PR TITLE
fix: サンプル動画パスを環境変数ベースに変更 (#23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,19 @@ MP4/MKV入力 → probe.py（メタデータ取得）
 
 ### 動画サンプルデータ
 
-テスト・開発用の録画データ: `E:\royalstraightflesh\videos\`
+テスト・開発用の録画データは環境変数 `ALLAGANEYE_SAMPLE_VIDEO_DIR` で指定する。
+
+```bash
+# Windows (デフォルトの録画保存先)
+set ALLAGANEYE_SAMPLE_VIDEO_DIR=E:\royalstraightflesh\videos
+
+# Linux / macOS
+export ALLAGANEYE_SAMPLE_VIDEO_DIR=/path/to/videos
+```
+
 - MKV: OBSの長時間録画（30-80GB、複数試合を含む）
 - サブディレクトリ（`20260116/` 等）: 手動で試合分割済みのMP4（`YYYYMMDD_N.mp4`）
+- 未設定の場合、`sample_video_dir` fixture を使うテスト（`slow` マーカー）はスキップされる
 
 ## リリース戦略
 

--- a/docs/reference-videos.md
+++ b/docs/reference-videos.md
@@ -100,4 +100,4 @@ yt-dlp --download-sections "*0:00-5:00" -o "sample_%(id)s.%(ext)s" "<URL>"
 ```
 
 > 著作権に注意: テスト用の短いサンプルに留め、リポジトリにはコミットしないこと。
-> プロジェクトのサンプルデータは `E:\royalstraightflesh\videos\` にある自前の録画を使用する。
+> プロジェクトのサンプルデータは環境変数 `ALLAGANEYE_SAMPLE_VIDEO_DIR` で指定したディレクトリの自前の録画を使用する（詳細は `CLAUDE.md` 参照）。

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures for Allagan Eye."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -7,8 +8,18 @@ import pytest
 
 @pytest.fixture
 def sample_video_dir() -> Path:
-    """Path to sample video data directory."""
-    return Path(r"E:\royalstraightflesh\videos")
+    """Path to sample video data directory.
+
+    Reads from ALLAGANEYE_SAMPLE_VIDEO_DIR environment variable.
+    Skips the test if the variable is not set or the directory does not exist.
+    """
+    env_path = os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR")
+    if not env_path:
+        pytest.skip("ALLAGANEYE_SAMPLE_VIDEO_DIR not set")
+    path = Path(env_path)
+    if not path.is_dir():
+        pytest.skip(f"Sample video directory not found: {path}")
+    return path
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- `tests/conftest.py`: ハードコードされた Windows パス (`E:\royalstraightflesh\videos`) を環境変数 `ALLAGANEYE_SAMPLE_VIDEO_DIR` から読み込むように変更
- 未設定時は `pytest.skip()` でテストをスキップ（CI の Linux 環境で安全に動作）
- ディレクトリが存在しない場合もスキップ
- `CLAUDE.md` と `docs/reference-videos.md` のパス記載を環境変数ベースに更新

関連: #23

## Checklist

- [x] 全テスト通過（`pytest`）— 47 passed
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`）
- [x] 関連ドキュメント更新（CLAUDE.md, reference-videos.md）

## Test plan

- [x] `ALLAGANEYE_SAMPLE_VIDEO_DIR` 未設定で `pytest` → 全テスト通過（slow テストはスキップ）
- [ ] lead-engineer レビュー
- [ ] テスター確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)