### PR TITLE
docs: 部分失敗時のファイル残存について説明を追加 (#18)

### DIFF
--- a/allaganeye/video/splitter.py
+++ b/allaganeye/video/splitter.py
@@ -78,4 +78,5 @@ def _ffmpeg_split(
     if result.returncode != 0:
         raise VideoProcessingError(
             f"ffmpeg split failed for {output.name}: {result.stderr[-500:]}"
+            " (previously output files may remain in the output directory)"
         )

--- a/allaganeye/video/splitter.py
+++ b/allaganeye/video/splitter.py
@@ -78,5 +78,5 @@ def _ffmpeg_split(
     if result.returncode != 0:
         raise VideoProcessingError(
             f"ffmpeg split failed for {output.name}: {result.stderr[-500:]}"
-            " (previously output files may remain in the output directory)"
+            " (previous output files may remain in the output directory)"
         )

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -63,3 +63,7 @@ allaganeye split your_recording.mkv --min-match-duration 120.0
 ```
 
 詳細は `allaganeye split --help` で確認できます。
+
+### 分割が途中で失敗した場合
+
+途中で失敗しても、成功済みの出力ファイル（`match_001.mp4` 等）は出力ディレクトリに残ります。再実行すれば自動的に上書きされるため、手動削除は不要です。

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,9 +83,7 @@ def test_split_blackout_threshold_over_255(tmp_path):
 def test_split_negative_min_match_duration(tmp_path):
     fake_file = tmp_path / "video.mp4"
     fake_file.write_bytes(b"\x00")
-    result = runner.invoke(
-        app, ["split", str(fake_file), "--min-match-duration", "-1"]
-    )
+    result = runner.invoke(app, ["split", str(fake_file), "--min-match-duration", "-1"])
     assert result.exit_code == 5
 
 
@@ -134,9 +132,7 @@ def test_split_output_dir_long_form(mock_run_split, fake_video, tmp_path):
 @patch(MODULE)
 def test_split_sample_interval(mock_run_split, fake_video):
     """--sample-interval option is forwarded to config."""
-    result = runner.invoke(
-        app, ["split", str(fake_video), "--sample-interval", "2.5"]
-    )
+    result = runner.invoke(app, ["split", str(fake_video), "--sample-interval", "2.5"])
 
     assert result.exit_code == 0
     config = mock_run_split.call_args[0][1]

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -134,9 +134,7 @@ def test_probe_normal_mp4(mock_run, tmp_path):
     """Normal ffprobe output is parsed correctly."""
     video = tmp_path / "test.mp4"
     video.touch()
-    mock_run.return_value = _mock_result(
-        stdout=_make_ffprobe_output(duration="1800.5")
-    )
+    mock_run.return_value = _mock_result(stdout=_make_ffprobe_output(duration="1800.5"))
 
     result = probe_video(video)
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -205,9 +205,7 @@ class TestMkdirError:
         with patch.object(
             Path, "mkdir", side_effect=PermissionError("Permission denied")
         ):
-            with pytest.raises(
-                AllaganEyeError, match="Cannot create output directory"
-            ):
+            with pytest.raises(AllaganEyeError, match="Cannot create output directory"):
                 run_split(Path("video.mp4"), config)
 
 


### PR DESCRIPTION
## Summary

- `splitter.py`: エラーメッセージに「出力済みファイルが残っている可能性がある」旨を追記
- `docs/quickstart.md`: 分割途中失敗時の動作（再実行で上書き）を説明するセクションを追加

lead-1 方針に従い、クリーンアップは実装せず説明の追加のみ。

関連: #18

## Checklist

- [x] 全テスト通過（`pytest`）— 104 passed
- [x] Lint 通過（`ruff check .`）
- [x] 関連ドキュメント更新（quickstart.md）

## Test plan

- [x] 既存テスト通過確認
- [ ] lead-engineer レビュー
- [ ] テスター確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)