### PR TITLE
feat: 分割境界に暗転内パディングを導入 (#39)

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -78,6 +78,15 @@ def detect_match_boundaries(
     )
 
 
+_BLACKOUT_PADDING = 3.0
+"""Seconds to offset cut points into blackout regions.
+
+With ``-c copy``, FFmpeg can only cut at keyframes (~2s apart for OBS).
+By placing cut points inside blackout regions, keyframe drift never
+clips actual match footage.
+"""
+
+
 def _extract_segments(
     blackout_times: list[float],
     total_duration: float,
@@ -88,6 +97,10 @@ def _extract_segments(
 
     Groups consecutive blackout frames into blackout regions,
     then extracts gaps between them as match candidates.
+
+    Cut points are offset into the blackout regions by
+    ``_BLACKOUT_PADDING`` so that keyframe-level imprecision in
+    ``-c copy`` mode never clips match footage.
     """
     if not blackout_times:
         # No blackouts found — entire video is one segment
@@ -116,20 +129,40 @@ def _extract_segments(
     # Before first blackout
     if blackout_regions[0][0] > 0:
         seg_start = 0.0
-        seg_end = blackout_regions[0][0]
+        seg_end = _padded_end(blackout_regions[0])
+        seg_end = min(seg_end, total_duration)
         if seg_end - seg_start >= min_match_duration:
             segments.append({"start": seg_start, "end": seg_end})
 
     # Between blackout regions
     for i in range(len(blackout_regions) - 1):
-        seg_start = blackout_regions[i][1]
-        seg_end = blackout_regions[i + 1][0]
+        seg_start = _padded_start(blackout_regions[i])
+        seg_start = max(seg_start, 0.0)
+        seg_end = _padded_end(blackout_regions[i + 1])
+        seg_end = min(seg_end, total_duration)
         if seg_end - seg_start >= min_match_duration:
             segments.append({"start": seg_start, "end": seg_end})
 
     # After last blackout
-    last_end = blackout_regions[-1][1]
-    if total_duration - last_end >= min_match_duration:
-        segments.append({"start": last_end, "end": total_duration})
+    seg_start = _padded_start(blackout_regions[-1])
+    seg_start = max(seg_start, 0.0)
+    if total_duration - seg_start >= min_match_duration:
+        segments.append({"start": seg_start, "end": total_duration})
 
     return segments
+
+
+def _padded_end(region: tuple[float, float]) -> float:
+    """Offset the segment end into the blackout region start."""
+    region_start, region_end = region
+    region_duration = region_end - region_start
+    effective_padding = min(_BLACKOUT_PADDING, region_duration / 2)
+    return region_start + effective_padding
+
+
+def _padded_start(region: tuple[float, float]) -> float:
+    """Offset the segment start into the blackout region end."""
+    region_start, region_end = region
+    region_duration = region_end - region_start
+    effective_padding = min(_BLACKOUT_PADDING, region_duration / 2)
+    return region_end - effective_padding

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,9 +83,7 @@ def test_split_blackout_threshold_over_255(tmp_path):
 def test_split_negative_min_match_duration(tmp_path):
     fake_file = tmp_path / "video.mp4"
     fake_file.write_bytes(b"\x00")
-    result = runner.invoke(
-        app, ["split", str(fake_file), "--min-match-duration", "-1"]
-    )
+    result = runner.invoke(app, ["split", str(fake_file), "--min-match-duration", "-1"])
     assert result.exit_code == 5
 
 
@@ -134,9 +132,7 @@ def test_split_output_dir_long_form(mock_run_split, fake_video, tmp_path):
 @patch(MODULE)
 def test_split_sample_interval(mock_run_split, fake_video):
     """--sample-interval option is forwarded to config."""
-    result = runner.invoke(
-        app, ["split", str(fake_video), "--sample-interval", "2.5"]
-    )
+    result = runner.invoke(app, ["split", str(fake_video), "--sample-interval", "2.5"])
 
     assert result.exit_code == 0
     config = mock_run_split.call_args[0][1]

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -7,7 +7,11 @@ import numpy as np
 import pytest
 
 from allaganeye.exceptions import VideoProcessingError
-from allaganeye.video.detector import _extract_segments, detect_match_boundaries
+from allaganeye.video.detector import (
+    _BLACKOUT_PADDING,
+    _extract_segments,
+    detect_match_boundaries,
+)
 
 
 # --- Helpers ---
@@ -94,7 +98,7 @@ class TestExtractSegments:
         assert len(result) == 0
 
     def test_single_blackout_two_matches(self):
-        """Single blackout region splits video into two matches."""
+        """Single blackout region splits video into two matches with padding."""
         blackout_times = [600.0, 601.0, 602.0, 603.0]
         result = _extract_segments(
             blackout_times,
@@ -104,8 +108,10 @@ class TestExtractSegments:
         )
         assert len(result) == 2
         assert result[0]["start"] == 0.0
-        assert result[0]["end"] == 600.0
-        assert result[1]["start"] == 603.0
+        # seg_end padded into blackout: region (600, 603), padding clamped to 1.5
+        assert result[0]["end"] == pytest.approx(601.5)
+        # seg_start padded into blackout: 603 - 1.5 = 601.5
+        assert result[1]["start"] == pytest.approx(601.5)
         assert result[1]["end"] == 1800.0
 
     def test_short_segment_filtered(self):
@@ -117,18 +123,18 @@ class TestExtractSegments:
             sample_interval=1.0,
             min_match_duration=300.0,
         )
-        # First segment: 0-100s (too short), second: 101-500s (399s, long enough)
+        # First segment: 0 to ~100.5 (too short), second: ~100.5 to 500 (long enough)
         assert len(result) == 1
-        assert result[0]["start"] == 101.0
+        assert result[0]["start"] == pytest.approx(100.5)
 
     def test_multiple_blackouts_three_matches(self):
-        """Multiple blackout regions create multiple match segments."""
+        """Multiple blackout regions create multiple match segments with padding."""
         blackout_times = [
-            # First blackout at ~600s
+            # First blackout at ~600s (region: 600-602, duration 2s, padding clamped to 1.0)
             600.0,
             601.0,
             602.0,
-            # Second blackout at ~1800s
+            # Second blackout at ~1800s (region: 1800-1802, duration 2s, padding clamped to 1.0)
             1800.0,
             1801.0,
             1802.0,
@@ -140,10 +146,10 @@ class TestExtractSegments:
             min_match_duration=300.0,
         )
         assert len(result) == 3
-        assert result[0]["end"] == 600.0
-        assert result[1]["start"] == 602.0
-        assert result[1]["end"] == 1800.0
-        assert result[2]["start"] == 1802.0
+        assert result[0]["end"] == pytest.approx(601.0)
+        assert result[1]["start"] == pytest.approx(601.0)
+        assert result[1]["end"] == pytest.approx(1801.0)
+        assert result[2]["start"] == pytest.approx(1801.0)
 
     def test_consecutive_blackouts_merged(self):
         """Consecutive blackout frames within tolerance are merged."""
@@ -154,9 +160,58 @@ class TestExtractSegments:
             sample_interval=1.0,
             min_match_duration=300.0,
         )
+        # Region: (600, 604), duration 4s, padding clamped to 2.0
         assert len(result) == 2
-        assert result[0]["end"] == 600.0
-        assert result[1]["start"] == 604.0
+        assert result[0]["end"] == pytest.approx(602.0)
+        assert result[1]["start"] == pytest.approx(602.0)
+
+    def test_padding_full_when_region_long(self):
+        """Full padding applied when blackout region >= 2 * padding."""
+        # Region: (600, 610), duration 10s > 2*3=6s → full padding of 3.0
+        blackout_times = list(range(600, 611))
+        result = _extract_segments(
+            [float(t) for t in blackout_times],
+            total_duration=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+        )
+        assert len(result) == 2
+        assert result[0]["end"] == pytest.approx(603.0)
+        assert result[1]["start"] == pytest.approx(607.0)
+
+    def test_padding_clamped_for_short_region(self):
+        """Padding clamped to half region duration for short blackout."""
+        # Region: (600, 602), duration 2s → padding = min(3.0, 1.0) = 1.0
+        blackout_times = [600.0, 601.0, 602.0]
+        result = _extract_segments(
+            blackout_times,
+            total_duration=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+        )
+        assert len(result) == 2
+        assert result[0]["end"] == pytest.approx(601.0)
+        assert result[1]["start"] == pytest.approx(601.0)
+
+    def test_padding_does_not_exceed_total_duration(self):
+        """seg_end clamped to total_duration when padding would overshoot."""
+        # Blackout near the very end: region (997, 1000)
+        # After last blackout: seg_start = 1000 - 1.5 = 998.5
+        # Only 1.5s left → too short for min_match_duration
+        blackout_times = [997.0, 998.0, 999.0, 1000.0]
+        result = _extract_segments(
+            blackout_times,
+            total_duration=1000.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+        )
+        assert len(result) == 1
+        # First segment end padded into blackout
+        assert result[0]["end"] == pytest.approx(998.5)
+
+    def test_padding_constant_value(self):
+        """_BLACKOUT_PADDING is 3.0 seconds."""
+        assert _BLACKOUT_PADDING == 3.0
 
 
 # ============================================================

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -134,9 +134,7 @@ def test_probe_normal_mp4(mock_run, tmp_path):
     """Normal ffprobe output is parsed correctly."""
     video = tmp_path / "test.mp4"
     video.touch()
-    mock_run.return_value = _mock_result(
-        stdout=_make_ffprobe_output(duration="1800.5")
-    )
+    mock_run.return_value = _mock_result(stdout=_make_ffprobe_output(duration="1800.5"))
 
     result = probe_video(video)
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -205,9 +205,7 @@ class TestMkdirError:
         with patch.object(
             Path, "mkdir", side_effect=PermissionError("Permission denied")
         ):
-            with pytest.raises(
-                AllaganEyeError, match="Cannot create output directory"
-            ):
+            with pytest.raises(AllaganEyeError, match="Cannot create output directory"):
                 run_split(Path("video.mp4"), config)
 
 


### PR DESCRIPTION
## Summary

- `detector.py`: `_extract_segments()` にパディングロジックを導入し、カット点が暗転区間の内部に収まることを保証
- `-c copy` のキーフレーム誤差（OBS ~2s）で試合映像が切れる問題を解消
- パディング定数 `_BLACKOUT_PADDING = 3.0` 秒（キーフレーム間隔 + マージン）
- 短い暗転区間ではパディングを区間の半分にクランプ
- `seg_start < 0` / `seg_end > total_duration` のガード付き
- テスト 5 件追加、既存テスト 4 件をパディング反映に更新

関連: #39, #16

## Checklist

- [x] 全テスト通過（`pytest`）— 108 passed
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`��
- [x] 関連ドキュメント更新（コード内 docstring）

## Test plan

- [x] パディング全適用（長い暗転区間）のテスト
- [x] パディングクランプ（短い暗転区間）のテスト
- [x] total_duration 超過防止のテスト
- [x] 既存テストのパディング反映確認
- [ ] lead-engineer レビュー
- [ ] テスター確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)