### PR TITLE
docs: ffmpeg インストールガイド拡充 (#40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ MP4/MKV入力 → probe.py（メタデータ取得）
 
 ### 外部依存
 
-- **ffmpeg / ffprobe**: PATH に存在する必要あり
+- **ffmpeg / ffprobe**: 4.1 以上。PATH に存在する必要あり
 - **Python パッケージ**: opencv-python, typer
 
 ### 動画サンプルデータ

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,17 +8,52 @@
 python --version
 ```
 
-### ffmpeg / ffprobe
+### ffmpeg / ffprobe (4.1 以上)
 
 ```bash
 ffmpeg -version
 ffprobe -version
 ```
 
-インストールされていない場合:
-- **Windows**: [ffmpeg.org](https://ffmpeg.org/download.html) からダウンロードし、PATH に追加
-- **macOS**: `brew install ffmpeg`
-- **Linux**: `sudo apt install ffmpeg`
+**最低バージョン: 4.1**（`-avoid_negative_ts make_zero` 等の機能を使用）
+
+#### インストール方法
+
+**Windows**（いずれか 1 つ）:
+
+```bash
+# winget（推奨）
+winget install Gyan.FFmpeg
+
+# scoop
+scoop install ffmpeg
+
+# Chocolatey
+choco install ffmpeg
+```
+
+パッケージマネージャを使わない場合は [gyan.dev](https://www.gyan.dev/ffmpeg/builds/) から `ffmpeg-release-essentials.zip` をダウンロードし、展開先の `bin/` フォルダを PATH に追加してください。
+
+**macOS**:
+
+```bash
+brew install ffmpeg
+```
+
+**Linux (Ubuntu/Debian)**:
+
+```bash
+sudo apt update && sudo apt install ffmpeg
+```
+
+#### インストール確認
+
+```bash
+ffmpeg -version   # "ffmpeg version 4.x" 以上が表示されること
+ffprobe -version  # "ffprobe version 4.x" 以上が表示されること
+```
+
+PATH が通っていない場合は、ターミナルを再起動するか環境変数の設定を確認してください。
 
 ## 2. インストール
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,9 +83,7 @@ def test_split_blackout_threshold_over_255(tmp_path):
 def test_split_negative_min_match_duration(tmp_path):
     fake_file = tmp_path / "video.mp4"
     fake_file.write_bytes(b"\x00")
-    result = runner.invoke(
-        app, ["split", str(fake_file), "--min-match-duration", "-1"]
-    )
+    result = runner.invoke(app, ["split", str(fake_file), "--min-match-duration", "-1"])
     assert result.exit_code == 5
 
 
@@ -134,9 +132,7 @@ def test_split_output_dir_long_form(mock_run_split, fake_video, tmp_path):
 @patch(MODULE)
 def test_split_sample_interval(mock_run_split, fake_video):
     """--sample-interval option is forwarded to config."""
-    result = runner.invoke(
-        app, ["split", str(fake_video), "--sample-interval", "2.5"]
-    )
+    result = runner.invoke(app, ["split", str(fake_video), "--sample-interval", "2.5"])
 
     assert result.exit_code == 0
     config = mock_run_split.call_args[0][1]

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -134,9 +134,7 @@ def test_probe_normal_mp4(mock_run, tmp_path):
     """Normal ffprobe output is parsed correctly."""
     video = tmp_path / "test.mp4"
     video.touch()
-    mock_run.return_value = _mock_result(
-        stdout=_make_ffprobe_output(duration="1800.5")
-    )
+    mock_run.return_value = _mock_result(stdout=_make_ffprobe_output(duration="1800.5"))
 
     result = probe_video(video)
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -205,9 +205,7 @@ class TestMkdirError:
         with patch.object(
             Path, "mkdir", side_effect=PermissionError("Permission denied")
         ):
-            with pytest.raises(
-                AllaganEyeError, match="Cannot create output directory"
-            ):
+            with pytest.raises(AllaganEyeError, match="Cannot create output directory"):
                 run_split(Path("video.mp4"), config)
 
 


### PR DESCRIPTION
## Summary

- `docs/quickstart.md`: ffmpeg セクションを拡充
  - 最低バージョン要件 4.1+ を明記
  - Windows: winget / scoop / Chocolatey / 手動インストール手順
  - macOS / Linux の手順を維持
  - インストール確認コマンドとトラブルシューティング
- `CLAUDE.md`: 外部依存に最低バージョン 4.1+ を追記

関連: #40

## Checklist

- [x] 全テスト通過（`pytest`）— 104 passed
- [x] Lint 通過（`ruff check .`）
- [x] 関連ドキュメント更新（quickstart.md, CLAUDE.md）

## Test plan

- [x] ドキュメント内容の正確性確認
- [x] lead-engineer レビュー（LGTM）
- [x] テスター確認（ドキュメントのみのため不要 — lead-1 判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)