### PR TITLE
docs: [doc] プレフィックスのロール選択ガイドラインを追加 #41

### DIFF
--- a/docs/issue-policy.md
+++ b/docs/issue-policy.md
@@ -45,7 +45,10 @@
 - `[bug]`/`[refactor]` issue は **初期ラベルを `role:lead-engineer` にする**（リードエンジニアの方針コメントが必要なため）。方針決定後、リードエンジニアが `role:engineer` に付替える
 - `[task]` issue は対象ロールの `role:*` ラベルを必ず付ける（prefix だけではどのロール向けか判別できないため）
 - `[question]` issue は回答を求めるロールの `role:*` ラベルを付ける
-- `[doc]` issue は対象ドキュメントの担当ロールの `role:*` ラベルを付ける
+- `[doc]` issue は内容に応じて起票者がロールを選択する:
+  - typo 修正、手順追記、記述の誤り → `role:engineer`
+  - バージョン要件、設計文書、方針策定 → `role:lead-engineer`
+  - プロジェクト方針、ロール定義、連携プロトコル → `role:director`
 - `[risk]` issue は `role:lead-engineer` ラベルを付ける（リスク評価はリードエンジニアが行う）
 - PR にも同様に、レビュー担当ロールの `role:*` ラベルを付ける（`docs/roles/protocol.md` 参照）
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,9 +83,7 @@ def test_split_blackout_threshold_over_255(tmp_path):
 def test_split_negative_min_match_duration(tmp_path):
     fake_file = tmp_path / "video.mp4"
     fake_file.write_bytes(b"\x00")
-    result = runner.invoke(
-        app, ["split", str(fake_file), "--min-match-duration", "-1"]
-    )
+    result = runner.invoke(app, ["split", str(fake_file), "--min-match-duration", "-1"])
     assert result.exit_code == 5
 
 
@@ -134,9 +132,7 @@ def test_split_output_dir_long_form(mock_run_split, fake_video, tmp_path):
 @patch(MODULE)
 def test_split_sample_interval(mock_run_split, fake_video):
     """--sample-interval option is forwarded to config."""
-    result = runner.invoke(
-        app, ["split", str(fake_video), "--sample-interval", "2.5"]
-    )
+    result = runner.invoke(app, ["split", str(fake_video), "--sample-interval", "2.5"])
 
     assert result.exit_code == 0
     config = mock_run_split.call_args[0][1]

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -134,9 +134,7 @@ def test_probe_normal_mp4(mock_run, tmp_path):
     """Normal ffprobe output is parsed correctly."""
     video = tmp_path / "test.mp4"
     video.touch()
-    mock_run.return_value = _mock_result(
-        stdout=_make_ffprobe_output(duration="1800.5")
-    )
+    mock_run.return_value = _mock_result(stdout=_make_ffprobe_output(duration="1800.5"))
 
     result = probe_video(video)
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -205,9 +205,7 @@ class TestMkdirError:
         with patch.object(
             Path, "mkdir", side_effect=PermissionError("Permission denied")
         ):
-            with pytest.raises(
-                AllaganEyeError, match="Cannot create output directory"
-            ):
+            with pytest.raises(AllaganEyeError, match="Cannot create output directory"):
                 run_split(Path("video.mp4"), config)
 
 


### PR DESCRIPTION
## Summary

- `docs/issue-policy.md`: `[doc]` issue のロールラベルを一律指定から、内容に応じて起票者が選択するルールに変更
  - typo 修正、手順追記 → `role:engineer`
  - 設計文書、方針策定 → `role:lead-engineer`
  - プロジェクト方針、ロール定義 → `role:director`
- `develop-0.1.0` 上のテストファイル 3 件のフォーマット修正（`ruff format`）

元 PR #44 (director-1) の CI 失敗を受け、lead-1 が再作成。

関連: #41

## Checklist

- [x] 全テスト通過（`pytest`）— 104 passed (0.61s)
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`）

## Test plan

- [x] ドキュメント内容の正確性確認
- [x] `ruff format --check .` 通過
- [ ] director レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)