### PR TITLE
perf: detector のフレーム読み取りをシーケンシャルに変更 (#46)

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -40,34 +40,49 @@ def detect_match_boundaries(
         if frame_step < 1:
             frame_step = 1
 
-        # Collect brightness values at sampled positions
+        # Collect brightness values at sampled positions.
+        # Uses sequential grab()/retrieve() instead of random-access
+        # set(CAP_PROP_POS_FRAMES) to avoid costly seeking on MKV files.
         blackout_times: list[float] = []
         frame_idx = 0
         consecutive_failures = 0
         max_consecutive_failures = 3
 
         while frame_idx < total_frames:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
-            ret, frame = cap.read()
-            if not ret:
-                consecutive_failures += 1
-                if consecutive_failures >= max_consecutive_failures:
-                    raise VideoProcessingError(
-                        f"Failed to read {max_consecutive_failures} consecutive "
-                        f"frames at position {frame_idx}/{total_frames}"
-                    )
-                frame_idx += frame_step
-                continue
+            if frame_idx % frame_step == 0:
+                # Sample frame: decode and analyze brightness
+                ret, frame = cap.read()
+                if not ret:
+                    consecutive_failures += 1
+                    if consecutive_failures >= max_consecutive_failures:
+                        raise VideoProcessingError(
+                            f"Failed to read {max_consecutive_failures} consecutive "
+                            f"frames at position {frame_idx}/{total_frames}"
+                        )
+                    frame_idx += 1
+                    continue
 
-            consecutive_failures = 0
-            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-            mean_brightness = float(np.mean(gray))
-            timestamp = frame_idx / fps
+                consecutive_failures = 0
+                gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+                mean_brightness = float(np.mean(gray))
+                timestamp = frame_idx / fps
 
-            if mean_brightness < blackout_threshold:
-                blackout_times.append(timestamp)
+                if mean_brightness < blackout_threshold:
+                    blackout_times.append(timestamp)
+            else:
+                # Non-sample frame: advance pointer without decoding
+                if not cap.grab():
+                    consecutive_failures += 1
+                    if consecutive_failures >= max_consecutive_failures:
+                        raise VideoProcessingError(
+                            f"Failed to read {max_consecutive_failures} consecutive "
+                            f"frames at position {frame_idx}/{total_frames}"
+                        )
+                    frame_idx += 1
+                    continue
+                consecutive_failures = 0
 
-            frame_idx += frame_step
+            frame_idx += 1
 
     finally:
         cap.release()

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -30,8 +30,9 @@ def _make_capture_mock(
     frames: dict[int, np.ndarray] | None = None,
     default_brightness: int = 128,
 ) -> MagicMock:
-    """Create a mock cv2.VideoCapture with configurable behavior.
+    """Create a mock cv2.VideoCapture with sequential read behavior.
 
+    Simulates grab()/read() sequential access pattern.
     Args:
         frames: dict mapping frame index to numpy frame.
             Missing indices use default_brightness.
@@ -52,11 +53,6 @@ def _make_capture_mock(
 
     current_frame = [0]
 
-    def set_pos(prop_id, value):
-        current_frame[0] = int(value)
-
-    cap.set.side_effect = set_pos
-
     if frames is None:
         frames = {}
 
@@ -64,11 +60,21 @@ def _make_capture_mock(
         idx = current_frame[0]
         if idx >= frame_count:
             return False, None
+        current_frame[0] += 1
         if idx in frames:
             return True, frames[idx]
         return True, _make_frame(default_brightness)
 
     cap.read.side_effect = read
+
+    def grab():
+        idx = current_frame[0]
+        if idx >= frame_count:
+            return False
+        current_frame[0] += 1
+        return True
+
+    cap.grab.side_effect = grab
 
     return cap
 
@@ -315,7 +321,7 @@ class TestDetectMatchBoundaries:
 
     @patch("allaganeye.video.detector.cv2.VideoCapture")
     def test_sample_interval_respected(self, mock_vc_class):
-        """frame_step = fps * sample_interval determines sampling stride."""
+        """frame_step = fps * sample_interval; only sampled frames are decoded."""
         fps = 30.0
         total_frames = 9000  # 300s
         cap = _make_capture_mock(
@@ -329,19 +335,18 @@ class TestDetectMatchBoundaries:
             min_match_duration=100.0,
         )
 
-        # frame_step = 30 * 2.0 = 60, frames sampled: 0, 60, 120, ...
-        set_calls = list(cap.set.call_args_list)
-        frame_indices = [int(c[0][1]) for c in set_calls]
-        if len(frame_indices) > 1:
-            strides = [
-                frame_indices[i + 1] - frame_indices[i]
-                for i in range(len(frame_indices) - 1)
-            ]
-            assert all(s == 60 for s in strides)
+        # frame_step = 30 * 2.0 = 60
+        # read() called for sampled frames, grab() for skipped frames
+        # Total read calls = total_frames / frame_step = 150
+        # Total grab calls = total_frames - read_calls = 8850
+        read_count = cap.read.call_count
+        grab_count = cap.grab.call_count
+        assert read_count == 150
+        assert grab_count == total_frames - read_count
 
     @patch("allaganeye.video.detector.cv2.VideoCapture")
     def test_sample_interval_very_small(self, mock_vc_class):
-        """Very small sample_interval clamps frame_step to 1."""
+        """Very small sample_interval clamps frame_step to 1 (every frame sampled)."""
         fps = 30.0
         total_frames = 90  # 3s, small for speed
         cap = _make_capture_mock(
@@ -356,14 +361,9 @@ class TestDetectMatchBoundaries:
         )
 
         # frame_step = int(30 * 0.01) = 0 → clamped to 1
-        set_calls = list(cap.set.call_args_list)
-        frame_indices = [int(c[0][1]) for c in set_calls]
-        if len(frame_indices) > 1:
-            strides = [
-                frame_indices[i + 1] - frame_indices[i]
-                for i in range(len(frame_indices) - 1)
-            ]
-            assert all(s == 1 for s in strides)
+        # Every frame is sampled via read(), no grab() calls
+        assert cap.read.call_count == total_frames
+        assert cap.grab.call_count == 0
 
     @patch("allaganeye.video.detector.cv2.VideoCapture")
     def test_custom_threshold(self, mock_vc_class):
@@ -437,13 +437,13 @@ class TestDetectMatchBoundaries:
             7: 3600.0,  # CAP_PROP_FRAME_COUNT
         }.get(prop, 0.0)
 
-        # Every read fails
+        # Every read/grab fails
         cap.read.return_value = (False, None)
+        cap.grab.return_value = False
 
         mock_cv2.VideoCapture.return_value = cap
         mock_cv2.CAP_PROP_FPS = 5
         mock_cv2.CAP_PROP_FRAME_COUNT = 7
-        mock_cv2.CAP_PROP_POS_FRAMES = 1
 
         with pytest.raises(VideoProcessingError, match="consecutive"):
             detect_match_boundaries(Path("test.mp4"), min_match_duration=1.0)


### PR DESCRIPTION
## Summary

- `detector.py`: `cap.set(CAP_PROP_POS_FRAMES)` によるランダムシークを廃止し、`grab()`/`read()` のシーケンシャルアクセスに変更
  - サンプル対象フレーム (`frame_idx % frame_step == 0`): `read()` でデコード + 輝度解析
  - サンプル対象外フレーム: `grab()` のみ（デコードなし、ポインタ進めるだけ）
  - MKV 大容量ファイル (30-80GB) でのランダムシーク→デコードのオーバーヘッドを除去
- `tests/test_detector.py`: モックを sequential read 対応に更新
  - `_make_capture_mock`: `read()` と `grab()` が内部カウンタを自動進行
  - `test_sample_interval_respected`: `read`/`grab` の呼び出し回数で検証
  - `test_consecutive_read_failures_raises`: `grab.return_value = False` 追加

関連: #46

## Checklist

- [x] 全テスト通過（`pytest`）— 108 passed
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`）
- [x] consecutive_failures ロジック維持

## Test plan

- [x] 既存 25 件のテスト全通過
- [x] サンプル間隔による read/grab 比率の検証
- [x] 連続失敗時のエラー送出確認
- [ ] lead-engineer レビュー
- [ ] テスター確認（実動画での速度計測は #14 テスト時に実施予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)