### PR TITLE
fix: MKV の FRAME_COUNT 不正時に duration フォールバック (#48)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -33,6 +33,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
         )
     boundaries = detect_match_boundaries(
         video_path,
+        duration_hint=metadata["duration"],
         sample_interval=config.sample_interval,
         blackout_threshold=config.blackout_threshold,
         min_match_duration=config.min_match_duration,

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -11,6 +11,7 @@ from allaganeye.exceptions import VideoProcessingError
 def detect_match_boundaries(
     video_path: Path,
     *,
+    duration_hint: float | None = None,
     sample_interval: float = 1.0,
     blackout_threshold: float = 15.0,
     min_match_duration: float = 300.0,
@@ -21,6 +22,11 @@ def detect_match_boundaries(
     frames, and returns non-blackout segments that are longer than
     min_match_duration.
 
+    Args:
+        duration_hint: Video duration in seconds from ffprobe. Used as
+            fallback when CAP_PROP_FRAME_COUNT returns <= 0 (common with
+            MKV containers, especially after abnormal OBS shutdown).
+
     Returns list of dicts with 'start' and 'end' keys (seconds).
     """
     cap = cv2.VideoCapture(str(video_path))
@@ -29,11 +35,19 @@ def detect_match_boundaries(
             raise VideoProcessingError(f"Cannot open video: {video_path}")
 
         fps = cap.get(cv2.CAP_PROP_FPS)
-        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        if fps <= 0 or total_frames <= 0:
+        if fps <= 0:
             raise VideoProcessingError(
                 "Cannot read video properties (fps or frame count)"
             )
+
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        if total_frames <= 0:
+            if duration_hint is not None and duration_hint > 0:
+                total_frames = int(fps * duration_hint)
+            else:
+                raise VideoProcessingError(
+                    "Cannot read video properties (fps or frame count)"
+                )
 
         duration = total_frames / fps
         frame_step = int(fps * sample_interval)

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -240,11 +240,72 @@ class TestDetectMatchBoundaries:
 
     @patch("allaganeye.video.detector.cv2.VideoCapture")
     def test_frame_count_zero(self, mock_vc_class):
-        """frame_count=0 raises VideoProcessingError."""
+        """frame_count=0 without duration_hint raises VideoProcessingError."""
         mock_vc_class.return_value = _make_capture_mock(fps=30.0, frame_count=0)
 
         with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
             detect_match_boundaries(Path("test.mp4"))
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_frame_count_zero_with_duration_hint(self, mock_vc_class):
+        """frame_count=0 with duration_hint falls back to fps * duration."""
+        # frame_count=0 but we provide a 9000-frame equivalent mock
+        # that returns frames when read sequentially
+        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
+        # Override get to return 0 for FRAME_COUNT but still allow reads
+        original_get = cap.get.side_effect
+
+        def get_with_zero_frames(prop_id):
+            import cv2
+
+            if prop_id == cv2.CAP_PROP_FRAME_COUNT:
+                return 0
+            return original_get(prop_id)
+
+        cap.get.side_effect = get_with_zero_frames
+        mock_vc_class.return_value = cap
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=300.0,  # 300s * 30fps = 9000 frames
+            min_match_duration=100.0,
+        )
+        assert len(result) == 1
+        assert result[0]["start"] == 0.0
+        assert result[0]["end"] == pytest.approx(300.0)
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_frame_count_negative_with_duration_hint(self, mock_vc_class):
+        """frame_count=-1 (MKV) with duration_hint uses fallback."""
+        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
+        original_get = cap.get.side_effect
+
+        def get_with_negative_frames(prop_id):
+            import cv2
+
+            if prop_id == cv2.CAP_PROP_FRAME_COUNT:
+                return -1
+            return original_get(prop_id)
+
+        cap.get.side_effect = get_with_negative_frames
+        mock_vc_class.return_value = cap
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=300.0,
+            min_match_duration=100.0,
+        )
+        assert len(result) == 1
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_frame_count_zero_with_zero_duration_hint(self, mock_vc_class):
+        """frame_count=0 with duration_hint=0 still raises."""
+        mock_vc_class.return_value = _make_capture_mock(fps=30.0, frame_count=0)
+
+        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
+            detect_match_boundaries(
+                Path("test.mp4"), duration_hint=0.0, min_match_duration=100.0
+            )
 
     @patch("allaganeye.video.detector.cv2.VideoCapture")
     def test_negative_fps(self, mock_vc_class):

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -76,6 +76,7 @@ def test_pipeline_happy_path(mock_probe, mock_detect, mock_split, tmp_path):
     mock_probe.assert_called_once_with(video)
     mock_detect.assert_called_once_with(
         video,
+        duration_hint=PROBE_RESULT["duration"],
         sample_interval=config.sample_interval,
         blackout_threshold=config.blackout_threshold,
         min_match_duration=config.min_match_duration,
@@ -285,6 +286,7 @@ def test_pipeline_config_params_forwarded(
 
     mock_detect.assert_called_once_with(
         Path("input.mp4"),
+        duration_hint=PROBE_RESULT["duration"],
         sample_interval=2.0,
         blackout_threshold=20.0,
         min_match_duration=120.0,


### PR DESCRIPTION
## Summary

- `detector.py`: `duration_hint` 引数を追加。`CAP_PROP_FRAME_COUNT <= 0` の場合、`fps * duration_hint` でフレーム数を推定
- `split_matches.py`: `probe_video()` の duration を `duration_hint` として渡す
- OBS の MKV 録画（特に異常終了ファイル）で FRAME_COUNT が -1 を返すケースに対応

関連: #48

## 設計選択

lead-1 推奨の **方針 A**（`duration_hint` 引数追加）を採用。`probe_video()` の結果を `split_matches.py` が既に保持しているため、重複呼び出しを回避。

## Checklist

- [x] 全テスト通過（`pytest`）— 111 passed
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`）

## Test plan

- [x] `frame_count=0` + `duration_hint` → フォールバック成功
- [x] `frame_count=-1` + `duration_hint` → フォールバック成功
- [x] `frame_count=0` + `duration_hint=0` → エラー送出
- [x] `frame_count=0` + `duration_hint=None` → エラー送出（既存テスト）
- [x] パイプラインテスト: `duration_hint` 引数の受け渡し確認
- [ ] lead-engineer レビュー
- [ ] テスター確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)