### PR TITLE
feat: 検知フェーズにプログレス表示を追加 (#49)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -31,13 +31,36 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             f"Detecting match boundaries "
             f"(interval={config.sample_interval}s, threshold={config.blackout_threshold})"
         )
-    boundaries = detect_match_boundaries(
-        video_path,
-        duration_hint=metadata["duration"],
-        sample_interval=config.sample_interval,
-        blackout_threshold=config.blackout_threshold,
-        min_match_duration=config.min_match_duration,
-    )
+
+        total_duration = metadata["duration"]
+        fps = metadata["fps"]
+        estimated_frames = int(fps * total_duration)
+
+        with typer.progressbar(length=estimated_frames, label="Detecting") as progress:
+            last_pos = [0]
+
+            def on_progress(frame_idx: int, total: int, blackout_count: int) -> None:
+                advance = frame_idx - last_pos[0]
+                if advance > 0:
+                    progress.update(advance)
+                last_pos[0] = frame_idx
+
+            boundaries = detect_match_boundaries(
+                video_path,
+                duration_hint=metadata["duration"],
+                sample_interval=config.sample_interval,
+                blackout_threshold=config.blackout_threshold,
+                min_match_duration=config.min_match_duration,
+                progress_callback=on_progress,
+            )
+    else:
+        boundaries = detect_match_boundaries(
+            video_path,
+            duration_hint=metadata["duration"],
+            sample_interval=config.sample_interval,
+            blackout_threshold=config.blackout_threshold,
+            min_match_duration=config.min_match_duration,
+        )
 
     if not boundaries:
         raise DetectionError(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1,5 +1,6 @@
 """Match boundary detection using OpenCV frame analysis."""
 
+from collections.abc import Callable
 from pathlib import Path
 
 import cv2
@@ -15,6 +16,7 @@ def detect_match_boundaries(
     sample_interval: float = 1.0,
     blackout_threshold: float = 15.0,
     min_match_duration: float = 300.0,
+    progress_callback: Callable[[int, int, int], None] | None = None,
 ) -> list[dict]:
     """Detect match boundaries by finding blackout frames.
 
@@ -26,6 +28,9 @@ def detect_match_boundaries(
         duration_hint: Video duration in seconds from ffprobe. Used as
             fallback when CAP_PROP_FRAME_COUNT returns <= 0 (common with
             MKV containers, especially after abnormal OBS shutdown).
+        progress_callback: Optional callback invoked at each sampled frame
+            with ``(frame_idx, total_frames, blackout_count)``.  Allows the
+            caller to display progress without coupling detector to UI.
 
     Returns list of dicts with 'start' and 'end' keys (seconds).
     """
@@ -95,6 +100,9 @@ def detect_match_boundaries(
                     frame_idx += 1
                     continue
                 consecutive_failures = 0
+
+            if progress_callback is not None and frame_idx % frame_step == 0:
+                progress_callback(frame_idx, total_frames, len(blackout_times))
 
             frame_idx += 1
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -528,3 +528,73 @@ class TestDetectMatchBoundaries:
             detect_match_boundaries(Path("test.mp4"))
 
         cap.release.assert_called_once()
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_progress_callback_called(self, mock_vc_class):
+        """progress_callback is called for each sampled frame."""
+        fps = 30.0
+        total_frames = 9000  # 300s
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=fps, frame_count=total_frames, default_brightness=128
+        )
+        calls = []
+
+        def on_progress(frame_idx, total, blackout_count):
+            calls.append((frame_idx, total, blackout_count))
+
+        detect_match_boundaries(
+            Path("test.mp4"),
+            sample_interval=1.0,
+            min_match_duration=100.0,
+            progress_callback=on_progress,
+        )
+
+        # frame_step = 30, sampled frames: 0, 30, 60, ... → 300 calls
+        assert len(calls) == 300
+        # First call: frame 0, total 9000, 0 blackouts
+        assert calls[0] == (0, total_frames, 0)
+        # All calls have correct total_frames
+        assert all(c[1] == total_frames for c in calls)
+        # blackout_count is non-decreasing
+        counts = [c[2] for c in calls]
+        assert counts == sorted(counts)
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_progress_callback_none_default(self, mock_vc_class):
+        """No callback (default) works without error."""
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=30.0, frame_count=9000, default_brightness=128
+        )
+
+        # Should not raise — progress_callback defaults to None
+        result = detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
+        assert len(result) == 1
+
+    @patch("allaganeye.video.detector.cv2.VideoCapture")
+    def test_progress_callback_with_blackouts(self, mock_vc_class):
+        """progress_callback reports increasing blackout count."""
+        fps = 30.0
+        total_frames = 54000  # 1800s
+
+        black_frames = {}
+        for sec in range(598, 603):
+            black_frames[int(sec * fps)] = _make_frame(5)
+
+        mock_vc_class.return_value = _make_capture_mock(
+            fps=fps,
+            frame_count=total_frames,
+            frames=black_frames,
+            default_brightness=128,
+        )
+        calls = []
+
+        detect_match_boundaries(
+            Path("test.mp4"),
+            sample_interval=1.0,
+            min_match_duration=300.0,
+            progress_callback=lambda fi, t, bc: calls.append((fi, t, bc)),
+        )
+
+        # Should have blackout_count > 0 in later calls
+        max_blackouts = max(c[2] for c in calls)
+        assert max_blackouts == 5  # frames at 598, 599, 600, 601, 602


### PR DESCRIPTION
## Summary

- `detector.py`: `progress_callback: Callable[[int, int, int], None] | None` 引数を追加
  - サンプルフレームごとに `(frame_idx, total_frames, blackout_count)` を通知
  - detector は typer に依存しない（UI 層との分離）
  - `None`（デフォルト）では動作変更なし
- `split_matches.py`: `--verbose` 時に `typer.progressbar()` でプログレスバーを表示
  - 非 verbose 時はプログレスなし（バッチ実行に影響なし）
- テスト 3 件追加（コールバック呼び出し検証、デフォルト None、blackout count 検証）

関連: #49

## Checklist

- [x] 全テスト通過（`pytest`）— 111 passed
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`）

## Test plan

- [x] `progress_callback` が正しい引数・回数で呼ばれることを検証
- [x] `progress_callback=None` で既存テストが壊れないことを確認
- [x] blackout_count が非減少であることを検証
- [ ] lead-engineer レビュー
- [ ] テスター確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)