### PR TITLE
perf: detector を ffmpeg パイ���ベースに全面置き換え (#53)

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -104,8 +104,12 @@ def _sample_brightness_ffmpeg(
     if duration_hint is not None and duration_hint > 0:
         total_samples = int(duration_hint / sample_interval)
 
+    assert proc.stdout is not None  # guaranteed by stdout=PIPE
+    assert proc.stderr is not None  # guaranteed by stderr=PIPE
+
     blackout_times: list[float] = []
     sample_idx = 0
+    stderr_tail = ""
 
     try:
         while True:
@@ -123,14 +127,12 @@ def _sample_brightness_ffmpeg(
             sample_idx += 1
     finally:
         proc.stdout.close()
+        stderr_tail = proc.stderr.read().decode(errors="replace")[-500:]
+        proc.stderr.close()
         proc.wait()
 
     if proc.returncode != 0 and sample_idx == 0:
-        stderr = proc.stderr.read().decode(errors="replace")[-500:]
-        proc.stderr.close()
-        raise VideoProcessingError(f"ffmpeg frame sampling failed: {stderr}")
-    if proc.stderr:
-        proc.stderr.close()
+        raise VideoProcessingError(f"ffmpeg frame sampling failed: {stderr_tail}")
 
     return blackout_times
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1,12 +1,16 @@
-"""Match boundary detection using OpenCV frame analysis."""
+"""Match boundary detection using ffmpeg frame sampling."""
 
+import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
-import cv2
 import numpy as np
 
 from allaganeye.exceptions import VideoProcessingError
+
+_SAMPLE_WIDTH = 320
+_SAMPLE_HEIGHT = 180
+_FRAME_SIZE = _SAMPLE_WIDTH * _SAMPLE_HEIGHT  # grayscale, 1 byte per pixel
 
 
 def detect_match_boundaries(
@@ -20,99 +24,115 @@ def detect_match_boundaries(
 ) -> list[dict]:
     """Detect match boundaries by finding blackout frames.
 
-    Samples frames at the given interval, detects blackout (low brightness)
-    frames, and returns non-blackout segments that are longer than
-    min_match_duration.
+    Uses ffmpeg to sample frames at the given interval, converting to
+    low-resolution grayscale for fast brightness analysis.  This avoids
+    the OpenCV VideoCapture bottleneck of sequentially walking every
+    frame in large MKV files.
 
     Args:
-        duration_hint: Video duration in seconds from ffprobe. Used as
-            fallback when CAP_PROP_FRAME_COUNT returns <= 0 (common with
-            MKV containers, especially after abnormal OBS shutdown).
+        duration_hint: Video duration in seconds from ffprobe.  Used to
+            estimate total sample count for progress reporting.
         progress_callback: Optional callback invoked at each sampled frame
-            with ``(frame_idx, total_frames, blackout_count)``.  Allows the
-            caller to display progress without coupling detector to UI.
+            with ``(sample_index, total_samples, blackout_count)``.  Allows
+            the caller to display progress without coupling detector to UI.
 
     Returns list of dicts with 'start' and 'end' keys (seconds).
     """
-    cap = cv2.VideoCapture(str(video_path))
-    try:
-        if not cap.isOpened():
-            raise VideoProcessingError(f"Cannot open video: {video_path}")
+    blackout_times = _sample_brightness_ffmpeg(
+        video_path,
+        sample_interval=sample_interval,
+        blackout_threshold=blackout_threshold,
+        duration_hint=duration_hint,
+        progress_callback=progress_callback,
+    )
 
-        fps = cap.get(cv2.CAP_PROP_FPS)
-        if fps <= 0:
+    duration = duration_hint if duration_hint is not None and duration_hint > 0 else 0.0
+    if duration <= 0:
+        # Estimate duration from last sample timestamp
+        if blackout_times:
+            duration = blackout_times[-1] + sample_interval
+        else:
+            # No blackouts and no duration hint — cannot determine duration
             raise VideoProcessingError(
-                "Cannot read video properties (fps or frame count)"
+                "Cannot determine video duration. Provide duration_hint via probe."
             )
 
-        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        if total_frames <= 0:
-            if duration_hint is not None and duration_hint > 0:
-                total_frames = int(fps * duration_hint)
-            else:
-                raise VideoProcessingError(
-                    "Cannot read video properties (fps or frame count)"
-                )
-
-        duration = total_frames / fps
-        frame_step = int(fps * sample_interval)
-        if frame_step < 1:
-            frame_step = 1
-
-        # Collect brightness values at sampled positions.
-        # Uses sequential grab()/retrieve() instead of random-access
-        # set(CAP_PROP_POS_FRAMES) to avoid costly seeking on MKV files.
-        blackout_times: list[float] = []
-        frame_idx = 0
-        consecutive_failures = 0
-        max_consecutive_failures = 3
-
-        while frame_idx < total_frames:
-            if frame_idx % frame_step == 0:
-                # Sample frame: decode and analyze brightness
-                ret, frame = cap.read()
-                if not ret:
-                    consecutive_failures += 1
-                    if consecutive_failures >= max_consecutive_failures:
-                        raise VideoProcessingError(
-                            f"Failed to read {max_consecutive_failures} consecutive "
-                            f"frames at position {frame_idx}/{total_frames}"
-                        )
-                    frame_idx += 1
-                    continue
-
-                consecutive_failures = 0
-                gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-                mean_brightness = float(np.mean(gray))
-                timestamp = frame_idx / fps
-
-                if mean_brightness < blackout_threshold:
-                    blackout_times.append(timestamp)
-            else:
-                # Non-sample frame: advance pointer without decoding
-                if not cap.grab():
-                    consecutive_failures += 1
-                    if consecutive_failures >= max_consecutive_failures:
-                        raise VideoProcessingError(
-                            f"Failed to read {max_consecutive_failures} consecutive "
-                            f"frames at position {frame_idx}/{total_frames}"
-                        )
-                    frame_idx += 1
-                    continue
-                consecutive_failures = 0
-
-            if progress_callback is not None and frame_idx % frame_step == 0:
-                progress_callback(frame_idx, total_frames, len(blackout_times))
-
-            frame_idx += 1
-
-    finally:
-        cap.release()
-
-    # Build segments from non-blackout regions
     return _extract_segments(
         blackout_times, duration, sample_interval, min_match_duration
     )
+
+
+def _sample_brightness_ffmpeg(
+    video_path: Path,
+    *,
+    sample_interval: float,
+    blackout_threshold: float,
+    duration_hint: float | None,
+    progress_callback: Callable[[int, int, int], None] | None,
+) -> list[float]:
+    """Sample frame brightness using ffmpeg pipe.
+
+    Runs ffmpeg with a ``select`` filter to extract one frame per
+    *sample_interval* seconds, scaled to 320x180 grayscale.  Raw pixel
+    data is piped to Python for brightness analysis.
+    """
+    cmd = [
+        "ffmpeg",
+        "-i",
+        str(video_path),
+        "-vf",
+        f"select='not(mod(t\\,{sample_interval}))',setpts=N/FRAME_RATE/TB",
+        "-vsync",
+        "vfr",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "gray",
+        "-s",
+        f"{_SAMPLE_WIDTH}x{_SAMPLE_HEIGHT}",
+        "pipe:1",
+    ]
+
+    try:
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError as e:
+        raise VideoProcessingError(
+            "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
+        ) from e
+
+    total_samples = 0
+    if duration_hint is not None and duration_hint > 0:
+        total_samples = int(duration_hint / sample_interval)
+
+    blackout_times: list[float] = []
+    sample_idx = 0
+
+    try:
+        while True:
+            raw = proc.stdout.read(_FRAME_SIZE)
+            if len(raw) < _FRAME_SIZE:
+                break
+            brightness = float(np.frombuffer(raw, dtype=np.uint8).mean())
+            timestamp = sample_idx * sample_interval
+            if brightness < blackout_threshold:
+                blackout_times.append(timestamp)
+
+            if progress_callback is not None:
+                progress_callback(sample_idx, total_samples, len(blackout_times))
+
+            sample_idx += 1
+    finally:
+        proc.stdout.close()
+        proc.wait()
+
+    if proc.returncode != 0 and sample_idx == 0:
+        stderr = proc.stderr.read().decode(errors="replace")[-500:]
+        proc.stderr.close()
+        raise VideoProcessingError(f"ffmpeg frame sampling failed: {stderr}")
+    if proc.stderr:
+        proc.stderr.close()
+
+    return blackout_times
 
 
 _BLACKOUT_PADDING = 3.0

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,14 +1,15 @@
 """Tests for match boundary detection."""
 
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     _BLACKOUT_PADDING,
+    _FRAME_SIZE,
     _extract_segments,
     detect_match_boundaries,
 )
@@ -17,66 +18,33 @@ from allaganeye.video.detector import (
 # --- Helpers ---
 
 
-def _make_frame(brightness: int) -> np.ndarray:
-    """Create a 2x2 BGR frame with uniform brightness."""
-    return np.full((2, 2, 3), brightness, dtype=np.uint8)
-
-
-def _make_capture_mock(
-    *,
-    is_opened: bool = True,
-    fps: float = 30.0,
-    frame_count: int = 9000,
-    frames: dict[int, np.ndarray] | None = None,
+def _make_raw_frames(
+    count: int,
     default_brightness: int = 128,
-) -> MagicMock:
-    """Create a mock cv2.VideoCapture with sequential read behavior.
+    overrides: dict[int, int] | None = None,
+) -> bytes:
+    """Build raw grayscale pipe output for *count* frames.
 
-    Simulates grab()/read() sequential access pattern.
-    Args:
-        frames: dict mapping frame index to numpy frame.
-            Missing indices use default_brightness.
+    Each frame is _FRAME_SIZE bytes of uniform brightness.
+    *overrides* maps sample index → brightness for specific frames.
     """
-    cap = MagicMock()
-    cap.isOpened.return_value = is_opened
+    if overrides is None:
+        overrides = {}
+    buf = bytearray()
+    for i in range(count):
+        brightness = overrides.get(i, default_brightness)
+        buf.extend(bytes([brightness]) * _FRAME_SIZE)
+    return bytes(buf)
 
-    def get_prop(prop_id):
-        import cv2
 
-        if prop_id == cv2.CAP_PROP_FPS:
-            return fps
-        if prop_id == cv2.CAP_PROP_FRAME_COUNT:
-            return frame_count
-        return 0.0
-
-    cap.get.side_effect = get_prop
-
-    current_frame = [0]
-
-    if frames is None:
-        frames = {}
-
-    def read():
-        idx = current_frame[0]
-        if idx >= frame_count:
-            return False, None
-        current_frame[0] += 1
-        if idx in frames:
-            return True, frames[idx]
-        return True, _make_frame(default_brightness)
-
-    cap.read.side_effect = read
-
-    def grab():
-        idx = current_frame[0]
-        if idx >= frame_count:
-            return False
-        current_frame[0] += 1
-        return True
-
-    cap.grab.side_effect = grab
-
-    return cap
+def _mock_popen(stdout_data: bytes, returncode: int = 0, stderr_data: bytes = b""):
+    """Create a mock subprocess.Popen that yields *stdout_data*."""
+    proc = MagicMock()
+    proc.stdout = BytesIO(stdout_data)
+    proc.stderr = BytesIO(stderr_data)
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    return proc
 
 
 # ============================================================
@@ -114,9 +82,7 @@ class TestExtractSegments:
         )
         assert len(result) == 2
         assert result[0]["start"] == 0.0
-        # seg_end padded into blackout: region (600, 603), padding clamped to 1.5
         assert result[0]["end"] == pytest.approx(601.5)
-        # seg_start padded into blackout: 603 - 1.5 = 601.5
         assert result[1]["start"] == pytest.approx(601.5)
         assert result[1]["end"] == 1800.0
 
@@ -129,18 +95,15 @@ class TestExtractSegments:
             sample_interval=1.0,
             min_match_duration=300.0,
         )
-        # First segment: 0 to ~100.5 (too short), second: ~100.5 to 500 (long enough)
         assert len(result) == 1
         assert result[0]["start"] == pytest.approx(100.5)
 
     def test_multiple_blackouts_three_matches(self):
         """Multiple blackout regions create multiple match segments with padding."""
         blackout_times = [
-            # First blackout at ~600s (region: 600-602, duration 2s, padding clamped to 1.0)
             600.0,
             601.0,
             602.0,
-            # Second blackout at ~1800s (region: 1800-1802, duration 2s, padding clamped to 1.0)
             1800.0,
             1801.0,
             1802.0,
@@ -166,14 +129,12 @@ class TestExtractSegments:
             sample_interval=1.0,
             min_match_duration=300.0,
         )
-        # Region: (600, 604), duration 4s, padding clamped to 2.0
         assert len(result) == 2
         assert result[0]["end"] == pytest.approx(602.0)
         assert result[1]["start"] == pytest.approx(602.0)
 
     def test_padding_full_when_region_long(self):
         """Full padding applied when blackout region >= 2 * padding."""
-        # Region: (600, 610), duration 10s > 2*3=6s → full padding of 3.0
         blackout_times = list(range(600, 611))
         result = _extract_segments(
             [float(t) for t in blackout_times],
@@ -187,7 +148,6 @@ class TestExtractSegments:
 
     def test_padding_clamped_for_short_region(self):
         """Padding clamped to half region duration for short blackout."""
-        # Region: (600, 602), duration 2s → padding = min(3.0, 1.0) = 1.0
         blackout_times = [600.0, 601.0, 602.0]
         result = _extract_segments(
             blackout_times,
@@ -201,9 +161,6 @@ class TestExtractSegments:
 
     def test_padding_does_not_exceed_total_duration(self):
         """seg_end clamped to total_duration when padding would overshoot."""
-        # Blackout near the very end: region (997, 1000)
-        # After last blackout: seg_start = 1000 - 1.5 = 998.5
-        # Only 1.5s left → too short for min_match_duration
         blackout_times = [997.0, 998.0, 999.0, 1000.0]
         result = _extract_segments(
             blackout_times,
@@ -212,7 +169,6 @@ class TestExtractSegments:
             min_match_duration=300.0,
         )
         assert len(result) == 1
-        # First segment end padded into blackout
         assert result[0]["end"] == pytest.approx(998.5)
 
     def test_padding_constant_value(self):
@@ -221,80 +177,18 @@ class TestExtractSegments:
 
 
 # ============================================================
-# TestDetectMatchBoundaries
+# TestDetectMatchBoundaries (ffmpeg pipe based)
 # ============================================================
 
 
 class TestDetectMatchBoundaries:
-    """Tests for detect_match_boundaries() with mocked cv2.VideoCapture."""
+    """Tests for detect_match_boundaries() with mocked subprocess."""
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_video_cannot_open(self, mock_vc_class):
-        """VideoCapture open failure raises VideoProcessingError."""
-        mock_vc_class.return_value = _make_capture_mock(is_opened=False)
-
-        with pytest.raises(VideoProcessingError, match="Cannot open video"):
-            detect_match_boundaries(Path("test.mp4"))
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_fps_zero(self, mock_vc_class):
-        """fps=0 raises VideoProcessingError."""
-        mock_vc_class.return_value = _make_capture_mock(fps=0.0, frame_count=9000)
-
-        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
-            detect_match_boundaries(Path("test.mp4"))
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_frame_count_zero(self, mock_vc_class):
-        """frame_count=0 without duration_hint raises VideoProcessingError."""
-        mock_vc_class.return_value = _make_capture_mock(fps=30.0, frame_count=0)
-
-        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
-            detect_match_boundaries(Path("test.mp4"))
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_frame_count_zero_with_duration_hint(self, mock_vc_class):
-        """frame_count=0 with duration_hint falls back to fps * duration."""
-        # frame_count=0 but we provide a 9000-frame equivalent mock
-        # that returns frames when read sequentially
-        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
-        # Override get to return 0 for FRAME_COUNT but still allow reads
-        original_get = cap.get.side_effect
-
-        def get_with_zero_frames(prop_id):
-            import cv2
-
-            if prop_id == cv2.CAP_PROP_FRAME_COUNT:
-                return 0
-            return original_get(prop_id)
-
-        cap.get.side_effect = get_with_zero_frames
-        mock_vc_class.return_value = cap
-
-        result = detect_match_boundaries(
-            Path("test.mp4"),
-            duration_hint=300.0,  # 300s * 30fps = 9000 frames
-            min_match_duration=100.0,
-        )
-        assert len(result) == 1
-        assert result[0]["start"] == 0.0
-        assert result[0]["end"] == pytest.approx(300.0)
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_frame_count_negative_with_duration_hint(self, mock_vc_class):
-        """frame_count=-1 (MKV) with duration_hint uses fallback."""
-        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
-        original_get = cap.get.side_effect
-
-        def get_with_negative_frames(prop_id):
-            import cv2
-
-            if prop_id == cv2.CAP_PROP_FRAME_COUNT:
-                return -1
-            return original_get(prop_id)
-
-        cap.get.side_effect = get_with_negative_frames
-        mock_vc_class.return_value = cap
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_all_bright_frames(self, mock_popen):
+        """All bright frames → single segment covering full duration."""
+        data = _make_raw_frames(300, default_brightness=128)
+        mock_popen.return_value = _mock_popen(data)
 
         result = detect_match_boundaries(
             Path("test.mp4"),
@@ -302,77 +196,33 @@ class TestDetectMatchBoundaries:
             min_match_duration=100.0,
         )
         assert len(result) == 1
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_frame_count_zero_with_zero_duration_hint(self, mock_vc_class):
-        """frame_count=0 with duration_hint=0 still raises."""
-        mock_vc_class.return_value = _make_capture_mock(fps=30.0, frame_count=0)
-
-        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
-            detect_match_boundaries(
-                Path("test.mp4"), duration_hint=0.0, min_match_duration=100.0
-            )
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_negative_fps(self, mock_vc_class):
-        """Negative fps raises VideoProcessingError."""
-        mock_vc_class.return_value = _make_capture_mock(fps=-1.0, frame_count=9000)
-
-        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
-            detect_match_boundaries(Path("test.mp4"))
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_all_bright_frames(self, mock_vc_class):
-        """All bright frames → single segment covering full duration."""
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=30.0,
-            frame_count=9000,
-            default_brightness=128,
-        )
-
-        result = detect_match_boundaries(
-            Path("test.mp4"),
-            min_match_duration=100.0,
-        )
-        assert len(result) == 1
         assert result[0]["start"] == 0.0
         assert result[0]["end"] == pytest.approx(300.0)
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_all_black_frames(self, mock_vc_class):
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_all_black_frames(self, mock_popen):
         """All black frames → no segments (entire video is blackout)."""
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=30.0,
-            frame_count=9000,
-            default_brightness=5,
-        )
+        data = _make_raw_frames(300, default_brightness=5)
+        mock_popen.return_value = _mock_popen(data)
 
         result = detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=300.0,
             min_match_duration=100.0,
         )
         assert len(result) == 0
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_blackout_in_middle(self, mock_vc_class):
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_blackout_in_middle(self, mock_popen):
         """Blackout in middle splits video into two segments."""
-        fps = 30.0
-        total_frames = 54000  # 1800s
-
-        black_frames = {}
-        for sec in range(598, 603):
-            frame_idx = int(sec * fps)
-            black_frames[frame_idx] = _make_frame(5)
-
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            frames=black_frames,
-            default_brightness=128,
-        )
+        # 1800 samples (1800s at 1s interval)
+        overrides = {s: 5 for s in range(598, 603)}
+        data = _make_raw_frames(1800, default_brightness=128, overrides=overrides)
+        mock_popen.return_value = _mock_popen(data)
 
         result = detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=1800.0,
             sample_interval=1.0,
             min_match_duration=300.0,
         )
@@ -380,221 +230,155 @@ class TestDetectMatchBoundaries:
         assert result[0]["start"] == 0.0
         assert result[1]["end"] == pytest.approx(1800.0)
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_sample_interval_respected(self, mock_vc_class):
-        """frame_step = fps * sample_interval; only sampled frames are decoded."""
-        fps = 30.0
-        total_frames = 9000  # 300s
-        cap = _make_capture_mock(
-            fps=fps, frame_count=total_frames, default_brightness=128
-        )
-        mock_vc_class.return_value = cap
-
-        detect_match_boundaries(
-            Path("test.mp4"),
-            sample_interval=2.0,
-            min_match_duration=100.0,
-        )
-
-        # frame_step = 30 * 2.0 = 60
-        # read() called for sampled frames, grab() for skipped frames
-        # Total read calls = total_frames / frame_step = 150
-        # Total grab calls = total_frames - read_calls = 8850
-        read_count = cap.read.call_count
-        grab_count = cap.grab.call_count
-        assert read_count == 150
-        assert grab_count == total_frames - read_count
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_sample_interval_very_small(self, mock_vc_class):
-        """Very small sample_interval clamps frame_step to 1 (every frame sampled)."""
-        fps = 30.0
-        total_frames = 90  # 3s, small for speed
-        cap = _make_capture_mock(
-            fps=fps, frame_count=total_frames, default_brightness=128
-        )
-        mock_vc_class.return_value = cap
-
-        detect_match_boundaries(
-            Path("test.mp4"),
-            sample_interval=0.01,
-            min_match_duration=1.0,
-        )
-
-        # frame_step = int(30 * 0.01) = 0 → clamped to 1
-        # Every frame is sampled via read(), no grab() calls
-        assert cap.read.call_count == total_frames
-        assert cap.grab.call_count == 0
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_custom_threshold(self, mock_vc_class):
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_custom_threshold(self, mock_popen):
         """Brightness 20 with threshold 15 → not blackout → 1 segment."""
-        fps = 30.0
-        total_frames = 9000  # 300s
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            default_brightness=20,
-        )
+        data = _make_raw_frames(300, default_brightness=20)
+        mock_popen.return_value = _mock_popen(data)
 
         result = detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=300.0,
             blackout_threshold=15.0,
             min_match_duration=100.0,
         )
         assert len(result) == 1
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_custom_threshold_blackout(self, mock_vc_class):
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_custom_threshold_blackout(self, mock_popen):
         """Higher threshold makes same brightness frames count as blackout."""
-        fps = 30.0
-        total_frames = 9000
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            default_brightness=20,
-        )
+        data = _make_raw_frames(300, default_brightness=20)
+        mock_popen.return_value = _mock_popen(data)
 
         result = detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=300.0,
             blackout_threshold=25.0,
             min_match_duration=100.0,
         )
         assert len(result) == 0
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_custom_min_duration(self, mock_vc_class):
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_custom_min_duration(self, mock_popen):
         """min_match_duration filters short segments."""
-        fps = 30.0
-        total_frames = 54000  # 1800s
+        # Blackout at 200s
+        overrides = {s: 5 for s in range(198, 203)}
+        data = _make_raw_frames(1800, default_brightness=128, overrides=overrides)
+        mock_popen.return_value = _mock_popen(data)
 
-        # Blackout at 200s → segments: 0-200s (200s) and ~200-1800s (1600s)
-        black_frames = {}
-        for sec in range(198, 203):
-            black_frames[int(sec * fps)] = _make_frame(5)
-
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            frames=black_frames,
-            default_brightness=128,
-        )
-
-        # min_match_duration=300 → only the long segment
         result = detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=1800.0,
             min_match_duration=300.0,
         )
         assert len(result) == 1
-        assert result[0]["start"] > 100.0  # the second (long) segment
+        assert result[0]["start"] > 100.0
 
-    @patch("allaganeye.video.detector.cv2")
-    def test_consecutive_read_failures_raises(self, mock_cv2):
-        """3 consecutive read failures raise VideoProcessingError."""
-        cap = MagicMock()
-        cap.isOpened.return_value = True
-        cap.get.side_effect = lambda prop: {
-            5: 30.0,  # CAP_PROP_FPS
-            7: 3600.0,  # CAP_PROP_FRAME_COUNT
-        }.get(prop, 0.0)
-
-        # Every read/grab fails
-        cap.read.return_value = (False, None)
-        cap.grab.return_value = False
-
-        mock_cv2.VideoCapture.return_value = cap
-        mock_cv2.CAP_PROP_FPS = 5
-        mock_cv2.CAP_PROP_FRAME_COUNT = 7
-
-        with pytest.raises(VideoProcessingError, match="consecutive"):
-            detect_match_boundaries(Path("test.mp4"), min_match_duration=1.0)
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_release_called_on_success(self, mock_vc_class):
-        """cap.release() is called after successful processing."""
-        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
-        mock_vc_class.return_value = cap
-
-        detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
-        cap.release.assert_called_once()
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_release_called_on_property_error(self, mock_vc_class):
-        """cap.release() is called even when fps/frame_count error occurs."""
-        cap = _make_capture_mock(fps=0.0, frame_count=9000)
-        mock_vc_class.return_value = cap
-
-        with pytest.raises(VideoProcessingError):
-            detect_match_boundaries(Path("test.mp4"))
-
-        cap.release.assert_called_once()
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_progress_callback_called(self, mock_vc_class):
-        """progress_callback is called for each sampled frame."""
-        fps = 30.0
-        total_frames = 9000  # 300s
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps, frame_count=total_frames, default_brightness=128
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_ffmpeg_failure_no_output(self, mock_popen):
+        """ffmpeg failure with no output raises VideoProcessingError."""
+        mock_popen.return_value = _mock_popen(
+            b"", returncode=1, stderr_data=b"Error opening input"
         )
-        calls = []
 
-        def on_progress(frame_idx, total, blackout_count):
-            calls.append((frame_idx, total, blackout_count))
+        with pytest.raises(VideoProcessingError, match="frame sampling failed"):
+            detect_match_boundaries(
+                Path("test.mp4"), duration_hint=300.0, min_match_duration=100.0
+            )
+
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_ffmpeg_failure_partial_output(self, mock_popen):
+        """ffmpeg failure with partial output uses available frames."""
+        # 100 frames produced before failure (100s of 300s)
+        data = _make_raw_frames(100, default_brightness=128)
+        mock_popen.return_value = _mock_popen(data, returncode=1)
+
+        # Should not raise — partial data is usable
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=300.0,
+            min_match_duration=50.0,
+        )
+        assert len(result) >= 1
+
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_ffmpeg_not_found(self, mock_popen):
+        """FileNotFoundError raises VideoProcessingError."""
+        mock_popen.side_effect = FileNotFoundError("ffmpeg not found")
+
+        with pytest.raises(VideoProcessingError, match="ffmpeg not found"):
+            detect_match_boundaries(
+                Path("test.mp4"), duration_hint=300.0, min_match_duration=100.0
+            )
+
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_progress_callback_called(self, mock_popen):
+        """progress_callback is called for each sampled frame."""
+        data = _make_raw_frames(300, default_brightness=128)
+        mock_popen.return_value = _mock_popen(data)
+        calls = []
 
         detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=300.0,
             sample_interval=1.0,
             min_match_duration=100.0,
-            progress_callback=on_progress,
+            progress_callback=lambda si, t, bc: calls.append((si, t, bc)),
         )
 
-        # frame_step = 30, sampled frames: 0, 30, 60, ... → 300 calls
         assert len(calls) == 300
-        # First call: frame 0, total 9000, 0 blackouts
-        assert calls[0] == (0, total_frames, 0)
-        # All calls have correct total_frames
-        assert all(c[1] == total_frames for c in calls)
-        # blackout_count is non-decreasing
+        assert calls[0] == (0, 300, 0)
+        # total_samples consistent
+        assert all(c[1] == 300 for c in calls)
+        # blackout_count non-decreasing
         counts = [c[2] for c in calls]
         assert counts == sorted(counts)
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_progress_callback_none_default(self, mock_vc_class):
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_progress_callback_none_default(self, mock_popen):
         """No callback (default) works without error."""
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=30.0, frame_count=9000, default_brightness=128
-        )
+        data = _make_raw_frames(300, default_brightness=128)
+        mock_popen.return_value = _mock_popen(data)
 
-        # Should not raise — progress_callback defaults to None
-        result = detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
+        result = detect_match_boundaries(
+            Path("test.mp4"), duration_hint=300.0, min_match_duration=100.0
+        )
         assert len(result) == 1
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_progress_callback_with_blackouts(self, mock_vc_class):
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_progress_callback_with_blackouts(self, mock_popen):
         """progress_callback reports increasing blackout count."""
-        fps = 30.0
-        total_frames = 54000  # 1800s
-
-        black_frames = {}
-        for sec in range(598, 603):
-            black_frames[int(sec * fps)] = _make_frame(5)
-
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            frames=black_frames,
-            default_brightness=128,
-        )
+        overrides = {s: 5 for s in range(598, 603)}
+        data = _make_raw_frames(1800, default_brightness=128, overrides=overrides)
+        mock_popen.return_value = _mock_popen(data)
         calls = []
 
         detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=1800.0,
             sample_interval=1.0,
             min_match_duration=300.0,
-            progress_callback=lambda fi, t, bc: calls.append((fi, t, bc)),
+            progress_callback=lambda si, t, bc: calls.append((si, t, bc)),
         )
 
-        # Should have blackout_count > 0 in later calls
         max_blackouts = max(c[2] for c in calls)
-        assert max_blackouts == 5  # frames at 598, 599, 600, 601, 602
+        assert max_blackouts == 5
+
+    @patch("allaganeye.video.detector.subprocess.Popen")
+    def test_sample_interval_in_ffmpeg_command(self, mock_popen):
+        """sample_interval is passed to ffmpeg select filter."""
+        data = _make_raw_frames(150, default_brightness=128)
+        mock_popen.return_value = _mock_popen(data)
+
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=300.0,
+            sample_interval=2.0,
+            min_match_duration=100.0,
+        )
+
+        cmd = mock_popen.call_args[0][0]
+        # Verify select filter uses sample_interval
+        vf_idx = cmd.index("-vf")
+        vf_value = cmd[vf_idx + 1]
+        assert "mod(t\\,2.0)" in vf_value


### PR DESCRIPTION
## Summary

- `detector.py`: OpenCV VideoCapture を完全廃止し、ffmpeg パイプベースのフレーム抽出に置き換え
  - `select='not(mod(t\,N))'` フィルタで sample_interval 秒間隔のフレームのみ抽出
  - `-s 320x180 -pix_fmt gray` で低解像度 grayscale（デコード負荷 1/36）
  - `subprocess.Popen` + pipe で Python にストリーム、`np.frombuffer` + `np.mean` で輝度計算
  - ffmpeg のキーフレームシーク + マルチスレッドデコードを活用
- 推定改善: 60fps × 37GB MKV で数十分〜1時間 → **1-3 分**
- `cv2` への依存を検知フェーズから除去
- 外部 API 維持: `duration_hint`, `progress_callback`, `sample_interval` 等すべて互換
- テスト 23 件を subprocess モックベースに全面書き換え

関連: #53

## 設計判断

| 項目 | 決定 |
|---|---|
| フレーム抽出方式 | ffmpeg `select` フィルタ + pipe (lead-1 方針通り) |
| 解像度 | 320x180 (輝度計算に十分、デコード負荷最小) |
| 部分出力の扱い | ffmpeg 失敗時もフレームが 1+ あれば活用 |
| エラーハンドリング | returncode != 0 かつ出力 0 フレームで VideoProcessingError |

## Checklist

- [x] 全テスト通過（`pytest`）— 106 passed
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`）

## Test plan

- [x] 全フレーム明るい → 1 セグメント
- [x] 全フレーム暗い → 0 セグメント
- [x] 中間に暗転 → 2 セグメント
- [x] ffmpeg 失敗（出力なし）→ エラー送出
- [x] ffmpeg 失敗（部分出力）→ 利用可能データで続行
- [x] ffmpeg 未インストール → エラー送出
- [x] progress_callback 呼び出し検証
- [x] select フィルタに sample_interval が反映されることを検証
- [ ] lead-engineer レビュー
- [ ] テスター確認（実動画での速度計測は #14 テスト時に実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)