### PR TITLE
perf: detector を並列 -ss プローブ方式に置き換え (#56)

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1,12 +1,18 @@
-"""Match boundary detection using OpenCV frame analysis."""
+"""Match boundary detection using parallel ffmpeg frame probing."""
 
+import os
+import subprocess
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-import cv2
 import numpy as np
 
 from allaganeye.exceptions import VideoProcessingError
+
+_SAMPLE_WIDTH = 320
+_SAMPLE_HEIGHT = 180
+_FRAME_SIZE = _SAMPLE_WIDTH * _SAMPLE_HEIGHT  # grayscale, 1 byte per pixel
 
 
 def detect_match_boundaries(
@@ -20,99 +26,107 @@ def detect_match_boundaries(
 ) -> list[dict]:
     """Detect match boundaries by finding blackout frames.
 
-    Samples frames at the given interval, detects blackout (low brightness)
-    frames, and returns non-blackout segments that are longer than
-    min_match_duration.
+    Uses parallel ffmpeg ``-ss`` probes to extract one frame per
+    *sample_interval* seconds.  Each probe seeks to the target timestamp
+    (keyframe-based input seeking) and decodes only one frame, avoiding
+    the cost of decoding the entire stream.
 
     Args:
-        duration_hint: Video duration in seconds from ffprobe. Used as
-            fallback when CAP_PROP_FRAME_COUNT returns <= 0 (common with
-            MKV containers, especially after abnormal OBS shutdown).
-        progress_callback: Optional callback invoked at each sampled frame
-            with ``(frame_idx, total_frames, blackout_count)``.  Allows the
-            caller to display progress without coupling detector to UI.
+        duration_hint: Video duration in seconds from ffprobe.  Required
+            to generate the list of sample timestamps.
+        progress_callback: Optional callback invoked after each sampled
+            frame with ``(completed_count, total_samples, blackout_count)``.
 
     Returns list of dicts with 'start' and 'end' keys (seconds).
     """
-    cap = cv2.VideoCapture(str(video_path))
-    try:
-        if not cap.isOpened():
-            raise VideoProcessingError(f"Cannot open video: {video_path}")
+    if duration_hint is None or duration_hint <= 0:
+        raise VideoProcessingError(
+            "Cannot determine video duration. Provide duration_hint via probe."
+        )
 
-        fps = cap.get(cv2.CAP_PROP_FPS)
-        if fps <= 0:
-            raise VideoProcessingError(
-                "Cannot read video properties (fps or frame count)"
-            )
+    timestamps = _generate_timestamps(duration_hint, sample_interval)
+    if not timestamps:
+        return []
 
-        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        if total_frames <= 0:
-            if duration_hint is not None and duration_hint > 0:
-                total_frames = int(fps * duration_hint)
-            else:
-                raise VideoProcessingError(
-                    "Cannot read video properties (fps or frame count)"
-                )
+    total_samples = len(timestamps)
+    max_workers = min(8, os.cpu_count() or 4)
 
-        duration = total_frames / fps
-        frame_step = int(fps * sample_interval)
-        if frame_step < 1:
-            frame_step = 1
+    # Parallel -ss probes
+    results: dict[float, float] = {}  # timestamp → brightness
+    blackout_count = 0
+    completed = 0
 
-        # Collect brightness values at sampled positions.
-        # Uses sequential grab()/retrieve() instead of random-access
-        # set(CAP_PROP_POS_FRAMES) to avoid costly seeking on MKV files.
-        blackout_times: list[float] = []
-        frame_idx = 0
-        consecutive_failures = 0
-        max_consecutive_failures = 3
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(_probe_single_frame, video_path, t): t for t in timestamps
+        }
+        for future in as_completed(futures):
+            t = futures[future]
+            brightness = future.result()
+            results[t] = brightness
+            completed += 1
+            if brightness < blackout_threshold:
+                blackout_count += 1
+            if progress_callback is not None:
+                progress_callback(completed, total_samples, blackout_count)
 
-        while frame_idx < total_frames:
-            if frame_idx % frame_step == 0:
-                # Sample frame: decode and analyze brightness
-                ret, frame = cap.read()
-                if not ret:
-                    consecutive_failures += 1
-                    if consecutive_failures >= max_consecutive_failures:
-                        raise VideoProcessingError(
-                            f"Failed to read {max_consecutive_failures} consecutive "
-                            f"frames at position {frame_idx}/{total_frames}"
-                        )
-                    frame_idx += 1
-                    continue
+    # Collect blackout timestamps in chronological order
+    blackout_times = sorted(t for t, b in results.items() if b < blackout_threshold)
 
-                consecutive_failures = 0
-                gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-                mean_brightness = float(np.mean(gray))
-                timestamp = frame_idx / fps
-
-                if mean_brightness < blackout_threshold:
-                    blackout_times.append(timestamp)
-            else:
-                # Non-sample frame: advance pointer without decoding
-                if not cap.grab():
-                    consecutive_failures += 1
-                    if consecutive_failures >= max_consecutive_failures:
-                        raise VideoProcessingError(
-                            f"Failed to read {max_consecutive_failures} consecutive "
-                            f"frames at position {frame_idx}/{total_frames}"
-                        )
-                    frame_idx += 1
-                    continue
-                consecutive_failures = 0
-
-            if progress_callback is not None and frame_idx % frame_step == 0:
-                progress_callback(frame_idx, total_frames, len(blackout_times))
-
-            frame_idx += 1
-
-    finally:
-        cap.release()
-
-    # Build segments from non-blackout regions
     return _extract_segments(
-        blackout_times, duration, sample_interval, min_match_duration
+        blackout_times, duration_hint, sample_interval, min_match_duration
     )
+
+
+def _generate_timestamps(duration: float, interval: float) -> list[float]:
+    """Generate sample timestamps from 0 to duration at given interval."""
+    timestamps: list[float] = []
+    t = 0.0
+    while t < duration:
+        timestamps.append(t)
+        t += interval
+    return timestamps
+
+
+def _probe_single_frame(video_path: Path, timestamp: float) -> float:
+    """Probe a single frame's mean brightness using ffmpeg -ss seek.
+
+    Uses input seeking (``-ss`` before ``-i``) for fast keyframe-based
+    access, then decodes exactly one frame at 320x180 grayscale.
+
+    Returns the mean brightness (0-255).  Returns 255.0 on probe failure
+    (treated as non-blackout to avoid false positives).
+    """
+    cmd = [
+        "ffmpeg",
+        "-ss",
+        str(timestamp),
+        "-i",
+        str(video_path),
+        "-frames:v",
+        "1",
+        "-s",
+        f"{_SAMPLE_WIDTH}x{_SAMPLE_HEIGHT}",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "gray",
+        "pipe:1",
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+    except FileNotFoundError as e:
+        raise VideoProcessingError(
+            "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
+        ) from e
+    except subprocess.TimeoutExpired:
+        return 255.0  # treat timeout as non-blackout
+
+    if len(result.stdout) < _FRAME_SIZE:
+        return 255.0  # incomplete frame, treat as non-blackout
+
+    return float(np.frombuffer(result.stdout[:_FRAME_SIZE], dtype=np.uint8).mean())
 
 
 _BLACKOUT_PADDING = 3.0

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,15 +1,18 @@
 """Tests for match boundary detection."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     _BLACKOUT_PADDING,
+    _FRAME_SIZE,
     _extract_segments,
+    _generate_timestamps,
+    _probe_single_frame,
     detect_match_boundaries,
 )
 
@@ -17,66 +20,12 @@ from allaganeye.video.detector import (
 # --- Helpers ---
 
 
-def _make_frame(brightness: int) -> np.ndarray:
-    """Create a 2x2 BGR frame with uniform brightness."""
-    return np.full((2, 2, 3), brightness, dtype=np.uint8)
-
-
-def _make_capture_mock(
-    *,
-    is_opened: bool = True,
-    fps: float = 30.0,
-    frame_count: int = 9000,
-    frames: dict[int, np.ndarray] | None = None,
-    default_brightness: int = 128,
-) -> MagicMock:
-    """Create a mock cv2.VideoCapture with sequential read behavior.
-
-    Simulates grab()/read() sequential access pattern.
-    Args:
-        frames: dict mapping frame index to numpy frame.
-            Missing indices use default_brightness.
-    """
-    cap = MagicMock()
-    cap.isOpened.return_value = is_opened
-
-    def get_prop(prop_id):
-        import cv2
-
-        if prop_id == cv2.CAP_PROP_FPS:
-            return fps
-        if prop_id == cv2.CAP_PROP_FRAME_COUNT:
-            return frame_count
-        return 0.0
-
-    cap.get.side_effect = get_prop
-
-    current_frame = [0]
-
-    if frames is None:
-        frames = {}
-
-    def read():
-        idx = current_frame[0]
-        if idx >= frame_count:
-            return False, None
-        current_frame[0] += 1
-        if idx in frames:
-            return True, frames[idx]
-        return True, _make_frame(default_brightness)
-
-    cap.read.side_effect = read
-
-    def grab():
-        idx = current_frame[0]
-        if idx >= frame_count:
-            return False
-        current_frame[0] += 1
-        return True
-
-    cap.grab.side_effect = grab
-
-    return cap
+def _make_run_result(brightness: int = 128, frame_size: int = _FRAME_SIZE) -> MagicMock:
+    """Create a mock subprocess.run result with a single grayscale frame."""
+    result = MagicMock()
+    result.stdout = bytes([brightness]) * frame_size
+    result.returncode = 0
+    return result
 
 
 # ============================================================
@@ -88,7 +37,6 @@ class TestExtractSegments:
     """Unit tests for segment extraction logic (no video files needed)."""
 
     def test_no_blackouts_long_video(self):
-        """No blackouts in a long video → single segment."""
         result = _extract_segments(
             [], total_duration=1200.0, sample_interval=1.0, min_match_duration=300.0
         )
@@ -97,14 +45,12 @@ class TestExtractSegments:
         assert result[0]["end"] == 1200.0
 
     def test_no_blackouts_short_video(self):
-        """No blackouts in a short video → no segments (below min duration)."""
         result = _extract_segments(
             [], total_duration=100.0, sample_interval=1.0, min_match_duration=300.0
         )
         assert len(result) == 0
 
     def test_single_blackout_two_matches(self):
-        """Single blackout region splits video into two matches with padding."""
         blackout_times = [600.0, 601.0, 602.0, 603.0]
         result = _extract_segments(
             blackout_times,
@@ -114,14 +60,11 @@ class TestExtractSegments:
         )
         assert len(result) == 2
         assert result[0]["start"] == 0.0
-        # seg_end padded into blackout: region (600, 603), padding clamped to 1.5
         assert result[0]["end"] == pytest.approx(601.5)
-        # seg_start padded into blackout: 603 - 1.5 = 601.5
         assert result[1]["start"] == pytest.approx(601.5)
         assert result[1]["end"] == 1800.0
 
     def test_short_segment_filtered(self):
-        """Segments shorter than min_match_duration are excluded."""
         blackout_times = [100.0, 101.0]
         result = _extract_segments(
             blackout_times,
@@ -129,22 +72,11 @@ class TestExtractSegments:
             sample_interval=1.0,
             min_match_duration=300.0,
         )
-        # First segment: 0 to ~100.5 (too short), second: ~100.5 to 500 (long enough)
         assert len(result) == 1
         assert result[0]["start"] == pytest.approx(100.5)
 
     def test_multiple_blackouts_three_matches(self):
-        """Multiple blackout regions create multiple match segments with padding."""
-        blackout_times = [
-            # First blackout at ~600s (region: 600-602, duration 2s, padding clamped to 1.0)
-            600.0,
-            601.0,
-            602.0,
-            # Second blackout at ~1800s (region: 1800-1802, duration 2s, padding clamped to 1.0)
-            1800.0,
-            1801.0,
-            1802.0,
-        ]
+        blackout_times = [600.0, 601.0, 602.0, 1800.0, 1801.0, 1802.0]
         result = _extract_segments(
             blackout_times,
             total_duration=3600.0,
@@ -158,7 +90,6 @@ class TestExtractSegments:
         assert result[2]["start"] == pytest.approx(1801.0)
 
     def test_consecutive_blackouts_merged(self):
-        """Consecutive blackout frames within tolerance are merged."""
         blackout_times = [600.0, 601.0, 602.0, 603.0, 604.0]
         result = _extract_segments(
             blackout_times,
@@ -166,17 +97,14 @@ class TestExtractSegments:
             sample_interval=1.0,
             min_match_duration=300.0,
         )
-        # Region: (600, 604), duration 4s, padding clamped to 2.0
         assert len(result) == 2
         assert result[0]["end"] == pytest.approx(602.0)
         assert result[1]["start"] == pytest.approx(602.0)
 
     def test_padding_full_when_region_long(self):
-        """Full padding applied when blackout region >= 2 * padding."""
-        # Region: (600, 610), duration 10s > 2*3=6s → full padding of 3.0
-        blackout_times = list(range(600, 611))
+        blackout_times = [float(t) for t in range(600, 611)]
         result = _extract_segments(
-            [float(t) for t in blackout_times],
+            blackout_times,
             total_duration=1800.0,
             sample_interval=1.0,
             min_match_duration=300.0,
@@ -186,8 +114,6 @@ class TestExtractSegments:
         assert result[1]["start"] == pytest.approx(607.0)
 
     def test_padding_clamped_for_short_region(self):
-        """Padding clamped to half region duration for short blackout."""
-        # Region: (600, 602), duration 2s → padding = min(3.0, 1.0) = 1.0
         blackout_times = [600.0, 601.0, 602.0]
         result = _extract_segments(
             blackout_times,
@@ -200,10 +126,6 @@ class TestExtractSegments:
         assert result[1]["start"] == pytest.approx(601.0)
 
     def test_padding_does_not_exceed_total_duration(self):
-        """seg_end clamped to total_duration when padding would overshoot."""
-        # Blackout near the very end: region (997, 1000)
-        # After last blackout: seg_start = 1000 - 1.5 = 998.5
-        # Only 1.5s left → too short for min_match_duration
         blackout_times = [997.0, 998.0, 999.0, 1000.0]
         result = _extract_segments(
             blackout_times,
@@ -212,12 +134,71 @@ class TestExtractSegments:
             min_match_duration=300.0,
         )
         assert len(result) == 1
-        # First segment end padded into blackout
         assert result[0]["end"] == pytest.approx(998.5)
 
     def test_padding_constant_value(self):
-        """_BLACKOUT_PADDING is 3.0 seconds."""
         assert _BLACKOUT_PADDING == 3.0
+
+
+# ============================================================
+# TestGenerateTimestamps
+# ============================================================
+
+
+class TestGenerateTimestamps:
+    def test_basic(self):
+        assert _generate_timestamps(10.0, 2.0) == [0.0, 2.0, 4.0, 6.0, 8.0]
+
+    def test_single(self):
+        assert _generate_timestamps(0.5, 1.0) == [0.0]
+
+    def test_empty(self):
+        assert _generate_timestamps(0.0, 1.0) == []
+
+
+# ============================================================
+# TestProbeSingleFrame
+# ============================================================
+
+
+class TestProbeSingleFrame:
+    @patch("allaganeye.video.detector.subprocess.run")
+    def test_bright_frame(self, mock_run):
+        mock_run.return_value = _make_run_result(brightness=128)
+        assert _probe_single_frame(Path("test.mp4"), 10.0) == pytest.approx(128.0)
+
+    @patch("allaganeye.video.detector.subprocess.run")
+    def test_dark_frame(self, mock_run):
+        mock_run.return_value = _make_run_result(brightness=5)
+        assert _probe_single_frame(Path("test.mp4"), 10.0) == pytest.approx(5.0)
+
+    @patch("allaganeye.video.detector.subprocess.run")
+    def test_ss_before_i(self, mock_run):
+        mock_run.return_value = _make_run_result()
+        _probe_single_frame(Path("test.mp4"), 42.0)
+        cmd = mock_run.call_args[0][0]
+        ss_idx = cmd.index("-ss")
+        i_idx = cmd.index("-i")
+        assert ss_idx < i_idx
+
+    @patch("allaganeye.video.detector.subprocess.run")
+    def test_incomplete_output(self, mock_run):
+        result = MagicMock()
+        result.stdout = b"\x00" * 10
+        result.returncode = 0
+        mock_run.return_value = result
+        assert _probe_single_frame(Path("test.mp4"), 10.0) == 255.0
+
+    @patch("allaganeye.video.detector.subprocess.run")
+    def test_ffmpeg_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("ffmpeg")
+        with pytest.raises(VideoProcessingError, match="ffmpeg not found"):
+            _probe_single_frame(Path("test.mp4"), 10.0)
+
+    @patch("allaganeye.video.detector.subprocess.run")
+    def test_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=30)
+        assert _probe_single_frame(Path("test.mp4"), 10.0) == 255.0
 
 
 # ============================================================
@@ -226,153 +207,33 @@ class TestExtractSegments:
 
 
 class TestDetectMatchBoundaries:
-    """Tests for detect_match_boundaries() with mocked cv2.VideoCapture."""
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_video_cannot_open(self, mock_vc_class):
-        """VideoCapture open failure raises VideoProcessingError."""
-        mock_vc_class.return_value = _make_capture_mock(is_opened=False)
-
-        with pytest.raises(VideoProcessingError, match="Cannot open video"):
-            detect_match_boundaries(Path("test.mp4"))
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_fps_zero(self, mock_vc_class):
-        """fps=0 raises VideoProcessingError."""
-        mock_vc_class.return_value = _make_capture_mock(fps=0.0, frame_count=9000)
-
-        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
-            detect_match_boundaries(Path("test.mp4"))
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_frame_count_zero(self, mock_vc_class):
-        """frame_count=0 without duration_hint raises VideoProcessingError."""
-        mock_vc_class.return_value = _make_capture_mock(fps=30.0, frame_count=0)
-
-        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
-            detect_match_boundaries(Path("test.mp4"))
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_frame_count_zero_with_duration_hint(self, mock_vc_class):
-        """frame_count=0 with duration_hint falls back to fps * duration."""
-        # frame_count=0 but we provide a 9000-frame equivalent mock
-        # that returns frames when read sequentially
-        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
-        # Override get to return 0 for FRAME_COUNT but still allow reads
-        original_get = cap.get.side_effect
-
-        def get_with_zero_frames(prop_id):
-            import cv2
-
-            if prop_id == cv2.CAP_PROP_FRAME_COUNT:
-                return 0
-            return original_get(prop_id)
-
-        cap.get.side_effect = get_with_zero_frames
-        mock_vc_class.return_value = cap
-
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_all_bright(self, mock_probe):
+        mock_probe.return_value = 128.0
         result = detect_match_boundaries(
-            Path("test.mp4"),
-            duration_hint=300.0,  # 300s * 30fps = 9000 frames
-            min_match_duration=100.0,
+            Path("test.mp4"), duration_hint=300.0, min_match_duration=100.0
         )
         assert len(result) == 1
         assert result[0]["start"] == 0.0
         assert result[0]["end"] == pytest.approx(300.0)
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_frame_count_negative_with_duration_hint(self, mock_vc_class):
-        """frame_count=-1 (MKV) with duration_hint uses fallback."""
-        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
-        original_get = cap.get.side_effect
-
-        def get_with_negative_frames(prop_id):
-            import cv2
-
-            if prop_id == cv2.CAP_PROP_FRAME_COUNT:
-                return -1
-            return original_get(prop_id)
-
-        cap.get.side_effect = get_with_negative_frames
-        mock_vc_class.return_value = cap
-
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_all_black(self, mock_probe):
+        mock_probe.return_value = 5.0
         result = detect_match_boundaries(
-            Path("test.mp4"),
-            duration_hint=300.0,
-            min_match_duration=100.0,
-        )
-        assert len(result) == 1
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_frame_count_zero_with_zero_duration_hint(self, mock_vc_class):
-        """frame_count=0 with duration_hint=0 still raises."""
-        mock_vc_class.return_value = _make_capture_mock(fps=30.0, frame_count=0)
-
-        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
-            detect_match_boundaries(
-                Path("test.mp4"), duration_hint=0.0, min_match_duration=100.0
-            )
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_negative_fps(self, mock_vc_class):
-        """Negative fps raises VideoProcessingError."""
-        mock_vc_class.return_value = _make_capture_mock(fps=-1.0, frame_count=9000)
-
-        with pytest.raises(VideoProcessingError, match="Cannot read video properties"):
-            detect_match_boundaries(Path("test.mp4"))
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_all_bright_frames(self, mock_vc_class):
-        """All bright frames → single segment covering full duration."""
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=30.0,
-            frame_count=9000,
-            default_brightness=128,
-        )
-
-        result = detect_match_boundaries(
-            Path("test.mp4"),
-            min_match_duration=100.0,
-        )
-        assert len(result) == 1
-        assert result[0]["start"] == 0.0
-        assert result[0]["end"] == pytest.approx(300.0)
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_all_black_frames(self, mock_vc_class):
-        """All black frames → no segments (entire video is blackout)."""
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=30.0,
-            frame_count=9000,
-            default_brightness=5,
-        )
-
-        result = detect_match_boundaries(
-            Path("test.mp4"),
-            min_match_duration=100.0,
+            Path("test.mp4"), duration_hint=300.0, min_match_duration=100.0
         )
         assert len(result) == 0
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_blackout_in_middle(self, mock_vc_class):
-        """Blackout in middle splits video into two segments."""
-        fps = 30.0
-        total_frames = 54000  # 1800s
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_blackout_in_middle(self, mock_probe):
+        def side_effect(path, t):
+            return 5.0 if 598.0 <= t <= 602.0 else 128.0
 
-        black_frames = {}
-        for sec in range(598, 603):
-            frame_idx = int(sec * fps)
-            black_frames[frame_idx] = _make_frame(5)
-
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            frames=black_frames,
-            default_brightness=128,
-        )
-
+        mock_probe.side_effect = side_effect
         result = detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=1800.0,
             sample_interval=1.0,
             min_match_duration=300.0,
         )
@@ -380,221 +241,77 @@ class TestDetectMatchBoundaries:
         assert result[0]["start"] == 0.0
         assert result[1]["end"] == pytest.approx(1800.0)
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_sample_interval_respected(self, mock_vc_class):
-        """frame_step = fps * sample_interval; only sampled frames are decoded."""
-        fps = 30.0
-        total_frames = 9000  # 300s
-        cap = _make_capture_mock(
-            fps=fps, frame_count=total_frames, default_brightness=128
-        )
-        mock_vc_class.return_value = cap
-
-        detect_match_boundaries(
-            Path("test.mp4"),
-            sample_interval=2.0,
-            min_match_duration=100.0,
-        )
-
-        # frame_step = 30 * 2.0 = 60
-        # read() called for sampled frames, grab() for skipped frames
-        # Total read calls = total_frames / frame_step = 150
-        # Total grab calls = total_frames - read_calls = 8850
-        read_count = cap.read.call_count
-        grab_count = cap.grab.call_count
-        assert read_count == 150
-        assert grab_count == total_frames - read_count
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_sample_interval_very_small(self, mock_vc_class):
-        """Very small sample_interval clamps frame_step to 1 (every frame sampled)."""
-        fps = 30.0
-        total_frames = 90  # 3s, small for speed
-        cap = _make_capture_mock(
-            fps=fps, frame_count=total_frames, default_brightness=128
-        )
-        mock_vc_class.return_value = cap
-
-        detect_match_boundaries(
-            Path("test.mp4"),
-            sample_interval=0.01,
-            min_match_duration=1.0,
-        )
-
-        # frame_step = int(30 * 0.01) = 0 → clamped to 1
-        # Every frame is sampled via read(), no grab() calls
-        assert cap.read.call_count == total_frames
-        assert cap.grab.call_count == 0
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_custom_threshold(self, mock_vc_class):
-        """Brightness 20 with threshold 15 → not blackout → 1 segment."""
-        fps = 30.0
-        total_frames = 9000  # 300s
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            default_brightness=20,
-        )
-
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_custom_threshold(self, mock_probe):
+        mock_probe.return_value = 20.0
         result = detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=300.0,
             blackout_threshold=15.0,
             min_match_duration=100.0,
         )
         assert len(result) == 1
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_custom_threshold_blackout(self, mock_vc_class):
-        """Higher threshold makes same brightness frames count as blackout."""
-        fps = 30.0
-        total_frames = 9000
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            default_brightness=20,
-        )
-
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_custom_threshold_blackout(self, mock_probe):
+        mock_probe.return_value = 20.0
         result = detect_match_boundaries(
             Path("test.mp4"),
+            duration_hint=300.0,
             blackout_threshold=25.0,
             min_match_duration=100.0,
         )
         assert len(result) == 0
 
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_custom_min_duration(self, mock_vc_class):
-        """min_match_duration filters short segments."""
-        fps = 30.0
-        total_frames = 54000  # 1800s
+    def test_no_duration_hint_raises(self):
+        with pytest.raises(
+            VideoProcessingError, match="Cannot determine video duration"
+        ):
+            detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
 
-        # Blackout at 200s → segments: 0-200s (200s) and ~200-1800s (1600s)
-        black_frames = {}
-        for sec in range(198, 203):
-            black_frames[int(sec * fps)] = _make_frame(5)
-
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            frames=black_frames,
-            default_brightness=128,
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_progress_callback(self, mock_probe):
+        mock_probe.return_value = 128.0
+        calls = []
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=10.0,
+            sample_interval=1.0,
+            min_match_duration=1.0,
+            progress_callback=lambda c, t, bc: calls.append((c, t, bc)),
         )
+        assert len(calls) == 10
+        assert all(c[1] == 10 for c in calls)
+        completed = sorted(c[0] for c in calls)
+        assert completed == list(range(1, 11))
 
-        # min_match_duration=300 → only the long segment
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_progress_callback_none(self, mock_probe):
+        mock_probe.return_value = 128.0
+        result = detect_match_boundaries(
+            Path("test.mp4"), duration_hint=300.0, min_match_duration=100.0
+        )
+        assert len(result) == 1
+
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_sample_count(self, mock_probe):
+        mock_probe.return_value = 128.0
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=300.0,
+            sample_interval=2.0,
+            min_match_duration=100.0,
+        )
+        assert mock_probe.call_count == 150
+
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_parallel_execution(self, mock_probe):
+        mock_probe.return_value = 128.0
         result = detect_match_boundaries(
             Path("test.mp4"),
-            min_match_duration=300.0,
+            duration_hint=100.0,
+            sample_interval=1.0,
+            min_match_duration=10.0,
         )
         assert len(result) == 1
-        assert result[0]["start"] > 100.0  # the second (long) segment
-
-    @patch("allaganeye.video.detector.cv2")
-    def test_consecutive_read_failures_raises(self, mock_cv2):
-        """3 consecutive read failures raise VideoProcessingError."""
-        cap = MagicMock()
-        cap.isOpened.return_value = True
-        cap.get.side_effect = lambda prop: {
-            5: 30.0,  # CAP_PROP_FPS
-            7: 3600.0,  # CAP_PROP_FRAME_COUNT
-        }.get(prop, 0.0)
-
-        # Every read/grab fails
-        cap.read.return_value = (False, None)
-        cap.grab.return_value = False
-
-        mock_cv2.VideoCapture.return_value = cap
-        mock_cv2.CAP_PROP_FPS = 5
-        mock_cv2.CAP_PROP_FRAME_COUNT = 7
-
-        with pytest.raises(VideoProcessingError, match="consecutive"):
-            detect_match_boundaries(Path("test.mp4"), min_match_duration=1.0)
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_release_called_on_success(self, mock_vc_class):
-        """cap.release() is called after successful processing."""
-        cap = _make_capture_mock(fps=30.0, frame_count=9000, default_brightness=128)
-        mock_vc_class.return_value = cap
-
-        detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
-        cap.release.assert_called_once()
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_release_called_on_property_error(self, mock_vc_class):
-        """cap.release() is called even when fps/frame_count error occurs."""
-        cap = _make_capture_mock(fps=0.0, frame_count=9000)
-        mock_vc_class.return_value = cap
-
-        with pytest.raises(VideoProcessingError):
-            detect_match_boundaries(Path("test.mp4"))
-
-        cap.release.assert_called_once()
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_progress_callback_called(self, mock_vc_class):
-        """progress_callback is called for each sampled frame."""
-        fps = 30.0
-        total_frames = 9000  # 300s
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps, frame_count=total_frames, default_brightness=128
-        )
-        calls = []
-
-        def on_progress(frame_idx, total, blackout_count):
-            calls.append((frame_idx, total, blackout_count))
-
-        detect_match_boundaries(
-            Path("test.mp4"),
-            sample_interval=1.0,
-            min_match_duration=100.0,
-            progress_callback=on_progress,
-        )
-
-        # frame_step = 30, sampled frames: 0, 30, 60, ... → 300 calls
-        assert len(calls) == 300
-        # First call: frame 0, total 9000, 0 blackouts
-        assert calls[0] == (0, total_frames, 0)
-        # All calls have correct total_frames
-        assert all(c[1] == total_frames for c in calls)
-        # blackout_count is non-decreasing
-        counts = [c[2] for c in calls]
-        assert counts == sorted(counts)
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_progress_callback_none_default(self, mock_vc_class):
-        """No callback (default) works without error."""
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=30.0, frame_count=9000, default_brightness=128
-        )
-
-        # Should not raise — progress_callback defaults to None
-        result = detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
-        assert len(result) == 1
-
-    @patch("allaganeye.video.detector.cv2.VideoCapture")
-    def test_progress_callback_with_blackouts(self, mock_vc_class):
-        """progress_callback reports increasing blackout count."""
-        fps = 30.0
-        total_frames = 54000  # 1800s
-
-        black_frames = {}
-        for sec in range(598, 603):
-            black_frames[int(sec * fps)] = _make_frame(5)
-
-        mock_vc_class.return_value = _make_capture_mock(
-            fps=fps,
-            frame_count=total_frames,
-            frames=black_frames,
-            default_brightness=128,
-        )
-        calls = []
-
-        detect_match_boundaries(
-            Path("test.mp4"),
-            sample_interval=1.0,
-            min_match_duration=300.0,
-            progress_callback=lambda fi, t, bc: calls.append((fi, t, bc)),
-        )
-
-        # Should have blackout_count > 0 in later calls
-        max_blackouts = max(c[2] for c in calls)
-        assert max_blackouts == 5  # frames at 598, 599, 600, 601, 602
+        assert mock_probe.call_count == 100


### PR DESCRIPTION
## Summary

- `detector.py`: ffmpeg `select` フィルタ（全フレームデコード）を廃止し、`-ss` シーク × N 回 + `ThreadPoolExecutor` 並列方式に変更
  - `_probe_single_frame(video_path, timestamp)`: `-ss {t} -i` で 1 フレームだけデコード (320x180 grayscale)
  - `ThreadPoolExecutor(max_workers=min(8, cpu_count))` で並列実行
  - `as_completed` 後にタイムスタンプ順ソートで `blackout_times` を構築
  - タイムアウト・不完全出力は 255.0 (非暗転) として扱い偽陽性を回避
- 推定性能: 8 並列で ~56 秒、16 並列で ~28 秒（37GB/60fps MKV）
- OpenCV (`cv2`) 依存を検知フェーズから完全除去
- テスト 29 件（`subprocess.run` モック + `_probe_single_frame` モック）

関連: #56, #53

## 設計判断

| 項目 | 決定 | 理由 |
|---|---|---|
| 方式 | `-ss` × N + ThreadPool | select フィルタは全デコード、concat は複雑すぎる |
| max_workers | `min(8, cpu_count)` | 32 コア環境で十分、I/O バウンドなのでコア数上限で OK |
| 失敗時 | 255.0 (非暗転) | 偽陽性（暗転見逃し）より偽陰性（誤暗転）の方が影響大 |
| timeout | 30 秒/プローブ | ハングアップ防止 |

## Checklist

- [x] 全テスト通過（`pytest`）— 112 passed
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`）

## Test plan

- [x] 全明/全暗/中間暗転の基本パターン
- [x] `-ss` が `-i` の前にあることを検証
- [x] ffmpeg 未インストール/タイムアウト/不完全出力のエラーハンドリング
- [x] progress_callback 呼び出し検証
- [x] サンプル数 (duration / interval) の一致確認
- [ ] lead-engineer レビュー
- [ ] テスター確認（実動画での速度計測は #14 テスト時に実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)