### PR TITLE
feat: リスポーン暗転除外 + タイムスタンプ表示 (#60, #59)

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -49,6 +49,13 @@ def split(
     min_match_duration: Annotated[
         float, typer.Option(help="Minimum match duration in seconds")
     ] = 300.0,
+    min_blackout_duration: Annotated[
+        float,
+        typer.Option(
+            help="Minimum blackout duration to treat as match boundary (seconds). "
+            "Shorter blackouts (e.g. respawn) are ignored."
+        ),
+    ] = 3.0,
     dry_run: Annotated[
         bool, typer.Option("--dry-run", help="Detect only, do not split")
     ] = False,
@@ -72,6 +79,7 @@ def split(
             sample_interval=sample_interval,
             blackout_threshold=blackout_threshold,
             min_match_duration=min_match_duration,
+            min_blackout_duration=min_blackout_duration,
             dry_run=dry_run,
         )
 

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -51,6 +51,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
                 sample_interval=config.sample_interval,
                 blackout_threshold=config.blackout_threshold,
                 min_match_duration=config.min_match_duration,
+                min_blackout_duration=config.min_blackout_duration,
                 progress_callback=on_progress,
             )
     else:
@@ -60,6 +61,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             sample_interval=config.sample_interval,
             blackout_threshold=config.blackout_threshold,
             min_match_duration=config.min_match_duration,
+            min_blackout_duration=config.min_blackout_duration,
         )
 
     if not boundaries:

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -70,17 +70,35 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             "Try adjusting --blackout-threshold or --min-match-duration."
         )
 
-    typer.echo(f"Detected {len(boundaries)} match(es)")
+    # Display detection results with human-readable timestamps
+    source_duration = metadata["duration"]
+    typer.echo(
+        f"Detected {len(boundaries)} match(es) in {video_path.name} "
+        f"({_format_timestamp(source_duration)})"
+    )
+    typer.echo()
+
     for i, b in enumerate(boundaries, 1):
-        duration = b["end"] - b["start"]
-        if verbose:
+        dur = b["end"] - b["start"]
+        typer.echo(
+            f"  Match {i}: {_format_timestamp(b['start']):>7s} - "
+            f"{_format_timestamp(b['end']):>7s}  ({_format_duration(dur)})"
+        )
+
+    # Show significant gaps (>= 5 minutes)
+    gaps = _find_gaps(boundaries, source_duration, min_gap=300.0)
+    if gaps:
+        typer.echo()
+        for gap in gaps:
             typer.echo(
-                f"  Match {i}: {b['start']:.1f}s - {b['end']:.1f}s ({duration:.0f}s)"
+                f"  Gap: {_format_timestamp(gap['start'])} - "
+                f"{_format_timestamp(gap['end'])} "
+                f"({_format_duration(gap['duration'])})"
             )
 
     # Step 3: Split (unless dry-run)
     if config.dry_run:
-        typer.echo("Dry run: skipping split")
+        typer.echo("\nDry run: skipping split")
         return
 
     try:
@@ -95,7 +113,8 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
     # Write metadata
     result = {
         "source": str(video_path),
-        "source_duration": metadata["duration"],
+        "source_duration": source_duration,
+        "source_duration_display": _format_timestamp(source_duration),
         "note": (
             "Split times are approximate due to keyframe-aligned copy mode. "
             "Actual start/end may differ by up to the source keyframe interval "
@@ -106,10 +125,21 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
                 "index": i + 1,
                 "start_time": b["start"],
                 "end_time": b["end"],
+                "start_display": _format_timestamp(b["start"]),
+                "end_display": _format_timestamp(b["end"]),
                 "duration": b["end"] - b["start"],
+                "duration_display": _format_duration(b["end"] - b["start"]),
                 "output_file": str(f),
             }
             for i, (b, f) in enumerate(zip(boundaries, output_files, strict=True))
+        ],
+        "gaps": [
+            {
+                "start_display": _format_timestamp(g["start"]),
+                "end_display": _format_timestamp(g["end"]),
+                "duration_display": _format_duration(g["duration"]),
+            }
+            for g in gaps
         ],
     }
     metadata_path = config.output_dir / "metadata.json"
@@ -120,7 +150,40 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
     except OSError as e:
         raise AllaganEyeError(f"Cannot write metadata to {metadata_path}: {e}") from e
 
-    typer.echo(f"Output: {config.output_dir}")
+    typer.echo(f"\nOutput: {config.output_dir}")
     for f in output_files:
         typer.echo(f"  {f.name}")
     typer.echo(f"Metadata: {metadata_path}")
+
+
+def _format_timestamp(seconds: float) -> str:
+    """Format seconds as MM:SS or H:MM:SS."""
+    m, s = divmod(int(seconds), 60)
+    h, m = divmod(m, 60)
+    if h:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m:02d}:{s:02d}"
+
+
+def _format_duration(seconds: float) -> str:
+    """Format duration as e.g. '14m02s' or '1h05m'."""
+    total = int(seconds)
+    m, s = divmod(total, 60)
+    h, m = divmod(m, 60)
+    if h:
+        return f"{h}h{m:02d}m"
+    return f"{m}m{s:02d}s"
+
+
+def _find_gaps(
+    boundaries: list[dict], total_duration: float, *, min_gap: float = 300.0
+) -> list[dict]:
+    """Find significant gaps between detected matches."""
+    gaps: list[dict] = []
+    for i in range(len(boundaries) - 1):
+        gap_start = boundaries[i]["end"]
+        gap_end = boundaries[i + 1]["start"]
+        gap_dur = gap_end - gap_start
+        if gap_dur >= min_gap:
+            gaps.append({"start": gap_start, "end": gap_end, "duration": gap_dur})
+    return gaps

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -14,6 +14,7 @@ class SplitConfig:
     sample_interval: float = 1.0
     blackout_threshold: float = 15.0
     min_match_duration: float = 300.0
+    min_blackout_duration: float = 3.0
     dry_run: bool = False
 
     def __post_init__(self) -> None:
@@ -28,6 +29,10 @@ class SplitConfig:
         if self.min_match_duration <= 0:
             raise ConfigValidationError(
                 f"--min-match-duration must be positive, got {self.min_match_duration}"
+            )
+        if self.min_blackout_duration < 0:
+            raise ConfigValidationError(
+                f"--min-blackout-duration must be non-negative, got {self.min_blackout_duration}"
             )
 
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -22,6 +22,7 @@ def detect_match_boundaries(
     sample_interval: float = 1.0,
     blackout_threshold: float = 15.0,
     min_match_duration: float = 300.0,
+    min_blackout_duration: float = 3.0,
     progress_callback: Callable[[int, int, int], None] | None = None,
 ) -> list[dict]:
     """Detect match boundaries by finding blackout frames.
@@ -74,7 +75,11 @@ def detect_match_boundaries(
     blackout_times = sorted(t for t, b in results.items() if b < blackout_threshold)
 
     return _extract_segments(
-        blackout_times, duration_hint, sample_interval, min_match_duration
+        blackout_times,
+        duration_hint,
+        sample_interval,
+        min_match_duration,
+        min_blackout_duration,
     )
 
 
@@ -143,11 +148,14 @@ def _extract_segments(
     total_duration: float,
     sample_interval: float,
     min_match_duration: float,
+    min_blackout_duration: float = 3.0,
 ) -> list[dict]:
     """Extract match segments from blackout timestamps.
 
     Groups consecutive blackout frames into blackout regions,
-    then extracts gaps between them as match candidates.
+    filters out regions shorter than *min_blackout_duration* (e.g.
+    respawn blackouts), then extracts gaps between them as match
+    candidates.
 
     Cut points are offset into the blackout regions by
     ``_BLACKOUT_PADDING`` so that keyframe-level imprecision in
@@ -173,6 +181,17 @@ def _extract_segments(
             region_start = t
             region_end = t
     blackout_regions.append((region_start, region_end))
+
+    # Filter out short blackout regions (e.g. respawn blackouts 1-2s)
+    blackout_regions = [
+        (s, e) for s, e in blackout_regions if e - s >= min_blackout_duration
+    ]
+
+    if not blackout_regions:
+        # All blackouts were too short — treat as no blackouts
+        if total_duration >= min_match_duration:
+            return [{"start": 0.0, "end": total_duration}]
+        return []
 
     # Extract segments between blackout regions
     segments: list[dict] = []

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -65,18 +65,35 @@ class TestExtractSegments:
         assert result[1]["end"] == 1800.0
 
     def test_short_segment_filtered(self):
-        blackout_times = [100.0, 101.0]
+        """Segments shorter than min_match_duration are excluded."""
+        # Blackout at 100-104s (4s, passes min_blackout_duration=3)
+        blackout_times = [100.0, 101.0, 102.0, 103.0, 104.0]
         result = _extract_segments(
             blackout_times,
             total_duration=500.0,
             sample_interval=1.0,
             min_match_duration=300.0,
         )
+        # First segment: 0 to ~102 (too short), second: ~102 to 500 (long enough)
         assert len(result) == 1
-        assert result[0]["start"] == pytest.approx(100.5)
+        assert result[0]["start"] == pytest.approx(102.0)
 
     def test_multiple_blackouts_three_matches(self):
-        blackout_times = [600.0, 601.0, 602.0, 1800.0, 1801.0, 1802.0]
+        """Multiple blackout regions create multiple match segments with padding."""
+        blackout_times = [
+            # First blackout (600-604, 4s > 3s min_blackout)
+            600.0,
+            601.0,
+            602.0,
+            603.0,
+            604.0,
+            # Second blackout (1800-1804, 4s > 3s min_blackout)
+            1800.0,
+            1801.0,
+            1802.0,
+            1803.0,
+            1804.0,
+        ]
         result = _extract_segments(
             blackout_times,
             total_duration=3600.0,
@@ -84,10 +101,11 @@ class TestExtractSegments:
             min_match_duration=300.0,
         )
         assert len(result) == 3
-        assert result[0]["end"] == pytest.approx(601.0)
-        assert result[1]["start"] == pytest.approx(601.0)
-        assert result[1]["end"] == pytest.approx(1801.0)
-        assert result[2]["start"] == pytest.approx(1801.0)
+        # padding clamped to 2.0 (region duration 4s / 2)
+        assert result[0]["end"] == pytest.approx(602.0)
+        assert result[1]["start"] == pytest.approx(602.0)
+        assert result[1]["end"] == pytest.approx(1802.0)
+        assert result[2]["start"] == pytest.approx(1802.0)
 
     def test_consecutive_blackouts_merged(self):
         blackout_times = [600.0, 601.0, 602.0, 603.0, 604.0]
@@ -114,7 +132,9 @@ class TestExtractSegments:
         assert result[1]["start"] == pytest.approx(607.0)
 
     def test_padding_clamped_for_short_region(self):
-        blackout_times = [600.0, 601.0, 602.0]
+        """Padding clamped for region shorter than 2*padding but >= min_blackout."""
+        # Region 600-604 (4s): padding = min(3.0, 2.0) = 2.0
+        blackout_times = [600.0, 601.0, 602.0, 603.0, 604.0]
         result = _extract_segments(
             blackout_times,
             total_duration=1800.0,
@@ -122,8 +142,8 @@ class TestExtractSegments:
             min_match_duration=300.0,
         )
         assert len(result) == 2
-        assert result[0]["end"] == pytest.approx(601.0)
-        assert result[1]["start"] == pytest.approx(601.0)
+        assert result[0]["end"] == pytest.approx(602.0)
+        assert result[1]["start"] == pytest.approx(602.0)
 
     def test_padding_does_not_exceed_total_duration(self):
         blackout_times = [997.0, 998.0, 999.0, 1000.0]
@@ -138,6 +158,74 @@ class TestExtractSegments:
 
     def test_padding_constant_value(self):
         assert _BLACKOUT_PADDING == 3.0
+
+    def test_short_blackout_ignored(self):
+        """Blackout regions shorter than min_blackout_duration are ignored."""
+        # 1-2s respawn blackout should NOT split the video
+        blackout_times = [600.0, 601.0]  # 1s region
+        result = _extract_segments(
+            blackout_times,
+            total_duration=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+            min_blackout_duration=3.0,
+        )
+        # Short blackout ignored → entire video is one segment
+        assert len(result) == 1
+        assert result[0]["start"] == 0.0
+        assert result[0]["end"] == 1800.0
+
+    def test_long_blackout_kept(self):
+        """Blackout regions >= min_blackout_duration are kept as boundaries."""
+        # 5s blackout should split the video
+        blackout_times = [600.0, 601.0, 602.0, 603.0, 604.0, 605.0]
+        result = _extract_segments(
+            blackout_times,
+            total_duration=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+            min_blackout_duration=3.0,
+        )
+        assert len(result) == 2
+
+    def test_min_blackout_duration_zero(self):
+        """min_blackout_duration=0 keeps all blackout regions."""
+        blackout_times = [600.0, 601.0]  # 1s region
+        result = _extract_segments(
+            blackout_times,
+            total_duration=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+            min_blackout_duration=0.0,
+        )
+        # 1s blackout kept → two segments
+        assert len(result) == 2
+
+    def test_mixed_short_and_long_blackouts(self):
+        """Only long blackouts are used as boundaries, short ones ignored."""
+        blackout_times = [
+            # Short respawn blackout (1s, ignored)
+            600.0,
+            601.0,
+            # Long match boundary (5s, kept)
+            900.0,
+            901.0,
+            902.0,
+            903.0,
+            904.0,
+            905.0,
+        ]
+        result = _extract_segments(
+            blackout_times,
+            total_duration=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+            min_blackout_duration=3.0,
+        )
+        # Only the 5s blackout at 900s splits the video
+        assert len(result) == 2
+        assert result[0]["start"] == 0.0
+        assert result[1]["end"] == 1800.0
 
 
 # ============================================================

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -249,7 +249,7 @@ def test_pipeline_verbose_output(mock_probe, mock_detect, mock_split, tmp_path, 
 def test_pipeline_non_verbose_output(
     mock_probe, mock_detect, mock_split, tmp_path, capsys
 ):
-    """Non-verbose mode prints summary but not details."""
+    """Non-verbose mode prints match list with timestamps but not probe details."""
     mock_probe.return_value = PROBE_RESULT
     mock_detect.return_value = BOUNDARIES
     mock_split.return_value = _output_files(tmp_path)
@@ -259,8 +259,9 @@ def test_pipeline_non_verbose_output(
 
     output = capsys.readouterr().out
     assert "Detected 2 match(es)" in output
+    assert "Match 1:" in output
+    assert "Match 2:" in output
     assert "Probing:" not in output
-    assert "Match 1:" not in output
 
 
 # --- Config forwarding ---

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -80,6 +80,7 @@ def test_pipeline_happy_path(mock_probe, mock_detect, mock_split, tmp_path):
         sample_interval=config.sample_interval,
         blackout_threshold=config.blackout_threshold,
         min_match_duration=config.min_match_duration,
+        min_blackout_duration=config.min_blackout_duration,
     )
     mock_split.assert_called_once_with(video, BOUNDARIES, tmp_path)
     assert (tmp_path / "metadata.json").exists()
@@ -290,4 +291,5 @@ def test_pipeline_config_params_forwarded(
         sample_interval=2.0,
         blackout_threshold=20.0,
         min_match_duration=120.0,
+        min_blackout_duration=3.0,
     )


### PR DESCRIPTION
## Summary

### #60: min_blackout_duration パラメータ導入
- `_extract_segments()` で blackout region マージ後、`min_blackout_duration` (デフォルト 3.0s) 未満のリージョンを除外
- ダウン→リスポーン暗転 (1-2s) を試合境界と誤判定する問題を修正
- `--min-blackout-duration` CLI オプション追加
- テスト 4 件追加 (短/長/ゼロ/混合の暗転フィルタ)

### #59: タイムスタンプ表示 + gap 検出
- verbose/非verbose 共通で試合一覧を MM:SS 形式で表示
- 5 分以上の未検出区間 (gap) を表示
- metadata.json に `*_display` フィールドと `gaps` 配列を追加
- `_format_timestamp()`, `_format_duration()`, `_find_gaps()` ヘルパー追加

関連: #60, #59

## Checklist

- [x] 全テスト通過（`pytest`）— 116 passed
- [x] Lint 通過（`ruff check .`）
- [x] フォーマット通過（`ruff format --check .`）

## Test plan

- [x] 短い暗転 (1-2s) が除外されることを検証
- [x] 長い暗転 (5s+) が保持されることを検証
- [x] min_blackout_duration=0 で全暗転が保持されることを検証
- [x] 短/長混合の暗転で正しくフィルタされることを検証
- [x] タイムスタンプ表示 (MM:SS 形式) の確認
- [ ] lead-engineer レビュー
- [ ] テスター確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)