### PR TITLE
docs: MIT License を README.md と pyproject.toml に反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ output/
 
 ## ライセンス
 
-TBD
+[MIT License](LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "kobutachan-allaganeye"
 version = "0.1.0"
 description = "FF14 Frontline video auto-highlight extraction tool"
+license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
     "typer>=0.9",


### PR DESCRIPTION
## Summary

- `README.md`: ライセンス欄を「TBD」から「MIT License」（LICENSE ファイルへのリンク）に更新
- `pyproject.toml`: `license = {text = "MIT"}` フィールドを追加

## Test plan

- [x] ドキュメント内容の正確性確認
- [ ] lead-engineer レビュー

作成: director-1