### PR TITLE
perf: increase max_workers and auto-adjust sample_interval (#68)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -25,11 +25,22 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             f"FPS: {metadata['fps']:.2f}"
         )
 
+    # Auto-adjust sample_interval for long videos (C strategy from #68)
+    effective_interval = _auto_sample_interval(
+        metadata["duration"], config.sample_interval
+    )
+
     # Step 2: Detect match boundaries
     if verbose:
+        if effective_interval != config.sample_interval:
+            typer.echo(
+                f"  Auto-adjusted sample interval: "
+                f"{config.sample_interval}s → {effective_interval}s "
+                f"(video is {_format_duration(metadata['duration'])})"
+            )
         typer.echo(
             f"Detecting match boundaries "
-            f"(interval={config.sample_interval}s, threshold={config.blackout_threshold})"
+            f"(interval={effective_interval}s, threshold={config.blackout_threshold})"
         )
 
         total_duration = metadata["duration"]
@@ -48,7 +59,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             boundaries = detect_match_boundaries(
                 video_path,
                 duration_hint=metadata["duration"],
-                sample_interval=config.sample_interval,
+                sample_interval=effective_interval,
                 blackout_threshold=config.blackout_threshold,
                 min_match_duration=config.min_match_duration,
                 min_blackout_duration=config.min_blackout_duration,
@@ -58,7 +69,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
         boundaries = detect_match_boundaries(
             video_path,
             duration_hint=metadata["duration"],
-            sample_interval=config.sample_interval,
+            sample_interval=effective_interval,
             blackout_threshold=config.blackout_threshold,
             min_match_duration=config.min_match_duration,
             min_blackout_duration=config.min_blackout_duration,
@@ -173,6 +184,21 @@ def _format_duration(seconds: float) -> str:
     if h:
         return f"{h}h{m:02d}m"
     return f"{m}m{s:02d}s"
+
+
+def _auto_sample_interval(duration: float, configured_interval: float) -> float:
+    """Raise sample interval for long videos to reduce probe count.
+
+    Only adjusts when the configured interval is the default (1.0).
+    Thresholds chosen so total probes stay under ~3600 (≈ 5 min at 24 workers).
+    """
+    if configured_interval != 1.0:
+        return configured_interval
+    if duration > 7200:  # > 2h
+        return 3.0
+    if duration > 3600:  # > 1h
+        return 2.0
+    return configured_interval
 
 
 def _find_gaps(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -104,6 +104,8 @@ def _probe_single_frame(video_path: Path, timestamp: float) -> float:
     """
     cmd = [
         "ffmpeg",
+        "-threads",
+        "1",
         "-ss",
         str(timestamp),
         "-i",

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -50,7 +50,7 @@ def detect_match_boundaries(
         return []
 
     total_samples = len(timestamps)
-    max_workers = min(8, os.cpu_count() or 4)
+    max_workers = min(os.cpu_count() or 4, 24)
 
     # Parallel -ss probes
     results: dict[float, float] = {}  # timestamp → brightness

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from allaganeye.commands.split_matches import run_split
+from allaganeye.commands.split_matches import _auto_sample_interval, run_split
 from allaganeye.config import SplitConfig
 from allaganeye.exceptions import AllaganEyeError, DetectionError, VideoProcessingError
 
@@ -262,6 +262,56 @@ def test_pipeline_non_verbose_output(
     assert "Match 1:" in output
     assert "Match 2:" in output
     assert "Probing:" not in output
+
+
+# --- Auto sample interval ---
+
+
+class TestAutoSampleInterval:
+    def test_short_video_unchanged(self):
+        assert _auto_sample_interval(1800.0, 1.0) == 1.0
+
+    def test_one_hour_boundary_unchanged(self):
+        assert _auto_sample_interval(3600.0, 1.0) == 1.0
+
+    def test_over_one_hour(self):
+        assert _auto_sample_interval(3601.0, 1.0) == 2.0
+
+    def test_two_hour_boundary(self):
+        assert _auto_sample_interval(7200.0, 1.0) == 2.0
+
+    def test_over_two_hours(self):
+        assert _auto_sample_interval(7201.0, 1.0) == 3.0
+
+    def test_custom_interval_not_adjusted(self):
+        """User-specified interval is never auto-adjusted."""
+        assert _auto_sample_interval(9000.0, 0.5) == 0.5
+        assert _auto_sample_interval(9000.0, 2.0) == 2.0
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_auto_interval_long_video(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """Long video (>1h) auto-adjusts sample_interval from 1.0 to 2.0."""
+    probe = {**PROBE_RESULT, "duration": 5400.0}  # 1.5h
+    mock_probe.return_value = probe
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+
+    mock_detect.assert_called_once_with(
+        Path("input.mp4"),
+        duration_hint=5400.0,
+        sample_interval=2.0,
+        blackout_threshold=config.blackout_threshold,
+        min_match_duration=config.min_match_duration,
+        min_blackout_duration=config.min_blackout_duration,
+    )
 
 
 # --- Config forwarding ---


### PR DESCRIPTION
## Summary

- **max_workers**: `min(8, cpu_count)` → `min(cpu_count, 24)` で CPU コア数をより活用（戦略 D）
- **sample_interval 自動調整**: デフォルト値（1.0s）のまま長時間動画に突入する場合、自動で引き上げ（戦略 C）
  - 1h 超: 1.0s → 2.0s
  - 2h 超: 1.0s → 3.0s
  - `--sample-interval` 明示指定時は調整しない
- verbose モードで自動調整を通知

## 期待される改善

37GB/2h AV1 MKV（Issue #68 のベンチマーク環境）:
- 現状: interval=1.0, workers=8 → 7303 probes / 8 = ~24分
- 改善: interval=3.0, workers=24 → 2434 probes / 24 = ~2.7分（**約9倍高速化**）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `allaganeye/video/detector.py` | `max_workers` 上限を 8→24 に変更 |
| `allaganeye/commands/split_matches.py` | `_auto_sample_interval()` 追加、パイプラインに組み込み |
| `tests/test_split_matches.py` | `TestAutoSampleInterval` (7テスト) + パイプライン統合テスト |

## Test plan

- [x] 全 123 テスト通過
- [x] ruff check / ruff format 通過
- [ ] tester による実動画ベンチマーク（37GB MKV で 5分以内を確認）

関連: #68

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)