### PR TITLE
feat: add debug-brightness command (#29)

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -93,3 +93,42 @@ def split(
     except Exception as e:
         typer.echo(f"Unexpected error: {e}", err=True)
         raise typer.Exit(code=1) from None
+
+
+@app.command(name="debug-brightness")
+def debug_brightness(
+    video_path: Annotated[
+        Path, typer.Argument(help="Input video file (MP4/MKV/AVI/MOV)")
+    ],
+    start: Annotated[
+        float, typer.Option("--start", help="Start time in seconds")
+    ] = 0.0,
+    end: Annotated[
+        float | None,
+        typer.Option("--end", help="End time in seconds (default: video duration)"),
+    ] = None,
+    interval: Annotated[
+        float, typer.Option("--interval", help="Sampling interval in seconds")
+    ] = 1.0,
+) -> None:
+    """Probe frame brightness at regular intervals (CSV output for threshold tuning)."""
+    try:
+        if not video_path.exists():
+            raise InputFileError(f"File not found: {video_path}")
+
+        if video_path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            raise InputFileError(
+                f"Unsupported format: {video_path.suffix}. "
+                f"Supported: {', '.join(sorted(SUPPORTED_EXTENSIONS))}"
+            )
+
+        from allaganeye.commands.debug_brightness import run_debug_brightness
+
+        run_debug_brightness(video_path, start=start, end=end, interval=interval)
+
+    except AllaganEyeError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=e.exit_code) from None
+    except Exception as e:
+        typer.echo(f"Unexpected error: {e}", err=True)
+        raise typer.Exit(code=1) from None

--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -19,11 +19,12 @@ def run_debug_brightness(
 ) -> None:
     """Probe brightness at regular intervals and print CSV to stdout."""
     metadata = probe_video(video_path)
-    duration = metadata["duration"]
+    duration: float = metadata["duration"]
 
     if end is None:
         end = duration
-    end = min(end, duration)
+    else:
+        end = min(end, duration)
 
     if start >= end:
         typer.echo("Error: --start must be less than --end", err=True)

--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -1,0 +1,52 @@
+"""Debug-brightness command: probe frame brightness and output CSV."""
+
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import typer
+
+from allaganeye.video.detector import _generate_timestamps, _probe_single_frame
+from allaganeye.video.probe import probe_video
+
+
+def run_debug_brightness(
+    video_path: Path,
+    *,
+    start: float = 0.0,
+    end: float | None = None,
+    interval: float = 1.0,
+) -> None:
+    """Probe brightness at regular intervals and print CSV to stdout."""
+    metadata = probe_video(video_path)
+    duration = metadata["duration"]
+
+    if end is None:
+        end = duration
+    end = min(end, duration)
+
+    if start >= end:
+        typer.echo("Error: --start must be less than --end", err=True)
+        raise typer.Exit(code=1)
+
+    timestamps = _generate_timestamps(end - start, interval)
+    timestamps = [start + t for t in timestamps]
+
+    if not timestamps:
+        typer.echo("No timestamps to probe.", err=True)
+        raise typer.Exit(code=1)
+
+    max_workers = min(os.cpu_count() or 4, 24)
+    results: dict[float, float] = {}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(_probe_single_frame, video_path, t): t for t in timestamps
+        }
+        for future in as_completed(futures):
+            t = futures[future]
+            results[t] = future.result()
+
+    typer.echo("timestamp,brightness")
+    for t in sorted(results):
+        typer.echo(f"{t:.1f},{results[t]:.1f}")

--- a/tests/test_debug_brightness.py
+++ b/tests/test_debug_brightness.py
@@ -1,0 +1,127 @@
+"""Tests for debug-brightness command."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import click.exceptions
+import pytest
+
+from allaganeye.commands.debug_brightness import run_debug_brightness
+
+MODULE = "allaganeye.commands.debug_brightness"
+
+PROBE_RESULT = {
+    "duration": 300.0,
+    "width": 1920,
+    "height": 1080,
+    "fps": 30.0,
+    "codec": "h264",
+    "audio_codec": "aac",
+}
+
+
+@patch(f"{MODULE}._probe_single_frame")
+@patch(f"{MODULE}.probe_video")
+def test_csv_output(mock_probe_video, mock_probe_frame, capsys):
+    """Output is CSV with header and sorted rows."""
+    mock_probe_video.return_value = PROBE_RESULT
+    mock_probe_frame.return_value = 42.5
+
+    run_debug_brightness(Path("test.mp4"), start=0.0, end=3.0, interval=1.0)
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert lines[0] == "timestamp,brightness"
+    assert len(lines) == 4  # header + 3 rows (0.0, 1.0, 2.0)
+    assert lines[1] == "0.0,42.5"
+    assert lines[2] == "1.0,42.5"
+    assert lines[3] == "2.0,42.5"
+
+
+@patch(f"{MODULE}._probe_single_frame")
+@patch(f"{MODULE}.probe_video")
+def test_start_end_range(mock_probe_video, mock_probe_frame, capsys):
+    """--start and --end restrict the probed range."""
+    mock_probe_video.return_value = PROBE_RESULT
+    mock_probe_frame.return_value = 10.0
+
+    run_debug_brightness(Path("test.mp4"), start=100.0, end=103.0, interval=1.0)
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert len(lines) == 4  # header + 3 rows
+    assert "100.0" in lines[1]
+    assert "101.0" in lines[2]
+    assert "102.0" in lines[3]
+
+
+@patch(f"{MODULE}._probe_single_frame")
+@patch(f"{MODULE}.probe_video")
+def test_end_defaults_to_duration(mock_probe_video, mock_probe_frame, capsys):
+    """end=None uses video duration."""
+    mock_probe_video.return_value = {**PROBE_RESULT, "duration": 5.0}
+    mock_probe_frame.return_value = 50.0
+
+    run_debug_brightness(Path("test.mp4"), start=0.0, end=None, interval=1.0)
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert len(lines) == 6  # header + 5 rows (0,1,2,3,4)
+
+
+@patch(f"{MODULE}._probe_single_frame")
+@patch(f"{MODULE}.probe_video")
+def test_custom_interval(mock_probe_video, mock_probe_frame, capsys):
+    """Custom interval changes sample count."""
+    mock_probe_video.return_value = PROBE_RESULT
+    mock_probe_frame.return_value = 30.0
+
+    run_debug_brightness(Path("test.mp4"), start=0.0, end=5.0, interval=2.0)
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    # 0.0, 2.0, 4.0 = 3 rows
+    assert len(lines) == 4  # header + 3 rows
+
+
+@patch(f"{MODULE}._probe_single_frame")
+@patch(f"{MODULE}.probe_video")
+def test_end_clamped_to_duration(mock_probe_video, mock_probe_frame, capsys):
+    """--end beyond duration is clamped."""
+    mock_probe_video.return_value = {**PROBE_RESULT, "duration": 3.0}
+    mock_probe_frame.return_value = 20.0
+
+    run_debug_brightness(Path("test.mp4"), start=0.0, end=999.0, interval=1.0)
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert len(lines) == 4  # header + 3 rows (0,1,2)
+
+
+@patch(f"{MODULE}.probe_video")
+def test_start_ge_end_exits(mock_probe_video):
+    """start >= end raises SystemExit."""
+    mock_probe_video.return_value = PROBE_RESULT
+
+    with pytest.raises(click.exceptions.Exit):
+        run_debug_brightness(Path("test.mp4"), start=200.0, end=100.0, interval=1.0)
+
+
+@patch(f"{MODULE}._probe_single_frame")
+@patch(f"{MODULE}.probe_video")
+def test_varying_brightness(mock_probe_video, mock_probe_frame, capsys):
+    """Different brightness values per timestamp are correctly reported."""
+    mock_probe_video.return_value = PROBE_RESULT
+
+    def side_effect(path, t):
+        return {0.0: 5.0, 1.0: 128.0, 2.0: 42.3}.get(t, 100.0)
+
+    mock_probe_frame.side_effect = side_effect
+
+    run_debug_brightness(Path("test.mp4"), start=0.0, end=3.0, interval=1.0)
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert lines[1] == "0.0,5.0"
+    assert lines[2] == "1.0,128.0"
+    assert lines[3] == "2.0,42.3"


### PR DESCRIPTION
## Summary

- `allaganeye debug-brightness <video>` コマンドを新設
- 指定区間のフレーム輝度を CSV (timestamp,brightness) で stdout に出力
- `--start`, `--end`, `--interval` オプション対応
- `detector.py` の `_probe_single_frame` を再利用し、並列 ffmpeg プローブで高速実行

## 使用例

```bash
# 指定区間の輝度を確認
allaganeye debug-brightness video.mkv --start 2400 --end 2500 --interval 0.5

# 全区間（デフォルト interval=1.0）
allaganeye debug-brightness video.mkv
```

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `allaganeye/commands/debug_brightness.py` | 新規: プローブ実行 + CSV 出力 |
| `allaganeye/cli.py` | `debug-brightness` コマンド追加 |
| `tests/test_debug_brightness.py` | 新規: 7テスト |

## Test plan

- [x] 全 130 テスト通過
- [x] ruff check / ruff format 通過
- [ ] tester による実動画での CSV 出力確認

関連: #29, #71, #17

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)