### PR TITLE
feat: transition region expansion for boundary detection (#71)

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -74,6 +74,11 @@ def detect_match_boundaries(
     # Collect blackout timestamps in chronological order
     blackout_times = sorted(t for t, b in results.items() if b < blackout_threshold)
 
+    # Expand blackout regions with adjacent transition frames (#71)
+    blackout_times = _expand_with_transitions(
+        blackout_times, results, sample_interval, _TRANSITION_THRESHOLD
+    )
+
     return _extract_segments(
         blackout_times,
         duration_hint,
@@ -136,6 +141,15 @@ def _probe_single_frame(video_path: Path, timestamp: float) -> float:
     return float(np.frombuffer(result.stdout[:_FRAME_SIZE], dtype=np.uint8).mean())
 
 
+_TRANSITION_THRESHOLD = 55.0
+"""Brightness threshold for transition regions adjacent to blackouts.
+
+Game frames are typically 60-120, while lobby/waiting screens are ~51.
+Frames below this threshold that are adjacent to a blackout region are
+included in the expanded region, allowing short blackouts followed by
+lobby screens to be detected as match boundaries.
+"""
+
 _BLACKOUT_PADDING = 3.0
 """Seconds to offset cut points into blackout regions.
 
@@ -143,6 +157,63 @@ With ``-c copy``, FFmpeg can only cut at keyframes (~2s apart for OBS).
 By placing cut points inside blackout regions, keyframe drift never
 clips actual match footage.
 """
+
+
+def _expand_with_transitions(
+    blackout_times: list[float],
+    all_results: dict[float, float],
+    sample_interval: float,
+    transition_threshold: float,
+) -> list[float]:
+    """Expand blackout timestamps to include adjacent transition frames.
+
+    Groups blackout timestamps into regions, then for each region expands
+    forward and backward through timestamps where brightness is below
+    *transition_threshold*.  This captures lobby/waiting screens (~51
+    brightness) that follow match-boundary blackouts, making them long
+    enough to pass the min_blackout_duration filter while leaving short
+    respawn blackouts (followed by immediate 60+ game frames) unchanged.
+    """
+    if not blackout_times:
+        return blackout_times
+
+    sorted_timestamps = sorted(all_results)
+    tolerance = sample_interval * 2
+
+    # Group blackout timestamps into regions
+    regions: list[tuple[float, float]] = []
+    region_start = blackout_times[0]
+    region_end = blackout_times[0]
+    for t in blackout_times[1:]:
+        if t - region_end <= tolerance:
+            region_end = t
+        else:
+            regions.append((region_start, region_end))
+            region_start = t
+            region_end = t
+    regions.append((region_start, region_end))
+
+    # Expand each region with adjacent transition frames
+    expanded_timestamps: set[float] = set(blackout_times)
+    for reg_start, reg_end in regions:
+        # Expand backward
+        for t in reversed(sorted_timestamps):
+            if t >= reg_start:
+                continue
+            if all_results[t] < transition_threshold:
+                expanded_timestamps.add(t)
+            else:
+                break
+        # Expand forward
+        for t in sorted_timestamps:
+            if t <= reg_end:
+                continue
+            if all_results[t] < transition_threshold:
+                expanded_timestamps.add(t)
+            else:
+                break
+
+    return sorted(expanded_timestamps)
 
 
 def _extract_segments(

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -10,6 +10,8 @@ from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     _BLACKOUT_PADDING,
     _FRAME_SIZE,
+    _TRANSITION_THRESHOLD,
+    _expand_with_transitions,
     _extract_segments,
     _generate_timestamps,
     _probe_single_frame,
@@ -26,6 +28,108 @@ def _make_run_result(brightness: int = 128, frame_size: int = _FRAME_SIZE) -> Ma
     result.stdout = bytes([brightness]) * frame_size
     result.returncode = 0
     return result
+
+
+# ============================================================
+# TestExpandWithTransitions
+# ============================================================
+
+
+class TestExpandWithTransitions:
+    """Tests for transition region expansion (#71)."""
+
+    def test_no_blackouts_unchanged(self):
+        result = _expand_with_transitions([], {}, 1.0, 55.0)
+        assert result == []
+
+    def test_blackout_followed_by_lobby(self):
+        """Blackout followed by low-brightness lobby screen is expanded."""
+        # Blackout at t=100-101, followed by lobby (~51) for 20s
+        all_results = {}
+        for t in range(200):
+            all_results[float(t)] = 80.0  # game frames
+        all_results[100.0] = 5.0  # blackout
+        all_results[101.0] = 5.0  # blackout
+        for t in range(102, 122):
+            all_results[float(t)] = 51.0  # lobby screen
+
+        blackout_times = [100.0, 101.0]
+        result = _expand_with_transitions(blackout_times, all_results, 1.0, 55.0)
+
+        # Should include blackout + lobby frames
+        assert 100.0 in result
+        assert 101.0 in result
+        assert 102.0 in result
+        assert 121.0 in result
+        # Should not include game frames
+        assert 122.0 not in result
+        assert 99.0 not in result
+
+    def test_blackout_followed_by_game_not_expanded(self):
+        """Blackout followed by bright game frames is NOT expanded (respawn)."""
+        all_results = {}
+        for t in range(200):
+            all_results[float(t)] = 80.0
+        all_results[100.0] = 5.0  # blackout
+        all_results[101.0] = 5.0  # blackout
+
+        blackout_times = [100.0, 101.0]
+        result = _expand_with_transitions(blackout_times, all_results, 1.0, 55.0)
+
+        assert result == [100.0, 101.0]
+
+    def test_expansion_both_directions(self):
+        """Transition frames before and after blackout are included."""
+        all_results = {}
+        for t in range(50):
+            all_results[float(t)] = 80.0
+        # Transition before blackout
+        all_results[18.0] = 50.0
+        all_results[19.0] = 50.0
+        # Blackout
+        all_results[20.0] = 5.0
+        all_results[21.0] = 5.0
+        # Transition after blackout
+        all_results[22.0] = 50.0
+        all_results[23.0] = 50.0
+
+        blackout_times = [20.0, 21.0]
+        result = _expand_with_transitions(blackout_times, all_results, 1.0, 55.0)
+
+        assert 18.0 in result
+        assert 19.0 in result
+        assert 22.0 in result
+        assert 23.0 in result
+        assert 17.0 not in result
+        assert 24.0 not in result
+
+    def test_transition_threshold_constant(self):
+        assert _TRANSITION_THRESHOLD == 55.0
+
+    def test_expansion_enables_boundary_detection(self):
+        """End-to-end: short blackout + lobby passes min_blackout_duration after expansion."""
+        # Simulate: 2s blackout + 20s lobby = 22s expanded region
+        all_results = {}
+        for t in range(200):
+            all_results[float(t)] = 80.0
+        all_results[100.0] = 5.0
+        all_results[101.0] = 5.0
+        for t in range(102, 122):
+            all_results[float(t)] = 51.0
+
+        blackout_times = [100.0, 101.0]
+        expanded = _expand_with_transitions(blackout_times, all_results, 1.0, 55.0)
+
+        # Feed expanded times to _extract_segments
+        segments = _extract_segments(
+            expanded,
+            total_duration=200.0,
+            sample_interval=1.0,
+            min_match_duration=10.0,
+            min_blackout_duration=3.0,
+        )
+        # Should detect 2 segments (before and after the expanded blackout)
+        assert len(segments) == 2
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

- 暗転領域を遷移領域（brightness < 55.0）で前後に拡張する `_expand_with_transitions()` を追加
- リスポーン暗転（直後に brightness 60+ に回復）は拡張されず、`min_blackout_duration` で除外
- 試合境界暗転（直後に ~51 のロビー画面が 10-20s 持続）は拡張されて検出される

## メカニズム

| 暗転タイプ | 暗転 | 直後 | 拡張後 duration | 結果 |
|---|---|---|---|---|
| リスポーン (1-1.5s) | brightness < 15 | 即 60+ | 1-1.5s | 除外 |
| 試合境界 (2-3s) | brightness < 15 | ~51 が 20s | 22-23s | **検出** |

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `allaganeye/video/detector.py` | `_TRANSITION_THRESHOLD=55.0` 定数、`_expand_with_transitions()` 関数追加、`detect_match_boundaries` に組み込み |
| `tests/test_detector.py` | `TestExpandWithTransitions` (6テスト) |

## Test plan

- [x] 全 136 テスト通過
- [x] ruff check / ruff format 通過
- [ ] tester による実動画テスト（7試合検出の確認）

関連: #71, #17

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)