### PR TITLE
refactor: split _extract_segments into pipeline functions (#77)

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -74,15 +74,15 @@ def detect_match_boundaries(
     # Collect blackout timestamps in chronological order
     blackout_times = sorted(t for t, b in results.items() if b < blackout_threshold)
 
-    # Expand blackout regions with adjacent transition frames (#71)
-    blackout_times = _expand_with_transitions(
-        blackout_times, results, sample_interval, _TRANSITION_THRESHOLD
+    # Group into regions and expand with transition frames (#71)
+    blackout_regions = _group_blackout_regions(blackout_times, sample_interval)
+    blackout_regions = _expand_regions_with_transitions(
+        blackout_regions, results, sample_interval, _TRANSITION_THRESHOLD
     )
 
-    return _extract_segments(
-        blackout_times,
+    return _filter_and_extract_segments(
+        blackout_regions,
         duration_hint,
-        sample_interval,
         min_match_duration,
         min_blackout_duration,
     )
@@ -159,28 +159,19 @@ clips actual match footage.
 """
 
 
-def _expand_with_transitions(
+def _group_blackout_regions(
     blackout_times: list[float],
-    all_results: dict[float, float],
     sample_interval: float,
-    transition_threshold: float,
-) -> list[float]:
-    """Expand blackout timestamps to include adjacent transition frames.
+) -> list[tuple[float, float]]:
+    """Group consecutive blackout timestamps into contiguous regions.
 
-    Groups blackout timestamps into regions, then for each region expands
-    forward and backward through timestamps where brightness is below
-    *transition_threshold*.  This captures lobby/waiting screens (~51
-    brightness) that follow match-boundary blackouts, making them long
-    enough to pass the min_blackout_duration filter while leaving short
-    respawn blackouts (followed by immediate 60+ game frames) unchanged.
+    Timestamps within ``sample_interval * 2`` of each other are merged
+    into a single (start, end) region.
     """
     if not blackout_times:
-        return blackout_times
+        return []
 
-    sorted_timestamps = sorted(all_results)
     tolerance = sample_interval * 2
-
-    # Group blackout timestamps into regions
     regions: list[tuple[float, float]] = []
     region_start = blackout_times[0]
     region_end = blackout_times[0]
@@ -192,16 +183,39 @@ def _expand_with_transitions(
             region_start = t
             region_end = t
     regions.append((region_start, region_end))
+    return regions
 
-    # Expand each region with adjacent transition frames
-    expanded_timestamps: set[float] = set(blackout_times)
-    for reg_start, reg_end in regions:
+
+def _expand_regions_with_transitions(
+    blackout_regions: list[tuple[float, float]],
+    all_results: dict[float, float],
+    sample_interval: float,
+    transition_threshold: float,
+) -> list[tuple[float, float]]:
+    """Expand blackout regions to include adjacent transition frames.
+
+    For each region, expands forward and backward through timestamps
+    where brightness is below *transition_threshold*.  This captures
+    lobby/waiting screens (~51 brightness) that follow match-boundary
+    blackouts, making them long enough to pass the min_blackout_duration
+    filter while leaving short respawn blackouts (followed by immediate
+    60+ game frames) unchanged.
+    """
+    if not blackout_regions:
+        return blackout_regions
+
+    sorted_timestamps = sorted(all_results)
+
+    expanded: list[tuple[float, float]] = []
+    for reg_start, reg_end in blackout_regions:
+        new_start = reg_start
+        new_end = reg_end
         # Expand backward
         for t in reversed(sorted_timestamps):
             if t >= reg_start:
                 continue
             if all_results[t] < transition_threshold:
-                expanded_timestamps.add(t)
+                new_start = t
             else:
                 break
         # Expand forward
@@ -209,51 +223,43 @@ def _expand_with_transitions(
             if t <= reg_end:
                 continue
             if all_results[t] < transition_threshold:
-                expanded_timestamps.add(t)
+                new_end = t
             else:
                 break
+        expanded.append((new_start, new_end))
 
-    return sorted(expanded_timestamps)
+    # Merge overlapping regions after expansion
+    expanded.sort()
+    merged: list[tuple[float, float]] = [expanded[0]]
+    tolerance = sample_interval * 2
+    for start, end in expanded[1:]:
+        prev_start, prev_end = merged[-1]
+        if start - prev_end <= tolerance:
+            merged[-1] = (prev_start, max(prev_end, end))
+        else:
+            merged.append((start, end))
+
+    return merged
 
 
-def _extract_segments(
-    blackout_times: list[float],
+def _filter_and_extract_segments(
+    blackout_regions: list[tuple[float, float]],
     total_duration: float,
-    sample_interval: float,
     min_match_duration: float,
     min_blackout_duration: float = 3.0,
 ) -> list[dict]:
-    """Extract match segments from blackout timestamps.
+    """Filter blackout regions by duration and extract match segments.
 
-    Groups consecutive blackout frames into blackout regions,
-    filters out regions shorter than *min_blackout_duration* (e.g.
-    respawn blackouts), then extracts gaps between them as match
-    candidates.
-
-    Cut points are offset into the blackout regions by
-    ``_BLACKOUT_PADDING`` so that keyframe-level imprecision in
-    ``-c copy`` mode never clips match footage.
+    Removes regions shorter than *min_blackout_duration*, then extracts
+    gaps between remaining regions as match candidates.  Cut points are
+    offset into the blackout regions by ``_BLACKOUT_PADDING`` so that
+    keyframe-level imprecision in ``-c copy`` mode never clips match
+    footage.
     """
-    if not blackout_times:
-        # No blackouts found — entire video is one segment
+    if not blackout_regions:
         if total_duration >= min_match_duration:
             return [{"start": 0.0, "end": total_duration}]
         return []
-
-    # Group consecutive blackout times into regions
-    tolerance = sample_interval * 2
-    blackout_regions: list[tuple[float, float]] = []
-    region_start = blackout_times[0]
-    region_end = blackout_times[0]
-
-    for t in blackout_times[1:]:
-        if t - region_end <= tolerance:
-            region_end = t
-        else:
-            blackout_regions.append((region_start, region_end))
-            region_start = t
-            region_end = t
-    blackout_regions.append((region_start, region_end))
 
     # Filter out short blackout regions (e.g. respawn blackouts 1-2s)
     blackout_regions = [
@@ -261,7 +267,6 @@ def _extract_segments(
     ]
 
     if not blackout_regions:
-        # All blackouts were too short — treat as no blackouts
         if total_duration >= min_match_duration:
             return [{"start": 0.0, "end": total_duration}]
         return []

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -11,15 +11,30 @@ from allaganeye.video.detector import (
     _BLACKOUT_PADDING,
     _FRAME_SIZE,
     _TRANSITION_THRESHOLD,
-    _expand_with_transitions,
-    _extract_segments,
+    _expand_regions_with_transitions,
+    _filter_and_extract_segments,
     _generate_timestamps,
+    _group_blackout_regions,
     _probe_single_frame,
     detect_match_boundaries,
 )
 
 
 # --- Helpers ---
+
+
+def _extract_segments(
+    blackout_times: list[float],
+    total_duration: float,
+    sample_interval: float,
+    min_match_duration: float,
+    min_blackout_duration: float = 3.0,
+) -> list[dict]:
+    """Test helper: groups + filters + extracts (replaces old monolithic function)."""
+    regions = _group_blackout_regions(blackout_times, sample_interval)
+    return _filter_and_extract_segments(
+        regions, total_duration, min_match_duration, min_blackout_duration
+    )
 
 
 def _make_run_result(brightness: int = 128, frame_size: int = _FRAME_SIZE) -> MagicMock:
@@ -35,80 +50,15 @@ def _make_run_result(brightness: int = 128, frame_size: int = _FRAME_SIZE) -> Ma
 # ============================================================
 
 
-class TestExpandWithTransitions:
+class TestExpandRegionsWithTransitions:
     """Tests for transition region expansion (#71)."""
 
-    def test_no_blackouts_unchanged(self):
-        result = _expand_with_transitions([], {}, 1.0, 55.0)
+    def test_no_regions_unchanged(self):
+        result = _expand_regions_with_transitions([], {}, 1.0, 55.0)
         assert result == []
 
     def test_blackout_followed_by_lobby(self):
         """Blackout followed by low-brightness lobby screen is expanded."""
-        # Blackout at t=100-101, followed by lobby (~51) for 20s
-        all_results = {}
-        for t in range(200):
-            all_results[float(t)] = 80.0  # game frames
-        all_results[100.0] = 5.0  # blackout
-        all_results[101.0] = 5.0  # blackout
-        for t in range(102, 122):
-            all_results[float(t)] = 51.0  # lobby screen
-
-        blackout_times = [100.0, 101.0]
-        result = _expand_with_transitions(blackout_times, all_results, 1.0, 55.0)
-
-        # Should include blackout + lobby frames
-        assert 100.0 in result
-        assert 101.0 in result
-        assert 102.0 in result
-        assert 121.0 in result
-        # Should not include game frames
-        assert 122.0 not in result
-        assert 99.0 not in result
-
-    def test_blackout_followed_by_game_not_expanded(self):
-        """Blackout followed by bright game frames is NOT expanded (respawn)."""
-        all_results = {}
-        for t in range(200):
-            all_results[float(t)] = 80.0
-        all_results[100.0] = 5.0  # blackout
-        all_results[101.0] = 5.0  # blackout
-
-        blackout_times = [100.0, 101.0]
-        result = _expand_with_transitions(blackout_times, all_results, 1.0, 55.0)
-
-        assert result == [100.0, 101.0]
-
-    def test_expansion_both_directions(self):
-        """Transition frames before and after blackout are included."""
-        all_results = {}
-        for t in range(50):
-            all_results[float(t)] = 80.0
-        # Transition before blackout
-        all_results[18.0] = 50.0
-        all_results[19.0] = 50.0
-        # Blackout
-        all_results[20.0] = 5.0
-        all_results[21.0] = 5.0
-        # Transition after blackout
-        all_results[22.0] = 50.0
-        all_results[23.0] = 50.0
-
-        blackout_times = [20.0, 21.0]
-        result = _expand_with_transitions(blackout_times, all_results, 1.0, 55.0)
-
-        assert 18.0 in result
-        assert 19.0 in result
-        assert 22.0 in result
-        assert 23.0 in result
-        assert 17.0 not in result
-        assert 24.0 not in result
-
-    def test_transition_threshold_constant(self):
-        assert _TRANSITION_THRESHOLD == 55.0
-
-    def test_expansion_enables_boundary_detection(self):
-        """End-to-end: short blackout + lobby passes min_blackout_duration after expansion."""
-        # Simulate: 2s blackout + 20s lobby = 22s expanded region
         all_results = {}
         for t in range(200):
             all_results[float(t)] = 80.0
@@ -117,19 +67,98 @@ class TestExpandWithTransitions:
         for t in range(102, 122):
             all_results[float(t)] = 51.0
 
-        blackout_times = [100.0, 101.0]
-        expanded = _expand_with_transitions(blackout_times, all_results, 1.0, 55.0)
+        regions = [(100.0, 101.0)]
+        result = _expand_regions_with_transitions(regions, all_results, 1.0, 55.0)
 
-        # Feed expanded times to _extract_segments
-        segments = _extract_segments(
+        assert len(result) == 1
+        assert result[0][0] == 100.0  # no transition before
+        assert result[0][1] == 121.0  # expanded to end of lobby
+
+    def test_blackout_followed_by_game_not_expanded(self):
+        """Blackout followed by bright game frames is NOT expanded (respawn)."""
+        all_results = {}
+        for t in range(200):
+            all_results[float(t)] = 80.0
+        all_results[100.0] = 5.0
+        all_results[101.0] = 5.0
+
+        regions = [(100.0, 101.0)]
+        result = _expand_regions_with_transitions(regions, all_results, 1.0, 55.0)
+
+        assert result == [(100.0, 101.0)]
+
+    def test_expansion_both_directions(self):
+        """Transition frames before and after blackout are included."""
+        all_results = {}
+        for t in range(50):
+            all_results[float(t)] = 80.0
+        all_results[18.0] = 50.0
+        all_results[19.0] = 50.0
+        all_results[20.0] = 5.0
+        all_results[21.0] = 5.0
+        all_results[22.0] = 50.0
+        all_results[23.0] = 50.0
+
+        regions = [(20.0, 21.0)]
+        result = _expand_regions_with_transitions(regions, all_results, 1.0, 55.0)
+
+        assert len(result) == 1
+        assert result[0][0] == 18.0
+        assert result[0][1] == 23.0
+
+    def test_transition_threshold_constant(self):
+        assert _TRANSITION_THRESHOLD == 55.0
+
+    def test_expansion_enables_boundary_detection(self):
+        """End-to-end: short blackout + lobby passes min_blackout_duration after expansion."""
+        all_results = {}
+        for t in range(200):
+            all_results[float(t)] = 80.0
+        all_results[100.0] = 5.0
+        all_results[101.0] = 5.0
+        for t in range(102, 122):
+            all_results[float(t)] = 51.0
+
+        regions = [(100.0, 101.0)]
+        expanded = _expand_regions_with_transitions(regions, all_results, 1.0, 55.0)
+
+        segments = _filter_and_extract_segments(
             expanded,
             total_duration=200.0,
-            sample_interval=1.0,
             min_match_duration=10.0,
             min_blackout_duration=3.0,
         )
-        # Should detect 2 segments (before and after the expanded blackout)
         assert len(segments) == 2
+
+
+# ============================================================
+# TestGroupBlackoutRegions
+# ============================================================
+
+
+class TestGroupBlackoutRegions:
+    def test_empty(self):
+        assert _group_blackout_regions([], 1.0) == []
+
+    def test_single_timestamp(self):
+        result = _group_blackout_regions([100.0], 1.0)
+        assert result == [(100.0, 100.0)]
+
+    def test_consecutive_merged(self):
+        result = _group_blackout_regions([100.0, 101.0, 102.0], 1.0)
+        assert result == [(100.0, 102.0)]
+
+    def test_gap_splits(self):
+        result = _group_blackout_regions([100.0, 101.0, 200.0, 201.0], 1.0)
+        assert result == [(100.0, 101.0), (200.0, 201.0)]
+
+    def test_tolerance_is_double_interval(self):
+        """Timestamps within 2*interval are merged."""
+        result = _group_blackout_regions([100.0, 102.0], 1.0)  # gap=2.0, tolerance=2.0
+        assert result == [(100.0, 102.0)]
+
+        result = _group_blackout_regions([100.0, 103.0], 1.0)  # gap=3.0 > tolerance=2.0
+        assert len(result) == 2
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

`_extract_segments` を 3 つのパイプライン関数に分割するリファクタリング（動作変更なし）。

- `_group_blackout_regions(blackout_times, sample_interval)` — タイムスタンプを連続領域にグループ化
- `_expand_regions_with_transitions(regions, ...)` — 旧 `_expand_with_transitions` を領域ベースに変更
- `_filter_and_extract_segments(regions, ...)` — 旧 `_extract_segments` から領域グループ化を除去

## 目的

2パス精密計測（#77 の本体）を `_group_blackout_regions` と `_filter_and_extract_segments` の間に挿入するための準備。

## パイプライン

```
blackout_times
  → _group_blackout_regions()
  → _expand_regions_with_transitions()
  → ★ _refine_blackout_regions() ← 次の PR で追加
  → _filter_and_extract_segments()
```

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `allaganeye/video/detector.py` | 関数分割・リネーム |
| `tests/test_detector.py` | 新 API に対応 + `TestGroupBlackoutRegions` (5テスト) 追加 |

## Test plan

- [x] 全 141 テスト通過（動作変更なし）
- [x] ruff check / ruff format 通過

関連: #77

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)