### PR TITLE
feat: ffmpeg/ffprobe auto-discovery (#74)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 
 ### 外部依存
 
-- **ffmpeg / ffprobe**: 4.1 以上。PATH に存在する必要あり
+- **ffmpeg / ffprobe**: 4.1 以上。PATH、`ALLAGANEYE_FFMPEG` 環境変数、または winget の既知パスから自動検索（`allaganeye/ffmpeg_path.py`）
 - **Python パッケージ**: numpy, typer（opencv-python は L1 では不要。L2 以降で使用予定）
 
 ### 動画サンプルデータ

--- a/allaganeye/ffmpeg_path.py
+++ b/allaganeye/ffmpeg_path.py
@@ -1,0 +1,104 @@
+"""Resolve ffmpeg/ffprobe binary paths with auto-discovery."""
+
+import glob
+import os
+import shutil
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+from allaganeye.exceptions import VideoProcessingError
+
+_ENV_VAR = "ALLAGANEYE_FFMPEG"
+
+
+@lru_cache(maxsize=1)
+def find_ffmpeg() -> str:
+    """Find the ffmpeg binary path.
+
+    Resolution order:
+    1. shutil.which("ffmpeg") — works if PATH is set
+    2. ALLAGANEYE_FFMPEG env var — user-specified directory containing ffmpeg
+    3. Windows known paths — winget typical install location
+    4. Error with setup instructions
+    """
+    return _find_binary("ffmpeg")
+
+
+@lru_cache(maxsize=1)
+def find_ffprobe() -> str:
+    """Find the ffprobe binary path. Same resolution order as find_ffmpeg."""
+    return _find_binary("ffprobe")
+
+
+def _find_binary(name: str) -> str:
+    # 1. PATH lookup
+    found = shutil.which(name)
+    if found:
+        return found
+
+    # 2. Environment variable
+    env_dir = os.environ.get(_ENV_VAR)
+    if env_dir:
+        candidate = _check_dir(Path(env_dir), name)
+        if candidate:
+            return candidate
+
+    # 3. Windows known paths
+    if sys.platform == "win32":
+        candidate = _search_windows_known_paths(name)
+        if candidate:
+            return candidate
+
+    # 4. Error
+    raise VideoProcessingError(_error_message(name))
+
+
+def _check_dir(directory: Path, name: str) -> str | None:
+    """Check if a binary exists in the given directory."""
+    for ext in ("", ".exe"):
+        candidate = directory / f"{name}{ext}"
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def _search_windows_known_paths(name: str) -> str | None:
+    """Search common Windows installation paths for ffmpeg/ffprobe."""
+    local_app_data = os.environ.get("LOCALAPPDATA", "")
+    if not local_app_data:
+        return None
+
+    # winget: Gyan.FFmpeg package
+    pattern = os.path.join(
+        local_app_data,
+        "Microsoft",
+        "WinGet",
+        "Packages",
+        "Gyan.FFmpeg*",
+        "ffmpeg-*",
+        "bin",
+        f"{name}.exe",
+    )
+    matches = glob.glob(pattern)
+    if matches:
+        # Use the most recently modified match
+        matches.sort(key=os.path.getmtime, reverse=True)
+        return matches[0]
+
+    return None
+
+
+def _error_message(name: str) -> str:
+    lines = [
+        f"{name} not found. Install ffmpeg and ensure it is accessible.",
+        "",
+        "Options:",
+        "  1. Add ffmpeg to PATH",
+        f"  2. Set {_ENV_VAR} environment variable to the directory containing {name}",
+    ]
+    if sys.platform == "win32":
+        lines.append(
+            "  3. Install via winget: winget install Gyan.FFmpeg (auto-discovered)"
+        )
+    return "\n".join(lines)

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 
 from allaganeye.exceptions import VideoProcessingError
+from allaganeye.ffmpeg_path import find_ffmpeg
 
 _SAMPLE_WIDTH = 320
 _SAMPLE_HEIGHT = 180
@@ -114,7 +115,7 @@ def _probe_single_frame(video_path: Path, timestamp: float) -> float:
     (treated as non-blackout to avoid false positives).
     """
     cmd = [
-        "ffmpeg",
+        find_ffmpeg(),
         "-threads",
         "1",
         "-ss",

--- a/allaganeye/video/probe.py
+++ b/allaganeye/video/probe.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 from allaganeye.exceptions import InputFileError, VideoProcessingError
+from allaganeye.ffmpeg_path import find_ffprobe
 
 
 def _parse_frame_rate(rate_str: str) -> float:
@@ -25,7 +26,7 @@ def probe_video(video_path: Path) -> dict:
     try:
         result = subprocess.run(
             [
-                "ffprobe",
+                find_ffprobe(),
                 "-v",
                 "quiet",
                 "-print_format",

--- a/allaganeye/video/splitter.py
+++ b/allaganeye/video/splitter.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 
 from allaganeye.exceptions import VideoProcessingError
+from allaganeye.ffmpeg_path import find_ffmpeg
 
 
 def split_video(
@@ -53,7 +54,7 @@ def _ffmpeg_split(
     try:
         result = subprocess.run(
             [
-                "ffmpeg",
+                find_ffmpeg(),
                 "-y",
                 "-ss",
                 str(start),

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,7 +53,15 @@ ffmpeg -version   # "ffmpeg version 4.x" 以上が表示されること
 ffprobe -version  # "ffprobe version 4.x" 以上が表示されること
 ```
 
-PATH が通っていない場合は、ターミナルを再起動するか環境変数の設定を確認してください。
+**PATH が通らない場合**: Allagan Eye は winget のインストール先を自動検索するため、多くの場合 PATH の手動設定は不要です。自動検索で見つからない場合は `ALLAGANEYE_FFMPEG` 環境変数に ffmpeg/ffprobe の入ったディレクトリを指定してください:
+
+```bash
+# Windows
+set ALLAGANEYE_FFMPEG=C:\path\to\ffmpeg\bin
+
+# Linux / macOS
+export ALLAGANEYE_FFMPEG=/path/to/ffmpeg/bin
+```
 
 ## 2. インストール
 
@@ -114,3 +122,17 @@ allaganeye split your_recording.mkv --min-blackout-duration 5.0
 ### 分割が途中で失敗した場合
 
 途中で失敗しても、成功済みの出力ファイル（`match_001.mp4` 等）は出力ディレクトリに残ります。再実行すれば自動的に上書きされるため、手動削除は不要です。
+
+## 開発者向け
+
+### 実動画テストの実行
+
+実動画を使った統合テスト（`pytest -m slow`）には以下の環境変数が必要:
+
+```bash
+# Windows
+set ALLAGANEYE_SAMPLE_VIDEO_DIR=E:\path\to\videos
+
+# Linux / macOS
+export ALLAGANEYE_SAMPLE_VIDEO_DIR=/path/to/videos
+```

--- a/tests/test_ffmpeg_path.py
+++ b/tests/test_ffmpeg_path.py
@@ -1,0 +1,135 @@
+"""Tests for ffmpeg/ffprobe path resolution."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from allaganeye.exceptions import VideoProcessingError
+from allaganeye.ffmpeg_path import (
+    _ENV_VAR,
+    _check_dir,
+    _find_binary,
+    _search_windows_known_paths,
+    find_ffmpeg,
+    find_ffprobe,
+)
+
+
+class TestFindBinary:
+    """Tests for the 4-stage resolution logic."""
+
+    def test_found_via_which(self):
+        with patch(
+            "allaganeye.ffmpeg_path.shutil.which", return_value="/usr/bin/ffmpeg"
+        ):
+            result = _find_binary("ffmpeg")
+        assert result == "/usr/bin/ffmpeg"
+
+    def test_found_via_env_var(self, tmp_path):
+        ffmpeg_bin = tmp_path / "ffmpeg.exe"
+        ffmpeg_bin.touch()
+        with (
+            patch("allaganeye.ffmpeg_path.shutil.which", return_value=None),
+            patch.dict(os.environ, {_ENV_VAR: str(tmp_path)}),
+            patch(
+                "allaganeye.ffmpeg_path._search_windows_known_paths", return_value=None
+            ),
+        ):
+            result = _find_binary("ffmpeg")
+        assert result == str(ffmpeg_bin)
+
+    def test_env_var_dir_missing_binary(self, tmp_path):
+        """Env var dir exists but doesn't contain ffmpeg."""
+        with (
+            patch("allaganeye.ffmpeg_path.shutil.which", return_value=None),
+            patch.dict(os.environ, {_ENV_VAR: str(tmp_path)}),
+            patch(
+                "allaganeye.ffmpeg_path._search_windows_known_paths", return_value=None
+            ),
+        ):
+            with pytest.raises(VideoProcessingError, match="not found"):
+                _find_binary("ffmpeg")
+
+    def test_not_found_raises(self):
+        with (
+            patch("allaganeye.ffmpeg_path.shutil.which", return_value=None),
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "allaganeye.ffmpeg_path._search_windows_known_paths", return_value=None
+            ),
+        ):
+            with pytest.raises(VideoProcessingError, match="not found"):
+                _find_binary("ffmpeg")
+
+    def test_error_message_includes_env_var(self):
+        with (
+            patch("allaganeye.ffmpeg_path.shutil.which", return_value=None),
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "allaganeye.ffmpeg_path._search_windows_known_paths", return_value=None
+            ),
+        ):
+            with pytest.raises(VideoProcessingError, match=_ENV_VAR):
+                _find_binary("ffmpeg")
+
+    def test_priority_which_over_env(self, tmp_path):
+        """shutil.which takes precedence over env var."""
+        ffmpeg_bin = tmp_path / "ffmpeg.exe"
+        ffmpeg_bin.touch()
+        with (
+            patch(
+                "allaganeye.ffmpeg_path.shutil.which", return_value="/usr/bin/ffmpeg"
+            ),
+            patch.dict(os.environ, {_ENV_VAR: str(tmp_path)}),
+        ):
+            result = _find_binary("ffmpeg")
+        assert result == "/usr/bin/ffmpeg"
+
+
+class TestCheckDir:
+    def test_finds_exe(self, tmp_path):
+        (tmp_path / "ffmpeg.exe").touch()
+        assert _check_dir(tmp_path, "ffmpeg") == str(tmp_path / "ffmpeg.exe")
+
+    def test_finds_no_ext(self, tmp_path):
+        (tmp_path / "ffmpeg").touch()
+        assert _check_dir(tmp_path, "ffmpeg") == str(tmp_path / "ffmpeg")
+
+    def test_not_found(self, tmp_path):
+        assert _check_dir(tmp_path, "ffmpeg") is None
+
+
+class TestSearchWindowsKnownPaths:
+    def test_returns_none_without_localappdata(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert _search_windows_known_paths("ffmpeg") is None
+
+    def test_returns_none_when_no_match(self, tmp_path):
+        with patch.dict(os.environ, {"LOCALAPPDATA": str(tmp_path)}):
+            assert _search_windows_known_paths("ffmpeg") is None
+
+
+class TestCaching:
+    def test_find_ffmpeg_is_cached(self):
+        """find_ffmpeg returns cached result on second call."""
+        find_ffmpeg.cache_clear()
+        with patch(
+            "allaganeye.ffmpeg_path._find_binary", return_value="/usr/bin/ffmpeg"
+        ) as mock:
+            result1 = find_ffmpeg()
+            result2 = find_ffmpeg()
+        assert result1 == result2
+        mock.assert_called_once()
+        find_ffmpeg.cache_clear()
+
+    def test_find_ffprobe_is_cached(self):
+        find_ffprobe.cache_clear()
+        with patch(
+            "allaganeye.ffmpeg_path._find_binary", return_value="/usr/bin/ffprobe"
+        ) as mock:
+            result1 = find_ffprobe()
+            result2 = find_ffprobe()
+        assert result1 == result2
+        mock.assert_called_once()
+        find_ffprobe.cache_clear()


### PR DESCRIPTION
## Summary

ffmpeg/ffprobe のパスを 4段階で自動解決するヘルパーを追加。winget ユーザーは PATH 設定なしで利用可能に。

### 解決順序

1. `shutil.which()` — PATH に通っていれば即解決
2. `ALLAGANEYE_FFMPEG` 環境変数 — ユーザーが明示指定（PATH を汚さない）
3. Windows winget の既知パスを glob 検索 — `%LOCALAPPDATA%\Microsoft\WinGet\Packages\Gyan.FFmpeg*\*\bin`
4. 設定手順付きエラーメッセージ

結果は `lru_cache` でキャッシュ（毎回 glob しない）。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `allaganeye/ffmpeg_path.py` | 新規: `find_ffmpeg()`, `find_ffprobe()` + 自動検索ロジック |
| `allaganeye/video/detector.py` | `"ffmpeg"` → `find_ffmpeg()` |
| `allaganeye/video/probe.py` | `"ffprobe"` → `find_ffprobe()` |
| `allaganeye/video/splitter.py` | `"ffmpeg"` → `find_ffmpeg()` |
| `tests/test_ffmpeg_path.py` | 新規: 13テスト（4段階解決、キャッシュ、エラーメッセージ） |
| `docs/quickstart.md` | `ALLAGANEYE_FFMPEG` の説明 + 開発者向けセクション追加 |
| `CLAUDE.md` | 外部依存セクション更新 |

## Test plan

- [x] 全 160 テスト通過
- [x] ruff check / ruff format 通過
- [ ] tester: winget 環境で PATH 未設定の状態から自動検索が動作すること

関連: #74

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)