### PR TITLE
fix: replace opencv-python with numpy in dependencies (#85)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
     "typer>=0.9",
-    "opencv-python>=4.8",
+    "numpy>=1.24",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- `pyproject.toml`: `opencv-python>=4.8` → `numpy>=1.24`
- L1 では OpenCV 未使用（検知は ffmpeg プローブ）
- numpy は detector.py で直接使用（`np.frombuffer`, `np.mean`）

## Test plan

- [x] 全 147 テスト通過
- [x] ruff check / ruff format 通過

関連: #85

作成: lead-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)