### PR TITLE
docs: /release スキルに deferred issue レビューを必須化

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -16,12 +16,30 @@ description: バージョンバンプとリリースPRの作成を自動化す�
 
 ## 手順
 
+### Step 1: deferred issue のレビュー（必須）
+
+リリース前に `deferred` ラベル付き issue を全件レビューする。このステップはスキップできない。
+
+```bash
+gh issue list --repo Idios/kobutachan-allaganeye --state open --label "deferred" --json number,title,labels
+```
+
+- 各 issue について、次バージョンのスコープに含めるか・引き続き deferred かをユーザーに確認する
+- スコープに含める場合: `deferred` を外し、適切な `role:*` + 優先度ラベルに変更
+- deferred issue が 0 件の場合のみ自動で次ステップに進む
+- 1 件以上ある場合: **必ずユーザーに判断を求めてから** 次に進む
+
+### Step 2: リリース準備
+
 1. 現在のバージョンを `pyproject.toml` から取得
 2. 前回リリースタグ以降のコミットを分析:
    ```bash
    git log $(git describe --tags --abbrev=0 2>/dev/null || echo "HEAD~50")..HEAD --oneline
    ```
 3. バージョン種別を決定（引数指定 or コミット内容から自動判定）
+
+### Step 3: バージョンバンプと PR 作成
+
 4. `pyproject.toml` の `version` を更新
 5. リリースブランチを作成:
    ```bash
@@ -40,11 +58,15 @@ description: バージョンバンプとリリースPRの作成を自動化す�
    ### 変更内容
    <コミット分析結果のサマリー>
 
+   ### deferred issue レビュー結果
+   <Step 1 の判断結果を記載>
+
    ### チェックリスト
    - [ ] バージョン番号が正しい
    - [ ] 全テスト通過
+   - [ ] deferred issue を全件レビュー済み
    - [ ] CLAUDE.md の更新が必要な変更はない
    EOF
-   )" --label "release"
+   )" --label "release" --assignee Idios
    ```
 8. ユーザーに PR URL とバージョン変更内容を報告


### PR DESCRIPTION
## Summary

`/release` スキル実行時に `deferred` ラベル付き issue の全件レビューを必須ステップとして追加。

- Step 1 で deferred issue を一覧表示し、ユーザーに判断を求める
- 0 件の場合のみ自動で次へ進む
- PR チェックリストにも「deferred issue レビュー済み」を追加

これにより、リリース時の deferred issue 見落としを防止する。

関連: #83

## Test plan

- [x] スキル内容の正確性確認
- [ ] lead-engineer レビュー

作成: director-1