### PR TITLE
feat: --gpu mode with chunked parallel GPU decode (#37)

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -59,6 +59,14 @@ def split(
     dry_run: Annotated[
         bool, typer.Option("--dry-run", help="Detect only, do not split")
     ] = False,
+    gpu: Annotated[
+        bool,
+        typer.Option(
+            "--gpu/--no-gpu",
+            help="Use GPU-accelerated detection (chunked parallel decode). "
+            "Falls back to CPU if GPU is unavailable.",
+        ),
+    ] = False,
     verbose: Annotated[
         bool, typer.Option("-v", "--verbose", help="Verbose output")
     ] = False,
@@ -81,6 +89,7 @@ def split(
             min_match_duration=min_match_duration,
             min_blackout_duration=min_blackout_duration,
             dry_run=dry_run,
+            use_gpu=gpu,
         )
 
         from allaganeye.commands.split_matches import run_split

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -63,6 +63,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
                 blackout_threshold=config.blackout_threshold,
                 min_match_duration=config.min_match_duration,
                 min_blackout_duration=config.min_blackout_duration,
+                use_gpu=config.use_gpu,
                 progress_callback=on_progress,
             )
     else:
@@ -73,6 +74,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             blackout_threshold=config.blackout_threshold,
             min_match_duration=config.min_match_duration,
             min_blackout_duration=config.min_blackout_duration,
+            use_gpu=config.use_gpu,
         )
 
     if not boundaries:

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -16,6 +16,7 @@ class SplitConfig:
     min_match_duration: float = 300.0
     min_blackout_duration: float = 3.0
     dry_run: bool = False
+    use_gpu: bool = False
 
     def __post_init__(self) -> None:
         if self.sample_interval <= 0:

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -24,18 +24,16 @@ def detect_match_boundaries(
     blackout_threshold: float = 15.0,
     min_match_duration: float = 300.0,
     min_blackout_duration: float = 3.0,
+    use_gpu: bool = False,
     progress_callback: Callable[[int, int, int], None] | None = None,
 ) -> list[dict]:
     """Detect match boundaries by finding blackout frames.
 
-    Uses parallel ffmpeg ``-ss`` probes to extract one frame per
-    *sample_interval* seconds.  Each probe seeks to the target timestamp
-    (keyframe-based input seeking) and decodes only one frame, avoiding
-    the cost of decoding the entire stream.
-
     Args:
         duration_hint: Video duration in seconds from ffprobe.  Required
             to generate the list of sample timestamps.
+        use_gpu: If True, use chunked parallel GPU decode instead of
+            per-frame -ss probes.  Falls back to CPU on failure.
         progress_callback: Optional callback invoked after each sampled
             frame with ``(completed_count, total_samples, blackout_count)``.
 
@@ -46,31 +44,35 @@ def detect_match_boundaries(
             "Cannot determine video duration. Provide duration_hint via probe."
         )
 
-    timestamps = _generate_timestamps(duration_hint, sample_interval)
-    if not timestamps:
-        return []
+    # Pass 1: scan for blackout frames
+    if use_gpu:
+        from allaganeye.video.gpu_detector import scan_gpu
 
-    total_samples = len(timestamps)
-    max_workers = min(os.cpu_count() or 4, 24)
-
-    # Parallel -ss probes
-    results: dict[float, float] = {}  # timestamp → brightness
-    blackout_count = 0
-    completed = 0
-
-    with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futures = {
-            pool.submit(_probe_single_frame, video_path, t): t for t in timestamps
-        }
-        for future in as_completed(futures):
-            t = futures[future]
-            brightness = future.result()
-            results[t] = brightness
-            completed += 1
-            if brightness < blackout_threshold:
-                blackout_count += 1
-            if progress_callback is not None:
-                progress_callback(completed, total_samples, blackout_count)
+        try:
+            results = scan_gpu(
+                video_path,
+                duration_hint,
+                sample_interval,
+                blackout_threshold,
+                progress_callback,
+            )
+        except VideoProcessingError:
+            # GPU failed — fall back to CPU
+            results = _scan_cpu(
+                video_path,
+                duration_hint,
+                sample_interval,
+                blackout_threshold,
+                progress_callback,
+            )
+    else:
+        results = _scan_cpu(
+            video_path,
+            duration_hint,
+            sample_interval,
+            blackout_threshold,
+            progress_callback,
+        )
 
     # Collect blackout timestamps in chronological order
     blackout_times = sorted(t for t, b in results.items() if b < blackout_threshold)
@@ -93,6 +95,42 @@ def detect_match_boundaries(
         min_match_duration,
         effective_min,
     )
+
+
+def _scan_cpu(
+    video_path: Path,
+    duration_hint: float,
+    sample_interval: float,
+    blackout_threshold: float,
+    progress_callback: Callable[[int, int, int], None] | None = None,
+) -> dict[float, float]:
+    """CPU mode: parallel -ss probes, one ffmpeg process per frame."""
+    timestamps = _generate_timestamps(duration_hint, sample_interval)
+    if not timestamps:
+        return {}
+
+    total_samples = len(timestamps)
+    max_workers = min(os.cpu_count() or 4, 24)
+
+    results: dict[float, float] = {}
+    blackout_count = 0
+    completed = 0
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(_probe_single_frame, video_path, t): t for t in timestamps
+        }
+        for future in as_completed(futures):
+            t = futures[future]
+            brightness = future.result()
+            results[t] = brightness
+            completed += 1
+            if brightness < blackout_threshold:
+                blackout_count += 1
+            if progress_callback is not None:
+                progress_callback(completed, total_samples, blackout_count)
+
+    return results
 
 
 def _generate_timestamps(duration: float, interval: float) -> list[float]:

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -1,0 +1,148 @@
+"""GPU-accelerated match detection using chunked parallel ffmpeg decode."""
+
+import os
+import subprocess
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import numpy as np
+
+from allaganeye.exceptions import VideoProcessingError
+from allaganeye.ffmpeg_path import find_ffmpeg
+from allaganeye.video.detector import _FRAME_SIZE, _SAMPLE_HEIGHT, _SAMPLE_WIDTH
+
+
+def scan_gpu(
+    video_path: Path,
+    duration: float,
+    sample_interval: float,
+    blackout_threshold: float,
+    progress_callback: Callable[[int, int, int], None] | None = None,
+) -> dict[float, float]:
+    """GPU mode: chunked parallel decode with -hwaccel auto.
+
+    Splits the video timeline into chunks and runs one long-lived ffmpeg
+    process per chunk with GPU-accelerated decoding.  Each process uses
+    ``fps=1/{interval}`` to output one frame per interval, which is read
+    from stdout and analyzed for brightness.
+
+    Returns dict mapping timestamp → brightness, same as CPU mode.
+
+    Raises VideoProcessingError if GPU decode fails for all chunks.
+    """
+    num_chunks = min(os.cpu_count() or 4, 16)
+    chunk_duration = duration / num_chunks
+
+    chunks: list[tuple[float, float]] = []
+    for i in range(num_chunks):
+        chunk_start = i * chunk_duration
+        chunk_end = min((i + 1) * chunk_duration, duration)
+        chunks.append((chunk_start, chunk_end))
+
+    total_expected = int(duration / sample_interval)
+    results: dict[float, float] = {}
+    blackout_count = 0
+    completed = 0
+    gpu_failed = False
+
+    with ThreadPoolExecutor(max_workers=num_chunks) as pool:
+        futures = {
+            pool.submit(
+                _decode_chunk,
+                video_path,
+                chunk_start,
+                chunk_end,
+                sample_interval,
+            ): (chunk_start, chunk_end)
+            for chunk_start, chunk_end in chunks
+        }
+        for future in as_completed(futures):
+            chunk_start, chunk_end = futures[future]
+            try:
+                chunk_results = future.result()
+            except VideoProcessingError:
+                gpu_failed = True
+                break
+            for t, brightness in chunk_results.items():
+                results[t] = brightness
+                completed += 1
+                if brightness < blackout_threshold:
+                    blackout_count += 1
+                if progress_callback is not None:
+                    progress_callback(completed, total_expected, blackout_count)
+
+    if gpu_failed:
+        raise VideoProcessingError("GPU decode failed, falling back to CPU")
+
+    return results
+
+
+def _decode_chunk(
+    video_path: Path,
+    chunk_start: float,
+    chunk_end: float,
+    sample_interval: float,
+) -> dict[float, float]:
+    """Decode a single chunk using GPU-accelerated ffmpeg.
+
+    Runs one ffmpeg process that decodes from chunk_start to chunk_end,
+    outputting one frame per sample_interval via the fps filter.
+    """
+    chunk_duration = chunk_end - chunk_start
+    fps_value = 1.0 / sample_interval
+
+    cmd = [
+        find_ffmpeg(),
+        "-hwaccel",
+        "auto",
+        "-ss",
+        str(chunk_start),
+        "-t",
+        str(chunk_duration),
+        "-i",
+        str(video_path),
+        "-vf",
+        f"fps={fps_value},scale={_SAMPLE_WIDTH}:{_SAMPLE_HEIGHT},format=gray",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "gray",
+        "pipe:1",
+    ]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=max(300, int(chunk_duration * 2)),
+        )
+    except FileNotFoundError as e:
+        raise VideoProcessingError(
+            "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise VideoProcessingError(
+            f"GPU decode timed out for chunk {chunk_start}"
+        ) from e
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.decode(errors="replace")[-500:]
+        raise VideoProcessingError(f"GPU decode failed: {stderr}")
+
+    # Parse raw frames from stdout
+    data = proc.stdout
+    results: dict[float, float] = {}
+    frame_idx = 0
+    offset = 0
+
+    while offset + _FRAME_SIZE <= len(data):
+        frame = np.frombuffer(data[offset : offset + _FRAME_SIZE], dtype=np.uint8)
+        brightness = float(frame.mean())
+        timestamp = round(chunk_start + frame_idx * sample_interval, 4)
+        if timestamp < chunk_end:
+            results[timestamp] = brightness
+        offset += _FRAME_SIZE
+        frame_idx += 1
+
+    return results

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -1,0 +1,133 @@
+"""Tests for GPU-accelerated detection."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from allaganeye.exceptions import VideoProcessingError
+from allaganeye.video.detector import _FRAME_SIZE
+from allaganeye.video.gpu_detector import _decode_chunk, scan_gpu
+
+
+def _make_frames(brightness_values: list[int]) -> bytes:
+    """Create raw frame data for a sequence of brightness values."""
+    return b"".join(bytes([b]) * _FRAME_SIZE for b in brightness_values)
+
+
+class TestDecodeChunk:
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_parses_frames(self, mock_run):
+        """Correctly parses multiple frames from stdout."""
+        mock_run.return_value = MagicMock(
+            stdout=_make_frames([128, 5, 200]),
+            stderr=b"",
+            returncode=0,
+        )
+        result = _decode_chunk(Path("test.mp4"), 100.0, 103.0, 1.0)
+
+        assert len(result) == 3
+        assert result[100.0] == pytest.approx(128.0)
+        assert result[101.0] == pytest.approx(5.0)
+        assert result[102.0] == pytest.approx(200.0)
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_hwaccel_in_cmd(self, mock_run):
+        """ffmpeg command includes -hwaccel auto."""
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0)
+
+        cmd = mock_run.call_args[0][0]
+        assert "-hwaccel" in cmd
+        assert "auto" in cmd
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_nonzero_returncode_raises(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"error", returncode=1)
+        with pytest.raises(VideoProcessingError, match="GPU decode failed"):
+            _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0)
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_ffmpeg_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("ffmpeg")
+        with pytest.raises(VideoProcessingError, match="ffmpeg not found"):
+            _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0)
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_timeout_raises(self, mock_run):
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=300)
+        with pytest.raises(VideoProcessingError, match="timed out"):
+            _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0)
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_timestamps_respect_chunk_start(self, mock_run):
+        """Timestamps start from chunk_start, not 0."""
+        mock_run.return_value = MagicMock(
+            stdout=_make_frames([100, 100]),
+            stderr=b"",
+            returncode=0,
+        )
+        result = _decode_chunk(Path("test.mp4"), 500.0, 502.0, 1.0)
+
+        assert 500.0 in result
+        assert 501.0 in result
+        assert 0.0 not in result
+
+
+class TestScanGpu:
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_collects_all_chunks(self, mock_decode):
+        """Results from all chunks are merged."""
+        mock_decode.return_value = {0.0: 128.0}
+        result = scan_gpu(Path("test.mp4"), 10.0, 1.0, 15.0)
+
+        assert len(result) >= 1
+        assert mock_decode.call_count >= 1
+
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_gpu_failure_raises(self, mock_decode):
+        """GPU failure raises VideoProcessingError for fallback."""
+        mock_decode.side_effect = VideoProcessingError("GPU decode failed")
+
+        with pytest.raises(VideoProcessingError, match="falling back"):
+            scan_gpu(Path("test.mp4"), 10.0, 1.0, 15.0)
+
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_progress_callback(self, mock_decode):
+        """Progress callback is invoked."""
+        mock_decode.return_value = {0.0: 128.0, 1.0: 5.0}
+        calls: list[tuple] = []
+
+        scan_gpu(
+            Path("test.mp4"),
+            10.0,
+            1.0,
+            15.0,
+            progress_callback=lambda c, t, bc: calls.append((c, t, bc)),
+        )
+
+        assert len(calls) >= 1
+
+
+class TestGpuFallbackIntegration:
+    @patch("allaganeye.video.detector._scan_cpu")
+    @patch("allaganeye.video.gpu_detector.scan_gpu")
+    def test_fallback_to_cpu(self, mock_gpu, mock_cpu):
+        """GPU failure triggers CPU fallback in detect_match_boundaries."""
+        from allaganeye.video.detector import detect_match_boundaries
+
+        mock_gpu.side_effect = VideoProcessingError("GPU failed")
+        mock_cpu.return_value = {0.0: 128.0, 100.0: 128.0, 200.0: 128.0}
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=300.0,
+            min_match_duration=100.0,
+            use_gpu=True,
+        )
+
+        mock_gpu.assert_called_once()
+        mock_cpu.assert_called_once()
+        assert len(result) >= 1

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -81,6 +81,7 @@ def test_pipeline_happy_path(mock_probe, mock_detect, mock_split, tmp_path):
         blackout_threshold=config.blackout_threshold,
         min_match_duration=config.min_match_duration,
         min_blackout_duration=config.min_blackout_duration,
+        use_gpu=config.use_gpu,
     )
     mock_split.assert_called_once_with(video, BOUNDARIES, tmp_path)
     assert (tmp_path / "metadata.json").exists()
@@ -311,6 +312,7 @@ def test_pipeline_auto_interval_long_video(
         blackout_threshold=config.blackout_threshold,
         min_match_duration=config.min_match_duration,
         min_blackout_duration=config.min_blackout_duration,
+        use_gpu=config.use_gpu,
     )
 
 
@@ -343,4 +345,5 @@ def test_pipeline_config_params_forwarded(
         blackout_threshold=20.0,
         min_match_duration=120.0,
         min_blackout_duration=3.0,
+        use_gpu=False,
     )


### PR DESCRIPTION
## Summary

CPU/GPU 2方式の共存アーキテクチャを導入。既存の CPU モードに一切変更なし。

### CPU モード（`--no-gpu`、デフォルト）
既存の並列 `-ss` プローブ。変更なし。

### GPU モード（`--gpu`）
動画を N チャンクに分割し、各チャンクで 1 ffmpeg プロセスが `-hwaccel auto` + `fps` フィルタで間引きデコード。GPU コンテキスト初期化コストを償却。

```
detect_match_boundaries(use_gpu=True)
  ├── scan_gpu()  → チャンク並列 GPU デコード
  │   └── GPU 失敗時 → _scan_cpu() に自動フォールバック
  └── 共通パイプライン: transition expansion → refine → filter
```

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `allaganeye/video/gpu_detector.py` | 新規: `scan_gpu()`, `_decode_chunk()` |
| `allaganeye/video/detector.py` | `use_gpu` パラメータ追加、CPU スキャンを `_scan_cpu()` に抽出、GPU フォールバック |
| `allaganeye/config.py` | `SplitConfig.use_gpu: bool = False` |
| `allaganeye/cli.py` | `--gpu/--no-gpu` オプション |
| `allaganeye/commands/split_matches.py` | `use_gpu` パススルー |
| `tests/test_gpu_detector.py` | 新規: 10テスト（チャンクデコード、フォールバック、コマンド構築） |
| `tests/test_split_matches.py` | `use_gpu` パラメータ追加 |

## Test plan

- [x] 全 170 テスト通過（CPU モードのリグレッションなし）
- [x] ruff check / ruff format 通過
- [ ] tester: GPU 環境での `--gpu` ベンチマーク（37GB MKV）
- [ ] tester: GPU なし環境での `--gpu` フォールバック動作確認

関連: #37

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)