### PR TITLE
feat: --workers option for parallel detection (#4)

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -56,6 +56,10 @@ def split(
             "Shorter blackouts (e.g. respawn) are ignored."
         ),
     ] = 3.0,
+    workers: Annotated[
+        int | None,
+        typer.Option(help="Number of parallel workers for detection (default: auto)"),
+    ] = None,
     dry_run: Annotated[
         bool, typer.Option("--dry-run", help="Detect only, do not split")
     ] = False,
@@ -90,6 +94,7 @@ def split(
             min_blackout_duration=min_blackout_duration,
             dry_run=dry_run,
             use_gpu=gpu,
+            workers=workers,
         )
 
         from allaganeye.commands.split_matches import run_split
@@ -119,6 +124,10 @@ def debug_brightness(
     interval: Annotated[
         float, typer.Option("--interval", help="Sampling interval in seconds")
     ] = 1.0,
+    workers: Annotated[
+        int | None,
+        typer.Option(help="Number of parallel workers (default: auto)"),
+    ] = None,
 ) -> None:
     """Probe frame brightness at regular intervals (CSV output for threshold tuning)."""
     try:
@@ -133,7 +142,9 @@ def debug_brightness(
 
         from allaganeye.commands.debug_brightness import run_debug_brightness
 
-        run_debug_brightness(video_path, start=start, end=end, interval=interval)
+        run_debug_brightness(
+            video_path, start=start, end=end, interval=interval, workers=workers
+        )
 
     except AllaganEyeError as e:
         typer.echo(f"Error: {e}", err=True)

--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -1,6 +1,5 @@
 """Debug-brightness command: probe frame brightness and output CSV."""
 
-import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -16,6 +15,7 @@ def run_debug_brightness(
     start: float = 0.0,
     end: float | None = None,
     interval: float = 1.0,
+    workers: int | None = None,
 ) -> None:
     """Probe brightness at regular intervals and print CSV to stdout."""
     metadata = probe_video(video_path)
@@ -37,7 +37,9 @@ def run_debug_brightness(
         typer.echo("No timestamps to probe.", err=True)
         raise typer.Exit(code=1)
 
-    max_workers = min(os.cpu_count() or 4, 24)
+    from allaganeye.video.detector import _resolve_workers
+
+    max_workers = _resolve_workers(workers)
     results: dict[float, float] = {}
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -64,6 +64,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
                 min_match_duration=config.min_match_duration,
                 min_blackout_duration=config.min_blackout_duration,
                 use_gpu=config.use_gpu,
+                workers=config.workers,
                 progress_callback=on_progress,
             )
     else:
@@ -75,6 +76,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             min_match_duration=config.min_match_duration,
             min_blackout_duration=config.min_blackout_duration,
             use_gpu=config.use_gpu,
+            workers=config.workers,
         )
 
     if not boundaries:

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -17,8 +17,13 @@ class SplitConfig:
     min_blackout_duration: float = 3.0
     dry_run: bool = False
     use_gpu: bool = False
+    workers: int | None = None
 
     def __post_init__(self) -> None:
+        if self.workers is not None and self.workers < 1:
+            raise ConfigValidationError(
+                f"--workers must be at least 1, got {self.workers}"
+            )
         if self.sample_interval <= 0:
             raise ConfigValidationError(
                 f"--sample-interval must be positive, got {self.sample_interval}"

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -16,6 +16,13 @@ _SAMPLE_HEIGHT = 180
 _FRAME_SIZE = _SAMPLE_WIDTH * _SAMPLE_HEIGHT  # grayscale, 1 byte per pixel
 
 
+def _resolve_workers(workers: int | None) -> int:
+    """Resolve worker count: explicit value or auto-detect."""
+    if workers is not None:
+        return workers
+    return min(os.cpu_count() or 4, 24)
+
+
 def detect_match_boundaries(
     video_path: Path,
     *,
@@ -25,6 +32,7 @@ def detect_match_boundaries(
     min_match_duration: float = 300.0,
     min_blackout_duration: float = 3.0,
     use_gpu: bool = False,
+    workers: int | None = None,
     progress_callback: Callable[[int, int, int], None] | None = None,
 ) -> list[dict]:
     """Detect match boundaries by finding blackout frames.
@@ -63,6 +71,7 @@ def detect_match_boundaries(
                 duration_hint,
                 sample_interval,
                 blackout_threshold,
+                workers,
                 progress_callback,
             )
     else:
@@ -71,6 +80,7 @@ def detect_match_boundaries(
             duration_hint,
             sample_interval,
             blackout_threshold,
+            workers,
             progress_callback,
         )
 
@@ -85,7 +95,7 @@ def detect_match_boundaries(
 
     # 2nd pass: refine blackout regions at fine interval (#77)
     refined_regions = _refine_blackout_regions(
-        video_path, blackout_regions, blackout_threshold, duration_hint
+        video_path, blackout_regions, blackout_threshold, duration_hint, workers
     )
 
     effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)
@@ -102,6 +112,7 @@ def _scan_cpu(
     duration_hint: float,
     sample_interval: float,
     blackout_threshold: float,
+    workers: int | None = None,
     progress_callback: Callable[[int, int, int], None] | None = None,
 ) -> dict[float, float]:
     """CPU mode: parallel -ss probes, one ffmpeg process per frame."""
@@ -110,7 +121,7 @@ def _scan_cpu(
         return {}
 
     total_samples = len(timestamps)
-    max_workers = min(os.cpu_count() or 4, 24)
+    max_workers = _resolve_workers(workers)
 
     results: dict[float, float] = {}
     blackout_count = 0
@@ -305,6 +316,7 @@ def _refine_blackout_regions(
     blackout_regions: list[tuple[float, float]],
     blackout_threshold: float,
     total_duration: float,
+    workers: int | None = None,
 ) -> list[tuple[float, float]]:
     """Re-probe blackout regions at fine interval for precise duration.
 
@@ -315,7 +327,7 @@ def _refine_blackout_regions(
     if not blackout_regions:
         return blackout_regions
 
-    max_workers = min(os.cpu_count() or 4, 24)
+    max_workers = _resolve_workers(workers)
 
     # Collect all timestamps to probe (deduplicated)
     probe_timestamps: set[float] = set()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,22 @@ class TestSplitConfigValidation:
         with pytest.raises(ConfigValidationError, match="min-match-duration"):
             SplitConfig(min_match_duration=-100.0)
 
+    def test_workers_none_is_valid(self):
+        config = SplitConfig(workers=None)
+        assert config.workers is None
+
+    def test_workers_positive_is_valid(self):
+        config = SplitConfig(workers=4)
+        assert config.workers == 4
+
+    def test_workers_zero_raises(self):
+        with pytest.raises(ConfigValidationError, match="workers"):
+            SplitConfig(workers=0)
+
+    def test_workers_negative_raises(self):
+        with pytest.raises(ConfigValidationError, match="workers"):
+            SplitConfig(workers=-1)
+
     def test_exit_code_is_5(self):
         with pytest.raises(ConfigValidationError) as exc_info:
             SplitConfig(sample_interval=-1.0)

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -82,6 +82,7 @@ def test_pipeline_happy_path(mock_probe, mock_detect, mock_split, tmp_path):
         min_match_duration=config.min_match_duration,
         min_blackout_duration=config.min_blackout_duration,
         use_gpu=config.use_gpu,
+        workers=config.workers,
     )
     mock_split.assert_called_once_with(video, BOUNDARIES, tmp_path)
     assert (tmp_path / "metadata.json").exists()
@@ -313,6 +314,7 @@ def test_pipeline_auto_interval_long_video(
         min_match_duration=config.min_match_duration,
         min_blackout_duration=config.min_blackout_duration,
         use_gpu=config.use_gpu,
+        workers=config.workers,
     )
 
 
@@ -346,4 +348,5 @@ def test_pipeline_config_params_forwarded(
         min_match_duration=120.0,
         min_blackout_duration=3.0,
         use_gpu=False,
+        workers=None,
     )


### PR DESCRIPTION
## Summary

`--workers N` オプションを追加。検知の並列ワーカー数を明示制御可能に。

- デフォルト: auto (`min(cpu_count, 24)`)
- `--workers 4` で 4 並列に制限
- `split` と `debug-brightness` 両コマンドに追加
- `_resolve_workers()` でワーカー数解決を一元化

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `allaganeye/config.py` | `SplitConfig.workers: int \| None = None` + バリデーション |
| `allaganeye/cli.py` | `--workers` オプション（split, debug-brightness） |
| `allaganeye/video/detector.py` | `_resolve_workers()` 追加、`detect_match_boundaries` + `_refine_blackout_regions` に `workers` パラメータ |
| `allaganeye/commands/split_matches.py` | `config.workers` パススルー |
| `allaganeye/commands/debug_brightness.py` | `_resolve_workers` 使用 |
| `tests/test_config.py` | workers バリデーション 4テスト追加 |
| `tests/test_split_matches.py` | workers パラメータ forwarding 更新 |

## Test plan

- [x] 全 164 テスト通過
- [x] ruff check / ruff format 通過
- [ ] tester: `--workers 1` と `--workers 8` で動作確認

関連: #4

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)