### PR TITLE
docs: metadata.json フィールド定義と用途の明記 (#96)

### DIFF
--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -41,6 +41,42 @@ allaganeye split <video_path> [OPTIONS]
 - `output/match_001.mp4`, `match_002.mp4`, ...
 - `output/metadata.json`
 
+### metadata.json
+
+分割結果の機械可読な記録。外部ツールやスクリプトから参照可能。L2（メタデータ化）パイプラインの入力として使用予定。L2 未着手のため、フィールド構造は暫定であり破壊的変更の可能性がある。
+
+**トップレベル:**
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `source` | string | 入力動画のファイルパス |
+| `source_duration` | float | 入力動画の総再生時間（秒） |
+| `source_duration_display` | string | 総再生時間の表示形式（MM:SS or H:MM:SS） |
+| `note` | string | キーフレーム精度に関する注意書き |
+| `matches` | array | 検出された試合セグメント |
+| `gaps` | array | 試合間の有意なギャップ（≥5分） |
+
+**matches[]:**
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `index` | int | 1始まりの試合番号 |
+| `start_time` | float | 開始時刻（秒） |
+| `end_time` | float | 終了時刻（秒） |
+| `start_display` | string | 開始時刻の表示形式 |
+| `end_display` | string | 終了時刻の表示形式 |
+| `duration` | float | 試合時間（秒） |
+| `duration_display` | string | 試合時間の表示形式 |
+| `output_file` | string | 出力ファイルパス |
+
+**gaps[]:**
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `start_display` | string | ギャップ開始時刻 |
+| `end_display` | string | ギャップ終了時刻 |
+| `duration_display` | string | ギャップ時間 |
+
 ### Exit Codes
 
 | コード | 意味 |

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -73,6 +73,7 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
   "source": "2026-01-20 22-33-17.mkv",
   "source_duration": 7303.0,
   "source_duration_display": "2:01:43",
+  "note": "Split times are approximate due to keyframe-aligned copy mode. ...",
   "matches": [
     {
       "index": 1,


### PR DESCRIPTION
## Summary

metadata.json のフィールド定義をドキュメント化し、用途・安定性を明記。

### 追加内容

- **cli-spec.md**: metadata.json ���クション新設
  - 用途: L1 分割結果の機械可読記録、L2 パイプライン入力予定
  - 安定性: L2 未着手のため暫���、破壊的変更の可能性あり
  - フィールド定義テーブル（トップレベル / matches[] / gaps[]）
- **design-overview.md**: JSON 例に `note` フィールド追加

## Test plan

- [x] 全 174 テスト通過（ドキュメントのみ）
- [x] ruff check / ruff format 通過

関連: #96

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)