### PR TITLE
feat: debug-brightness --roi-mode scorebar (Phase 1) #111

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -128,6 +128,10 @@ def debug_brightness(
         int | None,
         typer.Option(help="Number of parallel workers (default: auto)"),
     ] = None,
+    roi_mode: Annotated[
+        str | None,
+        typer.Option("--roi-mode", help="ROI analysis mode (scorebar)"),
+    ] = None,
 ) -> None:
     """Probe frame brightness at regular intervals (CSV output for threshold tuning)."""
     try:
@@ -143,7 +147,12 @@ def debug_brightness(
         from allaganeye.commands.debug_brightness import run_debug_brightness
 
         run_debug_brightness(
-            video_path, start=start, end=end, interval=interval, workers=workers
+            video_path,
+            start=start,
+            end=end,
+            interval=interval,
+            workers=workers,
+            roi_mode=roi_mode,
         )
 
     except AllaganEyeError as e:

--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -3,10 +3,20 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+import numpy as np
 import typer
 
-from allaganeye.video.detector import _generate_timestamps, _probe_single_frame
+from allaganeye.video.detector import (
+    _SAMPLE_HEIGHT,
+    _SAMPLE_WIDTH,
+    _generate_timestamps,
+    _probe_frame_rgb,
+    _probe_single_frame,
+)
 from allaganeye.video.probe import probe_video
+
+# Scorebar ROI in 320x180 scaled frame (top-center region)
+_SCOREBAR_ROI = (80, 0, 240, 15)  # (x1, y1, x2, y2)
 
 
 def run_debug_brightness(
@@ -16,6 +26,7 @@ def run_debug_brightness(
     end: float | None = None,
     interval: float = 1.0,
     workers: int | None = None,
+    roi_mode: str | None = None,
 ) -> None:
     """Probe brightness at regular intervals and print CSV to stdout."""
     metadata = probe_video(video_path)
@@ -40,6 +51,17 @@ def run_debug_brightness(
     from allaganeye.video.detector import _resolve_workers
 
     max_workers = _resolve_workers(workers)
+
+    if roi_mode == "scorebar":
+        _run_scorebar_mode(video_path, timestamps, max_workers)
+    else:
+        _run_brightness_mode(video_path, timestamps, max_workers)
+
+
+def _run_brightness_mode(
+    video_path: Path, timestamps: list[float], max_workers: int
+) -> None:
+    """Original brightness-only CSV output."""
     results: dict[float, float] = {}
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
@@ -53,3 +75,38 @@ def run_debug_brightness(
     typer.echo("timestamp,brightness")
     for t in sorted(results):
         typer.echo(f"{t:.1f},{results[t]:.1f}")
+
+
+def _run_scorebar_mode(
+    video_path: Path, timestamps: list[float], max_workers: int
+) -> None:
+    """RGB probe with scorebar ROI analysis CSV output."""
+    results: dict[float, bytes | None] = {}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_probe_frame_rgb, video_path, t): t for t in timestamps}
+        for future in as_completed(futures):
+            t = futures[future]
+            results[t] = future.result()
+
+    x1, y1, x2, y2 = _SCOREBAR_ROI
+    typer.echo("timestamp,brightness,roi_r_mean,roi_g_mean,roi_b_mean,roi_brightness")
+    for t in sorted(results):
+        raw = results[t]
+        if raw is None:
+            typer.echo(f"{t:.1f},255.0,0.0,0.0,0.0,0.0")
+            continue
+
+        frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+            _SAMPLE_HEIGHT, _SAMPLE_WIDTH, 3
+        )
+        brightness = float(frame.mean())
+        roi = frame[y1:y2, x1:x2, :]
+        roi_r = float(roi[:, :, 0].mean())
+        roi_g = float(roi[:, :, 1].mean())
+        roi_b = float(roi[:, :, 2].mean())
+        roi_brightness = float(roi.mean())
+        typer.echo(
+            f"{t:.1f},{brightness:.1f},"
+            f"{roi_r:.1f},{roi_g:.1f},{roi_b:.1f},{roi_brightness:.1f}"
+        )

--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -1,13 +1,13 @@
 """Debug-brightness command: probe frame brightness and output CSV."""
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import partial
 from pathlib import Path
 
 import numpy as np
 import typer
 
 from allaganeye.video.detector import (
-    _SAMPLE_HEIGHT,
     _SAMPLE_WIDTH,
     _generate_timestamps,
     _probe_frame_rgb,
@@ -15,8 +15,18 @@ from allaganeye.video.detector import (
 )
 from allaganeye.video.probe import probe_video
 
-# Scorebar ROI in 320x180 scaled frame (top-center region)
-_SCOREBAR_ROI = (80, 0, 240, 15)  # (x1, y1, x2, y2)
+# Scorebar ROI as ratios of scaled frame dimensions
+_SCOREBAR_ROI_X_START = 0.25  # 25% from left
+_SCOREBAR_ROI_X_END = 0.75  # 75% from left
+_SCOREBAR_ROI_Y_START = 0.0  # top edge
+_SCOREBAR_ROI_Y_END = 0.08  # 8% from top
+
+
+def _scaled_height(src_width: int, src_height: int) -> int:
+    """Compute scaled height preserving aspect ratio, rounded to even."""
+    h = round(_SAMPLE_WIDTH * src_height / src_width)
+    h += h % 2  # round up to even (ffmpeg -2 requirement)
+    return h
 
 
 def run_debug_brightness(
@@ -53,7 +63,8 @@ def run_debug_brightness(
     max_workers = _resolve_workers(workers)
 
     if roi_mode == "scorebar":
-        _run_scorebar_mode(video_path, timestamps, max_workers)
+        scaled_h = _scaled_height(metadata["width"], metadata["height"])
+        _run_scorebar_mode(video_path, timestamps, max_workers, scaled_h)
     else:
         _run_brightness_mode(video_path, timestamps, max_workers)
 
@@ -78,18 +89,24 @@ def _run_brightness_mode(
 
 
 def _run_scorebar_mode(
-    video_path: Path, timestamps: list[float], max_workers: int
+    video_path: Path, timestamps: list[float], max_workers: int, scaled_h: int
 ) -> None:
     """RGB probe with scorebar ROI analysis CSV output."""
     results: dict[float, bytes | None] = {}
+    probe_fn = partial(_probe_frame_rgb, height=scaled_h)
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futures = {pool.submit(_probe_frame_rgb, video_path, t): t for t in timestamps}
+        futures = {pool.submit(probe_fn, video_path, t): t for t in timestamps}
         for future in as_completed(futures):
             t = futures[future]
             results[t] = future.result()
 
-    x1, y1, x2, y2 = _SCOREBAR_ROI
+    # Compute ROI pixel bounds from ratios
+    x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
+    x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
+    y1 = int(scaled_h * _SCOREBAR_ROI_Y_START)
+    y2 = int(scaled_h * _SCOREBAR_ROI_Y_END)
+
     typer.echo("timestamp,brightness,roi_r_mean,roi_g_mean,roi_b_mean,roi_brightness")
     for t in sorted(results):
         raw = results[t]
@@ -97,9 +114,7 @@ def _run_scorebar_mode(
             typer.echo(f"{t:.1f},255.0,0.0,0.0,0.0,0.0")
             continue
 
-        frame = np.frombuffer(raw, dtype=np.uint8).reshape(
-            _SAMPLE_HEIGHT, _SAMPLE_WIDTH, 3
-        )
+        frame = np.frombuffer(raw, dtype=np.uint8).reshape(scaled_h, _SAMPLE_WIDTH, 3)
         brightness = float(frame.mean())
         roi = frame[y1:y2, x1:x2, :]
         roi_r = float(roi[:, :, 0].mean())

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -197,6 +197,52 @@ def _probe_single_frame(video_path: Path, timestamp: float) -> float:
     return float(np.frombuffer(result.stdout[:_FRAME_SIZE], dtype=np.uint8).mean())
 
 
+_RGB_FRAME_SIZE = _SAMPLE_WIDTH * _SAMPLE_HEIGHT * 3  # 172800 bytes (rgb24)
+
+
+def _probe_frame_rgb(video_path: Path, timestamp: float) -> bytes | None:
+    """Probe a single frame as RGB24 raw bytes (320x180).
+
+    Same seeking strategy as ``_probe_single_frame`` but returns raw RGB
+    bytes instead of a scalar brightness value.  Used by debug-brightness
+    ROI analysis.
+
+    Returns None on probe failure (timeout, incomplete frame).
+    """
+    cmd = [
+        find_ffmpeg(),
+        "-threads",
+        "1",
+        "-ss",
+        str(timestamp),
+        "-i",
+        str(video_path),
+        "-frames:v",
+        "1",
+        "-s",
+        f"{_SAMPLE_WIDTH}x{_SAMPLE_HEIGHT}",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgb24",
+        "pipe:1",
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+    except FileNotFoundError as e:
+        raise VideoProcessingError(
+            "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
+        ) from e
+    except subprocess.TimeoutExpired:
+        return None
+
+    if len(result.stdout) < _RGB_FRAME_SIZE:
+        return None
+
+    return result.stdout[:_RGB_FRAME_SIZE]
+
+
 _TRANSITION_THRESHOLD = 55.0
 """Brightness threshold for transition regions adjacent to blackouts.
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -197,18 +197,19 @@ def _probe_single_frame(video_path: Path, timestamp: float) -> float:
     return float(np.frombuffer(result.stdout[:_FRAME_SIZE], dtype=np.uint8).mean())
 
 
-_RGB_FRAME_SIZE = _SAMPLE_WIDTH * _SAMPLE_HEIGHT * 3  # 172800 bytes (rgb24)
+def _probe_frame_rgb(
+    video_path: Path, timestamp: float, height: int = _SAMPLE_HEIGHT
+) -> bytes | None:
+    """Probe a single frame as RGB24 raw bytes with aspect-ratio preservation.
 
-
-def _probe_frame_rgb(video_path: Path, timestamp: float) -> bytes | None:
-    """Probe a single frame as RGB24 raw bytes (320x180).
-
-    Same seeking strategy as ``_probe_single_frame`` but returns raw RGB
-    bytes instead of a scalar brightness value.  Used by debug-brightness
-    ROI analysis.
+    Uses ``-vf scale={width}:-2`` to preserve the source aspect ratio while
+    scaling width to ``_SAMPLE_WIDTH``.  The caller provides the expected
+    ``height`` (computed from the source aspect ratio) so the function can
+    validate the output size.
 
     Returns None on probe failure (timeout, incomplete frame).
     """
+    rgb_size = _SAMPLE_WIDTH * height * 3
     cmd = [
         find_ffmpeg(),
         "-threads",
@@ -219,12 +220,10 @@ def _probe_frame_rgb(video_path: Path, timestamp: float) -> bytes | None:
         str(video_path),
         "-frames:v",
         "1",
-        "-s",
-        f"{_SAMPLE_WIDTH}x{_SAMPLE_HEIGHT}",
+        "-vf",
+        f"scale={_SAMPLE_WIDTH}:-2,format=rgb24",
         "-f",
         "rawvideo",
-        "-pix_fmt",
-        "rgb24",
         "pipe:1",
     ]
 
@@ -237,10 +236,10 @@ def _probe_frame_rgb(video_path: Path, timestamp: float) -> bytes | None:
     except subprocess.TimeoutExpired:
         return None
 
-    if len(result.stdout) < _RGB_FRAME_SIZE:
+    if len(result.stdout) < rgb_size:
         return None
 
-    return result.stdout[:_RGB_FRAME_SIZE]
+    return result.stdout[:rgb_size]
 
 
 _TRANSITION_THRESHOLD = 55.0

--- a/tests/test_debug_brightness.py
+++ b/tests/test_debug_brightness.py
@@ -130,10 +130,15 @@ def test_varying_brightness(mock_probe_video, mock_probe_frame, capsys):
 
 # --- Scorebar ROI mode tests ---
 
+# For 1920x1080 source, scaled height = round(320 * 1080 / 1920) = 180 (even)
+_SCALED_H = 180
 
-def _make_rgb_frame(r: int = 128, g: int = 128, b: int = 128) -> bytes:
-    """Create a 320x180 RGB24 frame filled with a uniform color."""
-    frame = np.zeros((180, 320, 3), dtype=np.uint8)
+
+def _make_rgb_frame(
+    r: int = 128, g: int = 128, b: int = 128, height: int = _SCALED_H
+) -> bytes:
+    """Create a 320xH RGB24 frame filled with a uniform color."""
+    frame = np.zeros((height, 320, 3), dtype=np.uint8)
     frame[:, :, 0] = r
     frame[:, :, 1] = g
     frame[:, :, 2] = b
@@ -163,14 +168,15 @@ def test_scorebar_csv_header(mock_probe_video, mock_probe_rgb, capsys):
 @patch(f"{MODULE}._probe_frame_rgb")
 @patch(f"{MODULE}.probe_video")
 def test_scorebar_roi_values(mock_probe_video, mock_probe_rgb, capsys):
-    """Scorebar mode computes correct ROI channel means."""
+    """Scorebar mode computes correct ROI channel means from ratio-based ROI."""
     mock_probe_video.return_value = PROBE_RESULT
-    # Create frame with distinct ROI: scorebar region (y=0:15, x=80:240) = red
-    frame = np.zeros((180, 320, 3), dtype=np.uint8)
+    # For 320x180: ROI x=80:240 (25%-75%), y=0:14 (0%-8%)
+    roi_y_end = int(_SCALED_H * 0.08)  # 14
+    frame = np.zeros((_SCALED_H, 320, 3), dtype=np.uint8)
     frame[:, :, :] = 50  # background
-    frame[0:15, 80:240, 0] = 200  # ROI red channel
-    frame[0:15, 80:240, 1] = 30  # ROI green channel
-    frame[0:15, 80:240, 2] = 80  # ROI blue channel
+    frame[0:roi_y_end, 80:240, 0] = 200  # ROI red channel
+    frame[0:roi_y_end, 80:240, 1] = 30  # ROI green channel
+    frame[0:roi_y_end, 80:240, 2] = 80  # ROI blue channel
     mock_probe_rgb.return_value = frame.tobytes()
 
     run_debug_brightness(

--- a/tests/test_debug_brightness.py
+++ b/tests/test_debug_brightness.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import click.exceptions
+import numpy as np
 import pytest
 
 from allaganeye.commands.debug_brightness import run_debug_brightness
@@ -125,3 +126,97 @@ def test_varying_brightness(mock_probe_video, mock_probe_frame, capsys):
     assert lines[1] == "0.0,5.0"
     assert lines[2] == "1.0,128.0"
     assert lines[3] == "2.0,42.3"
+
+
+# --- Scorebar ROI mode tests ---
+
+
+def _make_rgb_frame(r: int = 128, g: int = 128, b: int = 128) -> bytes:
+    """Create a 320x180 RGB24 frame filled with a uniform color."""
+    frame = np.zeros((180, 320, 3), dtype=np.uint8)
+    frame[:, :, 0] = r
+    frame[:, :, 1] = g
+    frame[:, :, 2] = b
+    return frame.tobytes()
+
+
+@patch(f"{MODULE}._probe_frame_rgb")
+@patch(f"{MODULE}.probe_video")
+def test_scorebar_csv_header(mock_probe_video, mock_probe_rgb, capsys):
+    """Scorebar mode outputs CSV with ROI columns."""
+    mock_probe_video.return_value = PROBE_RESULT
+    mock_probe_rgb.return_value = _make_rgb_frame(100, 50, 200)
+
+    run_debug_brightness(
+        Path("test.mp4"), start=0.0, end=2.0, interval=1.0, roi_mode="scorebar"
+    )
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert (
+        lines[0]
+        == "timestamp,brightness,roi_r_mean,roi_g_mean,roi_b_mean,roi_brightness"
+    )
+    assert len(lines) == 3  # header + 2 rows
+
+
+@patch(f"{MODULE}._probe_frame_rgb")
+@patch(f"{MODULE}.probe_video")
+def test_scorebar_roi_values(mock_probe_video, mock_probe_rgb, capsys):
+    """Scorebar mode computes correct ROI channel means."""
+    mock_probe_video.return_value = PROBE_RESULT
+    # Create frame with distinct ROI: scorebar region (y=0:15, x=80:240) = red
+    frame = np.zeros((180, 320, 3), dtype=np.uint8)
+    frame[:, :, :] = 50  # background
+    frame[0:15, 80:240, 0] = 200  # ROI red channel
+    frame[0:15, 80:240, 1] = 30  # ROI green channel
+    frame[0:15, 80:240, 2] = 80  # ROI blue channel
+    mock_probe_rgb.return_value = frame.tobytes()
+
+    run_debug_brightness(
+        Path("test.mp4"), start=0.0, end=1.0, interval=1.0, roi_mode="scorebar"
+    )
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    parts = lines[1].split(",")
+    assert len(parts) == 6
+    assert parts[0] == "0.0"
+    # ROI values should be the distinct values we set
+    assert float(parts[2]) == pytest.approx(200.0, abs=0.1)  # roi_r
+    assert float(parts[3]) == pytest.approx(30.0, abs=0.1)  # roi_g
+    assert float(parts[4]) == pytest.approx(80.0, abs=0.1)  # roi_b
+
+
+@patch(f"{MODULE}._probe_single_frame")
+@patch(f"{MODULE}.probe_video")
+def test_roi_mode_none_unchanged(mock_probe_video, mock_probe_frame, capsys):
+    """roi_mode=None produces original 2-column CSV."""
+    mock_probe_video.return_value = PROBE_RESULT
+    mock_probe_frame.return_value = 42.5
+
+    run_debug_brightness(
+        Path("test.mp4"), start=0.0, end=2.0, interval=1.0, roi_mode=None
+    )
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert lines[0] == "timestamp,brightness"
+    assert len(lines[1].split(",")) == 2
+
+
+@patch(f"{MODULE}._probe_frame_rgb")
+@patch(f"{MODULE}.probe_video")
+def test_scorebar_probe_failure(mock_probe_video, mock_probe_rgb, capsys):
+    """Probe failure (None) outputs fallback values."""
+    mock_probe_video.return_value = PROBE_RESULT
+    mock_probe_rgb.return_value = None
+
+    run_debug_brightness(
+        Path("test.mp4"), start=0.0, end=1.0, interval=1.0, roi_mode="scorebar"
+    )
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    parts = lines[1].split(",")
+    assert parts[1] == "255.0"  # fallback brightness


### PR DESCRIPTION
## Summary

Issue #111 Phase 1: `debug-brightness` に `--roi-mode scorebar` を追加し、スコアバー領域の RGB 情報を CSV 出力する。

### 変更内容

- **detector.py**: `_probe_frame_rgb()` 新規追加 — RGB24 raw bytes を返す（既存の grayscale probe は変更なし）
- **debug_brightness.py**: `roi_mode="scorebar"` 対応 — RGB probe + ROI 分析を別関数 `_run_scorebar_mode()` に分離
- **cli.py**: `--roi-mode` オプション追加
- **tests**: scorebar ROI テスト 4件追加（CSV ヘッダー、ROI 値計算、従来動作不変、probe 失敗時）

### ROI 定義

スコアバー位置（320x180 スケール時）: `x=80~240, y=0~15`（画面上部中央）

### CSV 出力例

```
timestamp,brightness,roi_r_mean,roi_g_mean,roi_b_mean,roi_brightness
100.0,85.3,45.2,38.1,52.7,45.3
```

### 次のステップ

Phase 1 の実測データを issue #111 にコメントで共有 → lead が判定基準を決定 → Phase 2 以降

## Test plan

- [x] `ruff check .` — pass
- [x] `ruff format --check .` — pass
- [x] `pytest` — 180 passed, 14 deselected
- [ ] 実動画テスト: `allaganeye debug-brightness recording.mkv --start 100 --end 200 --roi-mode scorebar`

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)