### PR TITLE
feat: scorebar判定ロジック (Phase 2) #111

### DIFF
--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -9,24 +9,17 @@ import typer
 
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
+    _SCOREBAR_ROI_X_END,
+    _SCOREBAR_ROI_X_START,
+    _SCOREBAR_ROI_Y_END,
+    _SCOREBAR_ROI_Y_START,
     _generate_timestamps,
     _probe_frame_rgb,
     _probe_single_frame,
+    _resolve_workers,
+    _scaled_height,
 )
 from allaganeye.video.probe import probe_video
-
-# Scorebar ROI as ratios of scaled frame dimensions
-_SCOREBAR_ROI_X_START = 0.25  # 25% from left
-_SCOREBAR_ROI_X_END = 0.75  # 75% from left
-_SCOREBAR_ROI_Y_START = 0.0  # top edge
-_SCOREBAR_ROI_Y_END = 0.08  # 8% from top
-
-
-def _scaled_height(src_width: int, src_height: int) -> int:
-    """Compute scaled height preserving aspect ratio, rounded to even."""
-    h = round(_SAMPLE_WIDTH * src_height / src_width)
-    h += h % 2  # round up to even (ffmpeg -2 requirement)
-    return h
 
 
 def run_debug_brightness(
@@ -57,8 +50,6 @@ def run_debug_brightness(
     if not timestamps:
         typer.echo("No timestamps to probe.", err=True)
         raise typer.Exit(code=1)
-
-    from allaganeye.video.detector import _resolve_workers
 
     max_workers = _resolve_workers(workers)
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -256,15 +256,25 @@ _SCOREBAR_ROI_Y_START = 0.0
 _SCOREBAR_ROI_Y_END = 0.08
 
 
+_SCOREBAR_CHANNEL_STD_THRESHOLD = 8.0
+"""Minimum cross-section channel std for scorebar detection.
+
+FL scorebar has 3GC color bands (red/blue/yellow).  When the ROI is split
+into left/center/right thirds, at least one RGB channel shows significant
+std across the three sections (15-35 for FL, ~5 for lobby/non-FL).
+Threshold 8.0 sits in the gap between lobby max (~5.3) and FL min (~15).
+"""
+
+
 def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
     """Determine if FL scorebar is present in the frame.
 
     Returns True if scorebar detected, False if not, or None if probe
     failed (raw_rgb is None).
 
-    Criteria (lead-1 Phase 2 spec, based on tester-1 measurements):
+    Criteria (lead-1 revised spec based on 3-section analysis, #121):
     - 20 < roi_brightness < 140 (FL match typical range)
-    - RGB channel std > 5 (scorebar has 3GC colors, not uniform)
+    - max cross-section channel std > 8.0 (3GC color separation)
     """
     if raw_rgb is None:
         return None
@@ -277,12 +287,33 @@ def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
     roi = frame[y1:y2, x1:x2, :]
 
     roi_brightness = float(roi.mean())
-    roi_r = float(roi[:, :, 0].mean())
-    roi_g = float(roi[:, :, 1].mean())
-    roi_b = float(roi[:, :, 2].mean())
-    rgb_std = float(np.std([roi_r, roi_g, roi_b]))
+    if not (20.0 < roi_brightness < 140.0):
+        return False
 
-    return (20.0 < roi_brightness < 140.0) and (rgb_std > 5.0)
+    # Split ROI into 3 sections and compute cross-section channel std
+    w = roi.shape[1]
+    sec_w = w // 3
+    left = roi[:, :sec_w, :]
+    center = roi[:, sec_w : 2 * sec_w, :]
+    right = roi[:, 2 * sec_w :, :]
+
+    section_means = []
+    for section in (left, center, right):
+        section_means.append(
+            [
+                float(section[:, :, 0].mean()),
+                float(section[:, :, 1].mean()),
+                float(section[:, :, 2].mean()),
+            ]
+        )
+
+    max_channel_std = max(
+        float(np.std([s[0] for s in section_means])),
+        float(np.std([s[1] for s in section_means])),
+        float(np.std([s[2] for s in section_means])),
+    )
+
+    return max_channel_std > _SCOREBAR_CHANNEL_STD_THRESHOLD
 
 
 _TRANSITION_THRESHOLD = 55.0

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -242,6 +242,49 @@ def _probe_frame_rgb(
     return result.stdout[:rgb_size]
 
 
+def _scaled_height(src_width: int, src_height: int) -> int:
+    """Compute scaled height preserving aspect ratio, rounded to even."""
+    h = round(_SAMPLE_WIDTH * src_height / src_width)
+    h += h % 2  # round up to even (ffmpeg -2 requirement)
+    return h
+
+
+# Scorebar ROI as ratios of scaled frame dimensions
+_SCOREBAR_ROI_X_START = 0.25
+_SCOREBAR_ROI_X_END = 0.75
+_SCOREBAR_ROI_Y_START = 0.0
+_SCOREBAR_ROI_Y_END = 0.08
+
+
+def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
+    """Determine if FL scorebar is present in the frame.
+
+    Returns True if scorebar detected, False if not, or None if probe
+    failed (raw_rgb is None).
+
+    Criteria (lead-1 Phase 2 spec, based on tester-1 measurements):
+    - 20 < roi_brightness < 140 (FL match typical range)
+    - RGB channel std > 5 (scorebar has 3GC colors, not uniform)
+    """
+    if raw_rgb is None:
+        return None
+
+    frame = np.frombuffer(raw_rgb, dtype=np.uint8).reshape(height, _SAMPLE_WIDTH, 3)
+    x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
+    x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
+    y1 = int(height * _SCOREBAR_ROI_Y_START)
+    y2 = int(height * _SCOREBAR_ROI_Y_END)
+    roi = frame[y1:y2, x1:x2, :]
+
+    roi_brightness = float(roi.mean())
+    roi_r = float(roi[:, :, 0].mean())
+    roi_g = float(roi[:, :, 1].mean())
+    roi_b = float(roi[:, :, 2].mean())
+    rgb_std = float(np.std([roi_r, roi_g, roi_b]))
+
+    return (20.0 < roi_brightness < 140.0) and (rgb_std > 5.0)
+
+
 _TRANSITION_THRESHOLD = 55.0
 """Brightness threshold for transition regions adjacent to blackouts.
 

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -1,0 +1,110 @@
+"""Scorebar-based blackout classification for FL match detection."""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from math import ceil
+from pathlib import Path
+
+from allaganeye.video.detector import (
+    _has_scorebar,
+    _probe_frame_rgb,
+    _resolve_workers,
+)
+
+
+def _probe_scorebar_context(
+    video_path: Path,
+    timestamps: list[float],
+    height: int,
+    workers: int | None,
+) -> list[bool | None]:
+    """Probe multiple timestamps and return has_scorebar for each.
+
+    Returns a list aligned with timestamps: True/False/None per frame.
+    """
+    max_workers = _resolve_workers(workers)
+    results: dict[float, bool | None] = {}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(_probe_frame_rgb, video_path, t, height): t for t in timestamps
+        }
+        for future in as_completed(futures):
+            t = futures[future]
+            raw = future.result()
+            results[t] = _has_scorebar(raw, height)
+
+    return [results[t] for t in timestamps]
+
+
+def _majority_scorebar(results: list[bool | None]) -> bool | None:
+    """Majority vote from scorebar results, ignoring None (probe failures).
+
+    Returns None if no successful probes.
+    """
+    valid = [r for r in results if r is not None]
+    if not valid:
+        return None
+    return sum(valid) >= ceil(len(valid) / 2)
+
+
+def classify_blackout(
+    video_path: Path,
+    region: tuple[float, float],
+    duration: float,
+    height: int,
+    workers: int | None = None,
+) -> str:
+    """Classify a blackout region by scorebar context.
+
+    Probes 3 frames before and 3 frames after the blackout at 1s intervals.
+    Uses majority vote on has_scorebar to determine context.
+
+    Returns one of:
+    - ``"in_match"``: both sides have scorebar → in-match blackout (#107)
+    - ``"match_boundary"``: one side has scorebar → match start/end
+    - ``"non_fl"``: neither side has scorebar → non-FL blackout (#109)
+    - ``"unknown"``: all probes failed on either side → keep boundary (safe)
+    """
+    pre_timestamps = [max(0.0, region[0] - d) for d in (3.0, 2.0, 1.0)]
+    post_timestamps = [min(duration, region[1] + d) for d in (1.0, 2.0, 3.0)]
+
+    pre_results = _probe_scorebar_context(video_path, pre_timestamps, height, workers)
+    post_results = _probe_scorebar_context(video_path, post_timestamps, height, workers)
+
+    pre_has = _majority_scorebar(pre_results)
+    post_has = _majority_scorebar(post_results)
+
+    if pre_has is None or post_has is None:
+        return "unknown"
+    if pre_has and post_has:
+        return "in_match"
+    if pre_has or post_has:
+        return "match_boundary"
+    return "non_fl"
+
+
+def filter_blackouts_with_scorebar(
+    video_path: Path,
+    blackout_regions: list[tuple[float, float]],
+    duration: float,
+    height: int,
+    workers: int | None = None,
+) -> list[tuple[float, float]]:
+    """Filter blackout regions using scorebar context.
+
+    Removes:
+    - ``"in_match"`` blackouts (e.g. character down, #107)
+    - ``"non_fl"`` blackouts (non-FL content boundaries, #109)
+
+    Keeps:
+    - ``"match_boundary"`` (FL match start/end)
+    - ``"unknown"`` (probe failure → safe side, keep boundary)
+    """
+    kept: list[tuple[float, float]] = []
+    for region in blackout_regions:
+        classification = classify_blackout(
+            video_path, region, duration, height, workers
+        )
+        if classification in ("match_boundary", "unknown"):
+            kept.append(region)
+    return kept

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -25,20 +25,37 @@ def _make_frame(
     height: int = _HEIGHT,
     bg: tuple[int, int, int] = (50, 50, 50),
     roi_color: tuple[int, int, int] | None = None,
+    roi_sections: tuple[
+        tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]
+    ]
+    | None = None,
 ) -> bytes:
-    """Create a 320xH RGB24 frame with optional distinct ROI color."""
+    """Create a 320xH RGB24 frame with optional ROI color.
+
+    roi_color: uniform color for entire ROI.
+    roi_sections: (left_rgb, center_rgb, right_rgb) for 3-section scorebar.
+    """
     frame = np.zeros((height, _SAMPLE_WIDTH, 3), dtype=np.uint8)
     frame[:, :, 0] = bg[0]
     frame[:, :, 1] = bg[1]
     frame[:, :, 2] = bg[2]
 
+    x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
+    x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
+    y2 = int(height * _SCOREBAR_ROI_Y_END)
+
     if roi_color is not None:
-        x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
-        x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
-        y2 = int(height * _SCOREBAR_ROI_Y_END)
         frame[0:y2, x1:x2, 0] = roi_color[0]
         frame[0:y2, x1:x2, 1] = roi_color[1]
         frame[0:y2, x1:x2, 2] = roi_color[2]
+    elif roi_sections is not None:
+        sec_w = (x2 - x1) // 3
+        for i, color in enumerate(roi_sections):
+            sx = x1 + i * sec_w
+            ex = x1 + (i + 1) * sec_w if i < 2 else x2
+            frame[0:y2, sx:ex, 0] = color[0]
+            frame[0:y2, sx:ex, 1] = color[1]
+            frame[0:y2, sx:ex, 2] = color[2]
 
     return frame.tobytes()
 
@@ -48,9 +65,9 @@ def _make_frame(
 
 class TestHasScorebar:
     def test_fl_match_frame(self):
-        """FL match frame with colored scorebar → True."""
-        # ROI: R=120, G=60, B=90 → brightness ~90, std ~24.5
-        raw = _make_frame(roi_color=(120, 60, 90))
+        """FL match frame with 3GC colored scorebar sections → True."""
+        # 3 distinct section colors → high cross-section std
+        raw = _make_frame(roi_sections=((60, 75, 100), (90, 95, 80), (65, 50, 55)))
         assert _has_scorebar(raw, _HEIGHT) is True
 
     def test_blackout_frame(self):
@@ -60,12 +77,15 @@ class TestHasScorebar:
 
     def test_bright_non_fl_frame(self):
         """Very bright non-FL frame (brightness > 160) → False."""
-        raw = _make_frame(bg=(200, 200, 200), roi_color=(180, 190, 200))
+        raw = _make_frame(
+            bg=(200, 200, 200),
+            roi_sections=((180, 190, 200), (170, 200, 220), (190, 180, 210)),
+        )
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_uniform_color_frame(self):
-        """Uniform ROI color (RGB std < 5) → False."""
-        raw = _make_frame(roi_color=(80, 80, 80))
+        """Uniform ROI sections (cross-section std < 8) → False."""
+        raw = _make_frame(roi_sections=((80, 80, 80), (82, 80, 80), (80, 80, 82)))
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_probe_failure(self):
@@ -73,22 +93,29 @@ class TestHasScorebar:
         assert _has_scorebar(None, _HEIGHT) is None
 
     def test_boundary_brightness_20(self):
-        """ROI brightness exactly 20 → False (not strictly greater)."""
-        # ROI with mean brightness ~20, but with color variation
-        raw = _make_frame(roi_color=(30, 15, 15))
+        """ROI brightness at 20 → False (not strictly greater)."""
+        raw = _make_frame(roi_sections=((30, 10, 10), (10, 30, 10), (10, 10, 30)))
+        # mean brightness ~16.7, below 20 → False
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_boundary_brightness_just_above_20(self):
         """ROI brightness just above 20 with color variation → True."""
-        raw = _make_frame(roi_color=(40, 20, 10))
-        result = _has_scorebar(raw, _HEIGHT)
-        # brightness ~23.3, std ~12.5 → True
-        assert result is True
+        raw = _make_frame(roi_sections=((40, 15, 10), (10, 40, 15), (15, 10, 40)))
+        # mean brightness ~21.7, cross-section R std ~16 → True
+        assert _has_scorebar(raw, _HEIGHT) is True
 
     def test_high_blue_non_fl(self):
-        """Non-FL with high blue (Match 2 type, roi_b > 200) → False."""
-        raw = _make_frame(roi_color=(170, 170, 225))
-        # brightness ~188, exceeds 140 → False
+        """Non-FL with high blue (Match 2 type) → False due to brightness."""
+        raw = _make_frame(
+            roi_sections=((150, 190, 230), (140, 200, 240), (110, 160, 200))
+        )
+        # mean brightness ~180, exceeds 140 → False
+        assert _has_scorebar(raw, _HEIGHT) is False
+
+    def test_lobby_like_uniform(self):
+        """Lobby-like frame: brightness in range but low cross-section std."""
+        raw = _make_frame(roi_sections=((55, 52, 47), (54, 53, 48), (53, 52, 46)))
+        # brightness ~51, but sections are nearly identical → std ~0.8 → False
         assert _has_scorebar(raw, _HEIGHT) is False
 
 

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1,0 +1,260 @@
+"""Tests for scorebar detection logic."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+from allaganeye.video.detector import (
+    _SAMPLE_WIDTH,
+    _SCOREBAR_ROI_X_END,
+    _SCOREBAR_ROI_X_START,
+    _SCOREBAR_ROI_Y_END,
+    _has_scorebar,
+)
+from allaganeye.video.scorebar import (
+    _majority_scorebar,
+    classify_blackout,
+    filter_blackouts_with_scorebar,
+)
+
+_HEIGHT = 180  # 16:9 scaled height
+
+
+def _make_frame(
+    height: int = _HEIGHT,
+    bg: tuple[int, int, int] = (50, 50, 50),
+    roi_color: tuple[int, int, int] | None = None,
+) -> bytes:
+    """Create a 320xH RGB24 frame with optional distinct ROI color."""
+    frame = np.zeros((height, _SAMPLE_WIDTH, 3), dtype=np.uint8)
+    frame[:, :, 0] = bg[0]
+    frame[:, :, 1] = bg[1]
+    frame[:, :, 2] = bg[2]
+
+    if roi_color is not None:
+        x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
+        x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
+        y2 = int(height * _SCOREBAR_ROI_Y_END)
+        frame[0:y2, x1:x2, 0] = roi_color[0]
+        frame[0:y2, x1:x2, 1] = roi_color[1]
+        frame[0:y2, x1:x2, 2] = roi_color[2]
+
+    return frame.tobytes()
+
+
+# --- _has_scorebar tests ---
+
+
+class TestHasScorebar:
+    def test_fl_match_frame(self):
+        """FL match frame with colored scorebar → True."""
+        # ROI: R=120, G=60, B=90 → brightness ~90, std ~24.5
+        raw = _make_frame(roi_color=(120, 60, 90))
+        assert _has_scorebar(raw, _HEIGHT) is True
+
+    def test_blackout_frame(self):
+        """Dark frame (brightness < 10) → False."""
+        raw = _make_frame(bg=(3, 3, 3), roi_color=(5, 5, 5))
+        assert _has_scorebar(raw, _HEIGHT) is False
+
+    def test_bright_non_fl_frame(self):
+        """Very bright non-FL frame (brightness > 160) → False."""
+        raw = _make_frame(bg=(200, 200, 200), roi_color=(180, 190, 200))
+        assert _has_scorebar(raw, _HEIGHT) is False
+
+    def test_uniform_color_frame(self):
+        """Uniform ROI color (RGB std < 5) → False."""
+        raw = _make_frame(roi_color=(80, 80, 80))
+        assert _has_scorebar(raw, _HEIGHT) is False
+
+    def test_probe_failure(self):
+        """None input (probe failure) → None."""
+        assert _has_scorebar(None, _HEIGHT) is None
+
+    def test_boundary_brightness_20(self):
+        """ROI brightness exactly 20 → False (not strictly greater)."""
+        # ROI with mean brightness ~20, but with color variation
+        raw = _make_frame(roi_color=(30, 15, 15))
+        assert _has_scorebar(raw, _HEIGHT) is False
+
+    def test_boundary_brightness_just_above_20(self):
+        """ROI brightness just above 20 with color variation → True."""
+        raw = _make_frame(roi_color=(40, 20, 10))
+        result = _has_scorebar(raw, _HEIGHT)
+        # brightness ~23.3, std ~12.5 → True
+        assert result is True
+
+    def test_high_blue_non_fl(self):
+        """Non-FL with high blue (Match 2 type, roi_b > 200) → False."""
+        raw = _make_frame(roi_color=(170, 170, 225))
+        # brightness ~188, exceeds 140 → False
+        assert _has_scorebar(raw, _HEIGHT) is False
+
+
+# --- _majority_scorebar tests ---
+
+
+class TestMajorityScorebar:
+    def test_all_true(self):
+        assert _majority_scorebar([True, True, True]) is True
+
+    def test_all_false(self):
+        assert _majority_scorebar([False, False, False]) is False
+
+    def test_majority_true(self):
+        assert _majority_scorebar([True, True, False]) is True
+
+    def test_majority_false(self):
+        assert _majority_scorebar([False, False, True]) is False
+
+    def test_all_none(self):
+        """All probe failures → None."""
+        assert _majority_scorebar([None, None, None]) is None
+
+    def test_partial_failure_majority_true(self):
+        """2 successes, 1 failure, majority True."""
+        assert _majority_scorebar([True, True, None]) is True
+
+    def test_partial_failure_single_true(self):
+        """1 success (True), 2 failures → True (1 >= ceil(1/2))."""
+        assert _majority_scorebar([True, None, None]) is True
+
+    def test_partial_failure_single_false(self):
+        """1 success (False), 2 failures → False (0 < ceil(1/2))."""
+        assert _majority_scorebar([False, None, None]) is False
+
+    def test_tie_two_values(self):
+        """1 True, 1 False, 1 None → True (1 >= ceil(2/2) = 1)."""
+        assert _majority_scorebar([True, False, None]) is True
+
+
+# --- classify_blackout tests ---
+
+SCOREBAR_MODULE = "allaganeye.video.scorebar"
+
+
+class TestClassifyBlackout:
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_in_match(self, mock_probe):
+        """Both sides have scorebar → in_match."""
+        mock_probe.side_effect = [
+            [True, True, True],  # pre
+            [True, True, True],  # post
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
+        assert result == "in_match"
+
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_match_boundary_start(self, mock_probe):
+        """Pre=False, Post=True → match_boundary (match start)."""
+        mock_probe.side_effect = [
+            [False, False, False],  # pre
+            [True, True, True],  # post
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
+        assert result == "match_boundary"
+
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_match_boundary_end(self, mock_probe):
+        """Pre=True, Post=False → match_boundary (match end)."""
+        mock_probe.side_effect = [
+            [True, True, True],  # pre
+            [False, False, False],  # post
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
+        assert result == "match_boundary"
+
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_non_fl(self, mock_probe):
+        """Neither side has scorebar → non_fl."""
+        mock_probe.side_effect = [
+            [False, False, False],  # pre
+            [False, False, False],  # post
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
+        assert result == "non_fl"
+
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_all_probes_failed(self, mock_probe):
+        """All probes failed → unknown."""
+        mock_probe.side_effect = [
+            [None, None, None],  # pre
+            [None, None, None],  # post
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
+        assert result == "unknown"
+
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_pre_failed_post_scorebar(self, mock_probe):
+        """Pre all failed, post has scorebar → unknown (safe side)."""
+        mock_probe.side_effect = [
+            [None, None, None],  # pre
+            [True, True, True],  # post
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
+        assert result == "unknown"
+
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_partial_failure_majority(self, mock_probe):
+        """Partial failures with majority vote."""
+        mock_probe.side_effect = [
+            [True, True, None],  # pre: 2/2 True
+            [False, None, None],  # post: 1/1 False
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
+        assert result == "match_boundary"
+
+
+# --- filter_blackouts_with_scorebar tests ---
+
+
+class TestFilterBlackouts:
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_keeps_match_boundary(self, mock_classify):
+        mock_classify.return_value = "match_boundary"
+        regions = [(100.0, 105.0), (200.0, 205.0)]
+        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        assert result == regions
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_removes_in_match(self, mock_classify):
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]
+        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        assert result == []
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_removes_non_fl(self, mock_classify):
+        mock_classify.return_value = "non_fl"
+        regions = [(100.0, 102.0)]
+        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        assert result == []
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_keeps_unknown(self, mock_classify):
+        """Unknown → safe side, keep boundary."""
+        mock_classify.return_value = "unknown"
+        regions = [(100.0, 102.0)]
+        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        assert result == regions
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_mixed_classifications(self, mock_classify):
+        """Mix of classifications: only boundary and unknown kept."""
+        mock_classify.side_effect = [
+            "match_boundary",
+            "in_match",
+            "non_fl",
+            "unknown",
+            "match_boundary",
+        ]
+        regions = [
+            (50.0, 55.0),
+            (100.0, 102.0),
+            (150.0, 155.0),
+            (200.0, 202.0),
+            (250.0, 255.0),
+        ]
+        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        assert result == [(50.0, 55.0), (200.0, 202.0), (250.0, 255.0)]


### PR DESCRIPTION
## Summary

Issue #111 Phase 2: スコアバー判定ロジックの実装。Phase 3（パイプライン統合）は別 PR。

### 変更内容

**detector.py:**
- `_scaled_height()` を debug_brightness.py から移動
- ROI 割合定数（`_SCOREBAR_ROI_X_START` 等）を移動
- `_has_scorebar(raw_rgb, height)` 新規追加 — ROI の brightness (20-140) + RGB std (> 5) で判定

**scorebar.py (新規):**
- `classify_blackout()` — 暗転前後 3 フレーム (1s 間隔) の has_scorebar を集計し分類
  - `in_match`: 前後ともスコアバーあり → 試合内暗転 (#107)
  - `match_boundary`: 片側のみ → 試合開始/終了
  - `non_fl`: 前後ともなし → 非 FL 暗転 (#109)
  - `unknown`: プローブ失敗 → 安全側で境界維持
- `filter_blackouts_with_scorebar()` — in_match と non_fl を除外、boundary と unknown を維持

**debug_brightness.py:**
- `_scaled_height()` と ROI 定数を detector.py からインポートに変更

### プローブ失敗の扱い

lead 承認済み: 失敗は `unknown` として集計から除外し、成功フレームのみで多数決。全件失敗時は境界を維持（安全側）。

### テスト

29 件追加（209 passed total）:
- `_has_scorebar`: 8 cases（FL 試合中/暗転/明るい非 FL/均一色/probe 失敗/境界値）
- `_majority_scorebar`: 9 cases（全 True/False/部分失敗/tie）
- `classify_blackout`: 7 cases（4 分類 + 部分失敗パターン）
- `filter_blackouts_with_scorebar`: 5 cases（各分類の除外/維持 + 混合）

## Test plan

- [x] `ruff check .` — pass
- [x] `ruff format --check .` — pass
- [x] `pytest` — 209 passed, 14 deselected

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)