### PR TITLE
feat: --roi-mode scorebar-detail で3分割ROI分析 #121

### DIFF
--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -62,9 +62,12 @@ def run_debug_brightness(
 
     max_workers = _resolve_workers(workers)
 
-    if roi_mode == "scorebar":
+    if roi_mode in ("scorebar", "scorebar-detail"):
         scaled_h = _scaled_height(metadata["width"], metadata["height"])
-        _run_scorebar_mode(video_path, timestamps, max_workers, scaled_h)
+        if roi_mode == "scorebar-detail":
+            _run_scorebar_detail_mode(video_path, timestamps, max_workers, scaled_h)
+        else:
+            _run_scorebar_mode(video_path, timestamps, max_workers, scaled_h)
     else:
         _run_brightness_mode(video_path, timestamps, max_workers)
 
@@ -124,4 +127,66 @@ def _run_scorebar_mode(
         typer.echo(
             f"{t:.1f},{brightness:.1f},"
             f"{roi_r:.1f},{roi_g:.1f},{roi_b:.1f},{roi_brightness:.1f}"
+        )
+
+
+def _run_scorebar_detail_mode(
+    video_path: Path, timestamps: list[float], max_workers: int, scaled_h: int
+) -> None:
+    """RGB probe with 3-section ROI analysis for scorebar color detection.
+
+    Splits the scorebar ROI into left/center/right thirds and outputs
+    per-section RGB means.  Used to identify 3GC color separation in
+    the FL scorebar.
+    """
+    results: dict[float, bytes | None] = {}
+    probe_fn = partial(_probe_frame_rgb, height=scaled_h)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(probe_fn, video_path, t): t for t in timestamps}
+        for future in as_completed(futures):
+            t = futures[future]
+            results[t] = future.result()
+
+    x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
+    x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
+    y1 = int(scaled_h * _SCOREBAR_ROI_Y_START)
+    y2 = int(scaled_h * _SCOREBAR_ROI_Y_END)
+    roi_w = x2 - x1
+    sec_w = roi_w // 3
+
+    header = (
+        "timestamp,roi_brightness,"
+        "left_r,left_g,left_b,"
+        "center_r,center_g,center_b,"
+        "right_r,right_g,right_b"
+    )
+    typer.echo(header)
+
+    for t in sorted(results):
+        raw = results[t]
+        if raw is None:
+            typer.echo(f"{t:.1f},0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0")
+            continue
+
+        frame = np.frombuffer(raw, dtype=np.uint8).reshape(scaled_h, _SAMPLE_WIDTH, 3)
+        roi = frame[y1:y2, x1:x2, :]
+        roi_brightness = float(roi.mean())
+
+        left = roi[:, :sec_w, :]
+        center = roi[:, sec_w : 2 * sec_w, :]
+        right = roi[:, 2 * sec_w :, :]
+
+        vals = []
+        for section in (left, center, right):
+            vals.extend(
+                [
+                    float(section[:, :, 0].mean()),
+                    float(section[:, :, 1].mean()),
+                    float(section[:, :, 2].mean()),
+                ]
+            )
+
+        typer.echo(
+            f"{t:.1f},{roi_brightness:.1f}," + ",".join(f"{v:.1f}" for v in vals)
         )

--- a/tests/test_debug_brightness.py
+++ b/tests/test_debug_brightness.py
@@ -226,3 +226,64 @@ def test_scorebar_probe_failure(mock_probe_video, mock_probe_rgb, capsys):
     lines = output.strip().split("\n")
     parts = lines[1].split(",")
     assert parts[1] == "255.0"  # fallback brightness
+
+
+# --- Scorebar detail mode tests ---
+
+
+@patch(f"{MODULE}._probe_frame_rgb")
+@patch(f"{MODULE}.probe_video")
+def test_scorebar_detail_csv_header(mock_probe_video, mock_probe_rgb, capsys):
+    """scorebar-detail mode outputs 3-section RGB CSV."""
+    mock_probe_video.return_value = PROBE_RESULT
+    mock_probe_rgb.return_value = _make_rgb_frame(100, 50, 200)
+
+    run_debug_brightness(
+        Path("test.mp4"), start=0.0, end=1.0, interval=1.0, roi_mode="scorebar-detail"
+    )
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert lines[0].startswith("timestamp,roi_brightness,")
+    assert "left_r,left_g,left_b" in lines[0]
+    assert "center_r,center_g,center_b" in lines[0]
+    assert "right_r,right_g,right_b" in lines[0]
+    # 11 columns: timestamp + roi_brightness + 3 sections * 3 channels
+    parts = lines[1].split(",")
+    assert len(parts) == 11
+
+
+@patch(f"{MODULE}._probe_frame_rgb")
+@patch(f"{MODULE}.probe_video")
+def test_scorebar_detail_section_values(mock_probe_video, mock_probe_rgb, capsys):
+    """scorebar-detail correctly reports per-section RGB."""
+    mock_probe_video.return_value = PROBE_RESULT
+    # Create frame with distinct left/center/right in ROI
+    roi_y_end = int(_SCALED_H * 0.08)  # 14
+    roi_x1, roi_x2 = 80, 240  # 25%-75% of 320
+    sec_w = (roi_x2 - roi_x1) // 3  # ~53
+
+    frame = np.zeros((_SCALED_H, 320, 3), dtype=np.uint8)
+    frame[0:roi_y_end, roi_x1 : roi_x1 + sec_w, :] = [200, 30, 30]  # left: red
+    frame[0:roi_y_end, roi_x1 + sec_w : roi_x1 + 2 * sec_w, :] = [
+        30,
+        200,
+        30,
+    ]  # center: green
+    frame[0:roi_y_end, roi_x1 + 2 * sec_w : roi_x2, :] = [30, 30, 200]  # right: blue
+    mock_probe_rgb.return_value = frame.tobytes()
+
+    run_debug_brightness(
+        Path("test.mp4"), start=0.0, end=1.0, interval=1.0, roi_mode="scorebar-detail"
+    )
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    parts = lines[1].split(",")
+    # left section should be red-dominant
+    assert float(parts[2]) > 150  # left_r
+    assert float(parts[3]) < 50  # left_g
+    # center section should be green-dominant
+    assert float(parts[6]) > 150  # center_g
+    # right section should be blue-dominant
+    assert float(parts[10]) > 150  # right_b


### PR DESCRIPTION
## Summary

Issue #121 の即時アクション: `--roi-mode scorebar-detail` を追加し、ROI を左1/3・中央1/3・右1/3 に分割した各セクションの RGB チャネル平均を出力する。

### 背景

`_has_scorebar` の `rgb_std > 5.0` 閾値が実動画で逆転（#121）。320x180 での ROI チャネル平均 std では FL スコアバーの 3GC 色分けを捉えられない。lead の方針: ROI を 3 分割してセクション間の色差を分析するデータ収集ツールを先行して追加。

### CSV 出力

```
timestamp,roi_brightness,left_r,left_g,left_b,center_r,center_g,center_b,right_r,right_g,right_b
```

### 使い方

```bash
allaganeye debug-brightness recording.mkv --start 600 --end 625 --interval 5 --roi-mode scorebar-detail
```

### テスト

2 件追加（182 passed total）:
- CSV ヘッダーと列数の検証
- 3 セクションに異なる色を設定し、正しいセクションから値が取得されることを検証

## Test plan

- [x] `ruff check .` — pass
- [x] `ruff format --check .` — pass
- [x] `pytest` — 182 passed, 14 deselected
- [ ] 実動画テスト: tester に委譲

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)