### PR TITLE
chore: idios-claudecode-tools テンプレートから設定・コマンド同期

### DIFF
--- a/.claude/commands/check-work.md
+++ b/.claude/commands/check-work.md
@@ -1,46 +1,290 @@
-現在のロールに基づいて、担当すべき作業を発見・優先順位付けします。
+現在のロールに応じた対応可能な作業（Issue・PR）を調査し、ロールの責務と優先度に基づいて次に取り組むべき作業を提案します。
 
-## 前提条件
+以下の手順を実行してください:
 
-- ロールが設定済みであること（ROLE ファイルが存在する）
-- ROLE ファイルが存在しない場合はエラーを返す
+**重要: issue の状態判断時は `gh issue view <番号> --comments` で必ずコメント全文を確認すること。** ボディだけで判断してはならない（コメントに着手宣言・完了報告・テスト結果など最新情報が含まれる）。
 
-## 手順
+## ステップ 1: ロールと現在の状態を確認する
 
-1. ROLE ファイルからロール名を取得
-2. GitHub Issue を検索:
-   ```bash
-   gh issue list --repo Idios/kobutachan-allaganeye --state open --label "role:<ロール名>" --json number,title,labels,assignees,body
-   ```
-3. GitHub PR を検索:
-   ```bash
-   gh pr list --repo Idios/kobutachan-allaganeye --state open --json number,title,labels,author,body,reviewDecision
-   ```
-4. ロール定義（`docs/roles/<role>.md`）に従い、以下の優先順位で作業を提示:
+1. `ROLE` ファイルを読んで現在のロールを確認する
+2. 現在のセッション ID を確認する（未宣言の場合はユーザーに確認する）
+3. `docs/roles/protocol.md` を読む（未読の場合のみ）
 
-### Director
-1. レビュー待ちの PR（`role:director` ラベル）
-2. リスク・意思決定の Issue
-3. プロセス改善の提案
+## ステップ 2: ロール別の作業候補を調査する
 
-### Lead Engineer
-1. レビュー待ちの PR（`role:lead-engineer` ラベル）
-2. 設計レビューの依頼
-3. バグの調査 Issue
+以下の **ロール名に該当するセクション** のみを実行する。
 
-### Engineer
-1. アサインされた Issue（`role:engineer` ラベル）
-2. 未着手の実装・リファクタリング Issue
-3. テスト不足の領域
+---
 
-### Tester
-1. テスト実行の依頼
-2. テスト不足の Issue（`role:tester` ラベル）
-3. エッジケースの発見
+### ディレクター の場合
 
-## 出力
+**Issues の調査:**
 
-優先順位順に作業リストを報告。各項目に:
-- Issue/PR 番号とタイトル
-- 推奨アクション
-- 関連ファイル（わかる場合）
+```bash
+gh issue list --state open --json number,title,labels,comments --limit 50
+```
+
+以下の条件に合うものを抽出する:
+- タイトルが `[question]` で始まる issue（方針・判断の回答が必要）
+- `role:director` ラベルが付いた issue
+
+抽出した各 issue について、**着手状態を確認する:**
+
+```bash
+gh issue view <番号> --comments
+```
+
+- **対応可能**: `着手:` コメントがないもの
+- **着手済み**: 他セッションが `着手:` コメントを投稿済み → 対象外
+
+**PRs の調査:**
+
+```bash
+gh pr list --state open --label "role:director" --json number,title,headRefName,author,createdAt
+```
+
+`role:director` ラベルが付いた PR（ディレクターがレビュー担当）を抽出する。
+
+**ディレクター定期見直し（担当 Issue/PR の処理後に実施）:**
+
+担当 Issue・PR がなくても、以下の見直しを毎回行う。
+
+**(a) 滞留 Issue/PR の検出:**
+
+```bash
+gh issue list --state all --json number,title,state,labels,comments,createdAt,closedAt --limit 30
+gh pr list --state all --json number,title,state,labels,comments,createdAt,mergedAt --limit 30
+```
+
+以下を検出して報告する:
+- **マージ済み PR に対応する issue がオープンのまま** — 作成者にクローズを依頼するコメントを投稿
+- **テスト未実施でマージされたコード PR** — テスト issue を作成して `role:tester` に割り当て
+- **レビューで複数回差し戻された PR** — 原因パターンを特定し、再発防止策を提案
+- **着手済みだが長期間（3日以上）進展がない issue** — 担当セッションへの確認コメントを提案
+
+**(b) プロセスルールの整合性チェック:**
+
+Explore サブエージェントを使い、**ロール定義・プロトコル・コマンド間** の矛盾・欠落を検出する:
+- `docs/roles/protocol.md` のルール vs `.claude/commands/` の実装
+- `docs/issue-policy.md` のラベルルール vs 実際の GitHub ラベル運用
+- `docs/roles/*.md` のロール定義間の整合性
+
+問題を発見した場合:
+- ディレクターのスコープ内（`docs/`, `.claude/`）なら直接修正して PR を作成
+- 他ロールのスコープなら issue を作成して `role:*` ラベルで割り当て
+
+**(c) 見直し結果の報告:**
+
+上記 (a)(b) の結果を、担当 Issue/PR の一覧と合わせて報告する。
+
+---
+
+### リードエンジニア の場合
+
+**Issues の調査:**
+
+```bash
+gh issue list --state open --json number,title,labels --limit 50
+```
+
+以下の条件に合うものを抽出する:
+- `role:lead-engineer` ラベルが付いた issue
+- またはタイトルが `[question]`/`[risk]`/`[bug]`/`[refactor]`/`[doc]` で始まる issue（ラベル未付与の場合のフォールバック）
+
+抽出した各 issue について、**着手状態を確認する:**
+
+```bash
+gh issue view <番号> --comments
+```
+
+- **対応可能**: `着手:` コメントがないもの
+- **着手済み**: 他セッションが `着手:` コメントを投稿済み → 対象外
+- **ブロック中**: `ブロック:` コメントが投稿されている → 対象外（ブロック原因の解決待ち）
+
+**PRs の調査:**
+
+```bash
+gh pr list --state open --label "role:lead-engineer" --json number,title,headRefName,author,createdAt
+```
+
+`role:lead-engineer` ラベルが付いた PR（リードエンジニアがレビュー担当）を抽出する。
+
+---
+
+### エンジニア の場合
+
+**Issues の調査:**
+
+```bash
+gh issue list --state open --json number,title,labels --limit 50
+```
+
+以下の条件に合うものを候補として抽出する:
+- `role:engineer` ラベルが付いた issue
+- またはタイトルが `[task]`/`[bug]`/`[refactor]` で始まる issue（ラベル未付与の場合のフォールバック）
+
+抽出した各 issue について、**着手状態と方針コメントを確認する:**
+
+```bash
+gh issue view <番号> --comments
+```
+
+各 issue を以下のいずれかに分類する:
+- **対応可能**: `着手:` コメントがなく、`[bug]`/`[refactor]` の場合はリードエンジニアの方針コメントがある
+- **着手済み**: 他セッションが `着手:` コメントを投稿済み → 対象外
+- **ブロック中**: `ブロック:` コメントが投稿されている → 対象外（ブロック原因の解決待ち）
+- **方針待ち**: `[bug]` / `[refactor]` でリードエンジニアの方針コメントがない → 対象外
+
+**PRs の調査（修正依頼された自 PR）:**
+
+```bash
+gh pr list --state open --label "role:engineer" --json number,title,headRefName,author,createdAt
+```
+
+`role:engineer` ラベルが付いた PR（レビューで修正依頼された自分の PR）を抽出する。
+
+---
+
+### テスター の場合
+
+**Issues の調査:**
+
+```bash
+gh issue list --state open --json number,title,labels --limit 50
+```
+
+以下の条件に合うものを抽出する:
+- `role:tester` ラベルが付いた issue
+- またはタイトルが `[task]` で始まる issue（ラベル未付与の場合のフォールバック）
+
+候補 issue について着手状態を確認する:
+
+```bash
+gh issue view <番号> --comments
+```
+
+- **対応可能**: `着手:` コメントがないもの
+- **着手済み**: 他セッションが `着手:` コメントを投稿済み → 対象外
+- **ブロック中**: `ブロック:` コメントが投稿されている → 対象外（ブロック原因の解決待ち）
+
+**PRs の調査（テスト対象 + 修正依頼された自 PR）:**
+
+```bash
+gh pr list --state open --label "role:tester" --json number,title,headRefName,author,createdAt
+```
+
+`role:tester` ラベルが付いた PR を抽出する。これにはテスト対象の PR と、レビューで修正依頼された自分の PR の両方が含まれる。
+
+---
+
+## ステップ 3: 優先順位を判断して次の作業を提案する
+
+ステップ 2 で収集した作業候補に、ロールの責務に基づいて優先順位を付ける。
+
+### 優先順位の判断基準（全ロール共通）
+
+以下の順で優先度が高い:
+
+1. **他ロールをブロックしている作業** — レビュー待ち PR、方針回答待ちの `[question]`、テスト待ちの PR
+2. **`P1-high` ラベル付きの Issue/PR**
+3. **`[bug]` の修正** — 品質に直結
+4. **`[risk]` の評価** — 放置するとリスクが拡大
+5. **`P2-medium` または優先度ラベルなしの `[task]`/`[refactor]`/`[doc]`**
+6. **`P3-low` ラベル付きの作業**
+
+### ロール別の追加判断基準
+
+**ディレクター:**
+- 定期見直し (a)(b) で検出した問題への対応を、担当 Issue/PR と同列で優先判断する
+- 他ロールの作業を止めている問題（未クローズ issue、ルール不整合）は最優先
+
+**リードエンジニア:**
+- PR レビューは issue 対応より優先（エンジニア・テスターの手を止めないため）
+- `[question]` への回答は次点（他ロールの判断待ちを解消）
+
+**エンジニア:**
+- `[bug]` は `[task]`/`[refactor]` より優先
+- 依存関係がある issue は上流から順に着手
+
+**テスター:**
+- コード変更 PR のテストは issue 対応より優先（マージがブロックされるため）
+- `P1-high` のテスト issue は最優先
+
+### 待機時のプロアクティブ改善
+
+担当 Issue・PR がゼロの場合、待機せず **自ロールの専門領域でコードベースの改善点を探す**。Explore サブエージェントを活用し、発見した問題は issue として報告する（`docs/issue-policy.md` に従う）。
+
+**原則:**
+- 調査のみ行い、直接修正はしない（issue で報告し、通常のレビューフローに乗せる）
+- 明確な問題だけを issue 化する。些末な指摘や好みの問題は報告しない
+- 1回の check-work で起票する issue は **最大3件** とする（issue 乱立防止）
+
+**ロール別の着眼点:**
+
+| ロール | 調査対象 | 着眼点 |
+|---|---|---|
+| リードエンジニア | ソースコード, `docs/` | ソースコード実装と技術ドキュメントの矛盾、設計上の懸念 |
+| エンジニア | ソースコード, テスト | コード品質、エラーハンドリングの不備、テストカバレッジの穴 |
+| テスター | テスト, スクリプト | テストコードと仕様の乖離、スクリプトの不備、ユーザビリティ上の問題 |
+
+> ディレクターは既存の「定期見直し (a)(b)」で同等の機能を持つため、このフォールバックは不要。
+
+### 提案の形式
+
+判断結果を以下の形式でユーザーに提示する:
+
+```
+## 次の作業の提案（<ロール名> / <セッション ID>）
+
+### 推奨: #<番号> <タイトル>
+**理由:** <なぜこれを最優先と判断したか（1文）>
+
+### その他の候補（優先度順）
+1. #<番号> <タイトル> — <状態>
+2. #<番号> <タイトル> — <状態>
+
+### 対象外
+- #<番号> ... → <除外理由>
+```
+
+担当 Issue・PR がゼロの場合は以下の形式にする:
+
+```
+## 次の作業の提案（<ロール名> / <セッション ID>）
+
+担当 Issue・PR はありません。プロアクティブ改善を実施します。
+```
+
+この場合、ユーザー確認なしで上記「待機時のプロアクティブ改善」に進む。
+
+担当作業がある場合は以下で停止:
+
+「上記の提案で進めてよいですか？別の作業を優先する場合は番号を教えてください。」
+
+## ステップ 4: 作業を開始する
+
+ユーザーが承認または別の作業を指定したら、`docs/roles/<ロール名>.md` の「作業の進め方」セクションに従って作業を開始する。
+
+**Issue に着手する場合（エンジニア・テスター）:**
+1. `gh issue comment <番号> --body "着手: <session-id>"` で着手宣言する
+2. ブランチを作成する: `git checkout -b <session-id>/issue-<番号>-<slug>`
+3. issue の内容を改めて詳しく読んで作業を開始する
+
+**Issue に着手する場合（ディレクター・リードエンジニア）:**
+1. issue の詳細を読む: `gh issue view <番号> --comments`
+2. ロール定義の作業手順に従って対応する（ドキュメント更新、方針回答のコメント投稿など）
+
+**作業完了後（PR 提出時）:**
+1. 関連 issue に完了コメントを投稿する: `gh issue comment <番号> --body "完了: <session-id> → PR #<PR番号>"`
+2. issue の `role:*` ラベルを次の担当ロール（= PR レビュー担当）に付替える: `gh issue edit <番号> --remove-label "role:<自分>" --add-label "role:<レビュー担当>"`
+3. issue 本文にチェックボックスがあれば、完了した項目をチェックする: `gh issue edit <番号> --body "..."`
+4. **作業ブランチに戻る**: `git checkout <session-id>/work` — PR 作成後に feature ブランチへ追加コミットしない
+5. 詳細は `docs/issue-policy.md` §7 参照
+
+**PR のテストを完了した場合（テスター）:**
+1. テスト結果コメントを PR に投稿する
+2. `role:tester` ラベルを外す。PR に他の `role:*` ラベル（レビュー担当）が残っていればそのまま。`role:tester` のみの場合はマージ担当ラベルを付ける
+3. **作業ブランチに戻る**: `git checkout <session-id>/work`
+
+**PR をレビューする場合:**
+1. `/review-pr <番号>` スキルを呼び出してレビューを開始する

--- a/.claude/commands/setup-session.md
+++ b/.claude/commands/setup-session.md
@@ -25,33 +25,46 @@ ls -d E:/projects/kobutachan-tools/kobutachan-allaganeye-<サフィックス> 2>
 
 ### 2a: 既存 worktree がある場合（再利用）
 
-1. そのディレクトリへ移動
-2. `git status` で状態確認
-3. ROLE ファイルが存在することを確認
-4. `/assume-role <role>` を実行
-
-### 2b: 既存 worktree がない場合（新規作成）
-
-1. main ブランチの最新を取得:
+1. work ブランチに切り替えてから main の最新を取り込む:
    ```bash
-   git -C E:/projects/kobutachan-tools/kobutachan-allaganeye fetch origin
+   cd E:/projects/kobutachan-tools/kobutachan-allaganeye-<サフィックス>
+   git checkout <セッション ID>/work
+   git fetch origin main
+   git merge origin/main
    ```
-2. worktree を作成:
-   ```bash
-   git -C E:/projects/kobutachan-tools/kobutachan-allaganeye worktree add -b <ブランチ名> E:/projects/kobutachan-tools/kobutachan-allaganeye-<サフィックス> origin/main
-   ```
-3. worktree に移動
-4. ROLE ファイルを作成:
-   ```bash
-   echo "<role>" > ROLE
-   ```
-5. `.claude/settings.local.json` を作成（同一ロールの worktree 間で共有するため、本体リポジトリからコピー）
-6. `/assume-role <role>` を実行
 
-## ステップ 3: 作業開始
+2. `settings.local.json` を同ロールの既存セッションからコピーする:
+   - 同ロールの worktree（番号1）から `.claude/settings.local.json` をコピー
+   - コピー元が存在しない場合はスキップ
 
-ユーザーに以下を報告:
+### 2b: worktree が存在しない場合（新規作成）
+
+1. メインリポジトリから worktree を作成する:
+   ```bash
+   cd E:/projects/kobutachan-tools/kobutachan-allaganeye
+   git worktree add ../kobutachan-allaganeye-<サフィックス> -b <セッション ID>/work
+   ```
+
+2. ROLE ファイルを作成する:
+   ```bash
+   echo "<ROLE ファイル値>" > E:/projects/kobutachan-tools/kobutachan-allaganeye-<サフィックス>/ROLE
+   ```
+   ※ 末尾に改行を含めること
+
+3. `settings.local.json` を同ロールの既存セッションからコピーする:
+   - 同ロールの worktree（番号1）の `.claude/settings.local.json` をコピー
+   - コピー元が存在しない場合はスキップ
+   ```bash
+   mkdir -p E:/projects/kobutachan-tools/kobutachan-allaganeye-<サフィックス>/.claude
+   cp E:/projects/kobutachan-tools/kobutachan-allaganeye-<コピー元サフィックス>/.claude/settings.local.json \
+      E:/projects/kobutachan-tools/kobutachan-allaganeye-<サフィックス>/.claude/settings.local.json
+   ```
+
+## ステップ 3: 完了報告
+
+以下を報告する:
 - worktree パス
 - ブランチ名
 - セッション ID
-- ロールの概要
+- 新規作成 or 再利用
+- settings.local.json のコピー元（コピーした場合）

--- a/.claude/commands/setup-session.md
+++ b/.claude/commands/setup-session.md
@@ -25,12 +25,12 @@ ls -d E:/projects/kobutachan-tools/kobutachan-allaganeye-<サフィックス> 2>
 
 ### 2a: 既存 worktree がある場合（再利用）
 
-1. work ブランチに切り替えてから main の最新を取り込む:
+1. work ブランチに切り替えてから開発ブランチの最新を取り込む:
    ```bash
    cd E:/projects/kobutachan-tools/kobutachan-allaganeye-<サフィックス>
    git checkout <セッション ID>/work
-   git fetch origin main
-   git merge origin/main
+   git fetch origin develop-0.1.0
+   git merge origin/develop-0.1.0
    ```
 
 2. `settings.local.json` を同ロールの既存セッションからコピーする:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
         ]
       }
     ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/apply-role.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/.claude/skills/create-task/SKILL.md
+++ b/.claude/skills/create-task/SKILL.md
@@ -1,33 +1,35 @@
 ---
 name: create-task
-description: GitHub Issueとしてタスクを作成する
+description: issue-policy.md に沿ったタスク issue を対話的に作成する
+user-invocable: true
+argument-hint: <タスクの概要（自然言語）>
 ---
 
-# タスク作成スキル
-
-GitHub Issue としてタスクを作成します。
-
-## 引数
-
-`$ARGUMENTS` にタスクの概要を自然言語で指定。
+ユーザーの指示に基づいて GitHub Issue を作成する。`docs/issue-policy.md` のルールに従うこと。
 
 ## 手順
 
-1. `docs/issue-policy.md` を読み、Issue 作成ルールを確認
-2. 引数からタスク内容を解析し、以下を決定:
-   - プレフィックス: `[bug]`, `[doc]`, `[refactor]`, `[task]`, `[question]`, `[risk]`
-   - ラベル: `bug`, `documentation`, `enhancement`, `question` + ロールラベル
-   - 担当ロール: タスク内容から適切なロールを推定
-3. 重複チェック:
+1. ユーザーの指示（`$ARGUMENTS`）からタスクの内容を把握する
+2. 適切な prefix を選択する（`[bug]`, `[doc]`, `[refactor]`, `[question]`, `[risk]`, `[task]`）
+3. `docs/issue-policy.md` §3 の対応テンプレートに沿って本文を作成する
+4. 作成前にユーザーにタイトルと本文を提示し、確認を得る
+5. ユーザーが承認したら `gh issue create` で作成する:
    ```bash
-   gh issue list --repo Idios/kobutachan-allaganeye --state open --search "<キーワード>" --json number,title
+   gh issue create \
+     --title "<prefix> <概要>" \
+     --body "<テンプレートに沿った本文>" \
+     --assignee "Idios" \
+     --label "<prefix に対応するラベル（該当する場合）>" \
+     --label "<対応ロールの role:* ラベル（該当する場合）>"
    ```
-4. 重複がなければ Issue を作成:
-   ```bash
-   gh issue create --repo Idios/kobutachan-allaganeye \
-     --title "<プレフィックス> <タイトル>" \
-     --body "<本文>" \
-     --assignee Idios \
-     --label "<ラベル1>,<ラベル2>"
-   ```
-5. ユーザーに Issue URL を報告
+
+## 注意事項
+
+- 1 issue = 1 つの問題・タスク。複数の問題をまとめない
+- 作成前に `gh issue list` で重複がないか確認する
+- ラベルは prefix に応じて設定する（`[risk]` は prefix ラベルなし）
+- `[task]` issue には対応ロールの `role:*` ラベルを必ず付ける（`docs/issue-policy.md` §2 参照）
+- `[question]` issue には回答を求めるロールの `role:*` ラベルを付ける
+- 優先度が明確な場合は `P1-high` / `P2-medium` / `P3-low` ラベルを付ける（`docs/issue-policy.md` §2 参照）
+- タイトルは日本語で 40 文字以内
+- 本文の末尾に `作成: <session-id>` を記載する

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,55 +1,41 @@
 ---
 name: review-pr
-description: PRのレビューとマージを自動化する
+description: PR をレビューし、懸念点があればコメント、なければ LGTM してマージする
+user-invocable: true
+argument-hint: <PR番号>
 ---
 
-# PR レビュースキル
+指定された PR をレビューする。以下の手順で進めること:
 
-指定された PR をレビューし、条件を満たせばマージします。
+1. `gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,files,commits,labels` で PR の概要を確認する
+2. PR の `role:*` ラベルが正しいか確認する（`docs/roles/protocol.md` §「PR レビューとマージ」参照）。元 issue がある場合は issue 作成者ロールがレビュー担当。誤りがあれば `gh pr edit` で修正してからレビューに進む
+3. `gh pr diff $ARGUMENTS` で差分を確認する
+4. 以下の観点でレビューする:
+   - 変更の意図が PR の説明と一致しているか
+   - `docs/roles/protocol.md` のルールに違反していないか
+   - 自ロールのレビュー権限範囲内か（protocol.md の「PR レビューとマージ」参照）
+   - ドキュメント変更の場合: 既存のドキュメントとの整合性、矛盾がないか
+   - コード変更の場合: アーキテクチャに沿っているか、セキュリティモデルが守られているか
+5. コード変更が含まれる場合、テスト確認を行う:
+   - PR コメントにテスターの `テスト完了: <session-id>` コメントがあるか確認する
+   - **ない場合**: マージ不可。「テスター確認待ち」とユーザーに報告し、マージは行わない
+   - **ある場合**: コメントに実行結果の要約（テスト件数・成否等）が含まれていることを確認し、問題なければマージ可と判断する
+   - ドキュメントのみの PR はこのステップをスキップする
+6. レビュー結果をユーザーに報告し、判断を仰ぐ:
+   - 懸念があれば具体的に指摘し、PR コメントするかユーザーに確認する
+   - 問題なければ LGTM コメントとマージの実施をユーザーに提案する
+   - **修正を依頼する場合**: PR に修正依頼コメントを投稿し、`role:*` ラベルを PR 作成者のロールに付替える（protocol.md §「レビューでの修正依頼時」参照）
+7. ユーザーが承認したら:
+   - `gh pr comment $ARGUMENTS --body "LGTM. <簡潔な理由> [<session-id>]"` でコメント
+   - **マージ権限の確認**: マージはリードエンジニアまたはディレクターのみ実行可能
+     - 自セッションが lead/director の場合: `gh pr merge $ARGUMENTS --squash` でマージ
+     - 自セッションが engineer/tester の場合: LGTM のみ行い、`role:*` ラベルを lead/director に付替え、マージは lead/director に委ねる旨をユーザーに伝える
+8. マージ後、PR に紐づく issue がある場合:
+   - `gh issue view <番号> --json body,comments` で issue 本文とコメントを取得する
+   - 本文に未チェックのチェックボックス（`- [ ]`）がないか確認する
+   - **未完了項目なし**: `gh issue close <番号> --comment "マージ確認: <session-id> ← PR #番号"` でクローズする
+   - **未完了項目あり**: PR の変更内容とコメントを照合し、実際に作業が完了しているか判断する
+     - **作業完了だがチェック漏れ**: `gh issue edit <番号> --body "..."` でチェックボックスを更新してからクローズする
+     - **実際に未完了の残作業あり**: クローズせず、issue 作成者のロールにラベルを付替える（`作成: <session-id>` から判定: `director-*` → `role:director`、`lead-*` → `role:lead-engineer`、`engineer-*` → `role:engineer`、`tester-*` → `role:tester`）
 
-## 引数
-
-`$ARGUMENTS` に PR 番号を指定（例: `42`）
-
-## 手順
-
-1. PR の情報を取得:
-   ```bash
-   gh pr view $ARGUMENTS --repo Idios/kobutachan-allaganeye --json number,title,body,labels,reviews,statusCheckRollup,mergeable,additions,deletions,files
-   ```
-2. PR の diff を取得:
-   ```bash
-   gh pr diff $ARGUMENTS --repo Idios/kobutachan-allaganeye
-   ```
-3. 以下の観点でレビュー:
-   - コードの正確性・安全性
-   - テストの有無と網羅性
-   - CLAUDE.md / docs の更新必要性
-   - コーディング規約への準拠
-   - チェックリストの完了状態
-4. レビュー結果を PR コメントで投稿:
-   ```bash
-   gh pr comment $ARGUMENTS --repo Idios/kobutachan-allaganeye --body "<レビュー内容>"
-   ```
-
-> **注意**: `gh pr review --approve` は使用しない（全ロールが同一アカウントのため self-approve 不可。`docs/roles/protocol.md` 参照）。レビュー結果はコメントで投稿する。
-
-## マージ条件（Lead Engineer / Director のみ）
-
-以下のすべてを満たす場合にマージ可能:
-- チェックリストが全て完了
-- コード変更を含む PR: テスターのテスト結果コメントがある
-- ドキュメントのみの PR: レビューコメントで LGTM
-- マージコンフリクトがない
-
-```bash
-gh pr merge $ARGUMENTS --repo Idios/kobutachan-allaganeye --squash
-```
-
-## 関連 Issue のクローズ
-
-PR マージ後、関連 Issue は **手動でクローズ** する（`Closes` / `Fixes` / `Resolves` キーワードは使用禁止。`docs/issue-policy.md` 参照）。
-
-```bash
-gh issue close <番号> --repo Idios/kobutachan-allaganeye --comment "マージ確認: <session-id> ← PR #$ARGUMENTS"
-```
+> **注意**: `gh pr review --approve` は使用しない（全ロールが同一アカウントのため self-approve 不可。`docs/roles/protocol.md` 参照）。


### PR DESCRIPTION
## Summary

- `idios-claudecode-tools` リポジトリの最新 multi-agent テンプレートから、コマンド・スキル・設定を同期
- 既存のプロジェクト固有パス・値は維持しつつ、テンプレートで強化された手順を取り込み

### 変更内容

| ファイル | 変更 |
|---|---|
| `.claude/commands/check-work.md` | ロール別詳細手順、定期見直し(a)(b)、プロアクティブ改善、提案フォーマット、ステップ4 作業開始手順を追加 |
| `.claude/skills/review-pr/SKILL.md` | フロントマター追加、ラベル検証・テスト確認フロー・マージ後 issue クローズ判定ロジックを詳細化 |
| `.claude/skills/create-task/SKILL.md` | フロントマター追加（`user-invocable`, `argument-hint`）、確認ステップ・注意事項を詳細化 |
| `.claude/settings.json` | PostCompact hook 追加（コンパクト後のロール再適用） |
| `.claude/commands/setup-session.md` | 既存 worktree 再利用時の `git merge origin/main` 手順、`settings.local.json` コピー手順を追加 |

## Test plan

- [ ] `/check-work` が各ロールで正しく動作すること
- [ ] `/review-pr` でテスト確認・issue クローズ判定が動作すること
- [ ] `/create-task` でフロントマターが反映されていること
- [ ] PostCompact 後にロールが再適用されること
- [ ] `/setup-session` で既存 worktree 再利用時に main がマージされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)