### PR TITLE
fix: _probe_single_frame / _probe_frame_rgb の returncode 検証追加 #155

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -207,6 +207,9 @@ def _probe_single_frame(video_path: Path, timestamp: float) -> float:
     except subprocess.TimeoutExpired:
         return 255.0  # treat timeout as non-blackout
 
+    if result.returncode != 0:
+        return 255.0  # ffmpeg error, treat as non-blackout
+
     if len(result.stdout) < _FRAME_SIZE:
         return 255.0  # incomplete frame, treat as non-blackout
 
@@ -250,6 +253,9 @@ def _probe_frame_rgb(
             "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
         ) from e
     except subprocess.TimeoutExpired:
+        return None
+
+    if result.returncode != 0:
         return None
 
     if len(result.stdout) < rgb_size:

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -504,6 +504,14 @@ class TestProbeSingleFrame:
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=30)
         assert _probe_single_frame(Path("test.mp4"), 10.0) == 255.0
 
+    @patch("allaganeye.video.detector.subprocess.run")
+    def test_nonzero_returncode(self, mock_run):
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = b"\x00" * _FRAME_SIZE  # valid-length but from failed process
+        mock_run.return_value = result
+        assert _probe_single_frame(Path("test.mp4"), 10.0) == 255.0
+
 
 # ============================================================
 # TestDetectMatchBoundaries

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -587,6 +587,7 @@ class TestProbeFrameRgb:
         from allaganeye.video.detector import _probe_frame_rgb
 
         result = MagicMock()
+        result.returncode = 0
         result.stdout = b"\x00" * 10  # way too short
         mock_run.return_value = result
         assert _probe_frame_rgb(Path("v.mp4"), 10.0) is None
@@ -601,11 +602,27 @@ class TestProbeFrameRgb:
 
         expected_size = _SAMPLE_WIDTH * _HEIGHT * 3
         result = MagicMock()
+        result.returncode = 0
         result.stdout = b"\x80" * expected_size
         mock_run.return_value = result
         raw = _probe_frame_rgb(Path("v.mp4"), 10.0, _HEIGHT)
         assert raw is not None
         assert len(raw) == expected_size
+
+    @patch("allaganeye.video.detector.subprocess.run")
+    @patch("allaganeye.video.detector.find_ffmpeg", return_value="ffmpeg")
+    def test_nonzero_returncode_returns_none(self, _mock_ff, mock_run):
+        """ffmpeg error exit → None (not partial data)."""
+        from unittest.mock import MagicMock
+
+        from allaganeye.video.detector import _probe_frame_rgb
+
+        expected_size = _SAMPLE_WIDTH * _HEIGHT * 3
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = b"\x00" * expected_size  # valid-length but from failed process
+        mock_run.return_value = result
+        assert _probe_frame_rgb(Path("v.mp4"), 10.0, _HEIGHT) is None
 
     def test_ffmpeg_not_found_raises(self):
         """ffmpeg not found → VideoProcessingError."""


### PR DESCRIPTION
## Summary

- `_probe_single_frame`: `returncode != 0` の場合に `255.0`（非暗転扱い）を返すガードを追加
- `_probe_frame_rgb`: `returncode != 0` の場合に `None` を返すガードを追加
- 両関数とも `returncode` チェックを `len(result.stdout)` チェックの前に配置し、不正データの解析を完全に回避
- 既存テストの MagicMock に `returncode = 0` を明示的に設定（テストの意図を正確に反映）
- 新規テスト `test_nonzero_returncode` を両関数に追加

## 対応 Issue

#155

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（244 passed）
- [x] `test_detector.py::TestProbeSingleFrame::test_nonzero_returncode` — returncode=1 で 255.0 を返すことを確認
- [x] `test_scorebar.py::TestProbeFrameRgb::test_nonzero_returncode_returns_none` — returncode=1 で None を返すことを確認

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)