### PR TITLE
fix: GPU/CPU 一貫性テストに src_resolution を追加 #154

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -398,6 +398,7 @@ def gpu_cpu_results(source_mkv: Path, source_metadata: dict) -> dict:
         blackout_threshold=15.0,
         min_match_duration=300.0,
         min_blackout_duration=3.0,
+        src_resolution=(source_metadata["width"], source_metadata["height"]),
     )
     gpu = detect_match_boundaries(
         source_mkv,
@@ -407,6 +408,7 @@ def gpu_cpu_results(source_mkv: Path, source_metadata: dict) -> dict:
         blackout_threshold=15.0,
         min_match_duration=300.0,
         min_blackout_duration=3.0,
+        src_resolution=(source_metadata["width"], source_metadata["height"]),
     )
     return {"cpu": cpu, "gpu": gpu}
 


### PR DESCRIPTION
## Summary

- `gpu_cpu_results` フィクスチャの CPU/GPU 両方の `detect_match_boundaries` 呼び出しに `src_resolution=(source_metadata["width"], source_metadata["height"])` を追加
- これにより scorebar フィルタリングが本番パス（`run_split`）と同様に有効化され、テスト条件の乖離を解消

## 対応 Issue

#154

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（247 passed）
- テストコードのみの変更（`tests/test_integration.py`）のため実データ検証は不要
- GPU/CPU 一貫性テスト自体は `slow` マーカー付き・GPU 必須のため、テスターによる実データ検証で結果の変化を確認予定

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)