### PR TITLE
docs: CLAUDE.md モジュール構成に video/scorebar.py を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | `video/probe.py` | ffprobe でメタデータ取得（解像度、fps、長さ） |
 | `video/detector.py` | ffmpeg 並列プローブで暗転検知、試合境界抽出（CPU モード） |
 | `video/gpu_detector.py` | GPU アクセラレーション検知（チャンク並列デコード） |
+| `video/scorebar.py` | スコアバーフィルタリング（暗転分類・試合内/非FL判定） |
 | `video/splitter.py` | FFmpeg で動画分割（-c copy） |
 
 ### 検知アルゴリズム（detector.py）


### PR DESCRIPTION
## Summary

- `CLAUDE.md` のモジュール構成テーブルに `video/scorebar.py` を追加
- Phase 2-3 (#111) で追加されたモジュールが記載漏れしていた

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 247 passed
- ドキュメントのみの変更

作成: lead-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)