### PR TITLE
feat: metadata.json に type フィールド追加 (Phase 4) #165

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -146,6 +146,7 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
                 "end_display": _format_timestamp(b["end"]),
                 "duration": b["end"] - b["start"],
                 "duration_display": _format_duration(b["end"] - b["start"]),
+                "type": b.get("type", "unknown"),
                 "output_file": str(f),
             }
             for i, (b, f) in enumerate(zip(boundaries, output_files, strict=True))

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -106,11 +106,12 @@ def detect_match_boundaries(
     )
 
     # Scorebar-based filtering: remove in-match and non-FL blackouts (#111)
+    region_classifications: list[str] | None = None
     if src_resolution is not None:
         from allaganeye.video.scorebar import filter_blackouts_with_scorebar
 
         height = _scaled_height(src_resolution[0], src_resolution[1])
-        refined_regions = filter_blackouts_with_scorebar(
+        refined_regions, region_classifications = filter_blackouts_with_scorebar(
             video_path, refined_regions, duration_hint, height, workers
         )
 
@@ -120,6 +121,7 @@ def detect_match_boundaries(
         duration_hint,
         min_match_duration,
         effective_min,
+        classifications=region_classifications,
     )
 
 
@@ -517,11 +519,22 @@ def _refine_blackout_regions(
     return _group_blackout_regions(fine_blackout_times, _REFINE_INTERVAL)
 
 
+_BOUNDARY_CLASSES = {"match_boundary", "in_match"}
+
+
+def _infer_segment_type(left_cls: str, right_cls: str) -> str:
+    """Infer segment type from adjacent blackout classifications."""
+    if left_cls in _BOUNDARY_CLASSES and right_cls in _BOUNDARY_CLASSES:
+        return "fl_match"
+    return "unknown"
+
+
 def _filter_and_extract_segments(
     blackout_regions: list[tuple[float, float]],
     total_duration: float,
     min_match_duration: float,
     min_blackout_duration: float = 3.0,
+    classifications: list[str] | None = None,
 ) -> list[dict]:
     """Filter blackout regions by duration and extract match segments.
 
@@ -530,20 +543,38 @@ def _filter_and_extract_segments(
     offset into the blackout regions by ``_BLACKOUT_PADDING`` so that
     keyframe-level imprecision in ``-c copy`` mode never clips match
     footage.
+
+    When *classifications* is provided, each segment receives a ``"type"``
+    field inferred from adjacent blackout classifications.
     """
     if not blackout_regions:
         if total_duration >= min_match_duration:
-            return [{"start": 0.0, "end": total_duration}]
+            return [{"start": 0.0, "end": total_duration, "type": "unknown"}]
         return []
 
     # Filter out short blackout regions (e.g. respawn blackouts 1-2s)
-    blackout_regions = [
-        (s, e) for s, e in blackout_regions if e - s >= min_blackout_duration
-    ]
+    if classifications is not None:
+        paired = [
+            (r, c)
+            for r, c in zip(blackout_regions, classifications, strict=True)
+            if r[1] - r[0] >= min_blackout_duration
+        ]
+        if paired:
+            blackout_regions, filtered_cls = [
+                list(x) for x in zip(*paired, strict=True)
+            ]
+        else:
+            blackout_regions = []
+            filtered_cls = []
+    else:
+        blackout_regions = [
+            (s, e) for s, e in blackout_regions if e - s >= min_blackout_duration
+        ]
+        filtered_cls = None
 
     if not blackout_regions:
         if total_duration >= min_match_duration:
-            return [{"start": 0.0, "end": total_duration}]
+            return [{"start": 0.0, "end": total_duration, "type": "unknown"}]
         return []
 
     # Extract segments between blackout regions
@@ -555,7 +586,13 @@ def _filter_and_extract_segments(
         seg_end = _padded_end(blackout_regions[0])
         seg_end = min(seg_end, total_duration)
         if seg_end - seg_start >= min_match_duration:
-            segments.append({"start": seg_start, "end": seg_end})
+            segments.append(
+                {
+                    "start": seg_start,
+                    "end": seg_end,
+                    "type": "unknown",
+                }
+            )
 
     # Between blackout regions
     for i in range(len(blackout_regions) - 1):
@@ -564,13 +601,30 @@ def _filter_and_extract_segments(
         seg_end = _padded_end(blackout_regions[i + 1])
         seg_end = min(seg_end, total_duration)
         if seg_end - seg_start >= min_match_duration:
-            segments.append({"start": seg_start, "end": seg_end})
+            seg_type = (
+                _infer_segment_type(filtered_cls[i], filtered_cls[i + 1])
+                if filtered_cls is not None
+                else "unknown"
+            )
+            segments.append(
+                {
+                    "start": seg_start,
+                    "end": seg_end,
+                    "type": seg_type,
+                }
+            )
 
     # After last blackout
     seg_start = _padded_start(blackout_regions[-1])
     seg_start = max(seg_start, 0.0)
     if total_duration - seg_start >= min_match_duration:
-        segments.append({"start": seg_start, "end": total_duration})
+        segments.append(
+            {
+                "start": seg_start,
+                "end": total_duration,
+                "type": "unknown",
+            }
+        )
 
     return segments
 

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -137,7 +137,7 @@ def filter_blackouts_with_scorebar(
     duration: float,
     height: int,
     workers: int | None = None,
-) -> list[tuple[float, float]]:
+) -> tuple[list[tuple[float, float]], list[str]]:
     """Filter blackout regions using scorebar context and duration.
 
     Removes:
@@ -152,6 +152,9 @@ def filter_blackouts_with_scorebar(
     Post-processing:
     - Merges consecutive ``"match_boundary"`` pairs separated by non-FL
       content (result screen / lobby) into a single boundary region.
+
+    Returns:
+        Tuple of (filtered_regions, filtered_classifications).
     """
     kept: list[tuple[float, float]] = []
     classifications: list[str] = []
@@ -202,7 +205,7 @@ def _merge_boundary_pairs(
     duration: float,
     height: int,
     workers: int | None,
-) -> list[tuple[float, float]]:
+) -> tuple[list[tuple[float, float]], list[str]]:
     """Merge consecutive match_boundary pairs separated by non-FL content.
 
     FL match transitions often produce two blackouts:
@@ -211,11 +214,15 @@ def _merge_boundary_pairs(
 
     When two consecutive match_boundary regions have a gap < _MERGE_GAP_MAX
     and the gap midpoint has no scorebar, merge them into one region.
+
+    Returns:
+        Tuple of (merged_regions, merged_classifications).
     """
     if len(regions) < 2:
-        return regions
+        return regions, classifications
 
     merged: list[tuple[float, float]] = []
+    merged_cls: list[str] = []
     i = 0
     while i < len(regions):
         if (
@@ -252,6 +259,7 @@ def _merge_boundary_pairs(
                         probe_results,
                     )
                     merged.append(merged_region)
+                    merged_cls.append("match_boundary")
                     i += 2
                     continue
                 logger.debug(
@@ -264,6 +272,7 @@ def _merge_boundary_pairs(
                     probe_results,
                 )
         merged.append(regions[i])
+        merged_cls.append(classifications[i])
         i += 1
 
-    return merged
+    return merged, merged_cls

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -18,6 +18,7 @@ from allaganeye.video.detector import (
     _filter_and_extract_segments,
     _generate_timestamps,
     _group_blackout_regions,
+    _infer_segment_type,
     _probe_single_frame,
     _refine_blackout_regions,
     detect_match_boundaries,
@@ -443,6 +444,92 @@ class TestExtractSegments:
         assert result[0]["start"] == 0.0
         assert result[1]["end"] == 1800.0
 
+    def test_type_unknown_without_classifications(self):
+        """All segments get type=unknown when no classifications provided."""
+        blackout_times = [600.0, 601.0, 602.0, 603.0, 604.0]
+        result = _extract_segments(
+            blackout_times,
+            total_duration=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+        )
+        assert len(result) == 2
+        assert all(s["type"] == "unknown" for s in result)
+
+    def test_type_fl_match_with_classifications(self):
+        """Segments between match_boundary blackouts get type=fl_match."""
+        regions = [(100.0, 105.0), (900.0, 905.0)]
+        cls = ["match_boundary", "match_boundary"]
+        result = _filter_and_extract_segments(
+            regions, 1800.0, 300.0, 3.0, classifications=cls
+        )
+        # Before first blackout: too short (102.5s < 300s) → excluded
+        # Between blackouts: fl_match (both sides match_boundary)
+        # After last blackout: unknown (tail segment)
+        assert len(result) == 2
+        assert result[0]["type"] == "fl_match"
+        assert result[1]["type"] == "unknown"
+
+    def test_type_unknown_with_mixed_classifications(self):
+        """Segments between non-boundary blackouts get type=unknown."""
+        regions = [(100.0, 105.0), (900.0, 905.0)]
+        cls = ["match_boundary", "unknown"]
+        result = _filter_and_extract_segments(
+            regions, 1800.0, 300.0, 3.0, classifications=cls
+        )
+        assert len(result) == 2
+        assert result[0]["type"] == "unknown"
+
+    def test_type_with_in_match_classifications(self):
+        """in_match classifications produce fl_match segments."""
+        regions = [(100.0, 105.0), (900.0, 905.0)]
+        cls = ["in_match", "match_boundary"]
+        result = _filter_and_extract_segments(
+            regions, 1800.0, 300.0, 3.0, classifications=cls
+        )
+        assert len(result) == 2
+        assert result[0]["type"] == "fl_match"
+
+    def test_classifications_filtered_with_regions(self):
+        """Short blackouts are filtered along with their classifications."""
+        regions = [(100.0, 101.0), (500.0, 505.0), (1200.0, 1205.0)]
+        cls = ["unknown", "match_boundary", "match_boundary"]
+        result = _filter_and_extract_segments(
+            regions, 1800.0, 300.0, 3.0, classifications=cls
+        )
+        # First region (1s) filtered out; remaining: match_boundary, match_boundary
+        assert len(result) == 3
+        assert result[1]["type"] == "fl_match"
+
+
+# ============================================================
+# TestInferSegmentType
+# ============================================================
+
+
+class TestInferSegmentType:
+    def test_both_match_boundary(self):
+        assert _infer_segment_type("match_boundary", "match_boundary") == "fl_match"
+
+    def test_both_in_match(self):
+        assert _infer_segment_type("in_match", "in_match") == "fl_match"
+
+    def test_mixed_boundary_and_in_match(self):
+        assert _infer_segment_type("match_boundary", "in_match") == "fl_match"
+        assert _infer_segment_type("in_match", "match_boundary") == "fl_match"
+
+    def test_unknown_left(self):
+        assert _infer_segment_type("unknown", "match_boundary") == "unknown"
+
+    def test_unknown_right(self):
+        assert _infer_segment_type("match_boundary", "unknown") == "unknown"
+
+    def test_both_unknown(self):
+        assert _infer_segment_type("unknown", "unknown") == "unknown"
+
+    def test_non_fl(self):
+        assert _infer_segment_type("non_fl", "match_boundary") == "unknown"
+
 
 # ============================================================
 # TestGenerateTimestamps
@@ -633,7 +720,10 @@ class TestDetectMatchBoundaries:
     def test_scorebar_filtering_called_with_resolution(self, mock_probe, mock_filter):
         """Scorebar filtering is invoked when src_resolution is provided."""
         mock_probe.return_value = 128.0
-        mock_filter.side_effect = lambda vp, regions, dur, h, w: regions
+        mock_filter.side_effect = lambda vp, regions, dur, h, w: (
+            regions,
+            ["match_boundary"] * len(regions),
+        )
         detect_match_boundaries(
             Path("test.mp4"),
             duration_hint=300.0,

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -245,60 +245,82 @@ class TestFilterBlackouts:
     def test_keeps_match_boundary(self, mock_classify):
         mock_classify.return_value = "match_boundary"
         regions = [(100.0, 105.0), (200.0, 205.0)]
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == regions
+        assert cls == ["match_boundary", "match_boundary"]
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_removes_short_in_match(self, mock_classify):
         """Short in_match (< 3.5s) = character down → removed."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]  # 2s duration
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == []
+        assert cls == []
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_keeps_long_in_match(self, mock_classify):
         """Long in_match (>= 3.5s) = FL match boundary → kept."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 108.0)]  # 8s duration
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == [(100.0, 108.0)]
+        assert cls == ["in_match"]
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_keeps_in_match_exactly_3_5s(self, mock_classify):
         """in_match at exactly 3.5s boundary → kept (not strictly less than)."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 103.5)]  # exactly 3.5s
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == [(100.0, 103.5)]
+        assert cls == ["in_match"]
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_removes_in_match_just_under_3_5s(self, mock_classify):
         """in_match at 3.49s → removed (strictly less than 3.5)."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 103.49)]  # 3.49s
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == []
+        assert cls == []
 
     def test_empty_regions(self):
         """Empty blackout list → empty result, no classify calls."""
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), [], 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(Path("v.mp4"), [], 300.0, _HEIGHT)
         assert result == []
+        assert cls == []
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_removes_non_fl(self, mock_classify):
         mock_classify.return_value = "non_fl"
         regions = [(100.0, 102.0)]
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == []
+        assert cls == []
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_keeps_unknown(self, mock_classify):
         """Unknown → safe side, keep boundary."""
         mock_classify.return_value = "unknown"
         regions = [(100.0, 102.0)]
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == regions
+        assert cls == ["unknown"]
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_mixed_classifications(self, mock_classify):
@@ -319,13 +341,16 @@ class TestFilterBlackouts:
             (250.0, 255.0),  # boundary → kept
             (280.0, 288.0),  # in_match 8s → kept
         ]
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == [
             (50.0, 55.0),
             (200.0, 202.0),
             (250.0, 255.0),
             (280.0, 288.0),
         ]
+        assert cls == ["match_boundary", "unknown", "match_boundary", "in_match"]
 
 
 DETECTOR_MODULE = "allaganeye.video.detector"
@@ -346,8 +371,11 @@ class TestMergeBoundaryPairs:
         mock_has_sb.return_value = False  # no scorebar in gap
 
         regions = [(100.0, 105.0), (200.0, 205.0)]  # gap=95s
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == [(100.0, 205.0)]
+        assert cls == ["match_boundary"]
 
     @patch(f"{SCOREBAR_MODULE}._has_scorebar")
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
@@ -361,8 +389,11 @@ class TestMergeBoundaryPairs:
         mock_has_sb.return_value = True  # scorebar in gap
 
         regions = [(100.0, 105.0), (200.0, 205.0)]
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == regions
+        assert cls == ["match_boundary", "match_boundary"]
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_no_merge_when_gap_exceeds_max(self, mock_classify):
@@ -370,10 +401,11 @@ class TestMergeBoundaryPairs:
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         gap = _MERGE_GAP_MAX + 100
         regions = [(100.0, 105.0), (105.0 + gap, 110.0 + gap)]
-        result = filter_blackouts_with_scorebar(
+        result, cls = filter_blackouts_with_scorebar(
             Path("v.mp4"), regions, 10000.0, _HEIGHT
         )
         assert result == regions
+        assert cls == ["match_boundary", "match_boundary"]
 
     @patch(f"{SCOREBAR_MODULE}._has_scorebar")
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
@@ -387,8 +419,11 @@ class TestMergeBoundaryPairs:
         mock_has_sb.return_value = None  # probe failure
 
         regions = [(100.0, 105.0), (200.0, 205.0)]
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == regions
+        assert cls == ["match_boundary", "match_boundary"]
 
     @patch(f"{SCOREBAR_MODULE}._has_scorebar")
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
@@ -406,9 +441,12 @@ class TestMergeBoundaryPairs:
         mock_has_sb.return_value = False
 
         regions = [(100.0, 105.0), (200.0, 205.0), (300.0, 305.0)]
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 400.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 400.0, _HEIGHT
+        )
         # First pair merges → (100, 205), third is separate
         assert result == [(100.0, 205.0), (300.0, 305.0)]
+        assert cls == ["match_boundary", "match_boundary"]
 
     @patch(f"{SCOREBAR_MODULE}._has_scorebar")
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
@@ -420,8 +458,11 @@ class TestMergeBoundaryPairs:
         mock_has_sb.return_value = False
 
         regions = [(100.0, 105.0), (705.0, 710.0)]  # gap = 600.0
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 1000.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 1000.0, _HEIGHT
+        )
         assert result == [(100.0, 710.0)]
+        assert cls == ["match_boundary"]
 
     @patch(f"{SCOREBAR_MODULE}._has_scorebar")
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
@@ -435,16 +476,22 @@ class TestMergeBoundaryPairs:
         mock_has_sb.return_value = False
 
         regions = [(100.0, 105.0), (705.1, 710.0)]  # gap = 600.1
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 1000.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 1000.0, _HEIGHT
+        )
         assert result == regions
+        assert cls == ["match_boundary", "match_boundary"]
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_single_region_no_merge(self, mock_classify):
         """Single region → no merge processing, returned as-is."""
         mock_classify.return_value = "match_boundary"
         regions = [(100.0, 105.0)]
-        result = filter_blackouts_with_scorebar(Path("v.mp4"), regions, 300.0, _HEIGHT)
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT
+        )
         assert result == regions
+        assert cls == ["match_boundary"]
 
 
 # --- _has_scorebar boundary tests ---

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -110,6 +110,7 @@ def test_pipeline_metadata_json_content(mock_probe, mock_detect, mock_split, tmp
     assert m1["start_time"] == 0.0
     assert m1["end_time"] == 600.0
     assert m1["duration"] == 600.0
+    assert m1["type"] == "unknown"
     assert "match_001" in m1["output_file"]
 
 


### PR DESCRIPTION
## Summary

- `scorebar.py`: `filter_blackouts_with_scorebar` / `_merge_boundary_pairs` の戻り値を `(regions, classifications)` タプルに変更し、分類結果を呼び出し元に伝播
- `detector.py`: `_infer_segment_type` ヘルパー追加（左右の暗転分類から `fl_match` / `unknown` を推論）、`_filter_and_extract_segments` に `classifications` パラメータ追加、各セグメントに `"type"` キー追加
- `split_matches.py`: metadata の各 match エントリに `"type"` フィールド追加
- テスト: 戻り値アンパック更新（17 箇所）、classifications アサーション追加、`_infer_segment_type` テスト 7 件追加、type フィールド境界テスト 5 件追加

## 対応 Issue

#165 (#111 Phase 4)

## セルフ検証

`ALLAGANEYE_SAMPLE_VIDEO_DIR` が未設定のため実データ検証は未実施。テスターによる実動画での独立検証を依頼。

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（261 passed）
- [ ] テスターによる実動画での metadata.json type フィールド確認

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)