### PR TITLE
docs: _has_scorebar docstring の閾値を 8.0 → 15.0 に修正 #158

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -297,7 +297,7 @@ def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
 
     Criteria (lead-1 revised spec based on 3-section analysis, #121):
     - 20 < roi_brightness < 140 (FL match typical range)
-    - max cross-section channel std > 8.0 (3GC color separation)
+    - max cross-section channel std > 15.0 (3GC color separation)
     """
     if raw_rgb is None:
         return None


### PR DESCRIPTION
## Summary

- `_has_scorebar` 関数の docstring に残っていた古い閾値 `> 8.0` を実装値 `> 15.0` に修正

## 対応 Issue

#158

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（249 passed）
- ドキュメントのみの変更のため実データ検証は不要

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)