### PR TITLE
fix: conftest.py の pyright エラーを修正 #169

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -40,7 +41,7 @@ def fake_video(tmp_path: Path) -> Path:
 
 
 @pytest.fixture(autouse=True)
-def _ffmpeg_interval(request: pytest.FixtureRequest) -> None:  # type: ignore[return]
+def _ffmpeg_interval(request: pytest.FixtureRequest) -> Iterator[None]:
     """Insert 1s interval after slow-marked tests to prevent GPU deadlock.
 
     Repeated ffmpeg calls can cause NVIDIA driver unresponsiveness due to


### PR DESCRIPTION
## Summary

- `tests/conftest.py:49` の `_ffmpeg_interval` フィクスチャの戻り値型を `None` → `Iterator[None]` に修正
- `# type: ignore[return]` コメントも除去
- CI の pyright エラー（reportReturnType）を解消

## 対応 Issue

#169

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pyright tests/conftest.py` — 0 errors
- [x] `pytest` — 249 passed, 28 deselected

作成: lead-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)