### PR TITLE
test: --min-blackout-duration の CLI テストと config バリデーションテスト追加 #161

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,6 +87,16 @@ def test_split_negative_min_match_duration(tmp_path):
     assert result.exit_code == 5
 
 
+def test_split_negative_min_blackout_duration(tmp_path):
+    """--min-blackout-duration -1 should fail validation (must be >= 0)."""
+    fake_file = tmp_path / "video.mp4"
+    fake_file.write_bytes(b"\x00")
+    result = runner.invoke(
+        app, ["split", str(fake_file), "--min-blackout-duration", "-1"]
+    )
+    assert result.exit_code == 5
+
+
 def test_split_workers_zero(tmp_path):
     """--workers 0 should fail validation (must be >= 1)."""
     fake_file = tmp_path / "video.mp4"
@@ -119,6 +129,7 @@ def test_split_default_options(mock_run_split, fake_video):
     assert config.sample_interval == 1.0
     assert config.blackout_threshold == 15.0
     assert config.min_match_duration == 300.0
+    assert config.min_blackout_duration == 3.0
     assert config.workers is None
     assert config.use_gpu is False
     assert config.dry_run is False
@@ -179,6 +190,18 @@ def test_split_min_match_duration(mock_run_split, fake_video):
     assert result.exit_code == 0
     config = mock_run_split.call_args[0][1]
     assert config.min_match_duration == 120.0
+
+
+@patch(MODULE)
+def test_split_min_blackout_duration(mock_run_split, fake_video):
+    """--min-blackout-duration option is forwarded to config."""
+    result = runner.invoke(
+        app, ["split", str(fake_video), "--min-blackout-duration", "5.0"]
+    )
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.min_blackout_duration == 5.0
 
 
 @patch(MODULE)
@@ -256,6 +279,8 @@ def test_split_all_options_combined(mock_run_split, fake_video, tmp_path):
             "25.0",
             "--min-match-duration",
             "60",
+            "--min-blackout-duration",
+            "5.0",
             "--workers",
             "4",
             "--gpu",
@@ -270,6 +295,7 @@ def test_split_all_options_combined(mock_run_split, fake_video, tmp_path):
     assert config.sample_interval == 0.5
     assert config.blackout_threshold == 25.0
     assert config.min_match_duration == 60.0
+    assert config.min_blackout_duration == 5.0
     assert config.workers == 4
     assert config.use_gpu is True
     assert config.dry_run is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,18 @@ class TestSplitConfigValidation:
         with pytest.raises(ConfigValidationError, match="min-match-duration"):
             SplitConfig(min_match_duration=-100.0)
 
+    def test_min_blackout_duration_zero_is_valid(self):
+        config = SplitConfig(min_blackout_duration=0.0)
+        assert config.min_blackout_duration == 0.0
+
+    def test_min_blackout_duration_positive_is_valid(self):
+        config = SplitConfig(min_blackout_duration=5.0)
+        assert config.min_blackout_duration == 5.0
+
+    def test_min_blackout_duration_negative_raises(self):
+        with pytest.raises(ConfigValidationError, match="min-blackout-duration"):
+            SplitConfig(min_blackout_duration=-1.0)
+
     def test_workers_none_is_valid(self):
         config = SplitConfig(workers=None)
         assert config.workers is None


### PR DESCRIPTION
## Summary

- `test_config.py`: `min_blackout_duration` の正常値(0.0, 5.0)・異常値(-1.0) バリデーションテスト 3 件追加
- `test_cli.py`: `--min-blackout-duration -1` のバリデーションエラー(exit code 5) テスト追加
- `test_cli.py`: `--min-blackout-duration 5.0` のオプション引き渡しテスト追加
- `test_cli.py`: `test_split_default_options` に `min_blackout_duration=3.0` のデフォルト値アサーション追加
- `test_cli.py`: `test_split_all_options_combined` に `--min-blackout-duration` を追加

## 対応 Issue

#161

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（266 passed）

作成: tester-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)