### PR TITLE
test: InputFileError / AllaganEyeError の CLI exit code テスト追加 #163

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from allaganeye.cli import app
-from allaganeye.exceptions import DetectionError, VideoProcessingError
+from allaganeye.exceptions import (
+    AllaganEyeError,
+    DetectionError,
+    InputFileError,
+    VideoProcessingError,
+)
 
 runner = CliRunner()
 
@@ -242,6 +247,24 @@ def test_split_detection_error_exit_code(mock_run_split, fake_video):
 
     result = runner.invoke(app, ["split", str(fake_video)])
     assert result.exit_code == 4
+
+
+@patch(MODULE)
+def test_split_input_file_error_exit_code(mock_run_split, fake_video):
+    """InputFileError from run_split produces exit code 2."""
+    mock_run_split.side_effect = InputFileError("No video stream found")
+
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 2
+
+
+@patch(MODULE)
+def test_split_base_error_exit_code(mock_run_split, fake_video):
+    """AllaganEyeError (base class) produces exit code 1."""
+    mock_run_split.side_effect = AllaganEyeError("generic error")
+
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 1
 
 
 @patch(MODULE)


### PR DESCRIPTION
## Summary

- `test_split_input_file_error_exit_code`: `run_split` 内部から `InputFileError` が raise された場合に exit code 2 を返すことを検証
- `test_split_base_error_exit_code`: `AllaganEyeError` (base class) の直接 raise で exit code 1 を返すことを検証
- 既存の `VideoProcessingError` (exit code 3), `DetectionError` (exit code 4), `RuntimeError` (exit code 1) と合わせ、全 exit code パスをカバー

## 対応 Issue

#163

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（244 passed）

作成: tester-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)