### PR TITLE
docs: CLAUDE.md・cli-spec.md のドキュメント不整合修正 #182 #183

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | `cli.py` | Typer CLIエントリポイント。コマンドルーティング |
 | `config.py` | 設定管理（検知閾値、出力パス等） |
 | `exceptions.py` | エラークラス + exit code マッピング |
+| `ffmpeg_path.py` | ffmpeg/ffprobe のパス自動検索（winget, Homebrew, PATH, 環境変数） |
 | `commands/split_matches.py` | split コマンドのオーケストレーション。タイムスタンプ表示・gap 検出・sample_interval 自動調整 |
 | `commands/debug_brightness.py` | debug-brightness コマンド。フレーム輝度を CSV 出力（閾値チューニング用） |
 | `video/probe.py` | ffprobe でメタデータ取得（解像度、fps、長さ） |

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -12,7 +12,6 @@
 |---|---|
 | `--version` | バージョン表示 |
 | `--help` | ヘルプ表示 |
-| `--verbose` / `-v` | 詳細ログ出力 |
 
 ## split コマンド
 
@@ -109,6 +108,7 @@ allaganeye debug-brightness <video_path> [OPTIONS]
 | `--end` | 動画全長 | 終了時刻（秒） |
 | `--interval` | `1.0` | サンプリング間隔（秒） |
 | `--workers` | auto | 並列ワーカー数（デフォルト: 自動=`min(cpu_count, 24)`） |
+| `--roi-mode` | なし | ROI 分析モード。`scorebar`: スコアバー ROI の輝度・色情報を追加出力。`scorebar-detail`: セクション別の詳細情報も出力 |
 
 ### 出力形式
 


### PR DESCRIPTION
## Summary

- **#182**: CLAUDE.md のモジュール構成テーブルに `ffmpeg_path.py` エントリを追加
- **#183**: cli-spec.md の 2 点修正:
  - `debug-brightness` オプションテーブルに `--roi-mode` を追記（`scorebar` / `scorebar-detail`）
  - グローバルオプションから `--verbose` を削除（`split` サブコマンドのみのパラメータ）

## 対応 Issue

#182, #183

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（261 passed）
- ドキュメントのみの変更のため実データ検証は不要

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)