### PR TITLE
feat: 検知結果キャッシュによる再検知スキップ機能 #173

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -71,6 +71,10 @@ def split(
             "Falls back to CPU if GPU is unavailable.",
         ),
     ] = False,
+    no_cache: Annotated[
+        bool,
+        typer.Option("--no-cache", help="Ignore cached detection results"),
+    ] = False,
     verbose: Annotated[
         bool, typer.Option("-v", "--verbose", help="Verbose output")
     ] = False,
@@ -95,6 +99,7 @@ def split(
             dry_run=dry_run,
             use_gpu=gpu,
             workers=workers,
+            no_cache=no_cache,
         )
 
         from allaganeye.commands.split_matches import run_split

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -1,6 +1,7 @@
 """Split command: orchestrates video probing, detection, and splitting."""
 
 import json
+import logging
 from pathlib import Path
 
 import typer
@@ -10,6 +11,10 @@ from allaganeye.exceptions import AllaganEyeError, DetectionError
 from allaganeye.video.detector import detect_match_boundaries
 from allaganeye.video.probe import probe_video
 from allaganeye.video.splitter import split_video
+
+logger = logging.getLogger(__name__)
+
+_CACHE_VERSION = 1
 
 
 def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -> None:
@@ -29,6 +34,40 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
     effective_interval = _auto_sample_interval(
         metadata["duration"], config.sample_interval
     )
+
+    # Check detection cache
+    cache_path = config.output_dir / ".detection_cache.json"
+    if not config.no_cache:
+        cached = _load_cache(cache_path, video_path, effective_interval, config)
+        if cached is not None:
+            boundaries = cached
+            typer.echo(
+                f"Detected {len(boundaries)} match(es) in {video_path.name} "
+                f"({_format_timestamp(metadata['duration'])}) (cached)"
+            )
+            typer.echo()
+            for i, b in enumerate(boundaries, 1):
+                dur = b["end"] - b["start"]
+                typer.echo(
+                    f"  Match {i}: {_format_timestamp(b['start']):>7s} - "
+                    f"{_format_timestamp(b['end']):>7s}  ({_format_duration(dur)})"
+                )
+            gaps = _find_gaps(boundaries, metadata["duration"], min_gap=300.0)
+            if gaps:
+                typer.echo()
+                for gap in gaps:
+                    typer.echo(
+                        f"  Gap: {_format_timestamp(gap['start'])} - "
+                        f"{_format_timestamp(gap['end'])} "
+                        f"({_format_duration(gap['duration'])})"
+                    )
+            if config.dry_run:
+                typer.echo("\nDry run: skipping split")
+                return
+            # Jump to splitting
+            return _split_and_write_metadata(
+                video_path, boundaries, gaps, metadata, config
+            )
 
     # Step 2: Detect match boundaries
     if verbose:
@@ -113,10 +152,28 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
                 f"({_format_duration(gap['duration'])})"
             )
 
+    # Save detection cache
+    _save_cache(
+        cache_path, video_path, metadata, effective_interval, config, boundaries
+    )
+
     # Step 3: Split (unless dry-run)
     if config.dry_run:
         typer.echo("\nDry run: skipping split")
         return
+
+    _split_and_write_metadata(video_path, boundaries, gaps, metadata, config)
+
+
+def _split_and_write_metadata(
+    video_path: Path,
+    boundaries: list[dict],
+    gaps: list[dict],
+    metadata: dict,
+    config: SplitConfig,
+) -> None:
+    """Split video and write metadata.json."""
+    source_duration = metadata["duration"]
 
     try:
         config.output_dir.mkdir(parents=True, exist_ok=True)
@@ -220,3 +277,103 @@ def _find_gaps(
         if gap_dur >= min_gap:
             gaps.append({"start": gap_start, "end": gap_end, "duration": gap_dur})
     return gaps
+
+
+def _save_cache(
+    cache_path: Path,
+    video_path: Path,
+    probe_metadata: dict,
+    effective_interval: float,
+    config: SplitConfig,
+    boundaries: list[dict],
+) -> None:
+    """Save detection results to cache file."""
+    resolved = video_path.resolve()
+    try:
+        stat = resolved.stat()
+    except OSError:
+        logger.debug("Cannot stat source file for cache: %s", resolved)
+        return
+    cache_data = {
+        "cache_version": _CACHE_VERSION,
+        "source": str(resolved),
+        "source_size": stat.st_size,
+        "source_mtime": stat.st_mtime,
+        "probe": {
+            "duration": probe_metadata["duration"],
+            "width": probe_metadata["width"],
+            "height": probe_metadata["height"],
+            "fps": probe_metadata["fps"],
+            "codec": probe_metadata.get("codec", ""),
+        },
+        "params": {
+            "sample_interval": effective_interval,
+            "blackout_threshold": config.blackout_threshold,
+            "min_match_duration": config.min_match_duration,
+            "min_blackout_duration": config.min_blackout_duration,
+        },
+        "boundaries": boundaries,
+    }
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(
+            json.dumps(cache_data, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+    except OSError:
+        logger.debug("Failed to write detection cache to %s", cache_path)
+
+
+def _load_cache(
+    cache_path: Path,
+    video_path: Path,
+    effective_interval: float,
+    config: SplitConfig,
+) -> list[dict] | None:
+    """Load and validate detection cache. Returns boundaries or None."""
+    if not cache_path.is_file():
+        return None
+
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.debug("Detection cache unreadable: %s", cache_path)
+        return None
+
+    if data.get("cache_version") != _CACHE_VERSION:
+        logger.debug("Cache version mismatch")
+        return None
+
+    resolved = video_path.resolve()
+    if data.get("source") != str(resolved):
+        logger.debug("Cache source path mismatch")
+        return None
+
+    try:
+        stat = resolved.stat()
+    except OSError:
+        return None
+
+    if data.get("source_size") != stat.st_size:
+        logger.debug("Cache source size mismatch")
+        return None
+
+    if data.get("source_mtime") != stat.st_mtime:
+        logger.debug("Cache source mtime mismatch")
+        return None
+
+    params = data.get("params", {})
+    if (
+        params.get("sample_interval") != effective_interval
+        or params.get("blackout_threshold") != config.blackout_threshold
+        or params.get("min_match_duration") != config.min_match_duration
+        or params.get("min_blackout_duration") != config.min_blackout_duration
+    ):
+        logger.debug("Cache parameter mismatch")
+        return None
+
+    boundaries = data.get("boundaries")
+    if not isinstance(boundaries, list):
+        logger.debug("Cache boundaries invalid")
+        return None
+
+    return boundaries

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -18,6 +18,7 @@ class SplitConfig:
     dry_run: bool = False
     use_gpu: bool = False
     workers: int | None = None
+    no_cache: bool = False
 
     def __post_init__(self) -> None:
         if self.workers is not None and self.workers < 1:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -473,3 +473,12 @@ def test_debug_brightness_start_end_interval(mock_run, fake_video):
     assert kwargs["start"] == 10.0
     assert kwargs["end"] == 60.0
     assert kwargs["interval"] == 0.5
+
+
+@patch(MODULE)
+def test_no_cache_option_accepted(mock_run, fake_video):
+    """--no-cache option is accepted without error."""
+    result = runner.invoke(app, ["split", str(fake_video), "--no-cache"])
+    assert result.exit_code == 0
+    config = mock_run.call_args[0][1]
+    assert config.no_cache is True

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 
 import pytest
 
-from allaganeye.commands.split_matches import _auto_sample_interval, run_split
+from allaganeye.commands.split_matches import (
+    _auto_sample_interval,
+    _load_cache,
+    _save_cache,
+    run_split,
+)
 from allaganeye.config import SplitConfig
 from allaganeye.exceptions import AllaganEyeError, DetectionError, VideoProcessingError
 
@@ -354,3 +359,193 @@ def test_pipeline_config_params_forwarded(
         workers=None,
         src_resolution=(PROBE_RESULT["width"], PROBE_RESULT["height"]),
     )
+
+
+# ============================================================
+# Detection cache tests
+# ============================================================
+
+
+@pytest.fixture
+def cache_video(tmp_path):
+    """Create a real video file for cache tests."""
+    video = tmp_path / "test.mp4"
+    video.write_bytes(b"\x00" * 1024)
+    return video
+
+
+@pytest.fixture
+def cache_config(tmp_path):
+    return SplitConfig(
+        output_dir=tmp_path / "output",
+        sample_interval=1.0,
+        blackout_threshold=15.0,
+        min_match_duration=300.0,
+        min_blackout_duration=3.0,
+    )
+
+
+CACHE_BOUNDARIES = [
+    {"start": 0.0, "end": 600.0, "type": "fl_match"},
+    {"start": 700.0, "end": 1200.0, "type": "fl_match"},
+]
+
+
+class TestCacheRoundTrip:
+    def test_save_and_load(self, cache_video, cache_config, tmp_path):
+        """Save → load round-trip restores boundaries."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        result = _load_cache(cache_path, cache_video, 1.0, cache_config)
+        assert result == CACHE_BOUNDARIES
+
+    def test_size_mismatch(self, cache_video, cache_config, tmp_path):
+        """source_size mismatch → None."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        # Change file size
+        cache_video.write_bytes(b"\x00" * 2048)
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
+
+    def test_mtime_mismatch(self, cache_video, cache_config, tmp_path):
+        """source_mtime mismatch → None."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        # Modify cache to have wrong mtime
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        data["source_mtime"] = 0.0
+        cache_path.write_text(json.dumps(data), encoding="utf-8")
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
+
+    def test_param_mismatch_threshold(self, cache_video, cache_config, tmp_path):
+        """blackout_threshold mismatch → None."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        different_config = SplitConfig(
+            output_dir=tmp_path / "output", blackout_threshold=20.0
+        )
+        assert _load_cache(cache_path, cache_video, 1.0, different_config) is None
+
+    def test_param_mismatch_interval(self, cache_video, cache_config, tmp_path):
+        """sample_interval mismatch → None."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        assert _load_cache(cache_path, cache_video, 2.0, cache_config) is None
+
+    def test_version_mismatch(self, cache_video, cache_config, tmp_path):
+        """cache_version mismatch → None."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        data["cache_version"] = 999
+        cache_path.write_text(json.dumps(data), encoding="utf-8")
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
+
+    def test_path_mismatch(self, cache_video, cache_config, tmp_path):
+        """source path mismatch → None."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        other_video = tmp_path / "other.mp4"
+        other_video.write_bytes(b"\x00" * 1024)
+        assert _load_cache(cache_path, other_video, 1.0, cache_config) is None
+
+    def test_file_not_found(self, cache_video, cache_config, tmp_path):
+        """Cache file doesn't exist → None."""
+        cache_path = tmp_path / "nonexistent" / ".detection_cache.json"
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
+
+    def test_corrupted_json(self, cache_video, cache_config, tmp_path):
+        """Corrupted cache file → None (no exception)."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text("not valid json{{{", encoding="utf-8")
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
+
+
+class TestCachePipeline:
+    @patch(f"{MODULE}.split_video")
+    @patch(f"{MODULE}.detect_match_boundaries")
+    @patch(f"{MODULE}.probe_video")
+    def test_dry_run_saves_cache(self, mock_probe, mock_detect, mock_split, tmp_path):
+        """dry-run saves .detection_cache.json."""
+        video = tmp_path / "input.mp4"
+        video.write_bytes(b"\x00" * 512)
+        mock_probe.return_value = PROBE_RESULT
+        mock_detect.return_value = BOUNDARIES
+        config = SplitConfig(output_dir=tmp_path / "output", dry_run=True)
+        run_split(video, config)
+        assert (tmp_path / "output" / ".detection_cache.json").exists()
+
+    @patch(f"{MODULE}.split_video")
+    @patch(f"{MODULE}.detect_match_boundaries")
+    @patch(f"{MODULE}.probe_video")
+    def test_second_run_uses_cache(self, mock_probe, mock_detect, mock_split, tmp_path):
+        """2nd run skips detection when cache is valid."""
+        video = tmp_path / "input.mp4"
+        video.write_bytes(b"\x00" * 512)
+        mock_probe.return_value = PROBE_RESULT
+        mock_detect.return_value = BOUNDARIES
+        out = tmp_path / "output"
+        mock_split.return_value = [out / "match_001.mp4", out / "match_002.mp4"]
+        config = SplitConfig(output_dir=out, min_match_duration=60.0)
+        # 1st run: detect is called
+        run_split(video, config)
+        assert mock_detect.call_count == 1
+        # 2nd run: detect is NOT called (cached)
+        mock_split.return_value = [out / "match_001.mp4", out / "match_002.mp4"]
+        run_split(video, config)
+        assert mock_detect.call_count == 1  # still 1
+
+    @patch(f"{MODULE}.split_video")
+    @patch(f"{MODULE}.detect_match_boundaries")
+    @patch(f"{MODULE}.probe_video")
+    def test_param_change_triggers_redetect(
+        self, mock_probe, mock_detect, mock_split, tmp_path
+    ):
+        """Changed parameters invalidate cache → re-detect."""
+        video = tmp_path / "input.mp4"
+        video.write_bytes(b"\x00" * 512)
+        mock_probe.return_value = PROBE_RESULT
+        mock_detect.return_value = BOUNDARIES
+        config1 = SplitConfig(output_dir=tmp_path / "output", dry_run=True)
+        run_split(video, config1)
+        assert mock_detect.call_count == 1
+        # 2nd run with different threshold
+        config2 = SplitConfig(
+            output_dir=tmp_path / "output", blackout_threshold=20.0, dry_run=True
+        )
+        run_split(video, config2)
+        assert mock_detect.call_count == 2
+
+    @patch(f"{MODULE}.split_video")
+    @patch(f"{MODULE}.detect_match_boundaries")
+    @patch(f"{MODULE}.probe_video")
+    def test_no_cache_flag(self, mock_probe, mock_detect, mock_split, tmp_path):
+        """--no-cache ignores existing cache."""
+        video = tmp_path / "input.mp4"
+        video.write_bytes(b"\x00" * 512)
+        mock_probe.return_value = PROBE_RESULT
+        mock_detect.return_value = BOUNDARIES
+        config = SplitConfig(output_dir=tmp_path / "output", dry_run=True)
+        run_split(video, config)
+        assert mock_detect.call_count == 1
+        # 2nd run with --no-cache
+        config_no_cache = SplitConfig(
+            output_dir=tmp_path / "output", dry_run=True, no_cache=True
+        )
+        run_split(video, config_no_cache)
+        assert mock_detect.call_count == 2


### PR DESCRIPTION
## Summary

- **キャッシュ自動保存**: 検知完了後に `output_dir/.detection_cache.json` へ自動保存（dry-run/通常実行とも）
- **キャッシュ自動利用**: 次回実行時にファイルサイズ・mtime・全検知パラメータが一致すれば検知スキップ
- **`--no-cache` オプション**: キャッシュを無視して再検知
- **検証ロジック**: cache_version、source パス、source_size、source_mtime、params（sample_interval, blackout_threshold, min_match_duration, min_blackout_duration）を全検証

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `allaganeye/config.py` | `SplitConfig.no_cache` フィールド追加 |
| `allaganeye/cli.py` | `--no-cache` オプション追加 |
| `allaganeye/commands/split_matches.py` | `_save_cache` / `_load_cache` 追加、キャッシュヒット時のパス追加 |
| `tests/test_split_matches.py` | キャッシュテスト 13 件追加 |
| `tests/test_cli.py` | `--no-cache` 受理テスト 1 件追加 |

## 対応 Issue

#173

## セルフ検証

`ALLAGANEYE_SAMPLE_VIDEO_DIR` でのセルフ検証は実施していません（キャッシュは検知結果の保存・復元のみで、検知ロジック自体は変更なし）。テスターによる実動画での確認を依頼します。

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（289 passed）
- [x] キャッシュラウンドトリップテスト
- [x] 検証失敗 9 パターン（size/mtime/params/version/path/missing/corrupted）
- [x] パイプライン統合テスト 4 件（dry-run保存/2回目利用/パラメータ変更/--no-cache）
- [x] CLI テスト（--no-cache 受理）

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)