### PR TITLE
docs: README・cli-spec のドキュメント不整合修正 #186 #187 #188

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ OBS 等で録画した数時間分の動画を入力すると、試合の切れ�
 
 ```bash
 # 前提: Python 3.11+, ffmpeg 4.1+ がインストール済みであること
-git clone git@github.com:Idios/kobutachan-allaganeye.git
+git clone https://github.com/Idios/kobutachan-allaganeye.git
 cd kobutachan-allaganeye
 pip install -e .
+
+# まず検知結果を確認
+allaganeye split your_recording.mkv --dry-run
+# 結果が正しければ本実行
 allaganeye split your_recording.mkv
 ```
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -74,6 +74,7 @@ allaganeye split <video_path> [OPTIONS]
 | `end_display` | string | 終了時刻の表示形式 |
 | `duration` | float | 試合時間（秒） |
 | `duration_display` | string | 試合時間の表示形式 |
+| `type` | string | セグメントの種別（`"fl_match"` / `"unknown"`） |
 | `output_file` | string | 出力ファイルパス |
 
 **gaps[]:**


### PR DESCRIPTION
## Summary

- README.md: clone URL を SSH → HTTPS に変更（public 化対応、quickstart.md と統一）
- README.md: Quick Start に `--dry-run` → 本実行の推奨ワークフロー追加（quickstart.md と統一）
- cli-spec.md: metadata.json の matches[] テーブルに `type` フィールド追加（PR #171 で実装済み）

## 対応 Issue

#186, #187, #188

## Test plan

- [x] ドキュメントのみの変更

作成: lead-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)