### PR TITLE
fix: probe.py / splitter.py に subprocess timeout を追加 #192 #193

### DIFF
--- a/allaganeye/video/probe.py
+++ b/allaganeye/video/probe.py
@@ -38,10 +38,15 @@ def probe_video(video_path: Path) -> dict:
             capture_output=True,
             text=True,
             check=True,
+            timeout=30,
         )
     except FileNotFoundError as e:
         raise VideoProcessingError(
             "ffprobe not found. Please install ffmpeg and ensure it is in PATH."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise VideoProcessingError(
+            f"ffprobe timed out after 30s for {video_path}"
         ) from e
     except subprocess.CalledProcessError as e:
         raise VideoProcessingError(f"ffprobe failed: {e.stderr}") from e

--- a/allaganeye/video/splitter.py
+++ b/allaganeye/video/splitter.py
@@ -51,6 +51,7 @@ def _ffmpeg_split(
       readable (ffmpeg can produce very long diagnostic output).
     """
     duration = end - start
+    timeout = max(int(duration * 2) + 60, 120)
     try:
         result = subprocess.run(
             [
@@ -70,10 +71,15 @@ def _ffmpeg_split(
             ],
             capture_output=True,
             text=True,
+            timeout=timeout,
         )
     except FileNotFoundError as e:
         raise VideoProcessingError(
             "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise VideoProcessingError(
+            f"ffmpeg split timed out after {timeout}s for {output.name}"
         ) from e
 
     if result.returncode != 0:

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -339,3 +339,14 @@ def test_probe_missing_dimensions(mock_run, tmp_path):
     result = probe_video(video)
     assert result["width"] == 0
     assert result["height"] == 0
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+@patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe")
+def test_timeout_raises_video_processing_error(_mock_ffprobe, mock_run, tmp_path):
+    """ffprobe timeout raises VideoProcessingError."""
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffprobe", timeout=30)
+    video = tmp_path / "test.mp4"
+    video.write_bytes(b"")
+    with pytest.raises(VideoProcessingError, match="timed out"):
+        probe_video(video)

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -167,3 +167,26 @@ def test_split_partial_failure(mock_run, tmp_path):
 
     # First call succeeded, second failed
     assert mock_run.call_count == 2
+
+
+@patch("allaganeye.video.splitter.subprocess.run")
+@patch("allaganeye.video.splitter.find_ffmpeg", return_value="ffmpeg")
+def test_timeout_raises_video_processing_error(_mock_ffmpeg, mock_run, tmp_path):
+    """ffmpeg split timeout raises VideoProcessingError."""
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=120)
+    output = tmp_path / "out.mp4"
+    with pytest.raises(VideoProcessingError, match="timed out"):
+        _ffmpeg_split(Path("input.mp4"), start=0.0, end=600.0, output=output)
+
+
+@patch("allaganeye.video.splitter.subprocess.run")
+@patch("allaganeye.video.splitter.find_ffmpeg", return_value="ffmpeg")
+def test_timeout_scales_with_duration(_mock_ffmpeg, mock_run, tmp_path):
+    """Timeout scales: max(duration*2 + 60, 120)."""
+    result = MagicMock()
+    result.returncode = 0
+    mock_run.return_value = result
+    output = tmp_path / "out.mp4"
+    _ffmpeg_split(Path("input.mp4"), start=0.0, end=600.0, output=output)
+    # 600 * 2 + 60 = 1260 > 120
+    assert mock_run.call_args.kwargs["timeout"] == 1260


### PR DESCRIPTION
## Summary

- **#193 probe.py**: `subprocess.run` に `timeout=30` を追加。`TimeoutExpired` を `VideoProcessingError` に変換
- **#192 splitter.py**: `subprocess.run` に動的 timeout を追加（`max(duration*2 + 60, 120)` 秒）。`TimeoutExpired` を `VideoProcessingError` に変換

## 対応 Issue

#192, #193

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（292 passed）
- [x] `test_probe.py::test_timeout_raises_video_processing_error` — ffprobe timeout テスト
- [x] `test_splitter.py::test_timeout_raises_video_processing_error` — ffmpeg split timeout テスト
- [x] `test_splitter.py::test_timeout_scales_with_duration` — timeout 動的計算テスト

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)