### PR TITLE
fix: GPU フォールバック時に残チャンクの futures をキャンセル #195

### DIFF
--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -63,6 +63,7 @@ def scan_gpu(
                 chunk_results = future.result()
             except VideoProcessingError:
                 gpu_failed = True
+                pool.shutdown(wait=False, cancel_futures=True)
                 break
             for t, brightness in chunk_results.items():
                 results[t] = brightness

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -1,5 +1,6 @@
 """Tests for GPU-accelerated detection."""
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -93,6 +94,27 @@ class TestScanGpu:
 
         with pytest.raises(VideoProcessingError, match="falling back"):
             scan_gpu(Path("test.mp4"), 10.0, 1.0, 15.0)
+
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_gpu_failure_cancels_pending_futures(self, mock_decode):
+        """GPU failure cancels pending futures via shutdown(cancel_futures=True)."""
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise VideoProcessingError("GPU decode failed")
+            return {0.0: 128.0}
+
+        mock_decode.side_effect = side_effect
+
+        with pytest.raises(VideoProcessingError, match="falling back"):
+            scan_gpu(Path("test.mp4"), 100.0, 1.0, 15.0)
+
+        # With cancel_futures=True, not all chunks should have been executed
+        # (some were cancelled before starting)
+        assert call_count < min(os.cpu_count() or 4, 16)
 
     @patch("allaganeye.video.gpu_detector._decode_chunk")
     def test_progress_callback(self, mock_decode):


### PR DESCRIPTION
## Summary

- `scan_gpu()` で GPU デコードエラー発生時、`pool.shutdown(wait=False, cancel_futures=True)` を呼び出して待機キューの futures をキャンセル
- これにより、残りのチャンクの ffmpeg プロセスが全て完走するのを待たずに CPU フォールバックに移行
- テスト追加: GPU 失敗時に全チャンクが実行されないことを検証

## 対応 Issue

#195

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（290 passed）
- [x] `test_gpu_failure_cancels_pending_futures` — 1 チャンク失敗時に残りがキャンセルされることを確認

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)