### PR TITLE
refactor: probe_video / boundaries の戻り値を TypedDict 化 #196

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -3,14 +3,24 @@
 import json
 import logging
 from pathlib import Path
+from typing import TypedDict
 
 import typer
 
 from allaganeye.config import SplitConfig
 from allaganeye.exceptions import AllaganEyeError, DetectionError
-from allaganeye.video.detector import detect_match_boundaries
-from allaganeye.video.probe import probe_video
+from allaganeye.video.detector import MatchBoundary, detect_match_boundaries
+from allaganeye.video.probe import ProbeResult, probe_video
 from allaganeye.video.splitter import split_video
+
+
+class Gap(TypedDict):
+    """A significant gap between detected matches."""
+
+    start: float
+    end: float
+    duration: float
+
 
 logger = logging.getLogger(__name__)
 
@@ -167,9 +177,9 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
 
 def _split_and_write_metadata(
     video_path: Path,
-    boundaries: list[dict],
-    gaps: list[dict],
-    metadata: dict,
+    boundaries: list[MatchBoundary],
+    gaps: list[Gap],
+    metadata: ProbeResult,
     config: SplitConfig,
 ) -> None:
     """Split video and write metadata.json."""
@@ -266,10 +276,10 @@ def _auto_sample_interval(duration: float, configured_interval: float) -> float:
 
 
 def _find_gaps(
-    boundaries: list[dict], total_duration: float, *, min_gap: float = 300.0
-) -> list[dict]:
+    boundaries: list[MatchBoundary], total_duration: float, *, min_gap: float = 300.0
+) -> list[Gap]:
     """Find significant gaps between detected matches."""
-    gaps: list[dict] = []
+    gaps: list[Gap] = []
     for i in range(len(boundaries) - 1):
         gap_start = boundaries[i]["end"]
         gap_end = boundaries[i + 1]["start"]
@@ -282,10 +292,10 @@ def _find_gaps(
 def _save_cache(
     cache_path: Path,
     video_path: Path,
-    probe_metadata: dict,
+    probe_metadata: ProbeResult,
     effective_interval: float,
     config: SplitConfig,
-    boundaries: list[dict],
+    boundaries: list[MatchBoundary],
 ) -> None:
     """Save detection results to cache file."""
     resolved = video_path.resolve()
@@ -328,7 +338,7 @@ def _load_cache(
     video_path: Path,
     effective_interval: float,
     config: SplitConfig,
-) -> list[dict] | None:
+) -> list[MatchBoundary] | None:
     """Load and validate detection cache. Returns boundaries or None."""
     if not cache_path.is_file():
         return None

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -6,11 +6,21 @@ import subprocess
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import TypedDict
 
 import numpy as np
 
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.ffmpeg_path import find_ffmpeg
+
+
+class MatchBoundary(TypedDict):
+    """A detected match segment with start/end times and type."""
+
+    start: float
+    end: float
+    type: str
+
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +48,7 @@ def detect_match_boundaries(
     workers: int | None = None,
     src_resolution: tuple[int, int] | None = None,
     progress_callback: Callable[[int, int, int], None] | None = None,
-) -> list[dict]:
+) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
 
     Args:
@@ -535,7 +545,7 @@ def _filter_and_extract_segments(
     min_match_duration: float,
     min_blackout_duration: float = 3.0,
     classifications: list[str] | None = None,
-) -> list[dict]:
+) -> list[MatchBoundary]:
     """Filter blackout regions by duration and extract match segments.
 
     Removes regions shorter than *min_blackout_duration*, then extracts
@@ -578,7 +588,7 @@ def _filter_and_extract_segments(
         return []
 
     # Extract segments between blackout regions
-    segments: list[dict] = []
+    segments: list[MatchBoundary] = []
 
     # Before first blackout
     if blackout_regions[0][0] > 0:

--- a/allaganeye/video/probe.py
+++ b/allaganeye/video/probe.py
@@ -3,9 +3,21 @@
 import json
 import subprocess
 from pathlib import Path
+from typing import TypedDict
 
 from allaganeye.exceptions import InputFileError, VideoProcessingError
 from allaganeye.ffmpeg_path import find_ffprobe
+
+
+class ProbeResult(TypedDict):
+    """Metadata returned by probe_video()."""
+
+    duration: float
+    width: int
+    height: int
+    fps: float
+    codec: str
+    audio_codec: str | None
 
 
 def _parse_frame_rate(rate_str: str) -> float:
@@ -18,7 +30,7 @@ def _parse_frame_rate(rate_str: str) -> float:
     return fps if fps > 0 else 0.0
 
 
-def probe_video(video_path: Path) -> dict:
+def probe_video(video_path: Path) -> ProbeResult:
     """Extract video metadata using ffprobe.
 
     Returns dict with keys: duration, width, height, fps, codec, audio_codec.

--- a/allaganeye/video/splitter.py
+++ b/allaganeye/video/splitter.py
@@ -5,11 +5,12 @@ from pathlib import Path
 
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.ffmpeg_path import find_ffmpeg
+from allaganeye.video.detector import MatchBoundary
 
 
 def split_video(
     video_path: Path,
-    boundaries: list[dict],
+    boundaries: list[MatchBoundary],
     output_dir: Path,
 ) -> list[Path]:
     """Split video into segments using FFmpeg copy mode.

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -8,6 +8,7 @@ import pytest
 
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
+    MatchBoundary,
     _BLACKOUT_PADDING,
     _FRAME_SIZE,
     _REFINED_MIN_BLACKOUT,
@@ -34,7 +35,7 @@ def _extract_segments(
     sample_interval: float,
     min_match_duration: float,
     min_blackout_duration: float = 3.0,
-) -> list[dict]:
+) -> list[MatchBoundary]:
     """Test helper: groups + filters + extracts (replaces old monolithic function)."""
     regions = _group_blackout_regions(blackout_times, sample_interval)
     return _filter_and_extract_segments(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 from allaganeye.ffmpeg_path import find_ffmpeg
-from allaganeye.video.probe import probe_video
+from allaganeye.video.probe import ProbeResult, probe_video
 
 pytestmark = pytest.mark.slow
 
@@ -126,7 +126,7 @@ def source_mkv(split_subdir: Path) -> Path:
 
 
 @pytest.fixture(scope="session")
-def source_metadata(source_mkv: Path) -> dict:
+def source_metadata(source_mkv: Path) -> ProbeResult:
     """Probe metadata for the source MKV (cached for session)."""
     return probe_video(source_mkv)
 

--- a/tests/test_scorebar_regression.py
+++ b/tests/test_scorebar_regression.py
@@ -20,7 +20,7 @@ import pytest
 from allaganeye.commands.split_matches import run_split
 from allaganeye.config import SplitConfig
 from allaganeye.video.detector import detect_match_boundaries
-from allaganeye.video.probe import probe_video
+from allaganeye.video.probe import ProbeResult, probe_video
 
 pytestmark = pytest.mark.slow
 
@@ -75,7 +75,7 @@ def target_recording(request: pytest.FixtureRequest) -> tuple[str, Path]:
 
 
 @pytest.fixture(scope="session")
-def target_metadata(target_recording: tuple[str, Path]) -> dict:
+def target_metadata(target_recording: tuple[str, Path]) -> ProbeResult:
     _, mkv = target_recording
     return probe_video(mkv)
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -14,9 +14,11 @@ from allaganeye.commands.split_matches import (
 )
 from allaganeye.config import SplitConfig
 from allaganeye.exceptions import AllaganEyeError, DetectionError, VideoProcessingError
+from allaganeye.video.detector import MatchBoundary
+from allaganeye.video.probe import ProbeResult
 
 # Standard mock return values
-PROBE_RESULT = {
+PROBE_RESULT: ProbeResult = {
     "duration": 1800.0,
     "width": 1920,
     "height": 1080,
@@ -25,9 +27,9 @@ PROBE_RESULT = {
     "audio_codec": "aac",
 }
 
-BOUNDARIES = [
-    {"start": 0.0, "end": 600.0},
-    {"start": 610.0, "end": 1200.0},
+BOUNDARIES: list[MatchBoundary] = [
+    {"start": 0.0, "end": 600.0, "type": "unknown"},
+    {"start": 610.0, "end": 1200.0, "type": "unknown"},
 ]
 
 MODULE = "allaganeye.commands.split_matches"
@@ -385,7 +387,7 @@ def cache_config(tmp_path):
     )
 
 
-CACHE_BOUNDARIES = [
+CACHE_BOUNDARIES: list[MatchBoundary] = [
     {"start": 0.0, "end": 600.0, "type": "fl_match"},
     {"start": 700.0, "end": 1200.0, "type": "fl_match"},
 ]

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from allaganeye.exceptions import VideoProcessingError
+from allaganeye.video.detector import MatchBoundary
 from allaganeye.video.splitter import _ffmpeg_split, split_video
 
 
@@ -16,7 +17,7 @@ from allaganeye.video.splitter import _ffmpeg_split, split_video
 def test_split_nonexistent_file(tmp_path):
     """Splitting a nonexistent file raises VideoProcessingError."""
     fake = tmp_path / "nonexistent.mp4"
-    boundaries = [{"start": 0.0, "end": 10.0}]
+    boundaries: list[MatchBoundary] = [{"start": 0.0, "end": 10.0, "type": "unknown"}]
     with pytest.raises(VideoProcessingError):
         split_video(fake, boundaries, tmp_path)
 
@@ -77,7 +78,7 @@ def test_split_single_boundary(mock_run, tmp_path):
         args=["ffmpeg"], returncode=0, stdout="", stderr=""
     )
     video = tmp_path / "input.mp4"
-    boundaries = [{"start": 10.0, "end": 300.0}]
+    boundaries: list[MatchBoundary] = [{"start": 10.0, "end": 300.0, "type": "unknown"}]
 
     result = split_video(video, boundaries, tmp_path)
 
@@ -93,10 +94,10 @@ def test_split_multiple_boundaries(mock_run, tmp_path):
         args=["ffmpeg"], returncode=0, stdout="", stderr=""
     )
     video = tmp_path / "input.mp4"
-    boundaries = [
-        {"start": 0.0, "end": 600.0},
-        {"start": 610.0, "end": 1200.0},
-        {"start": 1210.0, "end": 1800.0},
+    boundaries: list[MatchBoundary] = [
+        {"start": 0.0, "end": 600.0, "type": "unknown"},
+        {"start": 610.0, "end": 1200.0, "type": "unknown"},
+        {"start": 1210.0, "end": 1800.0, "type": "unknown"},
     ]
 
     result = split_video(video, boundaries, tmp_path)
@@ -129,7 +130,7 @@ def test_split_ffmpeg_returns_nonzero(mock_run, tmp_path):
         args=["ffmpeg"], returncode=1, stdout="", stderr="encoding failed"
     )
     video = tmp_path / "input.mp4"
-    boundaries = [{"start": 0.0, "end": 300.0}]
+    boundaries: list[MatchBoundary] = [{"start": 0.0, "end": 300.0, "type": "unknown"}]
 
     with pytest.raises(VideoProcessingError, match="ffmpeg split failed"):
         split_video(video, boundaries, tmp_path)
@@ -140,7 +141,7 @@ def test_split_ffmpeg_not_found(mock_run, tmp_path):
     """Missing ffmpeg raises VideoProcessingError."""
     mock_run.side_effect = FileNotFoundError()
     video = tmp_path / "input.mp4"
-    boundaries = [{"start": 0.0, "end": 300.0}]
+    boundaries: list[MatchBoundary] = [{"start": 0.0, "end": 300.0, "type": "unknown"}]
 
     with pytest.raises(VideoProcessingError, match="ffmpeg not found"):
         split_video(video, boundaries, tmp_path)
@@ -157,9 +158,9 @@ def test_split_partial_failure(mock_run, tmp_path):
     )
     mock_run.side_effect = [success, failure]
     video = tmp_path / "input.mp4"
-    boundaries = [
-        {"start": 0.0, "end": 600.0},
-        {"start": 610.0, "end": 1200.0},
+    boundaries: list[MatchBoundary] = [
+        {"start": 0.0, "end": 600.0, "type": "unknown"},
+        {"start": 610.0, "end": 1200.0, "type": "unknown"},
     ]
 
     with pytest.raises(VideoProcessingError, match="ffmpeg split failed"):


### PR DESCRIPTION
## Summary

- `ProbeResult` TypedDict を `probe.py` に定義（duration, width, height, fps, codec, audio_codec）
- `MatchBoundary` TypedDict を `detector.py` に定義（start, end, type）
- `Gap` TypedDict を `split_matches.py` に定義（start, end, duration）
- `probe_video()`, `detect_match_boundaries()`, `_filter_and_extract_segments()`, `split_video()`, `_find_gaps()`, `_save_cache()`, `_load_cache()`, `_split_and_write_metadata()` の型アノテーションを更新
- テストの mock 値にも型注釈を追加

## 対応 Issue

#196

## Test plan

- [x] `ruff check .` 通過
- [x] `ruff format --check .` 通過
- [x] `pyright` 0 errors
- [x] `pytest` 全テスト通過（289 passed）
- 動作変更なし（型アノテーションのみ）

作成: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)