### PR TITLE
docs: quickstart.md に Git インストール手順と前提ソフトの説明を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ OBS 等で録画した数時間分の動画を入力すると、試合の切れ�
 > 更新方法は [Quick Start Guide — 更新](docs/quickstart.md#3-更新) を参照してください。
 
 ```bash
-# 前提: Python 3.11+, ffmpeg 4.1+ がインストール済みであること
+# 前提: Git, Python 3.11+, ffmpeg 4.1+ がインストール済みであること
+# 初めての方は docs/quickstart.md を参照
 git clone https://github.com/Idios/kobutachan-allaganeye.git
 cd kobutachan-allaganeye
 pip install -e .

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,52 @@
 
 ## 1. 前提条件の確認
 
+Allagan Eye を使うには以下の 3 つのソフトウェアが必要です:
+
+- **Git**: ツールのダウンロードと更新に使います
+- **Python**: ツールの実行環境です
+- **ffmpeg**: 動画の解析・分割を行うエンジンです
+
+### Git
+
+```bash
+git --version
+```
+
+#### インストール方法
+
+**Windows**（いずれか 1 つ）:
+
+```bash
+# git-scm.com からインストーラをダウンロード（推奨）
+# https://git-scm.com/downloads/win → デフォルト設定でインストール
+
+# winget
+winget install Git.Git
+```
+
+**macOS**:
+
+```bash
+# Xcode Command Line Tools（推奨）
+xcode-select --install
+
+# Homebrew
+brew install git
+```
+
+**Linux (Ubuntu/Debian)**:
+
+```bash
+sudo apt update && sudo apt install git
+```
+
+#### インストール確認
+
+```bash
+git --version   # "git version 2.x" 以上が表示されること
+```
+
 ### Python 3.11+
 
 ```bash


### PR DESCRIPTION
## Summary

- `docs/quickstart.md` §1 冒頭に Git/Python/ffmpeg の役割説明を追加
- Git のインストール手順を追加（Windows: git-scm.com/winget、macOS: xcode-select/Homebrew、Linux: apt）
- Git → Python → ffmpeg の順に配置（`git clone` → `pip install` → `allaganeye split` の使用順序と一致）
- `README.md` の Quick Start 前提行に Git を追加

## Test plan

- [x] ドキュメントのみの変更。ruff / pytest 通過を確認

作成: lead-1