### PR TITLE
docs: --no-cache オプション記載追加 + classify_blackout docstring 更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ allaganeye split <video_path>           # 試合分割
 allaganeye split <video_path> -o <dir>  # 出力先指定
 allaganeye split <video_path> --gpu     # GPU アクセラレーション検知
 allaganeye split <video_path> --workers 8  # ワーカー数指定
+allaganeye split <video_path> --no-cache   # キャッシュ無視で再検知
 allaganeye debug-brightness <video_path>   # フレーム輝度 CSV 出力
 ```
 

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -130,6 +130,17 @@ def _is_static_from_frames(
     return is_static
 
 
+_IN_MATCH_MAX_DURATION = 3.5
+"""Maximum blackout duration to consider as in-match (e.g. character down).
+
+Only ``"in_match"`` blackouts shorter than this are removed.  Longer
+``"in_match"`` blackouts are FL match boundaries and must be kept.
+
+Threshold: character down = 1.0-2.0s (refined measurement), short FL
+boundary = 4.5s+.  3.5s sits in the gap with 1.5s margin on each side.
+"""
+
+
 def classify_blackout(
     video_path: Path,
     region: tuple[float, float],
@@ -141,6 +152,13 @@ def classify_blackout(
 
     Probes 3 frames before and 3 frames after the blackout at 1s intervals.
     Uses majority vote on has_scorebar to determine context.
+
+    For short blackouts (< ``_IN_MATCH_MAX_DURATION``) classified as
+    ``"in_match"``, applies static screen detection: if the post or pre
+    frames are pixel-identical (loading/result screen), the scorebar
+    detection is overridden to ``False``, changing the classification to
+    ``"match_boundary"``.  This prevents loading screens that pass the
+    A1+A2 checks from being misclassified as in-match.  (#201)
 
     Returns one of:
     - ``"in_match"``: both sides have scorebar → in-match blackout (#107)
@@ -209,17 +227,6 @@ def classify_blackout(
     )
 
     return classification
-
-
-_IN_MATCH_MAX_DURATION = 3.5
-"""Maximum blackout duration to consider as in-match (e.g. character down).
-
-Only ``"in_match"`` blackouts shorter than this are removed.  Longer
-``"in_match"`` blackouts are FL match boundaries and must be kept.
-
-Threshold: character down = 1.0-2.0s (refined measurement), short FL
-boundary = 4.5s+.  3.5s sits in the gap with 1.5s margin on each side.
-"""
 
 
 _MERGE_GAP_MAX = 600.0

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -40,6 +40,7 @@ allaganeye split <video_path> [OPTIONS]
 | `--min-blackout-duration` | `3.0` | 最小暗転時間（秒）。これより短い暗転は無視 |
 | `--workers` | auto | 検知の並列ワーカー数（デフォルト: 自動=`min(cpu_count, 24)`） |
 | `--gpu` / `--no-gpu` | `false` | GPU アクセラレーション検知（チャンク並列デコード）。利用不可時は CPU フォールバック |
+| `--no-cache` | `false` | キャッシュされた検知結果を無視して再検知する |
 | `--dry-run` | `false` | 検知のみ実行し分割しない |
 | `-v`, `--verbose` | `false` | 詳細ログ出力 |
 


### PR DESCRIPTION
## Summary

- `docs/cli-spec.md` の split オプションテーブルに `--no-cache` を追加 (#222)
- `CLAUDE.md` の CLI セクションに `--no-cache` の使用例を追加 (#222)
- `scorebar.py` の `classify_blackout` docstring に静的画面検出オーバーライドの動作を追記 (#223)
- `_IN_MATCH_MAX_DURATION` 定数を `classify_blackout` の前に移動（論理的な依存順序の改善） (#223)

## Test plan

- [x] ruff / pyright / pytest 304 passed

作成: lead-1