### PR TITLE
refactor: バージョンを importlib.metadata で動的取得に変更 #226

### DIFF
--- a/allaganeye/__init__.py
+++ b/allaganeye/__init__.py
@@ -1,3 +1,8 @@
 """Allagan Eye - FF14 Frontline video auto-highlight extraction tool."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("kobutachan-allaganeye")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"


### PR DESCRIPTION
## 概要

`allaganeye/__init__.py` のハードコードされた `__version__` を `importlib.metadata.version()` による動的取得に変更。`pyproject.toml` の `version` を Single Source of Truth とする。

## 変更内容

- `allaganeye/__init__.py`: ハードコード `__version__ = "0.1.0"` → `importlib.metadata.version("kobutachan-allaganeye")` に変更
- 未インストール時のフォールバック: `"0.0.0-dev"`
- allaganeye-guard と同一パターン

## 影響範囲

- `allaganeye/__init__.py` のみ変更
- `cli.py` は変更不要（`from allaganeye import __version__` のまま）

## 確認結果

- `python -c "from allaganeye import __version__; print(__version__)"` → `0.1.0` ✓
- `ruff check .` / `ruff format --check .` → OK ✓
- `pytest` → 304 passed ✓

関連: #226
作成: engineer-2