### PR TITLE
fix: プログレスバーの length をサンプル数に修正 #229

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -93,17 +93,16 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
         )
 
         total_duration = metadata["duration"]
-        fps = metadata["fps"]
-        estimated_frames = int(fps * total_duration)
+        estimated_samples = max(1, int(total_duration / effective_interval))
 
-        with typer.progressbar(length=estimated_frames, label="Detecting") as progress:
+        with typer.progressbar(length=estimated_samples, label="Detecting") as progress:
             last_pos = [0]
 
-            def on_progress(frame_idx: int, total: int, blackout_count: int) -> None:
-                advance = frame_idx - last_pos[0]
+            def on_progress(completed: int, total: int, blackout_count: int) -> None:
+                advance = completed - last_pos[0]
                 if advance > 0:
                     progress.update(advance)
-                last_pos[0] = frame_idx
+                last_pos[0] = completed
 
             boundaries = detect_match_boundaries(
                 video_path,


### PR DESCRIPTION
## Summary

- プログレスバーの `length` を `fps * duration`（フレーム総数）から `duration / sample_interval`（サンプル数）に修正
- callback の引数名を `frame_idx` → `completed` にリネーム（実態に合わせた命名）
- `fps` / `estimated_frames` の不要な計算を削除

## 背景

`on_progress` callback は `(completed, total_samples, blackout_count)` を受け取るが、プログレスバーの `length` が `fps * duration`（例: 216,000）で設定されていたため、callback の `completed` 値（例: 最大 3,600）では バーがほぼ進まなかった。

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pyright` 通過
- [x] `pytest` 全テスト通過（309 passed）
- [ ] テスター: `allaganeye split <video> --verbose` でプログレスバーが 100% に到達することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)