### PR TITLE
fix: _refine_blackout_regions の future.result() で例外を捕捉 #230

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -583,7 +583,10 @@ def _refine_blackout_regions(
         }
         for future in as_completed(futures):
             t = futures[future]
-            results[t] = future.result()
+            try:
+                results[t] = future.result()
+            except VideoProcessingError:
+                results[t] = 255.0
 
     # Re-extract blackout regions from fine-grained data
     fine_blackout_times = sorted(

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -245,6 +245,29 @@ class TestRefineBlackoutRegions:
         probed_times = [call[0][1] for call in mock_probe.call_args_list]
         assert all(0.0 <= t <= 8.0 for t in probed_times)
 
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_video_processing_error_treated_as_non_blackout(self, mock_probe):
+        """VideoProcessingError from a future is caught and treated as 255.0."""
+        from allaganeye.exceptions import VideoProcessingError
+
+        call_count = 0
+
+        def side_effect(video_path, t):
+            nonlocal call_count
+            call_count += 1
+            if call_count % 3 == 0:
+                raise VideoProcessingError("ffmpeg not found")
+            return 5.0  # dark frame
+
+        mock_probe.side_effect = side_effect
+
+        regions = [(100.0, 102.0)]
+        result = _refine_blackout_regions(Path("test.mp4"), regions, 15.0, 1000.0)
+
+        # Should not raise; failed probes are treated as non-blackout (255.0)
+        # Some probes succeed (5.0 < 15.0 threshold), so we get a region
+        assert isinstance(result, list)
+
 
 # ============================================================
 # TestExtractSegments


### PR DESCRIPTION
## Summary

- `_refine_blackout_regions()` の `future.result()` で `VideoProcessingError` を捕捉し、255.0（非暗転）として安全側に倒す
- GPU パス (`gpu_detector.py:62`) と同じ例外処理パターンに統一
- テストケース追加: 一部 future が例外を送出しても処理が継続することを検証

## 根本原因分析

`ThreadPoolExecutor` + `as_completed` パターンで `future.result()` を例外捕捉なしで呼ぶコードが複数箇所に存在。GPU パスのみ対応済みだった。同じパターンの類似バグを #234 として起票済み。

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（310 passed）
- [ ] テスター: `_probe_single_frame` が例外を送出するケースでクラッシュしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)