### PR TITLE
fix: probe_video で duration <= 0 時に VideoProcessingError を送出 #231

### DIFF
--- a/allaganeye/video/probe.py
+++ b/allaganeye/video/probe.py
@@ -90,6 +90,10 @@ def probe_video(video_path: Path) -> ProbeResult:
         )
 
     duration = float(data.get("format", {}).get("duration", 0))
+    if duration <= 0:
+        raise VideoProcessingError(
+            "Cannot determine video duration from ffprobe output"
+        )
 
     return {
         "duration": duration,

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -296,7 +296,7 @@ def test_probe_ffprobe_not_found(mock_run, tmp_path):
 
 @patch("allaganeye.video.probe.subprocess.run")
 def test_probe_missing_duration(mock_run, tmp_path):
-    """Missing duration in format defaults to 0.0."""
+    """Missing duration in format raises VideoProcessingError."""
     video = tmp_path / "test.mp4"
     video.touch()
     data = {
@@ -314,8 +314,8 @@ def test_probe_missing_duration(mock_run, tmp_path):
     }
     mock_run.return_value = _mock_result(stdout=json.dumps(data))
 
-    result = probe_video(video)
-    assert result["duration"] == 0.0
+    with pytest.raises(VideoProcessingError, match="duration"):
+        probe_video(video)
 
 
 @patch("allaganeye.video.probe.subprocess.run")


### PR DESCRIPTION
## Summary

- `probe_video()` で `duration <= 0` の場合に `VideoProcessingError` を送出するよう検証を追加
- FPS の検証パターンと統一
- 既存テスト `test_probe_missing_duration` を `pytest.raises` に更新

## 根本原因分析

`probe_video` の戻り値フィールドの検証ポリシーが不統一だった（FPS は検証あり、duration/width/height は検証なし）。同じパターンの width/height 未検証を #236 として起票済み。

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（309 passed）
- [ ] テスター: duration メタデータのない動画での挙動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)