### PR TITLE
fix: scorebar.py と debug_brightness.py の future.result() 未捕捉例外を修正 #234

### DIFF
--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 import typer
 
+from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
     _SCOREBAR_ROI_X_END,
@@ -75,7 +76,10 @@ def _run_brightness_mode(
         }
         for future in as_completed(futures):
             t = futures[future]
-            results[t] = future.result()
+            try:
+                results[t] = future.result()
+            except VideoProcessingError:
+                results[t] = 255.0
 
     typer.echo("timestamp,brightness")
     for t in sorted(results):
@@ -93,7 +97,10 @@ def _run_scorebar_mode(
         futures = {pool.submit(probe_fn, video_path, t): t for t in timestamps}
         for future in as_completed(futures):
             t = futures[future]
-            results[t] = future.result()
+            try:
+                results[t] = future.result()
+            except VideoProcessingError:
+                results[t] = None
 
     # Compute ROI pixel bounds from ratios
     x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
@@ -137,7 +144,10 @@ def _run_scorebar_detail_mode(
         futures = {pool.submit(probe_fn, video_path, t): t for t in timestamps}
         for future in as_completed(futures):
             t = futures[future]
-            results[t] = future.result()
+            try:
+                results[t] = future.result()
+            except VideoProcessingError:
+                results[t] = None
 
     x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
     x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import numpy as np
 
+from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
     _SCOREBAR_ROI_X_END,
@@ -47,7 +48,10 @@ def _probe_scorebar_context(
         }
         for future in as_completed(futures):
             t = futures[future]
-            raw = future.result()
+            try:
+                raw = future.result()
+            except VideoProcessingError:
+                raw = None
             raw_frames[t] = raw
             scorebar_results[t] = _has_scorebar(raw, height)
 

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -933,3 +933,18 @@ class TestProbeScorebarContext:
         assert results == []
         assert frames == []
         assert mock_probe.call_count == 0
+
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar")
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
+    def test_video_processing_error_treated_as_none(self, mock_probe, mock_has):
+        """VideoProcessingError from future is caught and treated as None."""
+        from allaganeye.exceptions import VideoProcessingError
+
+        mock_probe.side_effect = VideoProcessingError("ffmpeg not found")
+        mock_has.side_effect = lambda raw, _h: True if raw is not None else None
+
+        results, frames = _probe_scorebar_context(
+            Path("dummy.mp4"), [1.0, 2.0], _HEIGHT, workers=1
+        )
+        assert results == [None, None]
+        assert frames == [None, None]


### PR DESCRIPTION
## Summary

- `scorebar.py` `_probe_scorebar_context`: `VideoProcessingError` → `raw=None` として既存の None フォールバックパスに合流
- `debug_brightness.py` 3箇所: brightness モードは `255.0`、scorebar/detail モードは `None` で既存パスに合流
- `TestProbeScorebarContext` にテスト追加

## 背景

#230 の修正時に横展開調査で発見した類似バグ。`ThreadPoolExecutor` + `as_completed` で `future.result()` を例外捕捉なしで呼ぶパターンが複数箇所に存在していた。GPU パス (`gpu_detector.py`) のみ対応済みだったものを全箇所統一。

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（310 passed）
- [ ] テスター: scorebar/debug-brightness コマンドの正常動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)