### PR TITLE
fix: probe_video で width/height <= 0 時に VideoProcessingError を送出 #236

### DIFF
--- a/allaganeye/video/probe.py
+++ b/allaganeye/video/probe.py
@@ -91,10 +91,17 @@ def probe_video(video_path: Path) -> ProbeResult:
 
     duration = float(data.get("format", {}).get("duration", 0))
 
+    width = int(video_stream.get("width", 0))
+    height = int(video_stream.get("height", 0))
+    if width <= 0 or height <= 0:
+        raise VideoProcessingError(
+            "Cannot determine video resolution from ffprobe output"
+        )
+
     return {
         "duration": duration,
-        "width": int(video_stream.get("width", 0)),
-        "height": int(video_stream.get("height", 0)),
+        "width": width,
+        "height": height,
         "fps": fps,
         "codec": video_stream.get("codec_name", "unknown"),
         "audio_codec": audio_stream.get("codec_name", "unknown")

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -320,7 +320,7 @@ def test_probe_missing_duration(mock_run, tmp_path):
 
 @patch("allaganeye.video.probe.subprocess.run")
 def test_probe_missing_dimensions(mock_run, tmp_path):
-    """Missing width/height defaults to 0."""
+    """Missing width/height raises VideoProcessingError."""
     video = tmp_path / "test.mp4"
     video.touch()
     data = {
@@ -336,9 +336,8 @@ def test_probe_missing_dimensions(mock_run, tmp_path):
     }
     mock_run.return_value = _mock_result(stdout=json.dumps(data))
 
-    result = probe_video(video)
-    assert result["width"] == 0
-    assert result["height"] == 0
+    with pytest.raises(VideoProcessingError, match="resolution"):
+        probe_video(video)
 
 
 @patch("allaganeye.video.probe.subprocess.run")


### PR DESCRIPTION
## Summary

- `probe_video()` で `width <= 0` または `height <= 0` の場合に `VideoProcessingError` を送出するよう検証を追加
- 下流の `_scaled_height(src_width=0, ...)` での `ZeroDivisionError` を防止
- FPS・duration (#231) と同じ検証パターンに統一
- 既存テスト `test_probe_missing_dimensions` を `pytest.raises` に更新

## 根本原因分析

#231 と同一の根本原因（`probe_video` の検証ポリシー不統一）。本 PR で `probe_video` の全数値フィールド（FPS, duration, width, height）の検証が統一完了。

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（309 passed）
- [ ] テスター: 解像度メタデータのない動画での挙動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)