### PR TITLE
fix: --roi-mode ヘルプテキストに scorebar-detail を追加 #242

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -135,7 +135,9 @@ def debug_brightness(
     ] = None,
     roi_mode: Annotated[
         str | None,
-        typer.Option("--roi-mode", help="ROI analysis mode (scorebar)"),
+        typer.Option(
+            "--roi-mode", help="ROI analysis mode (scorebar, scorebar-detail)"
+        ),
     ] = None,
 ) -> None:
     """Probe frame brightness at regular intervals (CSV output for threshold tuning)."""


### PR DESCRIPTION
## Summary

- `cli.py` の `--roi-mode` ヘルプテキストに `scorebar-detail` を追加
- 1行修正（ドキュメントのみ相当の変更）

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（309 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)