### PR TITLE
chore: テンプレートバージョンマーカーファイルを追加

### DIFF
--- a/.claude/template-version.json
+++ b/.claude/template-version.json
@@ -1,0 +1,4 @@
+{
+  "template": "multi-agent",
+  "version": "1.3.0"
+}


### PR DESCRIPTION
## Summary

- `/check-toolkit` がテンプレートバージョンを自動検出するための `.claude/template-version.json` を追加
- multi-agent テンプレート v1.3.0 として記録

## 背景

idios-claudecode-tools の catalog.json にテンプレートの `detect.file_marker` が追加された。プロジェクト側にマーカーファイルを配置することで、次回以降の `/check-toolkit` でテンプレートのバージョン差が自動検出される。

[director-1]