### PR TITLE
refactor: scorebar 回帰テストの冗長 without-scorebar 検出パスを排除 #245

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,11 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-markers = ["slow: marks tests requiring video files (deselect with '-m \"not slow\"')"]
-addopts = "-m 'not slow'"
+markers = [
+    "slow: marks tests requiring video files (deselect with '-m \"not slow\"')",
+    "baseline_regen: marks tests only needed during baseline regeneration",
+]
+addopts = "-m 'not slow and not baseline_regen'"
 
 [tool.ruff]
 target-version = "py311"

--- a/tests/test_scorebar_regression.py
+++ b/tests/test_scorebar_regression.py
@@ -117,7 +117,10 @@ def detection_without_scorebar(
     target_recording: tuple[str, Path],
     target_metadata: dict,
 ) -> dict:
-    """Run detection WITHOUT scorebar filtering and measure time."""
+    """Run detection WITHOUT scorebar filtering and measure time.
+
+    Only used by baseline_regen tests (TestPerformance, TestNoResolutionCompat).
+    """
     name, mkv = target_recording
     meta = target_metadata
 
@@ -205,7 +208,6 @@ class TestDetectionCount:
         self,
         target_recording: tuple[str, Path],
         detection_with_scorebar: dict,
-        detection_without_scorebar: dict,
     ):
         """Scorebar filtering does not lose real matches vs no filtering."""
         name, _ = target_recording
@@ -248,6 +250,7 @@ class TestMatchDurations:
 # --- 3. Performance: scorebar overhead ---
 
 
+@pytest.mark.baseline_regen
 class TestPerformance:
     """Scorebar filtering should add minimal overhead."""
 
@@ -340,6 +343,7 @@ def _load_baseline(name: str) -> dict | None:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+@pytest.mark.baseline_regen
 class TestNoResolutionCompat:
     """When src_resolution is omitted, behavior must be identical to pre-#124."""
 
@@ -434,7 +438,6 @@ class TestBaselineComparison:
         self,
         target_recording: tuple[str, Path],
         detection_with_scorebar: dict,
-        detection_without_scorebar: dict,
     ):
         """Scorebar should not produce significantly more matches than baseline.
 
@@ -442,10 +445,14 @@ class TestBaselineComparison:
         or at most +2 (edge cases where non-FL removal creates new segments).
         """
         name, _ = target_recording
-        with_sb = detection_with_scorebar["match_count"]
-        without_sb = detection_without_scorebar["match_count"]
+        baseline = _load_baseline(name)
+        if baseline is None:
+            pytest.skip(f"No baseline for {name}")
 
-        assert with_sb <= without_sb + 2, (
+        with_sb = detection_with_scorebar["match_count"]
+        baseline_count = baseline["match_count"]
+
+        assert with_sb <= baseline_count + 2, (
             f"{name}: scorebar produced {with_sb} matches vs "
-            f"baseline {without_sb} (fragmentation)"
+            f"baseline {baseline_count} (fragmentation)"
         )


### PR DESCRIPTION
## Summary

- `test_no_worse_than_without_scorebar`: `detection_without_scorebar` fixture 引数を削除（テスト本文で未使用）
- `test_scorebar_does_not_fragment`: `detection_without_scorebar["match_count"]` → `_load_baseline()["match_count"]` に置換
- `test_overhead_within_budget` + `TestNoResolutionCompat`: `@pytest.mark.baseline_regen` に移動（ベースライン再生成時のみ実行）
- `detection_without_scorebar` fixture は `baseline_regen` テスト用に維持（docstring に用途を明記）
- `pyproject.toml` に `baseline_regen` マーカーを登録、`addopts` で除外

## 効果

`pytest -m slow` 実行時に without-scorebar 検出パス（全動画で2回目の完全検出）がスキップされ、テスト時間が約半分に短縮。

## テスト collect 確認

- `slow and not baseline_regen`: 11/14 テスト collect（3件除外）
- 除外されたテスト: `TestPerformance.test_overhead_within_budget`, `TestNoResolutionCompat.test_same_count_as_baseline`, `TestNoResolutionCompat.test_boundaries_match_baseline`

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（309 passed, 28 deselected）
- [ ] テスター: `pytest -m slow` で退行なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)