### PR TITLE
refactor: slow テストマーカーを階層化 (probe/detect/pipeline/gpu) #245 #246

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dev = [
 testpaths = ["tests"]
 markers = [
     "slow: marks tests requiring video files (deselect with '-m \"not slow\"')",
+    "slow_probe: probe-only slow tests",
+    "slow_detect: detection slow tests",
+    "slow_pipeline: full pipeline slow tests",
+    "slow_gpu: GPU-specific slow tests",
     "baseline_regen: marks tests only needed during baseline regeneration",
 ]
 addopts = "-m 'not slow and not baseline_regen'"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -201,6 +201,7 @@ def any_video(_sample_video_dir_session: Path) -> Path:
 # --- Probe tests ---
 
 
+@pytest.mark.slow_probe
 class TestProbeRealVideo:
     """Test probe_video with real video files."""
 
@@ -236,6 +237,7 @@ class TestProbeRealVideo:
 # --- Detection tests ---
 
 
+@pytest.mark.slow_detect
 class TestDetectRealVideo:
     """Test detection results (from cached pipeline run)."""
 
@@ -328,6 +330,7 @@ class TestDetectRealVideo:
 # --- Split tests ---
 
 
+@pytest.mark.slow_pipeline
 class TestSplitRealVideo:
     """Test split output (from cached pipeline run)."""
 
@@ -355,6 +358,7 @@ class TestSplitRealVideo:
 # --- Metadata verification ---
 
 
+@pytest.mark.slow_pipeline
 class TestMetadataJson:
     """Test metadata.json content (from cached pipeline run)."""
 
@@ -416,6 +420,7 @@ def gpu_cpu_results(source_mkv: Path, source_metadata: dict) -> dict:
 # --- GPU/CPU consistency tests ---
 
 
+@pytest.mark.slow_gpu
 class TestGpuCpuConsistency:
     """Verify GPU and CPU detection produce consistent results."""
 

--- a/tests/test_scorebar_regression.py
+++ b/tests/test_scorebar_regression.py
@@ -186,6 +186,7 @@ def pipeline_output_with_scorebar(
 # --- 1. Functional regression: detection count ---
 
 
+@pytest.mark.slow_detect
 class TestDetectionCount:
     """Scorebar filtering should not reduce detection count vs manual splits."""
 
@@ -227,6 +228,7 @@ class TestDetectionCount:
 # --- 2. Functional regression: match durations ---
 
 
+@pytest.mark.slow_detect
 class TestMatchDurations:
     """Each detected match should be within plausible FL duration range."""
 
@@ -250,6 +252,7 @@ class TestMatchDurations:
 # --- 3. Performance: scorebar overhead ---
 
 
+@pytest.mark.slow_detect
 @pytest.mark.baseline_regen
 class TestPerformance:
     """Scorebar filtering should add minimal overhead."""
@@ -276,6 +279,7 @@ class TestPerformance:
 # --- 4. Pipeline output: metadata.json integrity ---
 
 
+@pytest.mark.slow_pipeline
 class TestMetadataIntegrity:
     """metadata.json should have all required fields."""
 
@@ -343,6 +347,7 @@ def _load_baseline(name: str) -> dict | None:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+@pytest.mark.slow_detect
 @pytest.mark.baseline_regen
 class TestNoResolutionCompat:
     """When src_resolution is omitted, behavior must be identical to pre-#124."""
@@ -390,6 +395,7 @@ class TestNoResolutionCompat:
 # --- 6. Baseline comparison: scorebar detection results ---
 
 
+@pytest.mark.slow_detect
 class TestBaselineComparison:
     """Compare scorebar detection against saved baselines.
 


### PR DESCRIPTION
## Summary

- `slow_probe`, `slow_detect`, `slow_pipeline`, `slow_gpu` サブマーカーを導入
- `baseline_regen` マーカーを導入（#245 の変更を包含）
- 既存の `pytest -m slow` は引き続き動作（サブマーカーは `slow` の子）

## マーカー集計

| マーカー | テスト数 |
|---|---|
| `slow_probe` | 3 |
| `slow_detect` (baseline_regen除外) | 10 |
| `slow_pipeline` | 10 |
| `slow_gpu` | 2 |
| `baseline_regen` | 3 |
| `slow` (all, baseline_regen除外) | 25 |

## #245 との関係

本 PR は #245 (PR #250) の `baseline_regen` 変更を包含しています。#250 と本 PR のどちらかをマージすれば `baseline_regen` が導入されます。両方マージする場合は後発側でコンフリクト解消が必要です。

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（309 passed, 28 deselected）
- [x] 各サブマーカーの collect 数が方針と一致
- [ ] テスター: `pytest -m slow_detect` 等でサブセット実行が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)