### PR TITLE
test: PR #233-#239 テストギャップ補完

### DIFF
--- a/tests/test_debug_brightness.py
+++ b/tests/test_debug_brightness.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from allaganeye.commands.debug_brightness import run_debug_brightness
+from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
     _SCOREBAR_ROI_X_END,
@@ -295,3 +296,84 @@ def test_scorebar_detail_section_values(mock_probe_video, mock_probe_rgb, capsys
     assert float(parts[6]) > 150  # center_g
     # right section should be blue-dominant
     assert float(parts[10]) > 150  # right_b
+
+
+# --- VideoProcessingError fallback tests (PR #238 gap coverage) ---
+
+
+@patch(f"{MODULE}._probe_single_frame")
+@patch(f"{MODULE}.probe_video")
+def test_brightness_mode_exception_fallback(mock_probe_video, mock_probe_frame, capsys):
+    """Brightness mode: VideoProcessingError → 255.0 fallback."""
+    mock_probe_video.return_value = PROBE_RESULT
+
+    def side_effect(path, t):
+        if t == 1.0:
+            raise VideoProcessingError("probe failed")
+        return 42.5
+
+    mock_probe_frame.side_effect = side_effect
+
+    run_debug_brightness(Path("test.mp4"), start=0.0, end=3.0, interval=1.0)
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    assert lines[1] == "0.0,42.5"
+    assert lines[2] == "1.0,255.0"  # fallback
+    assert lines[3] == "2.0,42.5"
+
+
+@patch(f"{MODULE}._probe_frame_rgb")
+@patch(f"{MODULE}.probe_video")
+def test_scorebar_mode_exception_fallback(mock_probe_video, mock_probe_rgb, capsys):
+    """Scorebar mode: VideoProcessingError → None → fallback row."""
+    mock_probe_video.return_value = PROBE_RESULT
+
+    def side_effect(path, t, *, height=180):
+        if t == 0.0:
+            raise VideoProcessingError("probe failed")
+        return _make_rgb_frame(100, 50, 200, height=height)
+
+    mock_probe_rgb.side_effect = side_effect
+
+    run_debug_brightness(
+        Path("test.mp4"), start=0.0, end=2.0, interval=1.0, roi_mode="scorebar"
+    )
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    # t=0.0 should have fallback values
+    parts_0 = lines[1].split(",")
+    assert parts_0[1] == "255.0"  # fallback brightness
+    # t=1.0 should have normal values
+    parts_1 = lines[2].split(",")
+    assert float(parts_1[1]) < 255.0
+
+
+@patch(f"{MODULE}._probe_frame_rgb")
+@patch(f"{MODULE}.probe_video")
+def test_scorebar_detail_mode_exception_fallback(
+    mock_probe_video, mock_probe_rgb, capsys
+):
+    """Scorebar-detail mode: VideoProcessingError → None → fallback row."""
+    mock_probe_video.return_value = PROBE_RESULT
+
+    def side_effect(path, t, *, height=180):
+        if t == 0.0:
+            raise VideoProcessingError("probe failed")
+        return _make_rgb_frame(100, 50, 200, height=height)
+
+    mock_probe_rgb.side_effect = side_effect
+
+    run_debug_brightness(
+        Path("test.mp4"), start=0.0, end=2.0, interval=1.0, roi_mode="scorebar-detail"
+    )
+
+    output = capsys.readouterr().out
+    lines = output.strip().split("\n")
+    # t=0.0 should have fallback (all zeros)
+    parts_0 = lines[1].split(",")
+    assert parts_0[1] == "0.0"  # roi_brightness fallback
+    # t=1.0 should have normal values
+    parts_1 = lines[2].split(",")
+    assert float(parts_1[1]) > 0.0

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -319,6 +319,50 @@ def test_probe_missing_duration(mock_run, tmp_path):
 
 
 @patch("allaganeye.video.probe.subprocess.run")
+def test_probe_duration_zero(mock_run, tmp_path):
+    """Explicit duration=0 raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(stdout=_make_ffprobe_output(duration="0"))
+    with pytest.raises(VideoProcessingError, match="duration"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_duration_negative(mock_run, tmp_path):
+    """Negative duration raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(stdout=_make_ffprobe_output(duration="-5.0"))
+    with pytest.raises(VideoProcessingError, match="duration"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_width_zero(mock_run, tmp_path):
+    """width=0 with valid height raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=_make_ffprobe_output(width=0, height=1080)
+    )
+    with pytest.raises(VideoProcessingError, match="resolution"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+def test_probe_height_zero(mock_run, tmp_path):
+    """height=0 with valid width raises VideoProcessingError."""
+    video = tmp_path / "test.mp4"
+    video.touch()
+    mock_run.return_value = _mock_result(
+        stdout=_make_ffprobe_output(width=1920, height=0)
+    )
+    with pytest.raises(VideoProcessingError, match="resolution"):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
 def test_probe_missing_dimensions(mock_run, tmp_path):
     """Missing width/height raises VideoProcessingError."""
     video = tmp_path / "test.mp4"

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -478,6 +478,74 @@ class TestCacheRoundTrip:
         assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
 
 
+# --- Progressbar tests (PR #233 gap coverage) ---
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_progressbar_length(mock_probe, mock_detect, mock_split, tmp_path):
+    """Progressbar length equals estimated_samples, not frame count."""
+    mock_probe.return_value = {**PROBE_RESULT, "duration": 1800.0}
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    with patch("typer.progressbar") as mock_bar:
+        mock_bar.return_value.__enter__ = lambda s: s
+        mock_bar.return_value.__exit__ = lambda s, *a: None
+        mock_bar.return_value.update = lambda n: None
+        run_split(Path("input.mp4"), config, verbose=True)
+
+    # interval=1.0 for 1800s → estimated_samples = 1800
+    mock_bar.assert_called_once()
+    assert mock_bar.call_args[1]["length"] == 1800
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_progressbar_tiny_video(mock_probe, mock_detect, mock_split, tmp_path):
+    """Progressbar length is at least 1 for very short videos."""
+    mock_probe.return_value = {**PROBE_RESULT, "duration": 0.5}
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    with patch("typer.progressbar") as mock_bar:
+        mock_bar.return_value.__enter__ = lambda s: s
+        mock_bar.return_value.__exit__ = lambda s, *a: None
+        mock_bar.return_value.update = lambda n: None
+        run_split(Path("input.mp4"), config, verbose=True)
+
+    # int(0.5 / 1.0) = 0, max(1, 0) = 1
+    mock_bar.assert_called_once()
+    assert mock_bar.call_args[1]["length"] == 1
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_progressbar_auto_interval(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """Progressbar length uses auto-adjusted interval for long videos."""
+    mock_probe.return_value = {**PROBE_RESULT, "duration": 7300.0}  # > 2h
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    with patch("typer.progressbar") as mock_bar:
+        mock_bar.return_value.__enter__ = lambda s: s
+        mock_bar.return_value.__exit__ = lambda s, *a: None
+        mock_bar.return_value.update = lambda n: None
+        run_split(Path("input.mp4"), config, verbose=True)
+
+    # auto interval = 3.0 for > 2h, estimated_samples = int(7300/3.0) = 2433
+    mock_bar.assert_called_once()
+    assert mock_bar.call_args[1]["length"] == 2433
+
+
 class TestCachePipeline:
     @patch(f"{MODULE}.split_video")
     @patch(f"{MODULE}.detect_match_boundaries")


### PR DESCRIPTION
## Summary

PR #233-#239 のテストギャップ分析で特定した不足テスト 10 件を追加。

## 追加テスト

### `tests/test_split_matches.py` (+3件, PR #233 対応)
- `test_verbose_progressbar_length`: progressbar の length が estimated_samples で初期化されることを検証
- `test_verbose_progressbar_tiny_video`: duration=0.5 で `max(1, 0)=1` になることを検証
- `test_verbose_progressbar_auto_interval`: 長時間動画 (>2h) で auto-adjusted interval が反映されることを検証

### `tests/test_probe.py` (+4件, PR #237/#239 対応)
- `test_probe_duration_zero`: duration="0" で VideoProcessingError
- `test_probe_duration_negative`: duration="-5.0" で VideoProcessingError
- `test_probe_width_zero`: width=0, height=1080 で VideoProcessingError
- `test_probe_height_zero`: width=1920, height=0 で VideoProcessingError

### `tests/test_debug_brightness.py` (+3件, PR #238 対応)
- `test_brightness_mode_exception_fallback`: VideoProcessingError → 255.0
- `test_scorebar_mode_exception_fallback`: VideoProcessingError → None → fallback row
- `test_scorebar_detail_mode_exception_fallback`: 同上

## 依存関係

本 PR は #233, #235, #237, #238, #239 のコード変更を含むブランチ上に構築。これらの PR がマージされた後にマージすること。

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過 (321 passed)

作成: tester-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)