### PR TITLE
test: test_detect_total_duration_accuracy の閾値を ±25% に緩和 #200

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -302,9 +302,9 @@ class TestDetectRealVideo:
             meta = probe_video(mp4)
             manual_total += meta["duration"]
 
-        # Allow 15% tolerance on total duration
+        # Allow 25% tolerance on total duration
         ratio = detected_total / manual_total
-        assert 0.85 <= ratio <= 1.15, (
+        assert 0.75 <= ratio <= 1.25, (
             f"Total duration ratio {ratio:.2f}: "
             f"detected {detected_total:.0f}s vs manual {manual_total:.0f}s"
         )


### PR DESCRIPTION
## Summary

- `test_detect_total_duration_accuracy` の duration ratio 閾値を `±15%` → `±25%` に緩和
- 20260118 の ratio 1.19 が PASS するようになる

## セルフ検証結果

| データセット | 結果 |
|---|---|
| 20260118 | **PASS** (ratio 1.19, 閾値 1.25) |

## 背景

- 20260118 の ratio は 1.26→1.21→1.19 と改善してきたが ±15% には未達
- Match 6-7 の連続ブロック（gap なし暗転）は同データ固有のエッジケース
- Lead 判断: マージスコアリング（案2）は P3-low に見合わない複雑性のため、閾値緩和を選択

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（321 passed）
- [x] 20260118 で PASS 確認（実データ）
- [ ] テスター: 他データセット（20260116, 20260119）で退行なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)