### PR TITLE
fix: baseline_regen テストが pytest -m slow で実行されないよう修正 #256

### DIFF
--- a/tests/test_scorebar_regression.py
+++ b/tests/test_scorebar_regression.py
@@ -22,7 +22,6 @@ from allaganeye.config import SplitConfig
 from allaganeye.video.detector import detect_match_boundaries
 from allaganeye.video.probe import ProbeResult, probe_video
 
-pytestmark = pytest.mark.slow
 
 # --- Helpers ---
 
@@ -186,6 +185,7 @@ def pipeline_output_with_scorebar(
 # --- 1. Functional regression: detection count ---
 
 
+@pytest.mark.slow
 @pytest.mark.slow_detect
 class TestDetectionCount:
     """Scorebar filtering should not reduce detection count vs manual splits."""
@@ -228,6 +228,7 @@ class TestDetectionCount:
 # --- 2. Functional regression: match durations ---
 
 
+@pytest.mark.slow
 @pytest.mark.slow_detect
 class TestMatchDurations:
     """Each detected match should be within plausible FL duration range."""
@@ -279,6 +280,7 @@ class TestPerformance:
 # --- 4. Pipeline output: metadata.json integrity ---
 
 
+@pytest.mark.slow
 @pytest.mark.slow_pipeline
 class TestMetadataIntegrity:
     """metadata.json should have all required fields."""
@@ -395,6 +397,7 @@ class TestNoResolutionCompat:
 # --- 6. Baseline comparison: scorebar detection results ---
 
 
+@pytest.mark.slow
 @pytest.mark.slow_detect
 class TestBaselineComparison:
     """Compare scorebar detection against saved baselines.


### PR DESCRIPTION
## Summary

- `test_scorebar_regression.py` のモジュールレベル `pytestmark = pytest.mark.slow` を削除
- 各テストクラスに個別に `@pytest.mark.slow` を付与
- `TestPerformance` と `TestNoResolutionCompat` には `slow` を付けず、`baseline_regen` + サブマーカーのみ

## 検証結果

```
# baseline_regen テストが slow に含まれないこと
pytest -m slow --collect-only | grep TestPerformance → 0件 ✅

# baseline_regen テストが明示指定で実行できること
pytest -m baseline_regen --collect-only → 3件 ✅
```

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（324 passed）
- [x] `pytest -m slow` で baseline_regen テストが除外されることを確認
- [ ] テスター: `pytest -m slow` で without-scorebar 検出パスが実行されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)