### PR TITLE
docs: 外部動画検査手順に guard 最新版更新ステップを追加

### DIFF
--- a/docs/guard-integration.md
+++ b/docs/guard-integration.md
@@ -220,11 +220,12 @@ GitHub の issue・PR に添付またはリンクされた動画ファイルに�
 ### 検査手順
 
 1. ファイルをダウンロードし、隔離ディレクトリに保存する
-2. `allaganeye-guard verify <file>` を実行する
-3. **PASS するまで allaganeye で処理しない**
-4. guard 未インストールの場合は先にインストールする（§7 参照）
-5. FAIL の場合は処理せず、issue・PR にコメントして提供者に確認を求める
-6. 検査結果（PASS / FAIL）を issue・PR にコメントとして記録する
+2. guard を最新版に更新する（`git pull && pip install -e .`）。YARA ルールセットは随時更新されるため、古いバージョンでの検査は不十分な可能性がある
+3. `allaganeye-guard verify <file>` を実行する
+4. **PASS するまで allaganeye で処理しない**
+5. guard 未インストールの場合は先にインストールする（§7 参照）
+6. FAIL の場合は処理せず、issue・PR にコメントして提供者に確認を求める
+7. 検査結果（PASS / FAIL）を issue・PR にコメントとして記録する
 
 ---
 


### PR DESCRIPTION
## Summary

- `docs/guard-integration.md` §8 の検査手順に「guard を最新版に更新する」ステップを追加
- YARA ルールセットは随時更新されるため、古いバージョンでの検査では不十分な可能性がある旨を明記

## 背景

#262 で guard v0.4.0 がリリースされた。外部動画の検査時に最新の guard を使用するルールがドキュメントに明記されていなかった。

[director-1]