### PR TITLE
docs: インストール手順に venv 作成・有効化ステップを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,20 @@ OBS 等で録画した数時間分の動画を入力すると、試合の切れ�
 > 詳しいセットアップ手順は [Quick Start Guide](docs/quickstart.md) を参照してください。
 > 更新方法は [Quick Start Guide — 更新](docs/quickstart.md#3-更新) を参照してください。
 
-```bash
-# 前提: Git, Python 3.11+, ffmpeg 4.1+ がインストール済みであること
-# 初めての方は docs/quickstart.md を参照
+```
 git clone https://github.com/Idios/kobutachan-allaganeye.git
 cd kobutachan-allaganeye
-python -m venv .venv && source .venv/Scripts/activate  # Windows Git Bash
+python -m venv .venv
+.venv\Scripts\activate.bat
 pip install -e .
 
-# まず検知結果を確認
+rem まず検知結果を確認
 allaganeye split your_recording.mkv --dry-run
-# 結果が正しければ本実行
+rem 結果が正しければ本実行
 allaganeye split your_recording.mkv
 ```
+
+> 上記は Windows コマンドプロンプトでの例です。PowerShell・Git Bash・Linux・macOS での手順は [Quick Start Guide](docs/quickstart.md) を参照してください。
 
 ## 使い方
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ OBS 等で録画した数時間分の動画を入力すると、試合の切れ�
 # 初めての方は docs/quickstart.md を参照
 git clone https://github.com/Idios/kobutachan-allaganeye.git
 cd kobutachan-allaganeye
+python -m venv .venv && source .venv/Scripts/activate  # Windows Git Bash
 pip install -e .
 
 # まず検知結果を確認

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -167,15 +167,37 @@ echo 'export ALLAGANEYE_FFMPEG=/path/to/ffmpeg/bin' >> ~/.zshrc
 ```bash
 git clone https://github.com/Idios/kobutachan-allaganeye.git
 cd kobutachan-allaganeye
+python -m venv .venv
+```
+
+仮想環境を有効化する:
+
+```bash
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
+
+# Windows (Git Bash / MSYS2)
+source .venv/Scripts/activate
+
+# Linux / macOS
+source .venv/bin/activate
+```
+
+パッケージをインストールする:
+
+```bash
 pip install -e .
 ```
 
 > SSH を使う場合: `git clone git@github.com:Idios/kobutachan-allaganeye.git`
 
+> **注意**: 仮想環境を使わずに `pip install -e .` すると、`allaganeye` コマンドが PATH の通らないディレクトリにインストールされることがあります（特に Microsoft Store 版 Python）。仮想環境の使用を推奨します。
+
 ## 3. 更新
 
 ```bash
 cd kobutachan-allaganeye
+source .venv/Scripts/activate   # または上記の有効化コマンド
 git pull
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -173,6 +173,9 @@ python -m venv .venv
 仮想環境を有効化する:
 
 ```bash
+# Windows (コマンドプロンプト)
+.venv\Scripts\activate.bat
+
 # Windows (PowerShell)
 .venv\Scripts\Activate.ps1
 


### PR DESCRIPTION
## Summary

- `docs/quickstart.md`: venv 作成・有効化の手順を追加（Windows PowerShell / Git Bash / Linux・macOS）
- `README.md`: Quick Start の pip install 前に venv 作成を追加
- PATH が通らない場合の注意書きを追加

## 背景

quickstart.md の手順に従って `pip install -e .` を実行すると、Microsoft Store 版 Python では Scripts ディレクトリが PATH に含まれず `allaganeye` コマンドが見つからない。

```
WARNING: The script allaganeye.exe is installed in '...\Scripts' which is not on PATH.
```

venv を使えば有効化時に Scripts が PATH に追加されるため、この問題が発生しない。

[director-1]