### PR TITLE
refactor: デフォルトで進捗表示し --quiet で抑制する設計に変更 #269

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ allaganeye split <video_path> -o <dir>  # 出力先指定
 allaganeye split <video_path> --gpu     # GPU アクセラレーション検知
 allaganeye split <video_path> --workers 8  # ワーカー数指定
 allaganeye split <video_path> --no-cache   # キャッシュ無視で再検知
+allaganeye split <video_path> --quiet      # 進捗抑制（出力ファイルのみ）
 allaganeye debug-brightness <video_path>   # フレーム輝度 CSV 出力
 ```
 

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -76,7 +76,16 @@ def split(
         typer.Option("--no-cache", help="Ignore cached detection results"),
     ] = False,
     verbose: Annotated[
-        bool, typer.Option("-v", "--verbose", help="Verbose output")
+        bool,
+        typer.Option(
+            "-v", "--verbose", help="Verbose output (metadata details, gap info)"
+        ),
+    ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "-q", "--quiet", help="Suppress progress output (final result only)"
+        ),
     ] = False,
 ) -> None:
     """Split a long recording into per-match video files."""
@@ -104,7 +113,7 @@ def split(
 
         from allaganeye.commands.split_matches import run_split
 
-        run_split(video_path, config, verbose=verbose)
+        run_split(video_path, config, verbose=verbose, quiet=quiet)
 
     except AllaganEyeError as e:
         typer.echo(f"Error: {e}", err=True)

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -27,13 +27,27 @@ logger = logging.getLogger(__name__)
 _CACHE_VERSION = 1
 
 
-def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -> None:
-    """Run the split pipeline: probe → detect → split."""
+def run_split(
+    video_path: Path,
+    config: SplitConfig,
+    *,
+    verbose: bool = False,
+    quiet: bool = False,
+) -> None:
+    """Run the split pipeline: probe → detect → split.
+
+    Output levels:
+    - Default: probe status, progress bar, match list, output files
+    - ``verbose``: adds metadata details, gap info, interval adjustment
+    - ``quiet``: suppresses all output except output file list
+    """
+    show = not quiet
+
     # Step 1: Probe video metadata
-    if verbose:
+    if show:
         typer.echo(f"Probing: {video_path}")
     metadata = probe_video(video_path)
-    if verbose:
+    if verbose and show:
         typer.echo(
             f"  Duration: {metadata['duration']:.1f}s, "
             f"Resolution: {metadata['width']}x{metadata['height']}, "
@@ -51,19 +65,21 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
         cached = _load_cache(cache_path, video_path, effective_interval, config)
         if cached is not None:
             boundaries = cached
-            typer.echo(
-                f"Detected {len(boundaries)} match(es) in {video_path.name} "
-                f"({_format_timestamp(metadata['duration'])}) (cached)"
-            )
-            typer.echo()
-            for i, b in enumerate(boundaries, 1):
-                dur = b["end"] - b["start"]
+            if show:
                 typer.echo(
-                    f"  Match {i}: {_format_timestamp(b['start']):>7s} - "
-                    f"{_format_timestamp(b['end']):>7s}  ({_format_duration(dur)})"
+                    f"Detected {len(boundaries)} match(es) in {video_path.name} "
+                    f"({_format_timestamp(metadata['duration'])}) (cached)"
                 )
+                typer.echo()
+                for i, b in enumerate(boundaries, 1):
+                    dur = b["end"] - b["start"]
+                    typer.echo(
+                        f"  Match {i}: {_format_timestamp(b['start']):>7s} - "
+                        f"{_format_timestamp(b['end']):>7s}  "
+                        f"({_format_duration(dur)})"
+                    )
             gaps = _find_gaps(boundaries, metadata["duration"], min_gap=300.0)
-            if gaps:
+            if show and verbose and gaps:
                 typer.echo()
                 for gap in gaps:
                     typer.echo(
@@ -74,60 +90,29 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             if config.dry_run:
                 typer.echo("\nDry run: skipping split")
                 return
-            # Jump to splitting
             return _split_and_write_metadata(
                 video_path, boundaries, gaps, metadata, config
             )
 
     # Step 2: Detect match boundaries
-    if verbose:
+    if verbose and show:
         if effective_interval != config.sample_interval:
             typer.echo(
                 f"  Auto-adjusted sample interval: "
                 f"{config.sample_interval}s → {effective_interval}s "
                 f"(video is {_format_duration(metadata['duration'])})"
             )
+
+    if show:
         typer.echo(
             f"Detecting match boundaries "
-            f"(interval={effective_interval}s, threshold={config.blackout_threshold})"
+            f"(interval={effective_interval}s, "
+            f"threshold={config.blackout_threshold})"
         )
 
-        total_duration = metadata["duration"]
-        estimated_samples = max(1, int(total_duration / effective_interval))
-
-        with typer.progressbar(length=estimated_samples, label="Detecting") as progress:
-            last_pos = [0]
-
-            def on_progress(completed: int, total: int, blackout_count: int) -> None:
-                advance = completed - last_pos[0]
-                if advance > 0:
-                    progress.update(advance)
-                last_pos[0] = completed
-
-            boundaries = detect_match_boundaries(
-                video_path,
-                duration_hint=metadata["duration"],
-                sample_interval=effective_interval,
-                blackout_threshold=config.blackout_threshold,
-                min_match_duration=config.min_match_duration,
-                min_blackout_duration=config.min_blackout_duration,
-                use_gpu=config.use_gpu,
-                workers=config.workers,
-                src_resolution=(metadata["width"], metadata["height"]),
-                progress_callback=on_progress,
-            )
-    else:
-        boundaries = detect_match_boundaries(
-            video_path,
-            duration_hint=metadata["duration"],
-            sample_interval=effective_interval,
-            blackout_threshold=config.blackout_threshold,
-            min_match_duration=config.min_match_duration,
-            min_blackout_duration=config.min_blackout_duration,
-            use_gpu=config.use_gpu,
-            workers=config.workers,
-            src_resolution=(metadata["width"], metadata["height"]),
-        )
+    boundaries = _run_detection(
+        video_path, metadata, effective_interval, config, quiet=quiet
+    )
 
     if not boundaries:
         raise DetectionError(
@@ -135,24 +120,24 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
             "Try adjusting --blackout-threshold or --min-match-duration."
         )
 
-    # Display detection results with human-readable timestamps
-    source_duration = metadata["duration"]
-    typer.echo(
-        f"Detected {len(boundaries)} match(es) in {video_path.name} "
-        f"({_format_timestamp(source_duration)})"
-    )
-    typer.echo()
-
-    for i, b in enumerate(boundaries, 1):
-        dur = b["end"] - b["start"]
+    # Display detection results
+    if show:
+        source_duration = metadata["duration"]
         typer.echo(
-            f"  Match {i}: {_format_timestamp(b['start']):>7s} - "
-            f"{_format_timestamp(b['end']):>7s}  ({_format_duration(dur)})"
+            f"Detected {len(boundaries)} match(es) in {video_path.name} "
+            f"({_format_timestamp(source_duration)})"
         )
+        typer.echo()
+        for i, b in enumerate(boundaries, 1):
+            dur = b["end"] - b["start"]
+            typer.echo(
+                f"  Match {i}: {_format_timestamp(b['start']):>7s} - "
+                f"{_format_timestamp(b['end']):>7s}  ({_format_duration(dur)})"
+            )
 
-    # Show significant gaps (>= 5 minutes)
-    gaps = _find_gaps(boundaries, source_duration, min_gap=300.0)
-    if gaps:
+    # Show significant gaps (verbose only)
+    gaps = _find_gaps(boundaries, metadata["duration"], min_gap=300.0)
+    if verbose and show and gaps:
         typer.echo()
         for gap in gaps:
             typer.echo(
@@ -172,6 +157,46 @@ def run_split(video_path: Path, config: SplitConfig, *, verbose: bool = False) -
         return
 
     _split_and_write_metadata(video_path, boundaries, gaps, metadata, config)
+
+
+def _run_detection(
+    video_path: Path,
+    metadata: ProbeResult,
+    effective_interval: float,
+    config: SplitConfig,
+    *,
+    quiet: bool = False,
+) -> list[MatchBoundary]:
+    """Run detection with optional progress bar."""
+    detect_kwargs = {
+        "duration_hint": metadata["duration"],
+        "sample_interval": effective_interval,
+        "blackout_threshold": config.blackout_threshold,
+        "min_match_duration": config.min_match_duration,
+        "min_blackout_duration": config.min_blackout_duration,
+        "use_gpu": config.use_gpu,
+        "workers": config.workers,
+        "src_resolution": (metadata["width"], metadata["height"]),
+    }
+
+    if not quiet:
+        total_duration = metadata["duration"]
+        estimated_samples = max(1, int(total_duration / effective_interval))
+
+        with typer.progressbar(length=estimated_samples, label="Detecting") as progress:
+            last_pos = [0]
+
+            def on_progress(completed: int, total: int, blackout_count: int) -> None:
+                advance = completed - last_pos[0]
+                if advance > 0:
+                    progress.update(advance)
+                last_pos[0] = completed
+
+            return detect_match_boundaries(
+                video_path, **detect_kwargs, progress_callback=on_progress
+            )
+
+    return detect_match_boundaries(video_path, **detect_kwargs)
 
 
 def _split_and_write_metadata(

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -42,7 +42,8 @@ allaganeye split <video_path> [OPTIONS]
 | `--gpu` / `--no-gpu` | `false` | GPU アクセラレーション検知（チャンク並列デコード）。利用不可時は CPU フォールバック |
 | `--no-cache` | `false` | キャッシュされた検知結果を無視して再検知する |
 | `--dry-run` | `false` | 検知のみ実行し分割しない |
-| `-v`, `--verbose` | `false` | 詳細ログ出力 |
+| `-v`, `--verbose` | `false` | 詳細出力（メタデータ詳細、gap 情報） |
+| `-q`, `--quiet` | `false` | 進捗出力を抑制（出力ファイル一覧のみ） |
 
 ### 出力
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,7 @@ def test_split_default_options(mock_run_split, fake_video):
     assert config.use_gpu is False
     assert config.dry_run is False
     assert kwargs["verbose"] is False
+    assert kwargs["quiet"] is False
 
 
 @patch(MODULE)
@@ -265,6 +266,24 @@ def test_split_verbose_long(mock_run_split, fake_video):
 
     assert result.exit_code == 0
     assert mock_run_split.call_args[1]["verbose"] is True
+
+
+@patch(MODULE)
+def test_split_quiet_short(mock_run_split, fake_video):
+    """-q flag sets quiet=True."""
+    result = runner.invoke(app, ["split", str(fake_video), "-q"])
+
+    assert result.exit_code == 0
+    assert mock_run_split.call_args[1]["quiet"] is True
+
+
+@patch(MODULE)
+def test_split_quiet_long(mock_run_split, fake_video):
+    """--quiet flag sets quiet=True."""
+    result = runner.invoke(app, ["split", str(fake_video), "--quiet"])
+
+    assert result.exit_code == 0
+    assert mock_run_split.call_args[1]["quiet"] is True
 
 
 @patch(MODULE)

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -81,16 +81,18 @@ def test_pipeline_happy_path(mock_probe, mock_detect, mock_split, tmp_path):
     run_split(video, config)
 
     mock_probe.assert_called_once_with(video)
-    mock_detect.assert_called_once_with(
-        video,
-        duration_hint=PROBE_RESULT["duration"],
-        sample_interval=config.sample_interval,
-        blackout_threshold=config.blackout_threshold,
-        min_match_duration=config.min_match_duration,
-        min_blackout_duration=config.min_blackout_duration,
-        use_gpu=config.use_gpu,
-        workers=config.workers,
-        src_resolution=(PROBE_RESULT["width"], PROBE_RESULT["height"]),
+    mock_detect.assert_called_once()
+    _, detect_kwargs = mock_detect.call_args
+    assert detect_kwargs["duration_hint"] == PROBE_RESULT["duration"]
+    assert detect_kwargs["sample_interval"] == config.sample_interval
+    assert detect_kwargs["blackout_threshold"] == config.blackout_threshold
+    assert detect_kwargs["min_match_duration"] == config.min_match_duration
+    assert detect_kwargs["min_blackout_duration"] == config.min_blackout_duration
+    assert detect_kwargs["use_gpu"] == config.use_gpu
+    assert detect_kwargs["workers"] == config.workers
+    assert detect_kwargs["src_resolution"] == (
+        PROBE_RESULT["width"],
+        PROBE_RESULT["height"],
     )
     mock_split.assert_called_once_with(video, BOUNDARIES, tmp_path)
     assert (tmp_path / "metadata.json").exists()
@@ -238,7 +240,7 @@ class TestMetadataWriteError:
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
 def test_pipeline_verbose_output(mock_probe, mock_detect, mock_split, tmp_path, capsys):
-    """Verbose mode prints probe info and match details."""
+    """Verbose mode prints probe details and gap info."""
     mock_probe.return_value = PROBE_RESULT
     mock_detect.return_value = BOUNDARIES
     mock_split.return_value = _output_files(tmp_path)
@@ -257,22 +259,42 @@ def test_pipeline_verbose_output(mock_probe, mock_detect, mock_split, tmp_path, 
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
-def test_pipeline_non_verbose_output(
-    mock_probe, mock_detect, mock_split, tmp_path, capsys
-):
-    """Non-verbose mode prints match list with timestamps but not probe details."""
+def test_pipeline_default_output(mock_probe, mock_detect, mock_split, tmp_path, capsys):
+    """Default mode prints probing status, match list, but not metadata details."""
     mock_probe.return_value = PROBE_RESULT
     mock_detect.return_value = BOUNDARIES
     mock_split.return_value = _output_files(tmp_path)
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
 
-    run_split(Path("input.mp4"), config, verbose=False)
+    run_split(Path("input.mp4"), config)
 
     output = capsys.readouterr().out
+    assert "Probing:" in output
     assert "Detected 2 match(es)" in output
     assert "Match 1:" in output
     assert "Match 2:" in output
+    # Metadata details only in verbose
+    assert "Duration:" not in output
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_quiet_output(mock_probe, mock_detect, mock_split, tmp_path, capsys):
+    """Quiet mode suppresses progress but still shows output files."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, quiet=True)
+
+    output = capsys.readouterr().out
     assert "Probing:" not in output
+    assert "Detecting match boundaries" not in output
+    assert "Match 1:" not in output
+    # Output files still shown
+    assert "Output:" in output
 
 
 # --- Auto sample interval ---
@@ -315,17 +337,10 @@ def test_pipeline_auto_interval_long_video(
 
     run_split(Path("input.mp4"), config)
 
-    mock_detect.assert_called_once_with(
-        Path("input.mp4"),
-        duration_hint=5400.0,
-        sample_interval=2.0,
-        blackout_threshold=config.blackout_threshold,
-        min_match_duration=config.min_match_duration,
-        min_blackout_duration=config.min_blackout_duration,
-        use_gpu=config.use_gpu,
-        workers=config.workers,
-        src_resolution=(1920, 1080),
-    )
+    mock_detect.assert_called_once()
+    _, detect_kwargs = mock_detect.call_args
+    assert detect_kwargs["sample_interval"] == 2.0
+    assert detect_kwargs["duration_hint"] == 5400.0
 
 
 # --- Config forwarding ---
@@ -350,17 +365,12 @@ def test_pipeline_config_params_forwarded(
 
     run_split(Path("input.mp4"), config)
 
-    mock_detect.assert_called_once_with(
-        Path("input.mp4"),
-        duration_hint=PROBE_RESULT["duration"],
-        sample_interval=2.0,
-        blackout_threshold=20.0,
-        min_match_duration=120.0,
-        min_blackout_duration=3.0,
-        use_gpu=False,
-        workers=None,
-        src_resolution=(PROBE_RESULT["width"], PROBE_RESULT["height"]),
-    )
+    mock_detect.assert_called_once()
+    _, detect_kwargs = mock_detect.call_args
+    assert detect_kwargs["sample_interval"] == 2.0
+    assert detect_kwargs["blackout_threshold"] == 20.0
+    assert detect_kwargs["min_match_duration"] == 120.0
+    assert detect_kwargs["min_blackout_duration"] == 3.0
 
 
 # ============================================================
@@ -484,7 +494,7 @@ class TestCacheRoundTrip:
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
-def test_verbose_progressbar_length(mock_probe, mock_detect, mock_split, tmp_path):
+def test_progressbar_length(mock_probe, mock_detect, mock_split, tmp_path):
     """Progressbar length equals estimated_samples, not frame count."""
     mock_probe.return_value = {**PROBE_RESULT, "duration": 1800.0}
     mock_detect.return_value = BOUNDARIES
@@ -495,7 +505,7 @@ def test_verbose_progressbar_length(mock_probe, mock_detect, mock_split, tmp_pat
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
-        run_split(Path("input.mp4"), config, verbose=True)
+        run_split(Path("input.mp4"), config)
 
     # interval=1.0 for 1800s → estimated_samples = 1800
     mock_bar.assert_called_once()
@@ -505,7 +515,7 @@ def test_verbose_progressbar_length(mock_probe, mock_detect, mock_split, tmp_pat
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
-def test_verbose_progressbar_tiny_video(mock_probe, mock_detect, mock_split, tmp_path):
+def test_progressbar_tiny_video(mock_probe, mock_detect, mock_split, tmp_path):
     """Progressbar length is at least 1 for very short videos."""
     mock_probe.return_value = {**PROBE_RESULT, "duration": 0.5}
     mock_detect.return_value = BOUNDARIES
@@ -516,7 +526,7 @@ def test_verbose_progressbar_tiny_video(mock_probe, mock_detect, mock_split, tmp
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
-        run_split(Path("input.mp4"), config, verbose=True)
+        run_split(Path("input.mp4"), config)
 
     # int(0.5 / 1.0) = 0, max(1, 0) = 1
     mock_bar.assert_called_once()
@@ -526,9 +536,7 @@ def test_verbose_progressbar_tiny_video(mock_probe, mock_detect, mock_split, tmp
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
-def test_verbose_progressbar_auto_interval(
-    mock_probe, mock_detect, mock_split, tmp_path
-):
+def test_progressbar_auto_interval(mock_probe, mock_detect, mock_split, tmp_path):
     """Progressbar length uses auto-adjusted interval for long videos."""
     mock_probe.return_value = {**PROBE_RESULT, "duration": 7300.0}  # > 2h
     mock_detect.return_value = BOUNDARIES
@@ -539,7 +547,7 @@ def test_verbose_progressbar_auto_interval(
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
-        run_split(Path("input.mp4"), config, verbose=True)
+        run_split(Path("input.mp4"), config)
 
     # auto interval = 3.0 for > 2h, estimated_samples = int(7300/3.0) = 2433
     mock_bar.assert_called_once()


### PR DESCRIPTION
## Summary

- デフォルトで probe 状況・プログレスバー・Match 一覧を表示（`--verbose` 不要に）
- `--verbose` (-v): メタデータ詳細、gap 情報を追加表示
- `--quiet` (-q): 進捗を抑制（出力ファイル一覧のみ）
- `detect_match_boundaries` の重複呼び出しを `_run_detection` ヘルパーに統合 (DRY)

## 表示マトリクス

| 表示内容 | デフォルト | --verbose | --quiet |
|---|---|---|---|
| Probing: ... | yes | yes | no |
| プログレスバー | yes | yes | no |
| Match 一覧 | yes | yes | no |
| メタデータ詳細 | no | yes | no |
| gap 情報 | no | yes | no |
| 出力ファイル一覧 | yes | yes | yes |

## 変更ファイル

- `allaganeye/cli.py` — `--quiet` オプション追加
- `allaganeye/commands/split_matches.py` — 表示ロジック再構成、`_run_detection` 追加
- `tests/test_cli.py` — quiet テスト追加
- `tests/test_split_matches.py` — テスト調整（デフォルト表示、quiet テスト追加）
- `docs/cli-spec.md`, `CLAUDE.md` — `--quiet` 追加

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（347 passed）
- [ ] テスター: `allaganeye split <video>` でデフォルト表示確認、`--quiet` で抑制確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)