### PR TITLE
refactor: CPU チャンク並列数と workers 上限を 32 に引き上げ #270

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 **Pass 1: 粗いスキャン**
 1. `duration_hint` から `sample_interval` 秒間隔のタイムスタンプを生成（長時間動画は自動で 2-3s に調整）
 2. 各タイムスタンプで `ffmpeg -threads 1 -ss {t} -i` により 1 フレームを 320x180 grayscale でデコード
-3. `ThreadPoolExecutor(max_workers=min(cpu_count, 24))` で並列実行
+3. `ThreadPoolExecutor(max_workers=min(cpu_count, 32))` で並列実行
 4. 各フレームの平均輝度が `blackout_threshold` 以下なら暗転と判定
 5. 連続する暗転フレームを `_group_blackout_regions()` で blackout region にマージ
 
@@ -102,7 +102,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 
 **GPU モード** (`--gpu`)
 - CPU モードの Pass 1 を GPU チャンク並列デコードで代替（`gpu_detector.py`）
-- 動画を N チャンク（`min(cpu_count, 16)`）に分割し、各チャンクで長寿命の ffmpeg プロセスを `-hwaccel auto` + `fps` フィルタで起動
+- 動画を N チャンク（`min(cpu_count, 32)`）に分割し、各チャンクで長寿命の ffmpeg プロセスを `-hwaccel auto` + `fps` フィルタで起動
 - GPU 初期化コストを分散し、1プロセスあたり多数フレームをデコードすることで効率化
 - Pass 1 以降の処理（transition expansion, Pass 2, フィルタリング）は CPU/GPU 共通
 - GPU 利用不可時は自動で CPU モードにフォールバック

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 
 **GPU モード** (`--gpu`)
 - CPU モードの Pass 1 を GPU チャンク並列デコードで代替（`gpu_detector.py`）
-- 動画を N チャンク（`min(cpu_count, 32)`）に分割し、各チャンクで長寿命の ffmpeg プロセスを `-hwaccel auto` + `fps` フィルタで起動
+- 動画を N チャンク（`min(cpu_count, 16)`）に分割し、各チャンクで長寿命の ffmpeg プロセスを `-hwaccel auto` + `fps` フィルタで起動
 - GPU 初期化コストを分散し、1プロセスあたり多数フレームをデコードすることで効率化
 - Pass 1 以降の処理（transition expansion, Pass 2, フィルタリング）は CPU/GPU 共通
 - GPU 利用不可時は自動で CPU モードにフォールバック

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -33,7 +33,7 @@ def _resolve_workers(workers: int | None) -> int:
     """Resolve worker count: explicit value or auto-detect."""
     if workers is not None:
         return workers
-    return min(os.cpu_count() or 4, 24)
+    return min(os.cpu_count() or 4, 32)
 
 
 def detect_match_boundaries(
@@ -240,7 +240,7 @@ def _scan_cpu(
         return {}
 
     total_samples = len(timestamps)
-    num_chunks = min(os.cpu_count() or 4, 16)
+    num_chunks = min(os.cpu_count() or 4, 32)
     chunk_duration = duration_hint / num_chunks
 
     # Distribute pre-computed timestamps to chunks (with overlap)


### PR DESCRIPTION
## Summary

- `_resolve_workers`: 上限 24 → 32（Pass 2 / scorebar 並列プローブ用）
- `_scan_cpu` `num_chunks`: 上限 16 → 32（CPU Pass 1 チャンク数）
- GPU モード（`gpu_detector.py`）は変更なし（VRAM ボトルネック考慮）
- CLAUDE.md のアーキテクチャ記述を更新

## セルフ検証結果（20260116, 16 コア環境）

| 項目 | Before | After | 変化 |
|---|---|---|---|
| elapsed | 633.9s | 593.5s | -6.4% |
| matches | 7 | 7 | 一致（退行なし） |

16 コア環境では `min(16, 32)` = 16 のため実質的なチャンク数は変わらず。elapsed の差はラン間変動の範囲内。32 コア以上の環境で本来の効果を発揮。

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（344 passed）
- [x] 実動画セルフ検証: 退行なし
- [ ] テスター: 実動画テストで退行なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)