### PR TITLE
fix: GPU モードで cuvid デコーダを明示指定し確実に GPU デコードを使用 #273

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -177,6 +177,7 @@ def _run_detection(
         "use_gpu": config.use_gpu,
         "workers": config.workers,
         "src_resolution": (metadata["width"], metadata["height"]),
+        "codec": metadata.get("codec"),
     }
 
     if not quiet:

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -47,6 +47,7 @@ def detect_match_boundaries(
     use_gpu: bool = False,
     workers: int | None = None,
     src_resolution: tuple[int, int] | None = None,
+    codec: str | None = None,
     progress_callback: Callable[[int, int, int], None] | None = None,
 ) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
@@ -80,6 +81,7 @@ def detect_match_boundaries(
                 sample_interval,
                 blackout_threshold,
                 progress_callback,
+                codec=codec,
             )
         except VideoProcessingError:
             # GPU failed — fall back to CPU

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -12,6 +12,17 @@ from allaganeye.exceptions import VideoProcessingError
 from allaganeye.ffmpeg_path import find_ffmpeg
 from allaganeye.video.detector import _FRAME_SIZE, _SAMPLE_HEIGHT, _SAMPLE_WIDTH
 
+_CUVID_CODEC_MAP: dict[str, str] = {
+    "h264": "h264_cuvid",
+    "hevc": "hevc_cuvid",
+    "av1": "av1_cuvid",
+    "vp9": "vp9_cuvid",
+    "vp8": "vp8_cuvid",
+    "mpeg1video": "mpeg1_cuvid",
+    "mpeg2video": "mpeg2_cuvid",
+    "mpeg4": "mpeg4_cuvid",
+}
+
 
 def scan_gpu(
     video_path: Path,
@@ -19,8 +30,9 @@ def scan_gpu(
     sample_interval: float,
     blackout_threshold: float,
     progress_callback: Callable[[int, int, int], None] | None = None,
+    codec: str | None = None,
 ) -> dict[float, float]:
-    """GPU mode: chunked parallel decode with -hwaccel auto.
+    """GPU mode: chunked parallel decode with cuvid hardware decoder.
 
     Splits the video timeline into chunks and runs one long-lived ffmpeg
     process per chunk with GPU-accelerated decoding.  Each process uses
@@ -54,6 +66,7 @@ def scan_gpu(
                 chunk_start,
                 chunk_end,
                 sample_interval,
+                codec,
             ): (chunk_start, chunk_end)
             for chunk_start, chunk_end in chunks
         }
@@ -84,19 +97,29 @@ def _decode_chunk(
     chunk_start: float,
     chunk_end: float,
     sample_interval: float,
+    codec: str | None = None,
 ) -> dict[float, float]:
     """Decode a single chunk using GPU-accelerated ffmpeg.
 
     Runs one ffmpeg process that decodes from chunk_start to chunk_end,
     outputting one frame per sample_interval via the fps filter.
+
+    When *codec* maps to a known cuvid decoder, uses explicit
+    ``-hwaccel cuda -c:v <codec>_cuvid`` for reliable GPU decode.
+    Falls back to ``-hwaccel auto`` for unknown codecs.
     """
     chunk_duration = chunk_end - chunk_start
     fps_value = 1.0 / sample_interval
 
+    cuvid_decoder = _CUVID_CODEC_MAP.get(codec or "")
+    if cuvid_decoder:
+        hwaccel_args = ["-hwaccel", "cuda", "-c:v", cuvid_decoder]
+    else:
+        hwaccel_args = ["-hwaccel", "auto"]
+
     cmd = [
         find_ffmpeg(),
-        "-hwaccel",
-        "auto",
+        *hwaccel_args,
         "-ss",
         str(chunk_start),
         "-t",


### PR DESCRIPTION
## Summary

- `gpu_detector.py`: `_CUVID_CODEC_MAP` で codec → cuvid デコーダをマッピング
- `-hwaccel auto` → `-hwaccel cuda -c:v <codec>_cuvid` に変更（対応 codec の場合）
- 未対応 codec は `-hwaccel auto` にフォールバック
- `detector.py`: `detect_match_boundaries` に `codec` 引数追加
- `split_matches.py`: `probe_video` の codec を伝播

## 背景

OBS 録画が AV1 コーデックに移行したことで、`-hwaccel auto` が CPU (libdav1d) にサイレントフォールバックしていた。`-c:v av1_cuvid` を明示指定することで GPU デコードが有効になり、~2 倍の高速化を確認。

## セルフ検証結果

```
# cuvid デコーダが使用されていることを確認
Command prefix: ffmpeg -hwaccel cuda -c:v av1_cuvid -ss 0.0 -t ...
Frames decoded: 5
```

| モード | 60s チャンク elapsed |
|---|---|
| CPU (libdav1d) | 4.0s |
| GPU (av1_cuvid) | 2.0s |

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（347 passed）
- [x] cuvid デコーダ使用を実動画で確認
- [ ] テスター: `allaganeye split <video> --gpu` で退行なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)