### PR TITLE
feat: GPU フォールバック検知と警告表示 #275

### DIFF
--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -1,5 +1,6 @@
 """GPU-accelerated match detection using chunked parallel ffmpeg decode."""
 
+import logging
 import os
 import subprocess
 from collections.abc import Callable
@@ -11,6 +12,8 @@ import numpy as np
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.ffmpeg_path import find_ffmpeg
 from allaganeye.video.detector import _FRAME_SIZE, _SAMPLE_HEIGHT, _SAMPLE_WIDTH
+
+logger = logging.getLogger(__name__)
 
 _CUVID_CODEC_MAP: dict[str, str] = {
     "h264": "h264_cuvid",
@@ -57,6 +60,9 @@ def scan_gpu(
     blackout_count = 0
     completed = 0
     gpu_failed = False
+    fallback_checked = False
+
+    cuvid_decoder = _CUVID_CODEC_MAP.get(codec or "")
 
     with ThreadPoolExecutor(max_workers=num_chunks) as pool:
         futures = {
@@ -73,11 +79,17 @@ def scan_gpu(
         for future in as_completed(futures):
             chunk_start, chunk_end = futures[future]
             try:
-                chunk_results = future.result()
+                chunk_results, stderr_text = future.result()
             except VideoProcessingError:
                 gpu_failed = True
                 pool.shutdown(wait=False, cancel_futures=True)
                 break
+
+            # Check GPU usage from the first completed chunk
+            if not fallback_checked:
+                fallback_checked = True
+                _check_gpu_usage(stderr_text, codec, cuvid_decoder)
+
             for t, brightness in chunk_results.items():
                 results[t] = brightness
                 completed += 1
@@ -92,21 +104,32 @@ def scan_gpu(
     return results
 
 
+def _check_gpu_usage(
+    stderr_text: str, codec: str | None, cuvid_decoder: str | None
+) -> None:
+    """Log GPU decode status based on ffmpeg stderr output."""
+    if cuvid_decoder and cuvid_decoder in stderr_text:
+        logger.info("GPU decode active: %s", cuvid_decoder)
+    elif "hwaccel" in stderr_text.lower() or "cuda" in stderr_text.lower():
+        logger.info("GPU decode active (hwaccel auto)")
+    else:
+        logger.warning(
+            "GPU acceleration not active for codec '%s', falling back to CPU decode",
+            codec or "unknown",
+        )
+
+
 def _decode_chunk(
     video_path: Path,
     chunk_start: float,
     chunk_end: float,
     sample_interval: float,
     codec: str | None = None,
-) -> dict[float, float]:
+) -> tuple[dict[float, float], str]:
     """Decode a single chunk using GPU-accelerated ffmpeg.
 
-    Runs one ffmpeg process that decodes from chunk_start to chunk_end,
-    outputting one frame per sample_interval via the fps filter.
-
-    When *codec* maps to a known cuvid decoder, uses explicit
-    ``-hwaccel cuda -c:v <codec>_cuvid`` for reliable GPU decode.
-    Falls back to ``-hwaccel auto`` for unknown codecs.
+    Returns ``(results_dict, stderr_text)`` so the caller can inspect
+    GPU usage from the first completed chunk.
     """
     chunk_duration = chunk_end - chunk_start
     fps_value = 1.0 / sample_interval
@@ -150,9 +173,10 @@ def _decode_chunk(
             f"GPU decode timed out for chunk {chunk_start}"
         ) from e
 
+    stderr_text = proc.stderr.decode(errors="replace")
+
     if proc.returncode != 0:
-        stderr = proc.stderr.decode(errors="replace")[-500:]
-        raise VideoProcessingError(f"GPU decode failed: {stderr}")
+        raise VideoProcessingError(f"GPU decode failed: {stderr_text[-500:]}")
 
     # Parse raw frames from stdout
     data = proc.stdout
@@ -169,4 +193,4 @@ def _decode_chunk(
         offset += _FRAME_SIZE
         frame_idx += 1
 
-    return results
+    return results, stderr_text

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -25,22 +25,37 @@ class TestDecodeChunk:
             stderr=b"",
             returncode=0,
         )
-        result = _decode_chunk(Path("test.mp4"), 100.0, 103.0, 1.0)
+        result, stderr = _decode_chunk(Path("test.mp4"), 100.0, 103.0, 1.0)
 
         assert len(result) == 3
         assert result[100.0] == pytest.approx(128.0)
         assert result[101.0] == pytest.approx(5.0)
         assert result[102.0] == pytest.approx(200.0)
+        assert isinstance(stderr, str)
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
-    def test_hwaccel_in_cmd(self, mock_run):
-        """ffmpeg command includes -hwaccel auto."""
+    def test_hwaccel_auto_when_no_codec(self, mock_run):
+        """ffmpeg command includes -hwaccel auto when codec is unknown."""
         mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
         _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0)
 
         cmd = mock_run.call_args[0][0]
         assert "-hwaccel" in cmd
         assert "auto" in cmd
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_hwaccel_cuda_with_known_codec(self, mock_run):
+        """ffmpeg command uses -hwaccel cuda -c:v av1_cuvid for AV1."""
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="av1")
+
+        cmd = mock_run.call_args[0][0]
+        assert "-hwaccel" in cmd
+        cuda_idx = cmd.index("-hwaccel")
+        assert cmd[cuda_idx + 1] == "cuda"
+        assert "-c:v" in cmd
+        cv_idx = cmd.index("-c:v")
+        assert cmd[cv_idx + 1] == "av1_cuvid"
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_nonzero_returncode_raises(self, mock_run):
@@ -70,7 +85,7 @@ class TestDecodeChunk:
             stderr=b"",
             returncode=0,
         )
-        result = _decode_chunk(Path("test.mp4"), 500.0, 502.0, 1.0)
+        result, _ = _decode_chunk(Path("test.mp4"), 500.0, 502.0, 1.0)
 
         assert 500.0 in result
         assert 501.0 in result
@@ -81,7 +96,7 @@ class TestScanGpu:
     @patch("allaganeye.video.gpu_detector._decode_chunk")
     def test_collects_all_chunks(self, mock_decode):
         """Results from all chunks are merged."""
-        mock_decode.return_value = {0.0: 128.0}
+        mock_decode.return_value = ({0.0: 128.0}, "")
         result = scan_gpu(Path("test.mp4"), 10.0, 1.0, 15.0)
 
         assert len(result) >= 1
@@ -105,7 +120,7 @@ class TestScanGpu:
             call_count += 1
             if call_count == 1:
                 raise VideoProcessingError("GPU decode failed")
-            return {0.0: 128.0}
+            return ({0.0: 128.0}, "")
 
         mock_decode.side_effect = side_effect
 
@@ -119,7 +134,7 @@ class TestScanGpu:
     @patch("allaganeye.video.gpu_detector._decode_chunk")
     def test_progress_callback(self, mock_decode):
         """Progress callback is invoked."""
-        mock_decode.return_value = {0.0: 128.0, 1.0: 5.0}
+        mock_decode.return_value = ({0.0: 128.0, 1.0: 5.0}, "")
         calls: list[tuple] = []
 
         scan_gpu(


### PR DESCRIPTION
## Summary

- `_decode_chunk` の戻り値を `(results, stderr_text)` タプルに変更
- `scan_gpu` で最初に完了したチャンクの stderr から GPU 使用状況を検査
- cuvid デコーダが使われていなければ `WARNING` ログ出力
- GPU 有効時は `INFO` ログでデコーダ名を表示
- テスト: cuvid デコーダ引数検証、既存テストをタプル戻り値に更新

## 表示

| 状況 | ログレベル | メッセージ |
|---|---|---|
| GPU 有効 | INFO | `GPU decode active: av1_cuvid` |
| CPU フォールバック | WARNING | `GPU acceleration not active for codec 'av1', falling back to CPU decode` |

## Test plan

- [x] `ruff check .` / `ruff format --check .` 通過
- [x] `pytest` 全テスト通過（348 passed）
- [ ] テスター: `allaganeye split <video> --gpu -v` で GPU バックエンド情報確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)