### PR TITLE
feat: detector へ音声 Fanfare 昇格を統合し問題2暗転を救済 #288

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ allaganeye split <video_path> -o <dir>  # 出力先指定
 allaganeye split <video_path> --gpu     # GPU アクセラレーション検知
 allaganeye split <video_path> --workers 8  # ワーカー数指定
 allaganeye split <video_path> --no-cache   # キャッシュ無視で再検知
+allaganeye split <video_path> --no-audio   # 音声昇格を無効化（視覚のみ）
 allaganeye split <video_path> --quiet      # 進捗抑制（出力ファイルのみ）
 allaganeye debug-brightness <video_path>   # フレーム輝度 CSV 出力
 ```
@@ -75,8 +76,13 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | `video/probe.py` | ffprobe でメタデータ取得（解像度、fps、長さ） |
 | `video/detector.py` | ffmpeg 並列プローブで暗転検知、試合境界抽出（CPU モード） |
 | `video/gpu_detector.py` | GPU アクセラレーション検知（チャンク並列デコード） |
-| `video/scorebar.py` | スコアバーフィルタリング（暗転分類・試合内/非FL判定） |
+| `video/scorebar.py` | スコアバーフィルタリング（暗転分類・試合内/非FL判定）+ 音声昇格 |
 | `video/splitter.py` | FFmpeg で動画分割（-c copy） |
+| `audio/extract.py` | ffmpeg で音声 PCM 抽出 |
+| `audio/features.py` | log-mel スペクトログラム計算と保存 |
+| `audio/matcher.py` | 参照 BGM と target の相互相関で peak 検出 |
+| `audio/scan.py` | 動画全域を走査して Fanfare ピークを返す |
+| `audio/refs/` | 同梱参照特徴量（`fanfare.npz`） |
 
 ### 検知アルゴリズム（detector.py）
 
@@ -96,6 +102,12 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 **スコアバーフィルタリング**（`src_resolution` 提供時、CLIのデフォルトパス）
 8. `filter_blackouts_with_scorebar()` で各暗転領域の前後フレームのスコアバー有無を判定し、暗転を分類（`match_boundary` / `in_match` / `non_fl`）
 9. `non_fl`（非FL暗転）と短い `in_match`（試合内暗転）を除外。隣接する `match_boundary` ペア間の短いギャップをマージ
+
+**音声昇格**（`--no-audio` 未指定時、#288）
+- `audio/scan.py` で動画全域の音声から Fanfare ピーク（log-mel 相関 sim ≥ 0.65）を抽出
+- `in_match` 分類された暗転のうち、暗転終了後 0-60s 以内に Fanfare ピークがあるものを `match_boundary` に昇格
+- スコアバー残像で誤分類された試合境界（例: 2026-04-08 57:53）を救済
+- 既知の制約: Fanfare は試合中にも弱いピーク（sim 0.65-0.75）を出すため、本条件のみでは偽陽性が混入しうる。WR 参照 (#301) 同梱後に WR→Fanfare 間隔による (B) 条件を追加して偽陽性除去
 
 **フィルタリング・抽出**
 10. `min(min_blackout_duration, _REFINED_MIN_BLACKOUT)` 未満の短い暗転を除外（リスポーン暗転の誤判定防止）

--- a/allaganeye/audio/__init__.py
+++ b/allaganeye/audio/__init__.py
@@ -36,6 +36,7 @@ from allaganeye.audio.matcher import (
     find_match_peaks,
     sliding_cosine_similarity,
 )
+from allaganeye.audio.scan import scan_fanfare_hits
 
 __all__ = [
     "BgmHit",
@@ -45,5 +46,6 @@ __all__ = [
     "load_features",
     "log_mel_spectrogram",
     "save_features",
+    "scan_fanfare_hits",
     "sliding_cosine_similarity",
 ]

--- a/allaganeye/audio/scan.py
+++ b/allaganeye/audio/scan.py
@@ -1,0 +1,56 @@
+"""Full-video BGM scanning for match boundary promotion (#288).
+
+Wraps the audio pipeline (extract → log-mel → sliding correlation → peaks)
+into a single call so higher-level detection code does not need to thread
+four primitives together.  The scan runs once per video; the resulting
+hits are reused for every blackout region evaluated during classification.
+"""
+
+from pathlib import Path
+
+from allaganeye.audio.extract import extract_pcm
+from allaganeye.audio.features import log_mel_spectrogram, load_features
+from allaganeye.audio.matcher import BgmHit, find_match_peaks, sliding_cosine_similarity
+from allaganeye.audio.refs import get_reference_path
+
+
+_DEFAULT_THRESHOLD = 0.65
+"""Similarity threshold shared with #287 horizontal validation.
+
+Fanfare reference hits FL match starts with sim in [0.65, 0.85] on the
+recordings covered by the cumulative coverage baseline.  Values below this
+band include unrelated BGM cues observed during validation.
+"""
+
+_DEFAULT_MIN_GAP_SECONDS = 30.0
+"""Minimum spacing between consecutive peaks.
+
+Fanfare plays for ~5s at most, so any second peak within 30s is the same
+event's side lobe rather than a separate match start.
+"""
+
+
+def scan_fanfare_hits(
+    video_path: Path,
+    *,
+    threshold: float = _DEFAULT_THRESHOLD,
+    min_gap_seconds: float = _DEFAULT_MIN_GAP_SECONDS,
+    ref_name: str = "fanfare",
+) -> list[BgmHit]:
+    """Scan the full audio track for reference-BGM peaks.
+
+    Returns hits sorted by timestamp (seconds from video start).  Raises
+    ``VideoProcessingError`` when audio extraction fails (e.g. missing
+    audio track); callers may catch this to fall back to audio-less
+    classification.
+    """
+    features, config, _ = load_features(get_reference_path(ref_name))
+    pcm = extract_pcm(video_path, sample_rate=config.sample_rate)
+    target = log_mel_spectrogram(pcm, config)
+    similarity = sliding_cosine_similarity(features, target)
+    return find_match_peaks(
+        similarity,
+        threshold=threshold,
+        min_gap_seconds=min_gap_seconds,
+        frames_per_second=config.frames_per_second,
+    )

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -75,6 +75,13 @@ def split(
         bool,
         typer.Option("--no-cache", help="Ignore cached detection results"),
     ] = False,
+    no_audio: Annotated[
+        bool,
+        typer.Option(
+            "--no-audio",
+            help="Disable audio-based match boundary promotion (Fanfare scan)",
+        ),
+    ] = False,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -109,6 +116,7 @@ def split(
             use_gpu=gpu,
             workers=workers,
             no_cache=no_cache,
+            no_audio=no_audio,
         )
 
         from allaganeye.commands.split_matches import run_split

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -7,8 +7,9 @@ from typing import TypedDict
 
 import typer
 
+from allaganeye.audio.matcher import BgmHit
 from allaganeye.config import SplitConfig
-from allaganeye.exceptions import AllaganEyeError, DetectionError
+from allaganeye.exceptions import AllaganEyeError, DetectionError, VideoProcessingError
 from allaganeye.video.detector import MatchBoundary, detect_match_boundaries
 from allaganeye.video.probe import ProbeResult, probe_video
 from allaganeye.video.splitter import split_video
@@ -24,7 +25,7 @@ class Gap(TypedDict):
 
 logger = logging.getLogger(__name__)
 
-_CACHE_VERSION = 1
+_CACHE_VERSION = 2
 
 
 def run_split(
@@ -103,6 +104,8 @@ def run_split(
                 f"(video is {_format_duration(metadata['duration'])})"
             )
 
+    audio_hits = _run_audio_scan(video_path, config, show=show, verbose=verbose)
+
     if show:
         typer.echo(
             f"Detecting match boundaries "
@@ -111,7 +114,12 @@ def run_split(
         )
 
     boundaries = _run_detection(
-        video_path, metadata, effective_interval, config, quiet=quiet
+        video_path,
+        metadata,
+        effective_interval,
+        config,
+        audio_hits=audio_hits,
+        quiet=quiet,
     )
 
     if not boundaries:
@@ -159,12 +167,46 @@ def run_split(
     _split_and_write_metadata(video_path, boundaries, gaps, metadata, config)
 
 
+def _run_audio_scan(
+    video_path: Path,
+    config: SplitConfig,
+    *,
+    show: bool,
+    verbose: bool,
+) -> list[BgmHit] | None:
+    """Scan the video for Fanfare peaks, returning hits or None.
+
+    Returns ``None`` when audio promotion is disabled (``--no-audio``) or
+    when the scan fails for a recoverable reason (missing audio track,
+    ffmpeg error).  Callers then proceed with scorebar-only filtering.
+    """
+    if config.no_audio:
+        return None
+
+    from allaganeye.audio.scan import scan_fanfare_hits
+
+    if show:
+        typer.echo("Scanning audio for Fanfare peaks")
+    try:
+        hits = scan_fanfare_hits(video_path)
+    except VideoProcessingError as e:
+        if show:
+            typer.echo(f"  audio scan skipped: {e}")
+        logger.warning("Audio scan failed for %s: %s", video_path, e)
+        return None
+
+    if show and verbose:
+        typer.echo(f"  {len(hits)} Fanfare peak(s) detected")
+    return hits
+
+
 def _run_detection(
     video_path: Path,
     metadata: ProbeResult,
     effective_interval: float,
     config: SplitConfig,
     *,
+    audio_hits: list[BgmHit] | None = None,
     quiet: bool = False,
 ) -> list[MatchBoundary]:
     """Run detection with optional progress bar."""
@@ -178,6 +220,7 @@ def _run_detection(
         "workers": config.workers,
         "src_resolution": (metadata["width"], metadata["height"]),
         "codec": metadata.get("codec"),
+        "audio_hits": audio_hits,
     }
 
     if not quiet:
@@ -346,6 +389,7 @@ def _save_cache(
             "blackout_threshold": config.blackout_threshold,
             "min_match_duration": config.min_match_duration,
             "min_blackout_duration": config.min_blackout_duration,
+            "no_audio": config.no_audio,
         },
         "boundaries": boundaries,
     }
@@ -402,6 +446,7 @@ def _load_cache(
         or params.get("blackout_threshold") != config.blackout_threshold
         or params.get("min_match_duration") != config.min_match_duration
         or params.get("min_blackout_duration") != config.min_blackout_duration
+        or params.get("no_audio") != config.no_audio
     ):
         logger.debug("Cache parameter mismatch")
         return None

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -19,6 +19,7 @@ class SplitConfig:
     use_gpu: bool = False
     workers: int | None = None
     no_cache: bool = False
+    no_audio: bool = False
 
     def __post_init__(self) -> None:
         if self.workers is not None and self.workers < 1:

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -3,13 +3,14 @@
 import logging
 import os
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import TypedDict
 
 import numpy as np
 
+from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.ffmpeg_path import find_ffmpeg
 
@@ -49,6 +50,7 @@ def detect_match_boundaries(
     src_resolution: tuple[int, int] | None = None,
     codec: str | None = None,
     progress_callback: Callable[[int, int, int], None] | None = None,
+    audio_hits: Sequence[BgmHit] | None = None,
 ) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
 
@@ -62,6 +64,10 @@ def detect_match_boundaries(
             blackouts and non-FL blackouts.
         progress_callback: Optional callback invoked after each sampled
             frame with ``(completed_count, total_samples, blackout_count)``.
+        audio_hits: Optional Fanfare peaks from audio scan (#288).  When
+            provided and scorebar filtering is active, blackouts
+            classified as ``"in_match"`` but near a Fanfare hit are
+            promoted to ``"match_boundary"``.
 
     Returns list of dicts with 'start' and 'end' keys (seconds).
     """
@@ -124,7 +130,12 @@ def detect_match_boundaries(
 
         height = _scaled_height(src_resolution[0], src_resolution[1])
         refined_regions, region_classifications = filter_blackouts_with_scorebar(
-            video_path, refined_regions, duration_hint, height, workers
+            video_path,
+            refined_regions,
+            duration_hint,
+            height,
+            workers,
+            audio_hits=audio_hits,
         )
 
     effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import numpy as np
 
+from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
@@ -145,6 +146,38 @@ boundary = 4.5s+.  3.5s sits in the gap with 1.5s margin on each side.
 """
 
 
+_AUDIO_PROMOTE_WINDOW_POST = 60.0
+"""Seconds AFTER a blackout to search for a Fanfare peak when promoting
+``"in_match"`` to ``"match_boundary"`` (#288).
+
+Fanfare plays during the match-start cinematic, landing 0-60s past the
+end of a boundary blackout on the recordings validated in #271.  A
+post-blackout-only window (rather than ±60s symmetric) avoids promoting
+in-match character-down blackouts that happen to precede a legitimate
+Fanfare from the next match.  The pre-side of a real boundary blackout
+has no Fanfare by construction — Fanfare never plays during an ongoing
+match.
+"""
+
+
+def _has_nearby_fanfare_hit(
+    region: tuple[float, float],
+    audio_hits: Sequence[BgmHit],
+    window: float = _AUDIO_PROMOTE_WINDOW_POST,
+) -> BgmHit | None:
+    """Return the first Fanfare hit within *window* seconds AFTER *region* end.
+
+    A hit qualifies when ``region_end <= hit.timestamp <= region_end + window``.
+    Returns ``None`` when no hit qualifies.
+    """
+    lo = region[1]
+    hi = region[1] + window
+    for hit in audio_hits:
+        if lo <= hit["timestamp"] <= hi:
+            return hit
+    return None
+
+
 def classify_blackout(
     video_path: Path,
     region: tuple[float, float],
@@ -255,6 +288,8 @@ def filter_blackouts_with_scorebar(
     duration: float,
     height: int,
     workers: int | None = None,
+    *,
+    audio_hits: Sequence[BgmHit] | None = None,
 ) -> tuple[list[tuple[float, float]], list[str]]:
     """Filter blackout regions using scorebar context and duration.
 
@@ -266,6 +301,13 @@ def filter_blackouts_with_scorebar(
     - Long ``"in_match"`` blackouts (>= 3.5s, FL match boundaries)
     - ``"match_boundary"`` (FL match start/end)
     - ``"unknown"`` (probe failure → safe side, keep boundary)
+
+    Audio promotion (#288):
+    When *audio_hits* is provided, a blackout initially classified as
+    ``"in_match"`` is promoted to ``"match_boundary"`` if any Fanfare
+    peak falls within ±60s of the region.  This rescues boundaries that
+    scorebar afterimage (visible ~30s past match end) causes to be
+    misclassified.
 
     Post-processing:
     - Merges consecutive ``"match_boundary"`` pairs separated by non-FL
@@ -281,6 +323,20 @@ def filter_blackouts_with_scorebar(
             video_path, region, duration, height, workers
         )
         region_duration = region[1] - region[0]
+
+        if classification == "in_match" and audio_hits is not None:
+            hit = _has_nearby_fanfare_hit(region, audio_hits)
+            if hit is not None:
+                logger.info(
+                    "PROMOTE [%.1f-%.1f] (%.1fs): in_match → match_boundary "
+                    "(fanfare t=%.1f sim=%.3f)",
+                    region[0],
+                    region[1],
+                    region_duration,
+                    hit["timestamp"],
+                    hit["similarity"],
+                )
+                classification = "match_boundary"
 
         if classification == "in_match" and region_duration < _IN_MATCH_MAX_DURATION:
             logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ markers = [
     "slow_pipeline: full pipeline slow tests",
     "slow_gpu: GPU-specific slow tests",
     "baseline_regen: marks tests only needed during baseline regeneration",
+    "real_audio_scan: opt out of the autouse _run_audio_scan mock (#288)",
 ]
 addopts = "-m 'not slow and not baseline_regen'"
 

--- a/tests/test_audio_scan.py
+++ b/tests/test_audio_scan.py
@@ -1,0 +1,97 @@
+"""Unit tests for allaganeye.audio.scan — mocked pipeline (#288)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+from allaganeye.audio.features import LogMelConfig
+from allaganeye.audio.scan import scan_fanfare_hits
+
+
+_SCAN_MODULE = "allaganeye.audio.scan"
+
+
+def _fake_features() -> tuple[np.ndarray, LogMelConfig, dict]:
+    """Small reference features compatible with LogMelConfig defaults."""
+    config = LogMelConfig()
+    features = np.ones((config.n_mels, 10), dtype=np.float32)
+    return features, config, {}
+
+
+@patch(f"{_SCAN_MODULE}.find_match_peaks")
+@patch(f"{_SCAN_MODULE}.sliding_cosine_similarity")
+@patch(f"{_SCAN_MODULE}.log_mel_spectrogram")
+@patch(f"{_SCAN_MODULE}.extract_pcm")
+@patch(f"{_SCAN_MODULE}.load_features")
+@patch(f"{_SCAN_MODULE}.get_reference_path")
+def test_scan_fanfare_hits_wires_pipeline(
+    mock_ref_path,
+    mock_load,
+    mock_extract,
+    mock_logmel,
+    mock_corr,
+    mock_peaks,
+):
+    """The four audio primitives are invoked in order and their output returned."""
+    mock_ref_path.return_value = Path("/fake/fanfare.npz")
+    mock_load.return_value = _fake_features()
+    mock_extract.return_value = np.zeros(22050, dtype=np.float32)
+    mock_logmel.return_value = np.zeros((80, 100), dtype=np.float32)
+    mock_corr.return_value = np.zeros(91, dtype=np.float32)
+    expected = [{"timestamp": 50.0, "similarity": 0.72}]
+    mock_peaks.return_value = expected
+
+    result = scan_fanfare_hits(Path("/fake/video.mkv"))
+
+    assert result == expected
+    mock_ref_path.assert_called_once_with("fanfare")
+    mock_load.assert_called_once()
+    mock_extract.assert_called_once()
+    mock_logmel.assert_called_once()
+    mock_corr.assert_called_once()
+    mock_peaks.assert_called_once()
+
+
+@patch(f"{_SCAN_MODULE}.find_match_peaks")
+@patch(f"{_SCAN_MODULE}.sliding_cosine_similarity")
+@patch(f"{_SCAN_MODULE}.log_mel_spectrogram")
+@patch(f"{_SCAN_MODULE}.extract_pcm")
+@patch(f"{_SCAN_MODULE}.load_features")
+@patch(f"{_SCAN_MODULE}.get_reference_path")
+def test_scan_fanfare_hits_forwards_threshold(
+    mock_ref_path,
+    mock_load,
+    mock_extract,
+    mock_logmel,
+    mock_corr,
+    mock_peaks,
+):
+    """Threshold and min_gap_seconds are forwarded to find_match_peaks."""
+    mock_ref_path.return_value = Path("/fake/fanfare.npz")
+    features, config, _ = _fake_features()
+    mock_load.return_value = (features, config, {})
+    mock_extract.return_value = np.zeros(22050, dtype=np.float32)
+    mock_logmel.return_value = np.zeros((80, 100), dtype=np.float32)
+    mock_corr.return_value = np.zeros(91, dtype=np.float32)
+    mock_peaks.return_value = []
+
+    scan_fanfare_hits(Path("/fake/v.mkv"), threshold=0.8, min_gap_seconds=45.0)
+
+    kwargs = mock_peaks.call_args.kwargs
+    assert kwargs["threshold"] == 0.8
+    assert kwargs["min_gap_seconds"] == 45.0
+    assert kwargs["frames_per_second"] == config.frames_per_second
+
+
+@patch(f"{_SCAN_MODULE}.get_reference_path")
+def test_scan_fanfare_hits_uses_custom_ref_name(mock_ref_path):
+    """ref_name parameter is passed to get_reference_path."""
+    mock_ref_path.side_effect = FileNotFoundError("stop early")
+
+    try:
+        scan_fanfare_hits(Path("/fake/v.mkv"), ref_name="war_room")
+    except FileNotFoundError:
+        pass
+
+    mock_ref_path.assert_called_once_with("war_room")

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     MatchBoundary,
@@ -759,7 +760,7 @@ class TestDetectMatchBoundaries:
     def test_scorebar_filtering_called_with_resolution(self, mock_chunk, mock_filter):
         """Scorebar filtering is invoked when src_resolution is provided."""
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si: {t: 128.0 for t in ts}
-        mock_filter.side_effect = lambda vp, regions, dur, h, w: (
+        mock_filter.side_effect = lambda vp, regions, dur, h, w, **kw: (
             regions,
             ["match_boundary"] * len(regions),
         )
@@ -784,6 +785,43 @@ class TestDetectMatchBoundaries:
             min_match_duration=100.0,
         )
         mock_filter.assert_not_called()
+
+    @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_audio_hits_forwarded_to_scorebar_filter(self, mock_chunk, mock_filter):
+        """audio_hits parameter is passed through to scorebar filtering (#288)."""
+        mock_chunk.side_effect = lambda vp, ts, cs, ce, si: {t: 128.0 for t in ts}
+        mock_filter.side_effect = lambda vp, regions, dur, h, w, **kw: (
+            regions,
+            ["match_boundary"] * len(regions),
+        )
+        hits: list[BgmHit] = [{"timestamp": 50.0, "similarity": 0.72}]
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=300.0,
+            min_match_duration=100.0,
+            src_resolution=(1920, 1080),
+            audio_hits=hits,
+        )
+        mock_filter.assert_called_once()
+        assert mock_filter.call_args.kwargs["audio_hits"] == hits
+
+    @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_audio_hits_default_none_forwarded_as_none(self, mock_chunk, mock_filter):
+        """Omitted audio_hits reaches the scorebar filter as None."""
+        mock_chunk.side_effect = lambda vp, ts, cs, ce, si: {t: 128.0 for t in ts}
+        mock_filter.side_effect = lambda vp, regions, dur, h, w, **kw: (
+            regions,
+            ["match_boundary"] * len(regions),
+        )
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=300.0,
+            min_match_duration=100.0,
+            src_resolution=(1920, 1080),
+        )
+        assert mock_filter.call_args.kwargs["audio_hits"] is None
 
 
 # ============================================================

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+from allaganeye.audio.matcher import BgmHit
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
     _SCOREBAR_CHANNEL_STD_THRESHOLD,
@@ -435,6 +436,159 @@ class TestFilterBlackouts:
             (280.0, 288.0),
         ]
         assert cls == ["match_boundary", "unknown", "match_boundary", "in_match"]
+
+
+class TestAudioPromotion:
+    """Audio-based in_match → match_boundary promotion (#288).
+
+    Fanfare is only searched AFTER the blackout end (post-blackout window),
+    not symmetrically, to avoid promoting in-match character-down blackouts
+    that happen to precede a legitimate next-match Fanfare.
+    """
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_short_in_match_promoted_by_post_fanfare(self, mock_classify):
+        """Short in_match with Fanfare 18s after end → promoted."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]  # 2s, would normally be removed
+        audio_hits: list[BgmHit] = [{"timestamp": 120.0, "similarity": 0.72}]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=audio_hits
+        )
+
+        assert result == regions
+        assert cls == ["match_boundary"]
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_long_in_match_promoted_by_post_fanfare(self, mock_classify):
+        """Long in_match with Fanfare after end → promoted."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 108.0)]  # 8s
+        audio_hits: list[BgmHit] = [{"timestamp": 120.0, "similarity": 0.68}]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=audio_hits
+        )
+
+        assert result == regions
+        assert cls == ["match_boundary"]
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_pre_blackout_fanfare_does_not_promote(self, mock_classify):
+        """Fanfare BEFORE blackout start → not promoted (prevents in-match false positives)."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]
+        # Fanfare from a previous match, ending 50s before this blackout
+        audio_hits: list[BgmHit] = [{"timestamp": 50.0, "similarity": 0.85}]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=audio_hits
+        )
+
+        assert result == []
+        assert cls == []
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_fanfare_far_past_window(self, mock_classify):
+        """Fanfare > 60s past end → not promoted."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]
+        audio_hits: list[BgmHit] = [
+            {"timestamp": 200.0, "similarity": 0.80}
+        ]  # region_end + 98
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=audio_hits
+        )
+
+        assert result == []
+        assert cls == []
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_no_audio_hits_does_not_change_behavior(self, mock_classify):
+        """audio_hits=None → legacy scorebar-only path (short in_match removed)."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=None
+        )
+
+        assert result == []
+        assert cls == []
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_empty_audio_hits_treated_as_no_hits(self, mock_classify):
+        """Empty audio_hits list → no promotion."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=[]
+        )
+
+        assert result == []
+        assert cls == []
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_non_in_match_not_affected_by_audio(self, mock_classify):
+        """non_fl/match_boundary classifications unchanged by audio hits."""
+        mock_classify.side_effect = ["non_fl", "match_boundary"]
+        regions = [(100.0, 102.0), (200.0, 205.0)]
+        audio_hits: list[BgmHit] = [
+            {"timestamp": 110.0, "similarity": 0.90},
+            {"timestamp": 210.0, "similarity": 0.88},
+        ]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=audio_hits
+        )
+
+        assert result == [(200.0, 205.0)]
+        assert cls == ["match_boundary"]
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_fanfare_at_window_far_edge(self, mock_classify):
+        """Fanfare at region_end + 60s → inclusive end → promoted."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]
+        audio_hits: list[BgmHit] = [{"timestamp": 162.0, "similarity": 0.66}]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=audio_hits
+        )
+
+        assert result == regions
+        assert cls == ["match_boundary"]
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_fanfare_just_past_window(self, mock_classify):
+        """Fanfare at region_end + 60.01s → outside window, no promotion."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]
+        audio_hits: list[BgmHit] = [{"timestamp": 162.01, "similarity": 0.90}]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=audio_hits
+        )
+
+        assert result == []
+        assert cls == []
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_fanfare_at_region_end_promoted(self, mock_classify):
+        """Fanfare exactly at region_end → on inclusive lower bound, promoted."""
+        mock_classify.return_value = "in_match"
+        regions = [(100.0, 102.0)]
+        audio_hits: list[BgmHit] = [{"timestamp": 102.0, "similarity": 0.70}]
+
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 300.0, _HEIGHT, audio_hits=audio_hits
+        )
+
+        assert result == regions
+        assert cls == ["match_boundary"]
 
 
 DETECTOR_MODULE = "allaganeye.video.detector"

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -42,6 +42,23 @@ def _output_files(output_dir: Path) -> list[Path]:
 # --- Fixtures ---
 
 
+@pytest.fixture(autouse=True)
+def _mock_audio_scan(request):
+    """Skip the real audio scan in every split_matches test by default.
+
+    The audio pipeline requires a real video file with an audio track; the
+    pipeline tests here use dummy paths, so the scan would fail with an
+    ffmpeg error.  Tests that need to exercise the real ``_run_audio_scan``
+    (e.g. to verify ``no_audio`` / error-handling branches) mark themselves
+    with ``@pytest.mark.real_audio_scan`` to opt out.
+    """
+    if request.node.get_closest_marker("real_audio_scan") is not None:
+        yield None
+        return
+    with patch(f"{MODULE}._run_audio_scan", return_value=None) as m:
+        yield m
+
+
 @pytest.fixture
 def config(tmp_path):
     return SplitConfig(output_dir=tmp_path / "output", min_match_duration=60.0)
@@ -454,6 +471,15 @@ class TestCacheRoundTrip:
         )
         assert _load_cache(cache_path, cache_video, 2.0, cache_config) is None
 
+    def test_param_mismatch_no_audio(self, cache_video, cache_config, tmp_path):
+        """no_audio mismatch → None (cache must be keyed to audio pipeline, #288)."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        different_config = SplitConfig(output_dir=tmp_path / "output", no_audio=True)
+        assert _load_cache(cache_path, cache_video, 1.0, different_config) is None
+
     def test_version_mismatch(self, cache_video, cache_config, tmp_path):
         """cache_version mismatch → None."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
@@ -627,3 +653,68 @@ class TestCachePipeline:
         )
         run_split(video, config_no_cache)
         assert mock_detect.call_count == 2
+
+
+# --- Audio scan integration (#288) ---
+
+
+class TestAudioScanIntegration:
+    """Audio scan pipeline wiring in run_split and _run_audio_scan (#288)."""
+
+    @patch(f"{MODULE}.split_video")
+    @patch(f"{MODULE}.detect_match_boundaries")
+    @patch(f"{MODULE}.probe_video")
+    def test_audio_hits_forwarded_to_detect(
+        self, mock_probe, mock_detect, mock_split, tmp_path, _mock_audio_scan
+    ):
+        """Scan output is forwarded to detect_match_boundaries via audio_hits."""
+        hits = [{"timestamp": 50.0, "similarity": 0.72}]
+        _mock_audio_scan.return_value = hits
+        mock_probe.return_value = PROBE_RESULT
+        mock_detect.return_value = BOUNDARIES
+        mock_split.return_value = _output_files(tmp_path)
+        config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+        run_split(Path("input.mp4"), config)
+
+        _, detect_kwargs = mock_detect.call_args
+        assert detect_kwargs["audio_hits"] == hits
+
+    @pytest.mark.real_audio_scan
+    def test_run_audio_scan_returns_none_when_disabled(self, tmp_path):
+        """config.no_audio=True skips audio scan without invoking scan_fanfare_hits."""
+        from allaganeye.commands.split_matches import _run_audio_scan
+
+        config = SplitConfig(
+            output_dir=tmp_path, min_match_duration=60.0, no_audio=True
+        )
+        result = _run_audio_scan(Path("input.mp4"), config, show=False, verbose=False)
+        assert result is None
+
+    @pytest.mark.real_audio_scan
+    @patch("allaganeye.audio.scan.scan_fanfare_hits")
+    def test_run_audio_scan_returns_hits_on_success(self, mock_scan, tmp_path):
+        """Successful scan returns hits verbatim."""
+        from allaganeye.commands.split_matches import _run_audio_scan
+
+        hits = [{"timestamp": 100.0, "similarity": 0.7}]
+        mock_scan.return_value = hits
+        config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+        result = _run_audio_scan(Path("input.mp4"), config, show=False, verbose=False)
+        assert result == hits
+        mock_scan.assert_called_once()
+
+    @pytest.mark.real_audio_scan
+    @patch("allaganeye.audio.scan.scan_fanfare_hits")
+    def test_run_audio_scan_falls_back_on_video_processing_error(
+        self, mock_scan, tmp_path
+    ):
+        """VideoProcessingError is caught; returns None instead of propagating."""
+        from allaganeye.commands.split_matches import _run_audio_scan
+
+        mock_scan.side_effect = VideoProcessingError("no audio track")
+        config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+        result = _run_audio_scan(Path("input.mp4"), config, show=False, verbose=False)
+        assert result is None


### PR DESCRIPTION
## Summary

- `in_match` 分類の暗転で暗転終了後 0-60s 以内に Fanfare ピーク (sim ≥ 0.65) が存在すれば `match_boundary` に昇格する経路を scorebar フィルタに追加
- 動画全域の音声スキャンを詳細検知前に 1 回実行、その結果を scorebar に渡す
- CLI `--no-audio` で音声昇格を無効化可能、cache params に `no_audio` を含めキャッシュ衝突を防止（cache_version 1→2）

## 背景

#287 で Fanfare 参照特徴量を同梱、#297 で `allow_pickle=False` 対応完了。本 PR でそれらを検出経路に統合。#271 の問題 2 (2026-04-08 録画 57:53 付近) を解決対象。

## スコープ調整

WR→Fanfare 間隔による (B) 条件は WR 参照特徴量未同梱のため対象外。 #301 で WR 参照作成後に別 PR で追加予定。本 PR は Fanfare 単独昇格 (A) 条件のみ実装。受け入れ条件のうち「20260118 三時刻偽陽性除去」は #301 に follow-up（#288 の着手コメントで lead に確認済）。

## 実装方針

- 視覚検知は既存のまま。Pass2 refine + scorebar 分類後に音声昇格を挿入
- 音声スキャンは動画単位で全域 1 回（`allaganeye/audio/scan.py::scan_fanfare_hits`）
- 昇格 window は **暗転終了後 0-60s**（pre 側は常に在中試合 BGM のため除外、in-match character-down の偽昇格を回避）

## テスト

### ユニット
- `tests/test_audio_scan.py`: scan パイプライン結線の検証（3 件）
- `tests/test_scorebar.py::TestAudioPromotion`: 昇格条件 9 件（post-only window、閾値境界、non-in_match 不変など）
- `tests/test_detector.py`: `audio_hits` が scorebar に forward されることを検証（2 件）
- `tests/test_split_matches.py::TestAudioScanIntegration`: `_run_audio_scan` の no_audio 分岐、`VideoProcessingError` フォールバック、cache params `no_audio` mismatch

### 統合 (slow)
- 既存 `tests/test_audio_integration.py` のカバレッジテスト維持（primary 8/8、cumulative 13/20）

### 静的チェック
- `ruff check .` / `ruff format --check .` / `pyright` / `pytest` 全通過（399 件）

## セルフ検証（実データ）

`ALLAGANEYE_SAMPLE_VIDEO_DIR=E:/royalstraightflesh/videos`、primary は `E:/videos/2026-04-08 21-14-05.mkv`。いずれも **`--dry-run --no-cache --gpu`** 実行（境界検知までを検証、実 mp4 切り出しは未実行）。

| 録画 | baseline | audio | 備考 |
|---|---|---|---|
| 2026-04-08 | 9 match | 12 match | **Match 5 が 40:38-57:51 で分割 (#288 問題 2 解決、target 57:53±2s)**。+28:38/+2:26:32 の 2 件は Fanfare ノイズ由来の偽昇格（#301 (B) 条件で抑制予定） |
| 20260116 | 7 | 7 | match 数維持、境界タイミングが数秒〜数分ズレ（より正確な試合終了時刻を検出） |
| 20260118 | 6 | 7 | +1:16:12 (Fanfare ノイズ)。既存境界は維持 |
| 20260119 | 9 | 9 | match 数維持、Match 2 start が 14:25→15:45 に shift |

**受け入れ条件**
- 2026-04-08 Match 4 が 57:53 付近で分割 ✓（検知結果として確認）
- 20260116/18/19 で既存境界（match 数）退行なし ✓
- 静的チェック全通過 ✓

**既知の制約**: Fanfare は試合中にも sim 0.65-0.75 の弱ピークを出すため、#301 の WR 参照同梱 + (B) 間隔条件が入るまでは偽昇格が少量混入する。影響範囲は CLAUDE.md に追記済。

## 未検証事項（テスターに委任）

本 PR の変更範囲は検知層（`video/detector.py`, `video/scorebar.py`, `audio/scan.py`, `commands/split_matches.py` の検知フェーズ）に限定されており、`video/splitter.py` の実 FFmpeg 切り出しには手を入れていない。以下の E2E 検証はテスターに委ねる:

- [x] `--dry-run` を外した実分割で期待どおりの mp4 ファイル群が生成されること（2026-04-08 録画推奨）
- [x] 出力 `metadata.json` が新しい boundary（特に 57:51 分割）を反映していること
- [x] 別録画（`20260116/18/19` 以外）での退行有無（engineer 検証との独立性のため）
- [x] `--no-audio` 指定時に従来挙動（音声昇格なし）に戻ることの E2E 確認

## Test plan

- [x] pytest 通過（`pytest`）
- [x] ruff check / ruff format / pyright 通過
- [x] 2026-04-08 録画で実分割を行い、Match 5 が 57:51 付近で切り出されること（engineer は `--dry-run` でのみ確認）
- [x] 20260116/18/19 で baseline に対する match 数退行がないこと
- [x] `--no-audio` で legacy 挙動に戻ること（TestAudioPromotion::test_no_audio_hits_does_not_change_behavior でカバー）
- [x] engineer 検証と**異なる録画**で独立検証（protocol §「実データ検証を伴う PR」）

[engineer-1]
