### PR TITLE
fix: em dash を ASCII に置換し Windows cp932 UnicodeEncodeError を修正 #292

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def _warn_if_stale(cache_dir: Path, current_hashes: dict[str, str]) -> None:
         ]
         print(
             f"\n[cache] WARNING: Detection cache may be stale "
-            f"— source files changed: {changed}"
+            f"-- source files changed: {changed}"
         )
         print("[cache] Run with --clear-test-cache to regenerate.")
 

--- a/tests/detection_cache.py
+++ b/tests/detection_cache.py
@@ -1,4 +1,4 @@
-"""Test detection cache — persists detection results across pytest sessions.
+"""Test detection cache -- persists detection results across pytest sessions.
 
 Caches the output of expensive ``detect_match_boundaries`` calls so that
 ``pytest -m slow`` can skip re-detection when neither source video files
@@ -110,7 +110,7 @@ def _validate_cache_entry(
     cached_hashes = data.get("source_hashes", {})
     if cached_hashes != source_hashes:
         changed = [k for k in source_hashes if source_hashes[k] != cached_hashes.get(k)]
-        logger.warning("Cache stale — source files changed: %s", changed)
+        logger.warning("Cache stale -- source files changed: %s", changed)
         return None
 
     fixtures = data.get("fixtures", {})


### PR DESCRIPTION
## Summary

- `tests/conftest.py` と `tests/detection_cache.py` の em dash `—` (U+2014) を `--` に置換
- Windows cp932 環境で pytest が INTERNALERROR になる問題を修正

Related: #292

## 根本原因分析

- PR #260 (engineer-1) で導入された非ASCII文字が Windows cp932 で符号化不可
- 残存する類似箇所（logger 内の `→` 等）は #308 で追跡

## Checklist

- [x] 全テスト通過（`pytest` — 405 passed）
- [x] Lint 通過（`ruff check .`）
- [x] 型チェック通過（`pyright`）
- [x] 関連ドキュメント更新: 不要
- [x] CLAUDE.md の更新: 不要

[engineer-2]
