### PR TITLE
fix: 全 .py ファイルの非ASCII文字を ASCII に置換 #308

### DIFF
--- a/allaganeye/audio/__init__.py
+++ b/allaganeye/audio/__init__.py
@@ -5,11 +5,11 @@ detection.  See ``allaganeye/video/`` for visual signals and the high-level
 ``commands/split_matches.py`` for orchestration.
 
 Public API:
-    extract_pcm — pull mono PCM from a video via ffmpeg
-    LogMelConfig / log_mel_spectrogram — compute reference/target features
-    save_features / load_features — persist/load .npz feature files
-    sliding_cosine_similarity / find_match_peaks — match a reference window
-    BgmHit — typed dict for matcher results
+    extract_pcm -- pull mono PCM from a video via ffmpeg
+    LogMelConfig / log_mel_spectrogram -- compute reference/target features
+    save_features / load_features -- persist/load .npz feature files
+    sliding_cosine_similarity / find_match_peaks -- match a reference window
+    BgmHit -- typed dict for matcher results
 
 Removal (director Q3 compliance, #284):
     If this module ever needs to be stripped from the distribution, the

--- a/allaganeye/audio/scan.py
+++ b/allaganeye/audio/scan.py
@@ -1,6 +1,6 @@
 """Full-video BGM scanning for match boundary promotion (#288).
 
-Wraps the audio pipeline (extract → log-mel → sliding correlation → peaks)
+Wraps the audio pipeline (extract -> log-mel -> sliding correlation -> peaks)
 into a single call so higher-level detection code does not need to thread
 four primitives together.  The scan runs once per video; the resulting
 hits are reused for every blackout region evaluated during classification.
@@ -8,7 +8,7 @@ hits are reused for every blackout region evaluated during classification.
 Multi-reference bundles (introduced in #289 for War Room, which requires
 both pre-patch and post-patch BGM windows) are handled transparently by
 taking the per-frame max across all references' sliding similarities
-before peak-finding — the OR-style detection described in issue #289
+before peak-finding -- the OR-style detection described in issue #289
 scope item (b).
 """
 

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -35,7 +35,7 @@ def run_split(
     verbose: bool = False,
     quiet: bool = False,
 ) -> None:
-    """Run the split pipeline: probe → detect → split.
+    """Run the split pipeline: probe -> detect -> split.
 
     Output levels:
     - Default: probe status, progress bar, match list, output files
@@ -100,7 +100,7 @@ def run_split(
         if effective_interval != config.sample_interval:
             typer.echo(
                 f"  Auto-adjusted sample interval: "
-                f"{config.sample_interval}s → {effective_interval}s "
+                f"{config.sample_interval}s -> {effective_interval}s "
                 f"(video is {_format_duration(metadata['duration'])})"
             )
 
@@ -332,7 +332,7 @@ def _auto_sample_interval(duration: float, configured_interval: float) -> float:
     """Raise sample interval for long videos to reduce probe count.
 
     Only adjusts when the configured interval is the default (1.0).
-    Thresholds chosen so total probes stay under ~3600 (≈ 5 min at 24 workers).
+    Thresholds chosen so total probes stay under ~3600 (~5 min at 24 workers).
     """
     if configured_interval != 1.0:
         return configured_interval

--- a/allaganeye/ffmpeg_path.py
+++ b/allaganeye/ffmpeg_path.py
@@ -17,9 +17,9 @@ def find_ffmpeg() -> str:
     """Find the ffmpeg binary path.
 
     Resolution order:
-    1. shutil.which("ffmpeg") — works if PATH is set
-    2. ALLAGANEYE_FFMPEG env var — user-specified directory containing ffmpeg
-    3. Windows known paths — winget typical install location
+    1. shutil.which("ffmpeg") -- works if PATH is set
+    2. ALLAGANEYE_FFMPEG env var -- user-specified directory containing ffmpeg
+    3. Windows known paths -- winget typical install location
     4. Error with setup instructions
     """
     return _find_binary("ffmpeg")

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -90,7 +90,7 @@ def detect_match_boundaries(
                 codec=codec,
             )
         except VideoProcessingError:
-            # GPU failed — fall back to CPU
+            # GPU failed -- fall back to CPU
             results = _scan_cpu(
                 video_path,
                 duration_hint,
@@ -480,7 +480,7 @@ def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
     roi_brightness = float(roi.mean())
     if not (20.0 < roi_brightness < 140.0):
         logger.debug(
-            "scorebar: brightness=%.1f (out of 20-140 range) → False",
+            "scorebar: brightness=%.1f (out of 20-140 range) -> False",
             roi_brightness,
         )
         return False
@@ -511,7 +511,7 @@ def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
     if max_channel_std <= _SCOREBAR_CHANNEL_STD_THRESHOLD:
         logger.debug(
             "scorebar: brightness=%.1f ch_std=[R=%.1f G=%.1f B=%.1f] "
-            "max=%.1f <= %.1f → False",
+            "max=%.1f <= %.1f -> False",
             roi_brightness,
             *channel_stds,
             max_channel_std,
@@ -527,7 +527,7 @@ def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
     if secondary_std <= _SCOREBAR_MIN_SECONDARY_STD:
         logger.debug(
             "scorebar: brightness=%.1f ch_std=[R=%.1f G=%.1f B=%.1f] "
-            "secondary=%.1f <= %.1f → False (A1)",
+            "secondary=%.1f <= %.1f -> False (A1)",
             roi_brightness,
             *channel_stds,
             secondary_std,
@@ -545,7 +545,7 @@ def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
     if max_edge <= _SCOREBAR_EDGE_THRESHOLD:
         logger.debug(
             "scorebar: brightness=%.1f ch_std max=%.1f "
-            "max_edge=%.1f <= %.1f → False (A2)",
+            "max_edge=%.1f <= %.1f -> False (A2)",
             roi_brightness,
             max_channel_std,
             max_edge,
@@ -555,7 +555,7 @@ def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
 
     logger.debug(
         "scorebar: brightness=%.1f ch_std=[R=%.1f G=%.1f B=%.1f] "
-        "secondary=%.1f max_edge=%.1f → True",
+        "secondary=%.1f max_edge=%.1f -> True",
         roi_brightness,
         *channel_stds,
         secondary_std,
@@ -583,8 +583,8 @@ _REFINE_WINDOW = 5.0
 _REFINED_MIN_BLACKOUT = 1.5
 """Min blackout duration when using refined (0.25s) measurements.
 
-At interval=0.25s, a 2.0s blackout measures ~1.5-1.75s (≥ 1.5 → detected)
-while a 1.5s respawn measures ~1.0-1.25s (< 1.5 → filtered).
+At interval=0.25s, a 2.0s blackout measures ~1.5-1.75s (>= 1.5 -> detected)
+while a 1.5s respawn measures ~1.0-1.25s (< 1.5 -> filtered).
 """
 
 _BLACKOUT_PADDING = 3.0
@@ -688,7 +688,7 @@ def _refine_blackout_regions(
 ) -> list[tuple[float, float]]:
     """Re-probe blackout regions at fine interval for precise duration.
 
-    For each region, probes ±_REFINE_WINDOW seconds at _REFINE_INTERVAL
+    For each region, probes +-_REFINE_WINDOW seconds at _REFINE_INTERVAL
     to get an accurate measurement of the blackout duration.  Returns
     updated regions with refined start/end times.
     """

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -42,7 +42,7 @@ def scan_gpu(
     ``fps=1/{interval}`` to output one frame per interval, which is read
     from stdout and analyzed for brightness.
 
-    Returns dict mapping timestamp → brightness, same as CPU mode.
+    Returns dict mapping timestamp -> brightness, same as CPU mode.
 
     Raises VideoProcessingError if GPU decode fails for all chunks.
     """

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -76,7 +76,7 @@ def _majority_scorebar(results: list[bool | None]) -> bool | None:
 _STATIC_SCREEN_MAD_THRESHOLD = 0.5
 """Max scorebar-ROI MAD to consider consecutive frames as a static screen.
 
-Loading/result screens are pixel-identical across seconds, giving MAD ≈ 0.
+Loading/result screens are pixel-identical across seconds, giving MAD ~= 0.
 FL match frames always differ (character motion, particles) with MAD > 1.5.
 Threshold 0.5 sits well inside the gap.
 """
@@ -124,7 +124,7 @@ def _is_static_from_frames(
     is_static = min_mad < _STATIC_SCREEN_MAD_THRESHOLD
 
     logger.debug(
-        "static_screen: frames=%d mads=%s min=%.2f thr=%.1f → %s",
+        "static_screen: frames=%d mads=%s min=%.2f thr=%.1f -> %s",
         len(raw_frames),
         [f"{m:.2f}" for m in mads],
         min_mad,
@@ -152,10 +152,10 @@ _AUDIO_PROMOTE_WINDOW_POST = 60.0
 
 Fanfare plays during the match-start cinematic, landing 0-60s past the
 end of a boundary blackout on the recordings validated in #271.  A
-post-blackout-only window (rather than ±60s symmetric) avoids promoting
+post-blackout-only window (rather than +-60s symmetric) avoids promoting
 in-match character-down blackouts that happen to precede a legitimate
 Fanfare from the next match.  The pre-side of a real boundary blackout
-has no Fanfare by construction — Fanfare never plays during an ongoing
+has no Fanfare by construction -- Fanfare never plays during an ongoing
 match.
 """
 
@@ -198,10 +198,10 @@ def classify_blackout(
     A1+A2 checks from being misclassified as in-match.  (#201)
 
     Returns one of:
-    - ``"in_match"``: both sides have scorebar → in-match blackout (#107)
-    - ``"match_boundary"``: one side has scorebar → match start/end
-    - ``"non_fl"``: neither side has scorebar → non-FL blackout (#109)
-    - ``"unknown"``: all probes failed on either side → keep boundary (safe)
+    - ``"in_match"``: both sides have scorebar -> in-match blackout (#107)
+    - ``"match_boundary"``: one side has scorebar -> match start/end
+    - ``"non_fl"``: neither side has scorebar -> non-FL blackout (#109)
+    - ``"unknown"``: all probes failed on either side -> keep boundary (safe)
     """
     pre_timestamps = sorted(set(max(0.0, region[0] - d) for d in (3.0, 2.0, 1.0)))
     post_timestamps = sorted(set(min(duration, region[1] + d) for d in (1.0, 2.0, 3.0)))
@@ -252,7 +252,7 @@ def classify_blackout(
 
     logger.debug(
         "classify region [%.1f-%.1f] (%.1fs): "
-        "pre=%s (votes=%s) post=%s (votes=%s) → %s",
+        "pre=%s (votes=%s) post=%s (votes=%s) -> %s",
         region[0],
         region[1],
         region[1] - region[0],
@@ -300,12 +300,12 @@ def filter_blackouts_with_scorebar(
     Keeps:
     - Long ``"in_match"`` blackouts (>= 3.5s, FL match boundaries)
     - ``"match_boundary"`` (FL match start/end)
-    - ``"unknown"`` (probe failure → safe side, keep boundary)
+    - ``"unknown"`` (probe failure -> safe side, keep boundary)
 
     Audio promotion (#288):
     When *audio_hits* is provided, a blackout initially classified as
     ``"in_match"`` is promoted to ``"match_boundary"`` if any Fanfare
-    peak falls within ±60s of the region.  This rescues boundaries that
+    peak falls within +-60s of the region.  This rescues boundaries that
     scorebar afterimage (visible ~30s past match end) causes to be
     misclassified.
 
@@ -328,7 +328,7 @@ def filter_blackouts_with_scorebar(
             hit = _has_nearby_fanfare_hit(region, audio_hits)
             if hit is not None:
                 logger.info(
-                    "PROMOTE [%.1f-%.1f] (%.1fs): in_match → match_boundary "
+                    "PROMOTE [%.1f-%.1f] (%.1fs): in_match -> match_boundary "
                     "(fanfare t=%.1f sim=%.3f)",
                     region[0],
                     region[1],
@@ -383,7 +383,7 @@ def _merge_boundary_pairs(
     """Merge consecutive match_boundary pairs separated by non-FL content.
 
     FL match transitions often produce two blackouts:
-      FL Match → blackout₁ (match_boundary) → lobby/result → blackout₂ (match_boundary) → FL Match
+      FL Match -> blackout1 (match_boundary) -> lobby/result -> blackout2 (match_boundary) -> FL Match
     The intermediate non-FL segment creates a false short "match".
 
     When two consecutive match_boundary regions have a gap < _MERGE_GAP_MAX
@@ -421,7 +421,7 @@ def _merge_boundary_pairs(
                 if all_valid and not any_scorebar:
                     merged_region = (regions[i][0], regions[i + 1][1])
                     logger.info(
-                        "MERGE  [%.1f-%.1f] + [%.1f-%.1f] → [%.1f-%.1f] "
+                        "MERGE  [%.1f-%.1f] + [%.1f-%.1f] -> [%.1f-%.1f] "
                         "(gap=%.0fs, probes=%s)",
                         regions[i][0],
                         regions[i][1],

--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -28,12 +28,12 @@ pyright
 ## コミットメッセージ
 
 Conventional Commits 形式:
-- `feat:` — 新機能
-- `fix:` — バグ修正
-- `refactor:` — リファクタリング
-- `test:` — テスト追加・修正
-- `docs:` — ドキュメント
-- `chore:` — ビルド・設定等
+- `feat:` -- 新機能
+- `fix:` -- バグ修正
+- `refactor:` -- リファクタリング
+- `test:` -- テスト追加・修正
+- `docs:` -- ドキュメント
+- `chore:` -- ビルド・設定等
 - 日本語 OK
 
 ## テスト
@@ -42,6 +42,14 @@ Conventional Commits 形式:
 - テストファイル: `tests/test_<モジュール名>.py`
 - fixture は `conftest.py` に集約
 - 動画ファイルが必要なテストには `@pytest.mark.slow` を付与
+
+## 文字エンコーディング
+
+- `print()` / `logger.*()` の引数（実行時に出力される文字列）は **ASCII 範囲のみ** 使用する
+- Windows のデフォルト `cp932` エンコーディングで `UnicodeEncodeError` を防止するため
+- 置換ルール: `→` -> `->`, `—` -> `--`, `≈` -> `~=`, `≥` -> `>=`
+- docstring・コメント内も同様に ASCII を推奨（pytest -v 等で出力される可能性があるため）
+- 日本語テキストは引き続き OK（コメント・docstring 内）
 
 ## エラーハンドリング
 

--- a/tests/generate_baselines.py
+++ b/tests/generate_baselines.py
@@ -54,7 +54,7 @@ def main() -> None:
             blackout_threshold=15.0,
             min_match_duration=300.0,
             min_blackout_duration=3.0,
-            # src_resolution omitted → no scorebar filtering
+            # src_resolution omitted -> no scorebar filtering
         )
         elapsed = time.monotonic() - start
 
@@ -76,7 +76,7 @@ def main() -> None:
         out_path.write_text(
             json.dumps(baseline, indent=2, ensure_ascii=False), encoding="utf-8"
         )
-        print(f"  → {out_path.name}: {len(boundaries)} matches, {elapsed:.1f}s")
+        print(f"  -> {out_path.name}: {len(boundaries)} matches, {elapsed:.1f}s")
 
     print("Done.")
 

--- a/tests/test_audio_extract.py
+++ b/tests/test_audio_extract.py
@@ -75,7 +75,7 @@ def test_extract_pcm_omits_seek_args_when_unset(_mock_ffmpeg, mock_run, tmp_path
 @patch("allaganeye.audio.extract.subprocess.run")
 @patch("allaganeye.audio.extract.find_ffmpeg", return_value="ffmpeg")
 def test_extract_pcm_ffmpeg_not_found(_mock_ffmpeg, mock_run, tmp_path):
-    """FileNotFoundError → VideoProcessingError with helpful message."""
+    """FileNotFoundError -> VideoProcessingError with helpful message."""
     video = tmp_path / "test.mp4"
     video.touch()
     mock_run.side_effect = FileNotFoundError()
@@ -87,7 +87,7 @@ def test_extract_pcm_ffmpeg_not_found(_mock_ffmpeg, mock_run, tmp_path):
 @patch("allaganeye.audio.extract.subprocess.run")
 @patch("allaganeye.audio.extract.find_ffmpeg", return_value="ffmpeg")
 def test_extract_pcm_timeout(_mock_ffmpeg, mock_run, tmp_path):
-    """TimeoutExpired → VideoProcessingError."""
+    """TimeoutExpired -> VideoProcessingError."""
     video = tmp_path / "test.mp4"
     video.touch()
     mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=1800)
@@ -99,7 +99,7 @@ def test_extract_pcm_timeout(_mock_ffmpeg, mock_run, tmp_path):
 @patch("allaganeye.audio.extract.subprocess.run")
 @patch("allaganeye.audio.extract.find_ffmpeg", return_value="ffmpeg")
 def test_extract_pcm_nonzero_returncode(_mock_ffmpeg, mock_run, tmp_path):
-    """Non-zero ffmpeg return code → VideoProcessingError including stderr tail."""
+    """Non-zero ffmpeg return code -> VideoProcessingError including stderr tail."""
     video = tmp_path / "test.mp4"
     video.touch()
     mock_run.return_value = _mock_result(returncode=1, stderr=b"some ffmpeg error here")
@@ -111,7 +111,7 @@ def test_extract_pcm_nonzero_returncode(_mock_ffmpeg, mock_run, tmp_path):
 @patch("allaganeye.audio.extract.subprocess.run")
 @patch("allaganeye.audio.extract.find_ffmpeg", return_value="ffmpeg")
 def test_extract_pcm_empty_output(_mock_ffmpeg, mock_run, tmp_path):
-    """Empty stdout (no audio track) → VideoProcessingError."""
+    """Empty stdout (no audio track) -> VideoProcessingError."""
     video = tmp_path / "test.mp4"
     video.touch()
     mock_run.return_value = _mock_result(stdout=b"")

--- a/tests/test_audio_integration.py
+++ b/tests/test_audio_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for allaganeye.audio — exercises real video files.
+"""Integration tests for allaganeye.audio -- exercises real video files.
 
 Requires:
 - ALLAGANEYE_SAMPLE_VIDEO_DIR pointing to a directory that contains the
@@ -152,8 +152,8 @@ _WAR_ROOM_COVERAGE_MIN = 0.50
 _WAR_ROOM_THRESHOLD = 0.65
 
 # Primary (2026-04-08) must retain sim_max at the lower edge of the
-# issue-stated baseline band [0.78, 0.88] — "no regression".  The original
-# ogg@0_1.5 reference actually produces sim_max ≈ 0.89 on 2026-04-08 (above
+# issue-stated baseline band [0.78, 0.88] -- "no regression".  The original
+# ogg@0_1.5 reference actually produces sim_max ~= 0.89 on 2026-04-08 (above
 # the upper edge of the stated band), so we interpret "maintain" as a
 # lower-bound guarantee: sim_max must stay >= 0.78.  Going higher than 0.88
 # is not a regression.
@@ -175,7 +175,7 @@ _WAR_ROOM_SAMPLE_EXPECTATIONS: list[tuple[str, str, list[float]]] = [
         "20260118",
         "2026-01-18 22-15-18.mkv",
         # 20260118 real match ends (user-confirmed in #286 follow-up):
-        # 1:05:25 / 1:27:33 / 1:47:44 → 3925, 5253, 6464.  The remaining
+        # 1:05:25 / 1:27:33 / 1:47:44 -> 3925, 5253, 6464.  The remaining
         # entries in the detector output were knockdown blackouts and are
         # excluded to avoid testing against false boundaries.
         [3925.0, 5253.3, 6464.0],
@@ -184,7 +184,7 @@ _WAR_ROOM_SAMPLE_EXPECTATIONS: list[tuple[str, str, list[float]]] = [
         "20260119",
         "2026-01-19 22-09-07.mkv",
         # 20260119 match ends (user-confirmed in #286 follow-up):
-        # 0:14:26 / 1:03:59 / 1:40:35 / 2:03:03 → 866, 3839, 6035, 7383.
+        # 0:14:26 / 1:03:59 / 1:40:35 / 2:03:03 -> 866, 3839, 6035, 7383.
         [866.0, 3839.0, 6035.0, 7383.0],
     ),
 ]
@@ -273,7 +273,7 @@ def test_war_room_sample_recordings_coverage(
 
 
 def test_war_room_primary_sim_maintained(_war_room_reference):
-    """Primary (2026-04-08) combined sim_max stays >= 0.78 — no regression."""
+    """Primary (2026-04-08) combined sim_max stays >= 0.78 -- no regression."""
     env_path = os.environ.get("ALLAGANEYE_AUDIO_TEST_VIDEO")
     if not env_path:
         pytest.skip("ALLAGANEYE_AUDIO_TEST_VIDEO not set")

--- a/tests/test_audio_scan.py
+++ b/tests/test_audio_scan.py
@@ -1,4 +1,4 @@
-"""Unit tests for allaganeye.audio.scan — mocked pipeline (#288)."""
+"""Unit tests for allaganeye.audio.scan -- mocked pipeline (#288)."""
 
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_debug_brightness.py
+++ b/tests/test_debug_brightness.py
@@ -304,7 +304,7 @@ def test_scorebar_detail_section_values(mock_probe_video, mock_probe_rgb, capsys
 @patch(f"{MODULE}._probe_single_frame")
 @patch(f"{MODULE}.probe_video")
 def test_brightness_mode_exception_fallback(mock_probe_video, mock_probe_frame, capsys):
-    """Brightness mode: VideoProcessingError → 255.0 fallback."""
+    """Brightness mode: VideoProcessingError -> 255.0 fallback."""
     mock_probe_video.return_value = PROBE_RESULT
 
     def side_effect(path, t):
@@ -326,7 +326,7 @@ def test_brightness_mode_exception_fallback(mock_probe_video, mock_probe_frame, 
 @patch(f"{MODULE}._probe_frame_rgb")
 @patch(f"{MODULE}.probe_video")
 def test_scorebar_mode_exception_fallback(mock_probe_video, mock_probe_rgb, capsys):
-    """Scorebar mode: VideoProcessingError → None → fallback row."""
+    """Scorebar mode: VideoProcessingError -> None -> fallback row."""
     mock_probe_video.return_value = PROBE_RESULT
 
     def side_effect(path, t, *, height=180):
@@ -355,7 +355,7 @@ def test_scorebar_mode_exception_fallback(mock_probe_video, mock_probe_rgb, caps
 def test_scorebar_detail_mode_exception_fallback(
     mock_probe_video, mock_probe_rgb, capsys
 ):
-    """Scorebar-detail mode: VideoProcessingError → None → fallback row."""
+    """Scorebar-detail mode: VideoProcessingError -> None -> fallback row."""
     mock_probe_video.return_value = PROBE_RESULT
 
     def side_effect(path, t, *, height=180):

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -227,7 +227,7 @@ class TestRefineBlackoutRegions:
 
     @patch("allaganeye.video.detector._probe_single_frame")
     def test_probes_limited_to_window(self, mock_probe):
-        """Probes are within ±REFINE_WINDOW of each region."""
+        """Probes are within +-REFINE_WINDOW of each region."""
         mock_probe.return_value = 128.0
 
         regions = [(500.0, 502.0)]
@@ -413,7 +413,7 @@ class TestExtractSegments:
             min_match_duration=300.0,
             min_blackout_duration=3.0,
         )
-        # Short blackout ignored → entire video is one segment
+        # Short blackout ignored -> entire video is one segment
         assert len(result) == 1
         assert result[0]["start"] == 0.0
         assert result[0]["end"] == 1800.0
@@ -441,7 +441,7 @@ class TestExtractSegments:
             min_match_duration=300.0,
             min_blackout_duration=0.0,
         )
-        # 1s blackout kept → two segments
+        # 1s blackout kept -> two segments
         assert len(result) == 2
 
     def test_mixed_short_and_long_blackouts(self):
@@ -489,7 +489,7 @@ class TestExtractSegments:
         result = _filter_and_extract_segments(
             regions, 1800.0, 300.0, 3.0, classifications=cls
         )
-        # Before first blackout: too short (102.5s < 300s) → excluded
+        # Before first blackout: too short (102.5s < 300s) -> excluded
         # Between blackouts: fl_match (both sides match_boundary)
         # After last blackout: unknown (tail segment)
         assert len(result) == 2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ Run with: pytest -m slow
 
 Design: The ``split_subdir`` fixture is parameterized over every
 subdirectory that contains both a source MKV and manual splits.
-The full pipeline (probe → detect → split) runs once per subdirectory
+The full pipeline (probe -> detect -> split) runs once per subdirectory
 via the ``pipeline_result`` fixture.  Individual tests verify different
 aspects of that single run to avoid repeated detection passes.
 """
@@ -312,7 +312,7 @@ class TestDetectRealVideo:
         """Detected boundary count is in the right ballpark vs manual splits.
 
         Transition expansion (#71/#75) and 2-pass refinement (#77/#79)
-        improved detection to 7/7.  Tolerance ±2 allows for edge cases
+        improved detection to 7/7.  Tolerance +-2 allows for edge cases
         in other recordings.
 
         Skipped when manual splits < 3 (likely incomplete hand-splitting).
@@ -521,11 +521,11 @@ class TestGpuCpuConsistency:
 
     @gpu_available
     def test_gpu_cpu_boundary_count_matches(self, gpu_cpu_results: dict):
-        """GPU and CPU modes detect similar number of matches (±1).
+        """GPU and CPU modes detect similar number of matches (+-1).
 
         Exact match is not guaranteed due to ffmpeg seek non-determinism:
         per-frame ``-ss`` (CPU) and chunked ``fps`` filter (GPU) may
-        decode different frames at the same timestamp, causing ±1
+        decode different frames at the same timestamp, causing +-1
         boundary difference at threshold edges.  (#214)
         """
         cpu = gpu_cpu_results["cpu"]
@@ -544,11 +544,11 @@ class TestGpuCpuConsistency:
 
         if abs(len(cpu) - len(gpu)) > 1:
             pytest.skip(
-                "Boundary count mismatch > 1 — see test_gpu_cpu_boundary_count_matches"
+                "Boundary count mismatch > 1 -- see test_gpu_cpu_boundary_count_matches"
             )
         if len(cpu) != len(gpu):
             pytest.skip(
-                "Boundary count differs by 1 — timestamp comparison not meaningful"
+                "Boundary count differs by 1 -- timestamp comparison not meaningful"
             )
 
         tolerance = 10.0  # seconds

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -73,18 +73,18 @@ def _make_frame(
 
 class TestHasScorebar:
     def test_fl_match_frame(self):
-        """FL match frame with 3GC colored scorebar sections → True."""
-        # 3 distinct section colors → high cross-section std
+        """FL match frame with 3GC colored scorebar sections -> True."""
+        # 3 distinct section colors -> high cross-section std
         raw = _make_frame(roi_sections=((60, 75, 100), (90, 95, 80), (65, 50, 55)))
         assert _has_scorebar(raw, _HEIGHT) is True
 
     def test_blackout_frame(self):
-        """Dark frame (brightness < 10) → False."""
+        """Dark frame (brightness < 10) -> False."""
         raw = _make_frame(bg=(3, 3, 3), roi_color=(5, 5, 5))
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_bright_non_fl_frame(self):
-        """Very bright non-FL frame (brightness > 160) → False."""
+        """Very bright non-FL frame (brightness > 160) -> False."""
         raw = _make_frame(
             bg=(200, 200, 200),
             roi_sections=((180, 190, 200), (170, 200, 220), (190, 180, 210)),
@@ -92,63 +92,63 @@ class TestHasScorebar:
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_uniform_color_frame(self):
-        """Uniform ROI sections (cross-section std < 15) → False."""
+        """Uniform ROI sections (cross-section std < 15) -> False."""
         raw = _make_frame(roi_sections=((80, 80, 80), (82, 80, 80), (80, 80, 82)))
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_probe_failure(self):
-        """None input (probe failure) → None."""
+        """None input (probe failure) -> None."""
         assert _has_scorebar(None, _HEIGHT) is None
 
     def test_boundary_brightness_20(self):
-        """ROI brightness at 20 → False (not strictly greater)."""
+        """ROI brightness at 20 -> False (not strictly greater)."""
         raw = _make_frame(roi_sections=((30, 10, 10), (10, 30, 10), (10, 10, 30)))
-        # mean brightness ~16.7, below 20 → False
+        # mean brightness ~16.7, below 20 -> False
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_boundary_brightness_just_above_20(self):
-        """ROI brightness just above 20 with color variation → True."""
+        """ROI brightness just above 20 with color variation -> True."""
         raw = _make_frame(roi_sections=((50, 15, 10), (10, 50, 15), (15, 10, 50)))
-        # mean brightness ~25, cross-section R std ~18 → True
+        # mean brightness ~25, cross-section R std ~18 -> True
         assert _has_scorebar(raw, _HEIGHT) is True
 
     def test_high_blue_non_fl(self):
-        """Non-FL with high blue (Match 2 type) → False due to brightness."""
+        """Non-FL with high blue (Match 2 type) -> False due to brightness."""
         raw = _make_frame(
             roi_sections=((150, 190, 230), (140, 200, 240), (110, 160, 200))
         )
-        # mean brightness ~180, exceeds 140 → False
+        # mean brightness ~180, exceeds 140 -> False
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_lobby_like_uniform(self):
         """Lobby-like frame: brightness in range but low cross-section std."""
         raw = _make_frame(roi_sections=((55, 52, 47), (54, 53, 48), (53, 52, 46)))
-        # brightness ~51, but sections are nearly identical → std ~0.8 → False
+        # brightness ~51, but sections are nearly identical -> std ~0.8 -> False
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_single_channel_gradient_rejected(self):
-        """Loading screen gradient: 1 channel high std, others low → False (A1).
+        """Loading screen gradient: 1 channel high std, others low -> False (A1).
 
         Simulates a loading screen where R varies across sections (std > 15)
         but G and B are nearly uniform (std < 12).
         """
         raw = _make_frame(roi_sections=((90, 60, 60), (50, 58, 62), (70, 62, 58)))
-        # R std: std([90,50,70]) ≈ 16.3 > 15 (passes primary)
-        # G std: std([60,58,62]) ≈ 1.6 < 12 (fails secondary)
-        # B std: std([60,62,58]) ≈ 1.6 < 12 (fails secondary)
-        # secondary_std ≈ 1.6 <= 12 → False (A1)
+        # R std: std([90,50,70]) ~= 16.3 > 15 (passes primary)
+        # G std: std([60,58,62]) ~= 1.6 < 12 (fails secondary)
+        # B std: std([60,62,58]) ~= 1.6 < 12 (fails secondary)
+        # secondary_std ~= 1.6 <= 12 -> False (A1)
         assert _has_scorebar(raw, _HEIGHT) is False
 
     def test_smooth_multi_channel_gradient_rejected(self):
-        """Smooth gradient with multi-channel variation but no sharp edges → False (A2).
+        """Smooth gradient with multi-channel variation but no sharp edges -> False (A2).
 
         Sections have gradually changing colors (no sharp band boundaries).
         """
         raw = _make_frame(roi_sections=((60, 80, 50), (65, 55, 80), (80, 65, 55)))
-        # R std: std([60,65,80]) ≈ 8.5
-        # G std: std([80,55,65]) ≈ 10.3
-        # B std: std([50,80,55]) ≈ 13.3
-        # max=13.3 < 15 → actually fails primary check, not A2
+        # R std: std([60,65,80]) ~= 8.5
+        # G std: std([80,55,65]) ~= 10.3
+        # B std: std([50,80,55]) ~= 13.3
+        # max=13.3 < 15 -> actually fails primary check, not A2
         # Need values that pass primary+A1 but fail A2
         # Use per-pixel smooth gradient instead of uniform sections
         # Create a frame with smooth gradient across the ROI (no sharp edges)
@@ -161,15 +161,15 @@ class TestHasScorebar:
         for x in range(roi_w):
             t = x / roi_w
             # Smooth gradient: R decreases, G stays, B increases
-            r = int(100 - 60 * t)  # 100 → 40
-            g = int(50 + 30 * t)  # 50 → 80
-            b = int(40 + 70 * t)  # 40 → 110
+            r = int(100 - 60 * t)  # 100 -> 40
+            g = int(50 + 30 * t)  # 50 -> 80
+            b = int(40 + 70 * t)  # 40 -> 110
             frame[0:y2, x1 + x, :] = (r, g, b)
         raw = frame.tobytes()
         # Section means approximate:
-        # Left: R≈90,G≈55,B≈52  Center: R≈70,G≈65,B≈75  Right: R≈50,G≈75,B≈98
-        # R std ≈ 16, G std ≈ 8, B std ≈ 19 → max 19>15, secondary 16>12 ✓
-        # But max edge per pixel ≈ 1-2 (smooth gradient) < 8 → False (A2)
+        # Left: R~=90,G~=55,B~=52  Center: R~=70,G~=65,B~=75  Right: R~=50,G~=75,B~=98
+        # R std ~= 16, G std ~= 8, B std ~= 19 -> max 19>15, secondary 16>12 OK
+        # But max edge per pixel ~= 1-2 (smooth gradient) < 8 -> False (A2)
         assert _has_scorebar(raw, _HEIGHT) is False
 
 
@@ -190,7 +190,7 @@ class TestMajorityScorebar:
         assert _majority_scorebar([False, False, True]) is False
 
     def test_all_none(self):
-        """All probe failures → None."""
+        """All probe failures -> None."""
         assert _majority_scorebar([None, None, None]) is None
 
     def test_partial_failure_majority_true(self):
@@ -198,15 +198,15 @@ class TestMajorityScorebar:
         assert _majority_scorebar([True, True, None]) is True
 
     def test_partial_failure_single_true(self):
-        """1 success (True), 2 failures → True (1 >= ceil(1/2))."""
+        """1 success (True), 2 failures -> True (1 >= ceil(1/2))."""
         assert _majority_scorebar([True, None, None]) is True
 
     def test_partial_failure_single_false(self):
-        """1 success (False), 2 failures → False (0 < ceil(1/2))."""
+        """1 success (False), 2 failures -> False (0 < ceil(1/2))."""
         assert _majority_scorebar([False, None, None]) is False
 
     def test_tie_two_values(self):
-        """1 True, 1 False, 1 None → True (1 >= ceil(2/2) = 1)."""
+        """1 True, 1 False, 1 None -> True (1 >= ceil(2/2) = 1)."""
         assert _majority_scorebar([True, False, None]) is True
 
 
@@ -219,7 +219,7 @@ class TestClassifyBlackout:
     @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_in_match(self, mock_probe, _mock_static):
-        """Both sides have scorebar, not static → in_match."""
+        """Both sides have scorebar, not static -> in_match."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([True, True, True], [f, f, f]),  # pre
@@ -231,7 +231,7 @@ class TestClassifyBlackout:
     @patch(f"{SCOREBAR_MODULE}._is_static_from_frames")
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_in_match_overridden_by_static_post(self, mock_probe, mock_static):
-        """Both sides scorebar, but post is static → match_boundary."""
+        """Both sides scorebar, but post is static -> match_boundary."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([True, True, True], [f, f, f]),  # pre
@@ -245,7 +245,7 @@ class TestClassifyBlackout:
     @patch(f"{SCOREBAR_MODULE}._is_static_from_frames")
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_in_match_overridden_by_static_pre(self, mock_probe, mock_static):
-        """Both sides scorebar, post not static but pre is → match_boundary."""
+        """Both sides scorebar, post not static but pre is -> match_boundary."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([True, True, True], [f, f, f]),  # pre
@@ -258,7 +258,7 @@ class TestClassifyBlackout:
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_match_boundary_start(self, mock_probe):
-        """Pre=False, Post=True → match_boundary (match start)."""
+        """Pre=False, Post=True -> match_boundary (match start)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([False, False, False], [f, f, f]),  # pre
@@ -269,7 +269,7 @@ class TestClassifyBlackout:
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_match_boundary_end(self, mock_probe):
-        """Pre=True, Post=False → match_boundary (match end)."""
+        """Pre=True, Post=False -> match_boundary (match end)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([True, True, True], [f, f, f]),  # pre
@@ -280,7 +280,7 @@ class TestClassifyBlackout:
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_non_fl(self, mock_probe):
-        """Neither side has scorebar → non_fl."""
+        """Neither side has scorebar -> non_fl."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([False, False, False], [f, f, f]),  # pre
@@ -291,7 +291,7 @@ class TestClassifyBlackout:
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_all_probes_failed(self, mock_probe):
-        """All probes failed → unknown."""
+        """All probes failed -> unknown."""
         mock_probe.side_effect = [
             ([None, None, None], [None, None, None]),  # pre
             ([None, None, None], [None, None, None]),  # post
@@ -301,7 +301,7 @@ class TestClassifyBlackout:
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_pre_failed_post_scorebar(self, mock_probe):
-        """Pre all failed, post has scorebar → unknown (safe side)."""
+        """Pre all failed, post has scorebar -> unknown (safe side)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([None, None, None], [None, None, None]),  # pre
@@ -338,7 +338,7 @@ class TestFilterBlackouts:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_removes_short_in_match(self, mock_classify):
-        """Short in_match (< 3.5s) = character down → removed."""
+        """Short in_match (< 3.5s) = character down -> removed."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]  # 2s duration
         result, cls = filter_blackouts_with_scorebar(
@@ -349,7 +349,7 @@ class TestFilterBlackouts:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_keeps_long_in_match(self, mock_classify):
-        """Long in_match (>= 3.5s) = FL match boundary → kept."""
+        """Long in_match (>= 3.5s) = FL match boundary -> kept."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 108.0)]  # 8s duration
         result, cls = filter_blackouts_with_scorebar(
@@ -360,7 +360,7 @@ class TestFilterBlackouts:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_keeps_in_match_exactly_3_5s(self, mock_classify):
-        """in_match at exactly 3.5s boundary → kept (not strictly less than)."""
+        """in_match at exactly 3.5s boundary -> kept (not strictly less than)."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 103.5)]  # exactly 3.5s
         result, cls = filter_blackouts_with_scorebar(
@@ -371,7 +371,7 @@ class TestFilterBlackouts:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_removes_in_match_just_under_3_5s(self, mock_classify):
-        """in_match at 3.49s → removed (strictly less than 3.5)."""
+        """in_match at 3.49s -> removed (strictly less than 3.5)."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 103.49)]  # 3.49s
         result, cls = filter_blackouts_with_scorebar(
@@ -381,7 +381,7 @@ class TestFilterBlackouts:
         assert cls == []
 
     def test_empty_regions(self):
-        """Empty blackout list → empty result, no classify calls."""
+        """Empty blackout list -> empty result, no classify calls."""
         result, cls = filter_blackouts_with_scorebar(Path("v.mp4"), [], 300.0, _HEIGHT)
         assert result == []
         assert cls == []
@@ -398,7 +398,7 @@ class TestFilterBlackouts:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_keeps_unknown(self, mock_classify):
-        """Unknown → safe side, keep boundary."""
+        """Unknown -> safe side, keep boundary."""
         mock_classify.return_value = "unknown"
         regions = [(100.0, 102.0)]
         result, cls = filter_blackouts_with_scorebar(
@@ -412,19 +412,19 @@ class TestFilterBlackouts:
         """Mix of classifications with duration-aware in_match filtering."""
         mock_classify.side_effect = [
             "match_boundary",  # kept
-            "in_match",  # short (2s) → removed
+            "in_match",  # short (2s) -> removed
             "non_fl",  # removed
             "unknown",  # kept
             "match_boundary",  # kept
-            "in_match",  # long (8s) → kept
+            "in_match",  # long (8s) -> kept
         ]
         regions = [
-            (50.0, 55.0),  # boundary → kept
-            (100.0, 102.0),  # in_match 2s → removed
-            (150.0, 155.0),  # non_fl → removed
-            (200.0, 202.0),  # unknown → kept
-            (250.0, 255.0),  # boundary → kept
-            (280.0, 288.0),  # in_match 8s → kept
+            (50.0, 55.0),  # boundary -> kept
+            (100.0, 102.0),  # in_match 2s -> removed
+            (150.0, 155.0),  # non_fl -> removed
+            (200.0, 202.0),  # unknown -> kept
+            (250.0, 255.0),  # boundary -> kept
+            (280.0, 288.0),  # in_match 8s -> kept
         ]
         result, cls = filter_blackouts_with_scorebar(
             Path("v.mp4"), regions, 300.0, _HEIGHT
@@ -439,7 +439,7 @@ class TestFilterBlackouts:
 
 
 class TestAudioPromotion:
-    """Audio-based in_match → match_boundary promotion (#288).
+    """Audio-based in_match -> match_boundary promotion (#288).
 
     Fanfare is only searched AFTER the blackout end (post-blackout window),
     not symmetrically, to avoid promoting in-match character-down blackouts
@@ -448,7 +448,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_short_in_match_promoted_by_post_fanfare(self, mock_classify):
-        """Short in_match with Fanfare 18s after end → promoted."""
+        """Short in_match with Fanfare 18s after end -> promoted."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]  # 2s, would normally be removed
         audio_hits: list[BgmHit] = [{"timestamp": 120.0, "similarity": 0.72}]
@@ -462,7 +462,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_long_in_match_promoted_by_post_fanfare(self, mock_classify):
-        """Long in_match with Fanfare after end → promoted."""
+        """Long in_match with Fanfare after end -> promoted."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 108.0)]  # 8s
         audio_hits: list[BgmHit] = [{"timestamp": 120.0, "similarity": 0.68}]
@@ -476,7 +476,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_pre_blackout_fanfare_does_not_promote(self, mock_classify):
-        """Fanfare BEFORE blackout start → not promoted (prevents in-match false positives)."""
+        """Fanfare BEFORE blackout start -> not promoted (prevents in-match false positives)."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]
         # Fanfare from a previous match, ending 50s before this blackout
@@ -491,7 +491,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_fanfare_far_past_window(self, mock_classify):
-        """Fanfare > 60s past end → not promoted."""
+        """Fanfare > 60s past end -> not promoted."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]
         audio_hits: list[BgmHit] = [
@@ -507,7 +507,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_no_audio_hits_does_not_change_behavior(self, mock_classify):
-        """audio_hits=None → legacy scorebar-only path (short in_match removed)."""
+        """audio_hits=None -> legacy scorebar-only path (short in_match removed)."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]
 
@@ -520,7 +520,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_empty_audio_hits_treated_as_no_hits(self, mock_classify):
-        """Empty audio_hits list → no promotion."""
+        """Empty audio_hits list -> no promotion."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]
 
@@ -550,7 +550,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_fanfare_at_window_far_edge(self, mock_classify):
-        """Fanfare at region_end + 60s → inclusive end → promoted."""
+        """Fanfare at region_end + 60s -> inclusive end -> promoted."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]
         audio_hits: list[BgmHit] = [{"timestamp": 162.0, "similarity": 0.66}]
@@ -564,7 +564,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_fanfare_just_past_window(self, mock_classify):
-        """Fanfare at region_end + 60.01s → outside window, no promotion."""
+        """Fanfare at region_end + 60.01s -> outside window, no promotion."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]
         audio_hits: list[BgmHit] = [{"timestamp": 162.01, "similarity": 0.90}]
@@ -578,7 +578,7 @@ class TestAudioPromotion:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_fanfare_at_region_end_promoted(self, mock_classify):
-        """Fanfare exactly at region_end → on inclusive lower bound, promoted."""
+        """Fanfare exactly at region_end -> on inclusive lower bound, promoted."""
         mock_classify.return_value = "in_match"
         regions = [(100.0, 102.0)]
         audio_hits: list[BgmHit] = [{"timestamp": 102.0, "similarity": 0.70}]
@@ -603,7 +603,7 @@ class TestMergeBoundaryPairs:
     def test_merge_when_gap_has_no_scorebar(
         self, mock_classify, mock_probe_rgb, mock_has_sb
     ):
-        """Consecutive match_boundary with non-FL gap → merged."""
+        """Consecutive match_boundary with non-FL gap -> merged."""
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         mock_probe_rgb.return_value = b"\x00" * 100
         mock_has_sb.return_value = False  # no scorebar in gap
@@ -621,10 +621,10 @@ class TestMergeBoundaryPairs:
     def test_no_merge_when_gap_has_scorebar(
         self, mock_classify, mock_probe_rgb, mock_has_sb
     ):
-        """Gap with scorebar detected (>=2 hits) → no merge."""
+        """Gap with scorebar detected (>=2 hits) -> no merge."""
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         mock_probe_rgb.return_value = b"\x00" * 100
-        mock_has_sb.return_value = True  # all 9 probes → scorebar
+        mock_has_sb.return_value = True  # all 9 probes -> scorebar
 
         regions = [(100.0, 105.0), (200.0, 205.0)]
         result, cls = filter_blackouts_with_scorebar(
@@ -639,7 +639,7 @@ class TestMergeBoundaryPairs:
     def test_no_merge_when_any_scorebar_hit(
         self, mock_classify, mock_probe_rgb, mock_has_sb
     ):
-        """Gap with any scorebar hit → no merge (strict zero-hit policy)."""
+        """Gap with any scorebar hit -> no merge (strict zero-hit policy)."""
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         mock_probe_rgb.return_value = b"\x00" * 100
         # 1 out of 9 probes returns True
@@ -665,7 +665,7 @@ class TestMergeBoundaryPairs:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_no_merge_when_gap_exceeds_max(self, mock_classify):
-        """Gap > _MERGE_GAP_MAX → no merge attempt."""
+        """Gap > _MERGE_GAP_MAX -> no merge attempt."""
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         gap = _MERGE_GAP_MAX + 100
         regions = [(100.0, 105.0), (105.0 + gap, 110.0 + gap)]
@@ -681,7 +681,7 @@ class TestMergeBoundaryPairs:
     def test_no_merge_when_probe_fails(
         self, mock_classify, mock_probe_rgb, mock_has_sb
     ):
-        """Probe failure (None) → no merge (safe side)."""
+        """Probe failure (None) -> no merge (safe side)."""
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         mock_probe_rgb.return_value = None
         mock_has_sb.return_value = None  # probe failure
@@ -712,7 +712,7 @@ class TestMergeBoundaryPairs:
         result, cls = filter_blackouts_with_scorebar(
             Path("v.mp4"), regions, 400.0, _HEIGHT
         )
-        # First pair merges → (100, 205), third is separate
+        # First pair merges -> (100, 205), third is separate
         assert result == [(100.0, 205.0), (300.0, 305.0)]
         assert cls == ["match_boundary", "match_boundary"]
 
@@ -720,7 +720,7 @@ class TestMergeBoundaryPairs:
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_merge_gap_exactly_600s(self, mock_classify, mock_probe_rgb, mock_has_sb):
-        """Gap exactly 600.0s (= _MERGE_GAP_MAX) → merge attempted."""
+        """Gap exactly 600.0s (= _MERGE_GAP_MAX) -> merge attempted."""
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         mock_probe_rgb.return_value = b"\x00" * 100
         mock_has_sb.return_value = False
@@ -738,7 +738,7 @@ class TestMergeBoundaryPairs:
     def test_no_merge_gap_just_over_600s(
         self, mock_classify, mock_probe_rgb, mock_has_sb
     ):
-        """Gap 600.1s (> _MERGE_GAP_MAX) → no merge."""
+        """Gap 600.1s (> _MERGE_GAP_MAX) -> no merge."""
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         mock_probe_rgb.return_value = b"\x00" * 100
         mock_has_sb.return_value = False
@@ -752,7 +752,7 @@ class TestMergeBoundaryPairs:
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_single_region_no_merge(self, mock_classify):
-        """Single region → no merge processing, returned as-is."""
+        """Single region -> no merge processing, returned as-is."""
         mock_classify.return_value = "match_boundary"
         regions = [(100.0, 105.0)]
         result, cls = filter_blackouts_with_scorebar(
@@ -769,7 +769,7 @@ class TestHasScorebarBoundaries:
     """Additional boundary tests for _has_scorebar thresholds."""
 
     def test_brightness_just_below_140(self):
-        """ROI brightness just below 140 with color variation → True."""
+        """ROI brightness just below 140 with color variation -> True."""
         # Aim for ~135 brightness with high cross-section std
         raw = _make_frame(
             roi_sections=((180, 100, 100), (100, 180, 100), (100, 100, 180))
@@ -777,11 +777,11 @@ class TestHasScorebarBoundaries:
         assert _has_scorebar(raw, _HEIGHT) is True
 
     def test_brightness_at_140(self):
-        """ROI brightness at 140 → False (not strictly less than)."""
+        """ROI brightness at 140 -> False (not strictly less than)."""
         raw = _make_frame(
             roi_sections=((180, 130, 100), (130, 180, 110), (110, 100, 180))
         )
-        # brightness ~140, at boundary → False
+        # brightness ~140, at boundary -> False
         result = _has_scorebar(raw, _HEIGHT)
         # Verify the threshold is exclusive at 140
         roi_y2 = int(_HEIGHT * _SCOREBAR_ROI_Y_END)
@@ -802,7 +802,7 @@ class TestHasScorebarBoundaries:
 
 class TestMajorityScorebarEdge:
     def test_empty_list(self):
-        """Empty list → None."""
+        """Empty list -> None."""
         assert _majority_scorebar([]) is None
 
 
@@ -813,7 +813,7 @@ class TestClassifyBlackoutBoundary:
     @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_region_at_video_start(self, mock_probe, _mock_static):
-        """Region near start (0.5s) → pre timestamps clamp to 0.0."""
+        """Region near start (0.5s) -> pre timestamps clamp to 0.0."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([True], [f]),  # pre: only 1 unique timestamp after dedup
@@ -828,7 +828,7 @@ class TestClassifyBlackoutBoundary:
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_region_at_video_end(self, mock_probe):
-        """Region near end → post timestamps clamp to duration."""
+        """Region near end -> post timestamps clamp to duration."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
             ([False, False, False], [f, f, f]),  # pre
@@ -847,23 +847,23 @@ class TestClassifyBlackoutBoundary:
 
 class TestScaledHeight:
     def test_1920x1080(self):
-        """Standard 16:9 → 180 (even)."""
+        """Standard 16:9 -> 180 (even)."""
         assert _scaled_height(1920, 1080) == 180
 
     def test_1280x720(self):
-        """720p 16:9 → 180."""
+        """720p 16:9 -> 180."""
         assert _scaled_height(1280, 720) == 180
 
     def test_2560x1440(self):
-        """1440p 16:9 → 180."""
+        """1440p 16:9 -> 180."""
         assert _scaled_height(2560, 1440) == 180
 
     def test_odd_result_rounds_to_even(self):
-        """4096x2160 → round(320*2160/4096) = 169 → +1 = 170."""
+        """4096x2160 -> round(320*2160/4096) = 169 -> +1 = 170."""
         assert _scaled_height(4096, 2160) == 170
 
     def test_4_3_aspect(self):
-        """1920x1200 (16:10) → round(320*1200/1920) = 200."""
+        """1920x1200 (16:10) -> round(320*1200/1920) = 200."""
         assert _scaled_height(1920, 1200) == 200
 
     def test_result_is_always_even(self):
@@ -888,7 +888,7 @@ class TestProbeFrameRgb:
     @patch("allaganeye.video.detector.subprocess.run")
     @patch("allaganeye.video.detector.find_ffmpeg", return_value="ffmpeg")
     def test_timeout_returns_none(self, _mock_ff, mock_run):
-        """Timeout → None."""
+        """Timeout -> None."""
         from subprocess import TimeoutExpired
 
         from allaganeye.video.detector import _probe_frame_rgb
@@ -899,7 +899,7 @@ class TestProbeFrameRgb:
     @patch("allaganeye.video.detector.subprocess.run")
     @patch("allaganeye.video.detector.find_ffmpeg", return_value="ffmpeg")
     def test_incomplete_frame_returns_none(self, _mock_ff, mock_run):
-        """Incomplete stdout → None."""
+        """Incomplete stdout -> None."""
         from unittest.mock import MagicMock
 
         from allaganeye.video.detector import _probe_frame_rgb
@@ -913,7 +913,7 @@ class TestProbeFrameRgb:
     @patch("allaganeye.video.detector.subprocess.run")
     @patch("allaganeye.video.detector.find_ffmpeg", return_value="ffmpeg")
     def test_valid_frame_returns_bytes(self, _mock_ff, mock_run):
-        """Complete frame → bytes."""
+        """Complete frame -> bytes."""
         from unittest.mock import MagicMock
 
         from allaganeye.video.detector import _probe_frame_rgb
@@ -930,7 +930,7 @@ class TestProbeFrameRgb:
     @patch("allaganeye.video.detector.subprocess.run")
     @patch("allaganeye.video.detector.find_ffmpeg", return_value="ffmpeg")
     def test_nonzero_returncode_returns_none(self, _mock_ff, mock_run):
-        """ffmpeg error exit → None (not partial data)."""
+        """ffmpeg error exit -> None (not partial data)."""
         from unittest.mock import MagicMock
 
         from allaganeye.video.detector import _probe_frame_rgb
@@ -943,7 +943,7 @@ class TestProbeFrameRgb:
         assert _probe_frame_rgb(Path("v.mp4"), 10.0, _HEIGHT) is None
 
     def test_ffmpeg_not_found_raises(self):
-        """ffmpeg not found → VideoProcessingError."""
+        """ffmpeg not found -> VideoProcessingError."""
         from allaganeye.video.detector import _probe_frame_rgb
         from allaganeye.exceptions import VideoProcessingError
 
@@ -979,26 +979,26 @@ class TestIsStaticFromFrames:
         return [_make_frame(roi_color=colors[i % len(colors)]) for i in range(count)]
 
     def test_static_screen_detected(self):
-        """Identical frames → static screen detected."""
+        """Identical frames -> static screen detected."""
         frames = self._make_static_frames()
         assert _is_static_from_frames(frames, _HEIGHT) is True
 
     def test_varying_frames_not_static(self):
-        """Different frames → not static."""
+        """Different frames -> not static."""
         frames = self._make_varying_frames()
         assert _is_static_from_frames(frames, _HEIGHT) is False
 
     def test_all_frames_none(self):
-        """All frames None → not static (safe side)."""
+        """All frames None -> not static (safe side)."""
         assert _is_static_from_frames([None, None, None], _HEIGHT) is False
 
     def test_only_one_valid_frame(self):
-        """Only 1 valid frame → not static (need >=2 for comparison)."""
+        """Only 1 valid frame -> not static (need >=2 for comparison)."""
         frame = self._make_static_frames(1)[0]
         assert _is_static_from_frames([frame, None, None], _HEIGHT) is False
 
     def test_single_transition_tolerated(self):
-        """Screen changes between F1-F2 but F2-F3 static → detected (#201).
+        """Screen changes between F1-F2 but F2-F3 static -> detected (#201).
 
         With min(MADs), a single static pair is enough to detect loading
         screens even when a transition occurs within the probe window.
@@ -1006,11 +1006,11 @@ class TestIsStaticFromFrames:
         f1 = _make_frame(roi_color=(50, 100, 150))
         f2 = _make_frame(roi_color=(87, 87, 87))
         f3 = _make_frame(roi_color=(87, 87, 87))
-        # F1-F2: high MAD, F2-F3: MAD=0 → min(MADs) = 0 < 0.5 → static
+        # F1-F2: high MAD, F2-F3: MAD=0 -> min(MADs) = 0 < 0.5 -> static
         assert _is_static_from_frames([f1, f2, f3], _HEIGHT) is True
 
     def test_threshold_boundary_above(self):
-        """MAD just above threshold → not static."""
+        """MAD just above threshold -> not static."""
         f1 = _make_frame(roi_color=(87, 87, 87))
         f2 = _make_frame(roi_color=(90, 90, 90))
         assert _is_static_from_frames([f1, f2], _HEIGHT) is False
@@ -1027,7 +1027,7 @@ class TestProbeScorebarContext:
     @patch(f"{SCOREBAR_MODULE}._has_scorebar", return_value=True)
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=_FAKE_FRAME)
     def test_duplicate_timestamps_probed_once(self, mock_probe, mock_has):
-        """Duplicate timestamps should be deduplicated — probe called once."""
+        """Duplicate timestamps should be deduplicated -- probe called once."""
         results, frames = _probe_scorebar_context(
             Path("dummy.mp4"), [1.0, 1.0, 1.0], _HEIGHT, workers=1
         )
@@ -1048,7 +1048,7 @@ class TestProbeScorebarContext:
         )
         assert len(results) == len(ts)
         assert len(frames) == len(ts)
-        # Each unique ts probed exactly once (3 unique → 3 calls)
+        # Each unique ts probed exactly once (3 unique -> 3 calls)
         assert mock_probe.call_count == 3
 
     @patch(f"{SCOREBAR_MODULE}._has_scorebar", return_value=None)
@@ -1064,7 +1064,7 @@ class TestProbeScorebarContext:
     @patch(f"{SCOREBAR_MODULE}._has_scorebar")
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
     def test_mixed_success_and_failure(self, mock_probe, mock_has):
-        """Mix of successful and failed probes — results match per-ts."""
+        """Mix of successful and failed probes -- results match per-ts."""
         mock_probe.side_effect = lambda _path, t, _h: _FAKE_FRAME if t == 1.0 else None
         mock_has.side_effect = lambda raw, _h: True if raw is not None else None
 

--- a/tests/test_scorebar_regression.py
+++ b/tests/test_scorebar_regression.py
@@ -172,7 +172,7 @@ def detection_without_scorebar(
         blackout_threshold=15.0,
         min_match_duration=300.0,
         min_blackout_duration=3.0,
-        # src_resolution omitted → no scorebar filtering
+        # src_resolution omitted -> no scorebar filtering
     )
     elapsed = time.monotonic() - start
 
@@ -287,7 +287,7 @@ class TestMatchDurations:
         for i, b in enumerate(detection_with_scorebar["boundaries"]):
             dur = b["end"] - b["start"]
             assert dur <= 2400.0, (
-                f"Match {i + 1}: {dur:.0f}s (>40min) — likely merged matches"
+                f"Match {i + 1}: {dur:.0f}s (>40min) -- likely merged matches"
             )
 
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -422,7 +422,7 @@ CACHE_BOUNDARIES: list[MatchBoundary] = [
 
 class TestCacheRoundTrip:
     def test_save_and_load(self, cache_video, cache_config, tmp_path):
-        """Save → load round-trip restores boundaries."""
+        """Save -> load round-trip restores boundaries."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         _save_cache(
             cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
@@ -431,7 +431,7 @@ class TestCacheRoundTrip:
         assert result == CACHE_BOUNDARIES
 
     def test_size_mismatch(self, cache_video, cache_config, tmp_path):
-        """source_size mismatch → None."""
+        """source_size mismatch -> None."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         _save_cache(
             cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
@@ -441,7 +441,7 @@ class TestCacheRoundTrip:
         assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
 
     def test_mtime_mismatch(self, cache_video, cache_config, tmp_path):
-        """source_mtime mismatch → None."""
+        """source_mtime mismatch -> None."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         _save_cache(
             cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
@@ -453,7 +453,7 @@ class TestCacheRoundTrip:
         assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
 
     def test_param_mismatch_threshold(self, cache_video, cache_config, tmp_path):
-        """blackout_threshold mismatch → None."""
+        """blackout_threshold mismatch -> None."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         _save_cache(
             cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
@@ -464,7 +464,7 @@ class TestCacheRoundTrip:
         assert _load_cache(cache_path, cache_video, 1.0, different_config) is None
 
     def test_param_mismatch_interval(self, cache_video, cache_config, tmp_path):
-        """sample_interval mismatch → None."""
+        """sample_interval mismatch -> None."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         _save_cache(
             cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
@@ -472,7 +472,7 @@ class TestCacheRoundTrip:
         assert _load_cache(cache_path, cache_video, 2.0, cache_config) is None
 
     def test_param_mismatch_no_audio(self, cache_video, cache_config, tmp_path):
-        """no_audio mismatch → None (cache must be keyed to audio pipeline, #288)."""
+        """no_audio mismatch -> None (cache must be keyed to audio pipeline, #288)."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         _save_cache(
             cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
@@ -481,7 +481,7 @@ class TestCacheRoundTrip:
         assert _load_cache(cache_path, cache_video, 1.0, different_config) is None
 
     def test_version_mismatch(self, cache_video, cache_config, tmp_path):
-        """cache_version mismatch → None."""
+        """cache_version mismatch -> None."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         _save_cache(
             cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
@@ -492,7 +492,7 @@ class TestCacheRoundTrip:
         assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
 
     def test_path_mismatch(self, cache_video, cache_config, tmp_path):
-        """source path mismatch → None."""
+        """source path mismatch -> None."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         _save_cache(
             cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
@@ -502,12 +502,12 @@ class TestCacheRoundTrip:
         assert _load_cache(cache_path, other_video, 1.0, cache_config) is None
 
     def test_file_not_found(self, cache_video, cache_config, tmp_path):
-        """Cache file doesn't exist → None."""
+        """Cache file doesn't exist -> None."""
         cache_path = tmp_path / "nonexistent" / ".detection_cache.json"
         assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
 
     def test_corrupted_json(self, cache_video, cache_config, tmp_path):
-        """Corrupted cache file → None (no exception)."""
+        """Corrupted cache file -> None (no exception)."""
         cache_path = tmp_path / "output" / ".detection_cache.json"
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_text("not valid json{{{", encoding="utf-8")
@@ -533,7 +533,7 @@ def test_progressbar_length(mock_probe, mock_detect, mock_split, tmp_path):
         mock_bar.return_value.update = lambda n: None
         run_split(Path("input.mp4"), config)
 
-    # interval=1.0 for 1800s → estimated_samples = 1800
+    # interval=1.0 for 1800s -> estimated_samples = 1800
     mock_bar.assert_called_once()
     assert mock_bar.call_args[1]["length"] == 1800
 
@@ -620,7 +620,7 @@ class TestCachePipeline:
     def test_param_change_triggers_redetect(
         self, mock_probe, mock_detect, mock_split, tmp_path
     ):
-        """Changed parameters invalidate cache → re-detect."""
+        """Changed parameters invalidate cache -> re-detect."""
         video = tmp_path / "input.mp4"
         video.write_bytes(b"\x00" * 512)
         mock_probe.return_value = PROBE_RESULT


### PR DESCRIPTION
## Summary

- production code (7ファイル) と test code (10ファイル) の非ASCII文字を ASCII 代替に一括置換
- `coding-conventions.md` に文字エンコーディングルールを追記し再発防止

### 置換ルール

| 非ASCII | ASCII | 箇所数 |
|---|---|---|
| `→` (U+2192) | `->` | ~50 |
| `—` (U+2014) | `--` | ~15 |
| `≈` (U+2248) | `~=` | ~5 |
| `≥` (U+2265) | `>=` | ~2 |
| `±` (U+00B1) | `+-` | ~5 |
| `₁` `₂` | `1` `2` | 2 |
| `✓` | `OK` | 1 |

Related: #308

## Checklist

- [x] 全テスト通過（`pytest` -- 405 passed）
- [x] Lint 通過（`ruff check .`）
- [x] 型チェック通過（`pyright`）
- [x] 関連ドキュメント更新: coding-conventions.md
- [x] CLAUDE.md の更新: 不要

[engineer-2]
