### PR TITLE
fix: check_cache_impact.py の git エラー握り潰しを修正 #300

### DIFF
--- a/tests/check_cache_impact.py
+++ b/tests/check_cache_impact.py
@@ -11,22 +11,33 @@ import sys
 from tests.detection_cache import _CACHE_SENSITIVE_FILES
 
 
+def _run_git(*args: str) -> str:
+    """Run a git command and return stdout.
+
+    Raises SystemExit with stderr message if git fails.
+    """
+    cmd = ["git", *args]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        print(f"ERROR: git command failed: {' '.join(cmd)}", file=sys.stderr)
+        if stderr:
+            print(f"  {stderr}", file=sys.stderr)
+        raise SystemExit(2)
+    return result.stdout
+
+
 def _get_changed_files(*, all_changes: bool = False) -> list[str]:
     """Return changed file paths relative to repo root."""
     if all_changes:
         # Staged + unstaged
-        cmd_staged = ["git", "diff", "--cached", "--name-only"]
-        cmd_unstaged = ["git", "diff", "--name-only"]
-        staged = subprocess.run(cmd_staged, capture_output=True, text=True, check=False)
-        unstaged = subprocess.run(
-            cmd_unstaged, capture_output=True, text=True, check=False
-        )
-        files = set(staged.stdout.splitlines()) | set(unstaged.stdout.splitlines())
+        staged_out = _run_git("diff", "--cached", "--name-only")
+        unstaged_out = _run_git("diff", "--name-only")
+        files = set(staged_out.splitlines()) | set(unstaged_out.splitlines())
         return [f.strip() for f in files if f.strip()]
 
-    cmd = ["git", "diff", "--cached", "--name-only"]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    return [f.strip() for f in result.stdout.splitlines() if f.strip()]
+    out = _run_git("diff", "--cached", "--name-only")
+    return [f.strip() for f in out.splitlines() if f.strip()]
 
 
 def _check_impact(changed_files: list[str]) -> list[str]:

--- a/tests/test_check_cache_impact.py
+++ b/tests/test_check_cache_impact.py
@@ -1,0 +1,74 @@
+"""Tests for tests/check_cache_impact.py -- git error handling (#300)."""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from tests.check_cache_impact import _get_changed_files, _run_git
+
+
+class TestRunGit:
+    """_run_git raises SystemExit on non-zero returncode."""
+
+    def test_success_returns_stdout(self) -> None:
+        """Normal git output -> returned as string."""
+        fake = subprocess.CompletedProcess(
+            args=["git", "status"], returncode=0, stdout="ok\n", stderr=""
+        )
+        with patch("tests.check_cache_impact.subprocess.run", return_value=fake):
+            assert _run_git("status") == "ok\n"
+
+    def test_nonzero_returncode_raises_system_exit(self) -> None:
+        """Non-zero returncode -> SystemExit(2)."""
+        fake = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: not a git repository",
+        )
+        with patch("tests.check_cache_impact.subprocess.run", return_value=fake):
+            with pytest.raises(SystemExit, match="2"):
+                _run_git("diff", "--cached", "--name-only")
+
+    def test_nonzero_stderr_printed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """stderr from git is printed to stderr."""
+        fake = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=1,
+            stdout="",
+            stderr="fatal: bad revision",
+        )
+        with patch("tests.check_cache_impact.subprocess.run", return_value=fake):
+            with pytest.raises(SystemExit):
+                _run_git("diff")
+        captured = capsys.readouterr()
+        assert "fatal: bad revision" in captured.err
+
+
+class TestGetChangedFiles:
+    """_get_changed_files propagates git failures."""
+
+    def test_git_failure_propagates(self) -> None:
+        """Git failure in _get_changed_files -> SystemExit."""
+        fake = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: not a git repository",
+        )
+        with patch("tests.check_cache_impact.subprocess.run", return_value=fake):
+            with pytest.raises(SystemExit):
+                _get_changed_files()
+
+    def test_success_returns_files(self) -> None:
+        """Normal output -> list of file paths."""
+        fake = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=0,
+            stdout="file_a.py\nfile_b.py\n",
+            stderr="",
+        )
+        with patch("tests.check_cache_impact.subprocess.run", return_value=fake):
+            result = _get_changed_files()
+        assert result == ["file_a.py", "file_b.py"]


### PR DESCRIPTION
## Summary

- `_run_git` ヘルパーを導入し、git コマンドの `returncode` を検証
- 非 0 の場合は stderr を表示して `SystemExit(2)` で終了
- テスト追加: `tests/test_check_cache_impact.py` (5 tests)

Related: #300

## Checklist

- [x] 全テスト通過（`pytest` -- 410 passed）
- [x] Lint 通過（`ruff check .`）
- [x] 型チェック通過（`pyright`）
- [x] 関連ドキュメント更新: 不要
- [x] CLAUDE.md の更新: 不要

[engineer-2]
