### PR TITLE
feat: GC紋章3点AND検出でscorebar FPを構造的に排除 #307

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 - **ffmpeg / ffprobe**: 4.1 以上。PATH、`ALLAGANEYE_FFMPEG` 環境変数、または OS 別既知パスから自動検索（`allaganeye/ffmpeg_path.py`）
   - Windows: winget (`Gyan.FFmpeg`) のインストール先を自動検索
   - macOS: Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`) を自動検索
-- **Python パッケージ**: numpy, typer（opencv-python は L1 では不要。L3 以降で使用予定）
+- **Python パッケージ**: numpy, typer, scipy, opencv-python-headless（scorebar V2 検出で使用 #307）
 - **対応プラットフォーム**: Windows のみ（実動画での動作確認済み）。Linux・macOS は未検証（CI では lint/型チェックのみ ubuntu で実行）
 
 ### 動画サンプルデータ

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -455,6 +455,174 @@ to detect chrominance-only boundaries (same luminance, different hue).
 """
 
 
+# ---------------------------------------------------------------------------
+# V2 Scorebar Detection: GC-Emblem 3-point AND (#307)
+# ---------------------------------------------------------------------------
+
+_SCOREBAR_V2_PROBE_WIDTH = 1920
+"""Probe width for V2 scorebar detection.
+
+GC emblem positions are defined at 1920x1080.  At lower resolutions the
+emblem regions are too small (3-6 px at 320x180) for meaningful feature
+extraction.
+"""
+
+_SCOREBAR_V2_PROBE_HEIGHT = 1080
+"""Probe height for V2 scorebar detection (16:9 at 1920 width)."""
+
+# GC emblem detection positions at 1920x1080 (absolute pixel coordinates).
+# Each tuple: (name, x1, y1, x2, y2).
+# Validated on 5 recordings (0408/0209/0116/0118/0119), N=156+ non-match
+# frames with zero FP.
+_EMBLEM_POSITIONS: list[tuple[str, int, int, int, int]] = [
+    ("left", 600, 2, 665, 40),
+    ("center", 828, 22, 862, 42),
+    ("right", 1263, 2, 1318, 40),
+]
+
+_EMBLEM_SAT_THRESHOLD = 70.0
+"""Minimum mean HSV saturation (of bright pixels) at each emblem position.
+
+GC emblems show high saturation (typically 100-220 in-match).  Lobby
+backgrounds at emblem positions show median saturation of 66-79, with
+occasional peaks up to 179 at individual positions -- but never all 3
+positions simultaneously exceeding the threshold.
+Validated: 5 recordings, 156+ non-match frames, zero 3-position FP.
+"""
+
+_EMBLEM_EDGE_THRESHOLD = 40.0
+"""Minimum Sobel edge density at each emblem position.
+
+GC emblem icons have complex internal structure producing high edge
+density (typically 60-200 in-match).  Lobby backgrounds at emblem
+positions show median edge density of 25-40.  Even individual positions
+exceeding the threshold (max 225) do not cause FP due to the 3-point
+AND condition.
+Validated: 5 recordings, 156+ non-match frames, zero 3-position FP.
+"""
+
+# Method selector: "v2" (GC-emblem 3-point AND) or "v1" (channel-std).
+_SCOREBAR_METHOD: str = "v2"
+
+
+def _probe_frame_rgb_hires(video_path: Path, timestamp: float) -> bytes | None:
+    """Probe a single frame at 1920x1080 for V2 scorebar detection.
+
+    Similar to ``_probe_frame_rgb`` but uses fixed 1920x1080 resolution
+    instead of the low-resolution 320x180.  Used only during the scorebar
+    classification phase, not for pass-1/pass-2 blackout detection.
+    """
+    width = _SCOREBAR_V2_PROBE_WIDTH
+    height = _SCOREBAR_V2_PROBE_HEIGHT
+    rgb_size = width * height * 3
+    cmd = [
+        find_ffmpeg(),
+        "-threads",
+        "1",
+        "-ss",
+        str(timestamp),
+        "-i",
+        str(video_path),
+        "-frames:v",
+        "1",
+        "-vf",
+        f"scale={width}:{height},format=rgb24",
+        "-f",
+        "rawvideo",
+        "pipe:1",
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+    except FileNotFoundError as e:
+        raise VideoProcessingError(
+            "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
+        ) from e
+    except subprocess.TimeoutExpired:
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    if len(result.stdout) < rgb_size:
+        return None
+
+    return result.stdout[:rgb_size]
+
+
+def _has_scorebar_v2(raw_rgb: bytes | None) -> bool | None:
+    """Determine if FL scorebar is present using GC-emblem 3-point AND.
+
+    Checks 3 fixed positions in the scorebar where GC emblems appear
+    (left/center/right).  At each position, computes HSV saturation and
+    Sobel edge density.  Returns True only if ALL 3 positions exceed
+    both thresholds (AND condition).
+
+    This exploits the structural invariant that FL scorebar always has
+    3 GC emblems at fixed positions, while lobby backgrounds never have
+    high-saturation + high-edge-density content at all 3 positions
+    simultaneously.
+
+    Requires 1920x1080 input (see ``_probe_frame_rgb_hires``).
+
+    Returns True if scorebar detected, False if not, or None if probe
+    failed (raw_rgb is None).
+
+    Validated on 5 recordings (0408/0209/0116/0118/0119):
+    - 156+ non-match frames: zero FP
+    - In-match TPR: 98.7% (FN only on UI-hidden transition frames)
+    """
+    if raw_rgb is None:
+        return None
+
+    try:
+        import cv2
+    except ImportError:
+        logger.warning(
+            "opencv-python-headless not installed; "
+            "falling back to V1 scorebar detection"
+        )
+        return None
+
+    width = _SCOREBAR_V2_PROBE_WIDTH
+    height = _SCOREBAR_V2_PROBE_HEIGHT
+    frame = np.frombuffer(raw_rgb, dtype=np.uint8).reshape(height, width, 3)
+
+    for name, x1, y1, x2, y2 in _EMBLEM_POSITIONS:
+        region = frame[y1:y2, x1:x2, :]
+        bgr = cv2.cvtColor(region, cv2.COLOR_RGB2BGR)
+        hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+        gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+
+        # Saturation of bright pixels (exclude very dark pixels)
+        val = hsv[:, :, 2].astype(np.float32)
+        sat = hsv[:, :, 1].astype(np.float32)
+        bright_mask = val > 30
+        if bright_mask.sum() > 5:
+            mean_sat = float(sat[bright_mask].mean())
+        else:
+            mean_sat = 0.0
+
+        # Edge density (Sobel magnitude)
+        sobel_x = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
+        sobel_y = cv2.Sobel(gray, cv2.CV_64F, 0, 1, ksize=3)
+        edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
+
+        if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
+            logger.debug(
+                "scorebar_v2: %s sat=%.1f edge=%.1f -> fail (th: sat>%.0f edge>%.0f)",
+                name,
+                mean_sat,
+                edge_density,
+                _EMBLEM_SAT_THRESHOLD,
+                _EMBLEM_EDGE_THRESHOLD,
+            )
+            return False
+
+    logger.debug("scorebar_v2: all 3 positions passed -> True")
+    return True
+
+
 def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:
     """Determine if FL scorebar is present in the frame.
 

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from math import ceil
 from pathlib import Path
 
@@ -12,12 +12,15 @@ from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
+    _SCOREBAR_METHOD,
     _SCOREBAR_ROI_X_END,
     _SCOREBAR_ROI_X_START,
     _SCOREBAR_ROI_Y_END,
     _SCOREBAR_ROI_Y_START,
     _has_scorebar,
+    _has_scorebar_v2,
     _probe_frame_rgb,
+    _probe_frame_rgb_hires,
     _resolve_workers,
 )
 
@@ -34,27 +37,73 @@ def _probe_scorebar_context(
 
     Returns a tuple of two lists aligned with *timestamps*:
     - scorebar results: True/False/None per frame
-    - raw RGB frame bytes: bytes/None per frame
+    - raw RGB frame bytes: bytes/None per frame (low-res for static detection)
+
+    When ``_SCOREBAR_METHOD == "v2"``, probes at 1920x1080 for GC-emblem
+    3-point AND detection.  V2 False is used as-is (no V1 fallback) to
+    avoid V1 FP on lobby backgrounds that would prevent correct merge
+    of match_boundary pairs.  V2 FN on UI-hidden in-match frames is
+    acceptable because ``classify_blackout``'s 3-frame majority vote
+    and downstream merge logic handle isolated false negatives.
 
     Duplicate timestamps are probed only once; results are shared.
     """
     max_workers = _resolve_workers(workers)
+    use_v2 = _SCOREBAR_METHOD == "v2"
     unique_ts = sorted(set(timestamps))
     scorebar_results: dict[float, bool | None] = {}
     raw_frames: dict[float, bytes | None] = {}
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futures = {
+        # Always probe low-res for static screen detection (classify_blackout)
+        lo_futures = {
             pool.submit(_probe_frame_rgb, video_path, t, height): t for t in unique_ts
         }
-        for future in as_completed(futures):
-            t = futures[future]
+        # V2: also probe high-res for emblem detection
+        hi_futures: dict[Future[bytes | None], float] = {}
+        if use_v2:
+            hi_futures = {
+                pool.submit(_probe_frame_rgb_hires, video_path, t): t for t in unique_ts
+            }
+
+        # Collect low-res results
+        for future in as_completed(lo_futures):
+            t = lo_futures[future]
             try:
                 raw = future.result()
             except VideoProcessingError:
                 raw = None
             raw_frames[t] = raw
-            scorebar_results[t] = _has_scorebar(raw, height)
+
+        # Collect high-res results and run V2 detection
+        hi_raws: dict[float, bytes | None] = {}
+        if use_v2:
+            for future in as_completed(hi_futures):
+                t = hi_futures[future]
+                try:
+                    raw = future.result()
+                except VideoProcessingError:
+                    raw = None
+                hi_raws[t] = raw
+
+        # Determine scorebar results.
+        # V2 True -> True (high specificity, eliminates lobby FP).
+        # V2 False -> False (V1 fallback disabled: V1 has FP on lobby
+        #   backgrounds that prevent correct merge of match_boundary
+        #   pairs; V2 FN on UI-hidden in-match frames is acceptable
+        #   because classify_blackout's 3-frame majority vote and
+        #   downstream merge logic handle isolated FN).
+        # V2 None -> V1 (opencv not installed).
+        for t in unique_ts:
+            if use_v2:
+                v2_result = _has_scorebar_v2(hi_raws.get(t))
+                if v2_result is not None:
+                    scorebar_results[t] = v2_result
+                else:
+                    # V2 failed (e.g. no opencv) -> use V1
+                    scorebar_results[t] = _has_scorebar(raw_frames[t], height)
+            else:
+                scorebar_results[t] = _has_scorebar(raw_frames[t], height)
 
     return (
         [scorebar_results[t] for t in timestamps],
@@ -266,19 +315,16 @@ def classify_blackout(
     return classification
 
 
-_MERGE_GAP_MAX = 600.0
+_MERGE_GAP_MAX: float | None = None
 """Maximum gap (seconds) between consecutive match_boundary regions to merge.
 
-FL match transitions often produce two blackouts separated by a non-FL
-segment (result screen, lobby, queue).  When the gap is short and has no
-scorebar at any of 9 probe points, the two boundaries are merged into
-one spanning the full transition.
-
-Measured gap durations (non-FL content between FL matches):
-- Result screen: 83-266s (1.4-4.4min)
-- Lobby/queue: 232-468s (3.9-7.8min)
-600s (10min) covers observed lobby gaps with margin.  9-point scorebar
-probes guard against merging real FL match content.
+``None`` means no limit -- any gap is eligible for merge as long as all
+9 probe points show no scorebar.  This is safe because V2 scorebar
+detection (GC-emblem 3-point AND at 1080p) reliably detects in-match
+frames: an FL match is 15-20 minutes, so at least 2-3 of 9 evenly
+spaced probes would detect scorebar within a match, preventing false
+merges.  Lobby/queue waits can exceed 1 hour during off-peak, so a
+fixed upper bound would miss legitimate merge opportunities.
 """
 
 
@@ -405,7 +451,7 @@ def _merge_boundary_pairs(
             and classifications[i + 1] == "match_boundary"
         ):
             gap = regions[i + 1][0] - regions[i][1]
-            if gap <= _MERGE_GAP_MAX:
+            if _MERGE_GAP_MAX is None or gap <= _MERGE_GAP_MAX:
                 # Probe 9 points evenly across the gap to reliably
                 # detect FL match content (scorebar intermittently visible)
                 gap_start = regions[i][1]
@@ -414,7 +460,10 @@ def _merge_boundary_pairs(
                     gap_start + (gap_end - gap_start) * k / 10 for k in range(1, 10)
                 ]
                 probe_results, _ = _probe_scorebar_context(
-                    video_path, probe_points, height, workers
+                    video_path,
+                    probe_points,
+                    height,
+                    workers,
                 )
                 all_valid = all(r is not None for r in probe_results)
                 any_scorebar = any(r is True for r in probe_results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "typer>=0.9",
     "numpy>=1.24",
     "scipy>=1.11",
+    "opencv-python-headless>=4.8",
 ]
 
 [project.scripts]

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -17,7 +17,6 @@ from allaganeye.video.detector import (
     _scaled_height,
 )
 from allaganeye.video.scorebar import (
-    _MERGE_GAP_MAX,
     _is_static_from_frames,
     _majority_scorebar,
     _probe_scorebar_context,
@@ -663,18 +662,6 @@ class TestMergeBoundaryPairs:
         assert result == regions
         assert cls == ["match_boundary", "match_boundary"]
 
-    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
-    def test_no_merge_when_gap_exceeds_max(self, mock_classify):
-        """Gap > _MERGE_GAP_MAX -> no merge attempt."""
-        mock_classify.side_effect = ["match_boundary", "match_boundary"]
-        gap = _MERGE_GAP_MAX + 100
-        regions = [(100.0, 105.0), (105.0 + gap, 110.0 + gap)]
-        result, cls = filter_blackouts_with_scorebar(
-            Path("v.mp4"), regions, 10000.0, _HEIGHT
-        )
-        assert result == regions
-        assert cls == ["match_boundary", "match_boundary"]
-
     @patch(f"{SCOREBAR_MODULE}._has_scorebar")
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
@@ -735,13 +722,24 @@ class TestMergeBoundaryPairs:
     @patch(f"{SCOREBAR_MODULE}._has_scorebar")
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
-    def test_no_merge_gap_just_over_600s(
+    def test_no_merge_when_scorebar_detected_in_gap(
         self, mock_classify, mock_probe_rgb, mock_has_sb
     ):
-        """Gap 600.1s (> _MERGE_GAP_MAX) -> no merge."""
+        """Scorebar detected in gap -> no merge (real match content)."""
         mock_classify.side_effect = ["match_boundary", "match_boundary"]
         mock_probe_rgb.return_value = b"\x00" * 100
-        mock_has_sb.return_value = False
+        # One of the gap probes detects scorebar -> no merge
+        mock_has_sb.side_effect = [
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ]
 
         regions = [(100.0, 105.0), (705.1, 710.0)]  # gap = 600.1
         result, cls = filter_blackouts_with_scorebar(

--- a/tests/test_scorebar_v2.py
+++ b/tests/test_scorebar_v2.py
@@ -1,0 +1,347 @@
+"""Tests for V2 scorebar detection: GC-emblem 3-point AND (#307).
+
+Covers:
+- ``_has_scorebar_v2``: per-emblem AND classification (sat + edge thresholds)
+- ``_probe_frame_rgb_hires``: 1080p ffmpeg probe error paths
+- ``_probe_scorebar_context`` V2 integration:
+  - V2 True path
+  - V2 False path (no V1 fallback)
+  - V2 None -> V1 fallback (opencv unavailable / probe failure)
+- ``_MERGE_GAP_MAX = None``: very large gaps (e.g. >1hr) eligible for merge
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from allaganeye.video.detector import (
+    _EMBLEM_EDGE_THRESHOLD,
+    _EMBLEM_POSITIONS,
+    _EMBLEM_SAT_THRESHOLD,
+    _SCOREBAR_V2_PROBE_HEIGHT,
+    _SCOREBAR_V2_PROBE_WIDTH,
+    _has_scorebar_v2,
+    _probe_frame_rgb_hires,
+)
+from allaganeye.video.scorebar import (
+    _probe_scorebar_context,
+    filter_blackouts_with_scorebar,
+)
+
+SCOREBAR_MODULE = "allaganeye.video.scorebar"
+DETECTOR_MODULE = "allaganeye.video.detector"
+
+
+def _empty_hires_frame() -> bytes:
+    """Return a 1920x1080 all-zero RGB24 frame (sat=0, edge=0)."""
+    return bytes(_SCOREBAR_V2_PROBE_WIDTH * _SCOREBAR_V2_PROBE_HEIGHT * 3)
+
+
+def _make_hires_frame_with_emblems(
+    emblem_color: tuple[int, int, int] = (200, 30, 30),
+    use_emblems: tuple[bool, bool, bool] = (True, True, True),
+    bg_color: tuple[int, int, int] = (40, 40, 40),
+) -> bytes:
+    """Build a 1920x1080 RGB frame with optional per-emblem high-feature regions.
+
+    Each "emblem" is filled with vertical stripes alternating the chosen
+    color and black.  This produces high HSV saturation (on the colored
+    pixels) AND high Sobel edge density (vertical stripes give strong
+    horizontal gradients without canceling out, unlike a checkerboard
+    pattern which sums to zero with a 3x3 Sobel kernel).
+    Bytes layout matches what ``_probe_frame_rgb_hires`` would produce:
+    row-major RGB24.
+    """
+    width = _SCOREBAR_V2_PROBE_WIDTH
+    height = _SCOREBAR_V2_PROBE_HEIGHT
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    frame[:, :, 0] = bg_color[0]
+    frame[:, :, 1] = bg_color[1]
+    frame[:, :, 2] = bg_color[2]
+
+    for (_, x1, y1, x2, y2), enable in zip(_EMBLEM_POSITIONS, use_emblems, strict=True):
+        if not enable:
+            continue
+        region = frame[y1:y2, x1:x2, :]
+        # 2-pixel-wide vertical stripes alternating bright color and black.
+        # Single-pixel stripes would alias against the 3x3 Sobel kernel
+        # (left/right neighbors carry the same value -> gradient cancels);
+        # 2-pixel stripes guarantee strong horizontal gradients.
+        for col in range(region.shape[1]):
+            block = (col // 2) % 2
+            if block == 0:
+                region[:, col, 0] = emblem_color[0]
+                region[:, col, 1] = emblem_color[1]
+                region[:, col, 2] = emblem_color[2]
+            else:
+                region[:, col, :] = 0
+
+    return frame.tobytes()
+
+
+# ---------------------------------------------------------------------------
+# _has_scorebar_v2
+# ---------------------------------------------------------------------------
+
+
+class TestHasScorebarV2:
+    def test_none_input_returns_none(self):
+        """Probe failure (None) -> None passthrough."""
+        assert _has_scorebar_v2(None) is None
+
+    def test_empty_frame_returns_false(self):
+        """All-zero frame -> 0 sat, 0 edge -> False (first emblem fails)."""
+        assert _has_scorebar_v2(_empty_hires_frame()) is False
+
+    def test_all_three_emblems_present_returns_true(self):
+        """All 3 emblems with high sat + high edge -> True."""
+        frame = _make_hires_frame_with_emblems(use_emblems=(True, True, True))
+        assert _has_scorebar_v2(frame) is True
+
+    def test_only_left_emblem_returns_false(self):
+        """Only left emblem -> AND fails on center -> False."""
+        frame = _make_hires_frame_with_emblems(use_emblems=(True, False, False))
+        assert _has_scorebar_v2(frame) is False
+
+    def test_only_two_emblems_returns_false(self):
+        """Two of three emblems -> AND fails -> False (3-point AND condition)."""
+        frame = _make_hires_frame_with_emblems(use_emblems=(True, True, False))
+        assert _has_scorebar_v2(frame) is False
+
+    def test_missing_center_emblem_returns_false(self):
+        """Center emblem missing -> False (AND requires all 3)."""
+        frame = _make_hires_frame_with_emblems(use_emblems=(True, False, True))
+        assert _has_scorebar_v2(frame) is False
+
+    def test_low_saturation_returns_false(self):
+        """Gray emblems (low saturation) -> False even with edges."""
+        # Gray checkerboard has high edges but zero saturation.
+        frame = _make_hires_frame_with_emblems(
+            emblem_color=(128, 128, 128), use_emblems=(True, True, True)
+        )
+        assert _has_scorebar_v2(frame) is False
+
+    def test_opencv_unavailable_returns_none(self):
+        """ImportError on cv2 -> None (lets caller fall back to V1)."""
+        # Force ImportError inside the function by removing cv2 from sys.modules
+        # and inserting a guard that raises on import.
+        import builtins
+        import sys
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "cv2":
+                raise ImportError("simulated missing cv2")
+            return real_import(name, *args, **kwargs)
+
+        saved = sys.modules.pop("cv2", None)
+        try:
+            with patch("builtins.__import__", side_effect=fake_import):
+                result = _has_scorebar_v2(_empty_hires_frame())
+            assert result is None
+        finally:
+            if saved is not None:
+                sys.modules["cv2"] = saved
+
+    def test_thresholds_are_documented_constants(self):
+        """Sanity: thresholds exist and match documented validation."""
+        # Saturation threshold derived from validation against lobby
+        # backgrounds (median 66-79) -- should sit at 70.
+        assert _EMBLEM_SAT_THRESHOLD == 70.0
+        assert _EMBLEM_EDGE_THRESHOLD == 40.0
+
+
+# ---------------------------------------------------------------------------
+# _probe_frame_rgb_hires
+# ---------------------------------------------------------------------------
+
+
+class TestProbeFrameRgbHires:
+    @patch(f"{DETECTOR_MODULE}.subprocess.run")
+    @patch(f"{DETECTOR_MODULE}.find_ffmpeg", return_value="ffmpeg")
+    def test_valid_frame_returns_bytes(self, _mock_ff, mock_run):
+        """Complete 1080p frame -> bytes of expected size."""
+        rgb_size = _SCOREBAR_V2_PROBE_WIDTH * _SCOREBAR_V2_PROBE_HEIGHT * 3
+        result = MagicMock(returncode=0, stdout=b"\xab" * rgb_size)
+        mock_run.return_value = result
+        out = _probe_frame_rgb_hires(Path("v.mp4"), 10.0)
+        assert out is not None
+        assert len(out) == rgb_size
+
+    @patch(f"{DETECTOR_MODULE}.subprocess.run")
+    @patch(f"{DETECTOR_MODULE}.find_ffmpeg", return_value="ffmpeg")
+    def test_timeout_returns_none(self, _mock_ff, mock_run):
+        """TimeoutExpired -> None (graceful)."""
+        from subprocess import TimeoutExpired
+
+        mock_run.side_effect = TimeoutExpired(cmd="ffmpeg", timeout=30)
+        assert _probe_frame_rgb_hires(Path("v.mp4"), 10.0) is None
+
+    @patch(f"{DETECTOR_MODULE}.subprocess.run")
+    @patch(f"{DETECTOR_MODULE}.find_ffmpeg", return_value="ffmpeg")
+    def test_nonzero_returncode_returns_none(self, _mock_ff, mock_run):
+        """ffmpeg error exit -> None."""
+        result = MagicMock(returncode=1, stdout=b"")
+        mock_run.return_value = result
+        assert _probe_frame_rgb_hires(Path("v.mp4"), 10.0) is None
+
+    @patch(f"{DETECTOR_MODULE}.subprocess.run")
+    @patch(f"{DETECTOR_MODULE}.find_ffmpeg", return_value="ffmpeg")
+    def test_incomplete_frame_returns_none(self, _mock_ff, mock_run):
+        """stdout shorter than expected RGB size -> None."""
+        result = MagicMock(returncode=0, stdout=b"\x00" * 100)
+        mock_run.return_value = result
+        assert _probe_frame_rgb_hires(Path("v.mp4"), 10.0) is None
+
+    def test_ffmpeg_not_found_raises(self):
+        """ffmpeg not found -> VideoProcessingError."""
+        from allaganeye.exceptions import VideoProcessingError
+
+        with patch(
+            f"{DETECTOR_MODULE}.subprocess.run", side_effect=FileNotFoundError()
+        ):
+            with patch(f"{DETECTOR_MODULE}.find_ffmpeg", return_value="ffmpeg"):
+                with pytest.raises(VideoProcessingError):
+                    _probe_frame_rgb_hires(Path("v.mp4"), 10.0)
+
+
+# ---------------------------------------------------------------------------
+# _probe_scorebar_context V2 integration
+# ---------------------------------------------------------------------------
+
+
+class TestProbeScorebarContextV2:
+    """V2/V1 routing in _probe_scorebar_context (#307).
+
+    Behavioral contract from the V2 PR:
+    - V2 True  -> True
+    - V2 False -> False (V1 fallback intentionally disabled)
+    - V2 None  -> V1 result (opencv missing or hi-res probe failed)
+    """
+
+    @patch(f"{SCOREBAR_MODULE}._SCOREBAR_METHOD", "v2")
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar_v2", return_value=True)
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar")
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb_hires", return_value=b"hi")
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=b"lo")
+    def test_v2_true_returns_true(self, _lo, _hi, mock_v1, _mock_v2):
+        """V2 True -> True; V1 not consulted."""
+        results, frames = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
+        assert results == [True]
+        # frames returned are LOW-RES (used for static-screen detection)
+        assert frames == [b"lo"]
+        mock_v1.assert_not_called()
+
+    @patch(f"{SCOREBAR_MODULE}._SCOREBAR_METHOD", "v2")
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar_v2", return_value=False)
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar", return_value=True)
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb_hires", return_value=b"hi")
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=b"lo")
+    def test_v2_false_returns_false_no_v1_fallback(self, _lo, _hi, mock_v1, _mock_v2):
+        """V2 False -> False; V1 NOT consulted (intentional, prevents lobby FP).
+
+        This is the key contract: even if V1 would return True on the same
+        frame, V2 False wins, because V1 has known FP on lobby backgrounds
+        that block correct merging of match_boundary pairs (PR #313 rationale).
+        """
+        results, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
+        assert results == [False]
+        mock_v1.assert_not_called()
+
+    @patch(f"{SCOREBAR_MODULE}._SCOREBAR_METHOD", "v2")
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar_v2", return_value=None)
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar", return_value=True)
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb_hires", return_value=None)
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=b"lo")
+    def test_v2_none_falls_back_to_v1(self, _lo, _hi, mock_v1, _mock_v2):
+        """V2 None (e.g. opencv missing or hi-res probe failed) -> V1 result."""
+        results, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
+        assert results == [True]
+        mock_v1.assert_called_once()
+
+    @patch(f"{SCOREBAR_MODULE}._SCOREBAR_METHOD", "v1")
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar_v2")
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar", return_value=True)
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb_hires")
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=b"lo")
+    def test_v1_method_skips_hires_probe(self, _lo, mock_hi, _mock_v1_fn, mock_v2):
+        """When METHOD=v1, no high-res probe and no V2 call."""
+        results, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
+        assert results == [True]
+        mock_hi.assert_not_called()
+        mock_v2.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _MERGE_GAP_MAX = None: no upper bound
+# ---------------------------------------------------------------------------
+
+
+class TestMergeGapNoLimit:
+    """PR #313 removed the 600s upper bound on _MERGE_GAP_MAX.
+
+    Verify gaps far larger than the old limit are now mergeable when
+    9-point probes show no scorebar.
+    """
+
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar")
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_merge_gap_one_hour(self, mock_classify, mock_probe_rgb, mock_has_sb):
+        """1 hour gap with no scorebar -> merge succeeds."""
+        mock_classify.side_effect = ["match_boundary", "match_boundary"]
+        mock_probe_rgb.return_value = b"\x00" * 100
+        mock_has_sb.return_value = False  # no scorebar across all 9 probes
+
+        # 3600s (1hr) gap -- well beyond the old 600s limit
+        regions = [(100.0, 105.0), (3705.0, 3710.0)]
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 7200.0, 180
+        )
+        assert result == [(100.0, 3710.0)]
+        assert cls == ["match_boundary"]
+
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar")
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_merge_gap_two_hours(self, mock_classify, mock_probe_rgb, mock_has_sb):
+        """2 hour gap with no scorebar -> merge still allowed (no upper bound)."""
+        mock_classify.side_effect = ["match_boundary", "match_boundary"]
+        mock_probe_rgb.return_value = b"\x00" * 100
+        mock_has_sb.return_value = False
+
+        regions = [(100.0, 105.0), (7305.0, 7310.0)]  # 7200s gap
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 14400.0, 180
+        )
+        assert result == [(100.0, 7310.0)]
+        assert cls == ["match_boundary"]
+
+    @patch(f"{SCOREBAR_MODULE}._has_scorebar")
+    @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb")
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_huge_gap_with_scorebar_not_merged(
+        self, mock_classify, mock_probe_rgb, mock_has_sb
+    ):
+        """Huge gap but scorebar detected mid-gap -> NOT merged.
+
+        Guards against the regression risk of removing the upper bound:
+        even at multi-hour gaps, the 9-point probe must still block merges
+        when an FL match is happening between the two boundaries.
+        """
+        mock_classify.side_effect = ["match_boundary", "match_boundary"]
+        mock_probe_rgb.return_value = b"\x00" * 100
+        # One mid-gap probe sees scorebar -> merge must be blocked
+        results = [False] * 9
+        results[4] = True
+        mock_has_sb.side_effect = results
+
+        regions = [(100.0, 105.0), (3705.0, 3710.0)]
+        result, cls = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 7200.0, 180
+        )
+        assert result == regions
+        assert cls == ["match_boundary", "match_boundary"]


### PR DESCRIPTION
## Summary

- `_has_scorebar` を V2 (GC-emblem 3-point AND at 1080p) に差し替え、ロビー背景の偽陽性を構造的に排除
- scorebar 分類フェーズのみ 1920x1080 でプローブ（Pass1/2 暗転検知は 320x180 のまま）
- `_MERGE_GAP_MAX` 上限を撤廃（9点 V2 プローブで安全性保証）
- `opencv-python-headless` 依存追加

## 変更内容

### `allaganeye/video/detector.py`
- `_has_scorebar_v2`: 3箇所の固定位置 (左 x=600-665, 中央 x=828-862, 右 x=1263-1318) で HSV彩度 + Sobel エッジ密度を AND 条件で判定
- `_probe_frame_rgb_hires`: 1080p プローブ関数
- `_SCOREBAR_METHOD`: V2/V1 切り替え定数（旧ロジック保持）

### `allaganeye/video/scorebar.py`
- `_probe_scorebar_context`: V2 統合（V2 True->True, V2 False->False, V2 None->V1 フォールバック）
- `_MERGE_GAP_MAX = None`: ギャップ上限撤廃。26分超のロビー待機もマージ可能に
- V1 フォールバック不採用の理由: V1 の lobby FP がマージを阻害するため

### 検証結果

| 録画 | 非試合フレーム | FP |
|---|---|---|
| 0408 | 43 | 0 |
| 0209 | 70タイムスタンプ | 0 |
| 0116 | 32 | 0 |
| 0118 | 31 | 0 |
| 0119 | 50 | 0 |

**0408**: 9->8 match
- FP gap マージ成功（M2+M3 統合）
- 26分ロビー待機のマージ成功（ユーザー確認済: 57:51 でリザルト->ロビー遷移）

## Test plan

- [x] `ruff check` / `ruff format --check` / `pyright` 全パス
- [x] `pytest` 413 テスト全パス
- [x] 0408 実動画: 9->8 match（受け入れ条件達成）
- [x] 20260116/19 実動画: match 数退行なし確認 (0116: 7->7, 0119: 9->9)
- [x] 20260118: V2 無関係の既存 Pass1/2 ギャップを issue #317 として追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)