### PR TITLE
docs: design-overview.md の外部依存表を実態に同期 #320

### DIFF
--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -136,14 +136,16 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
 
 | ツール | 用途 | 必須 | 検索方法 |
 |---|---|---|---|
-| ffmpeg 4.1+ | 動画分割・暗転検知プローブ | Yes | PATH → `ALLAGANEYE_FFMPEG` 環境変数 → OS 別既知パス（自動検索） |
+| ffmpeg 4.1+ | 動画分割・暗転検知プローブ | Yes | PATH -> `ALLAGANEYE_FFMPEG` 環境変数 -> OS 別既知パス（自動検索） |
 | ffprobe 4.1+ | 動画メタデータ取得 | Yes | 同上 |
+| typer (Python) | CLI フレームワーク | Yes | pip |
 | numpy (Python) | フレーム輝度計算 | Yes | pip |
-| OpenCV (Python) | L3 以降のフレーム解析（L1 では不使用） | No | - |
+| scipy (Python) | 音声特徴量の相互相関計算 | Yes | pip |
+| opencv-python-headless (Python) | scorebar V2 検出（GC エンブレム判定, #307） | Yes | pip |
 
 ## クロスプラットフォーム対応
 
-全モジュールが OS 非依存（subprocess + pathlib + numpy）。ffmpeg のパス検索のみ OS 別ロジックあり（`ffmpeg_path.py`）。
+全モジュールが OS 非依存（subprocess + pathlib + numpy + scipy + opencv）。ffmpeg のパス検索のみ OS 別ロジックあり（`ffmpeg_path.py`）。
 
 | 優先度 | OS | 状態 | ffmpeg 自動検索 |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

- design-overview.md の外部依存表に typer, scipy, opencv-python-headless を追加
- OpenCV の記載を「L3 以降（不使用）」から「scorebar V2 (#307) で使用中」に更新

## 要因分析

- 依存追加時（#287 scipy, #307 opencv）に design-overview.md の依存表が同期更新されなかった
- CLAUDE.md は正確に更新されていたが、design-overview.md は見落とされた
- #319 と同じ構造的問題: 同じ情報の複数箇所散在

## 調査結果

- CLAUDE.md: opencv-python-headless の記載あり -> 実態と一致。**変更不要**
- design-overview.md: scipy, typer, opencv 欠落/古い -> **修正済み**

## Checklist

- [x] 全テスト通過（`pytest` -- 434 passed）
- [x] Lint 通過（`ruff check .`）
- [x] pyproject.toml と依存表の整合性を確認済み

[engineer-2]