### PR TITLE
feat: 28分超 segment の二段スキャンで取り逃し境界を救済 #317

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -139,13 +139,27 @@ def detect_match_boundaries(
         )
 
     effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)
-    return _filter_and_extract_segments(
+    boundaries = _filter_and_extract_segments(
         refined_regions,
         duration_hint,
         min_match_duration,
         effective_min,
         classifications=region_classifications,
     )
+
+    # Re-scan suspicious long segments at finer interval (#317)
+    boundaries = _refine_long_segments(
+        boundaries,
+        video_path,
+        blackout_threshold,
+        min_match_duration,
+        min_blackout_duration,
+        src_resolution,
+        workers,
+        audio_hits,
+    )
+
+    return boundaries
 
 
 def _decode_chunk_cpu(
@@ -755,6 +769,25 @@ At interval=0.25s, a 2.0s blackout measures ~1.5-1.75s (>= 1.5 -> detected)
 while a 1.5s respawn measures ~1.0-1.25s (< 1.5 -> filtered).
 """
 
+_SUSPICIOUS_MATCH_MAX_DURATION = 28 * 60
+"""Trigger threshold for finer re-scan of long segments (#317).
+
+FL matches are typically 15-20 min, maximum 25 min.  A detected segment
+longer than 28 min strongly suggests one or more missed match boundaries
+within it.  Re-scanning at a finer sample interval can recover those
+boundaries when the coarse Pass 1 interval (auto-adjusted to 2-3s for
+long videos) misses brief 1.5-2.0s blackouts.
+"""
+
+_REFINEMENT_SAMPLE_INTERVAL = 1.0
+"""Fine-grained sample interval for segment refinement (#317).
+
+Used by ``_refine_long_segments`` when re-scanning suspicious segments.
+At 1.0s a 1.5s blackout is guaranteed to fall within at least one
+sample window.
+"""
+
+
 _BLACKOUT_PADDING = 3.0
 """Seconds to offset cut points into blackout regions.
 
@@ -1003,6 +1036,245 @@ def _filter_and_extract_segments(
                 "type": "unknown",
             }
         )
+
+    return segments
+
+
+def _refine_long_segments(
+    boundaries: list[MatchBoundary],
+    video_path: Path,
+    blackout_threshold: float,
+    min_match_duration: float,
+    min_blackout_duration: float,
+    src_resolution: tuple[int, int] | None,
+    workers: int | None,
+    audio_hits: Sequence[BgmHit] | None,
+) -> list[MatchBoundary]:
+    """Re-scan segments longer than the suspicious threshold (#317).
+
+    For each segment whose duration exceeds
+    ``_SUSPICIOUS_MATCH_MAX_DURATION``, re-runs Pass 1 at
+    ``_REFINEMENT_SAMPLE_INTERVAL`` (1.0s) within the segment range and
+    feeds the recovered blackout regions through the same scorebar
+    classification + filter pipeline.  Sub-segments produced by the
+    refinement replace the original long segment.
+
+    The refinement is **one level only**: if a refined sub-segment is
+    still longer than the threshold, it is left alone (warning logged)
+    rather than recursing.
+    """
+    if not boundaries:
+        return boundaries
+
+    suspicious_indices = [
+        i
+        for i, b in enumerate(boundaries)
+        if b["end"] - b["start"] > _SUSPICIOUS_MATCH_MAX_DURATION
+    ]
+    if not suspicious_indices:
+        return boundaries
+
+    refined = list(boundaries)
+    # Iterate in reverse so list slice replacement does not shift earlier indices
+    for idx in reversed(suspicious_indices):
+        segment = refined[idx]
+        sub_segments = _refine_one_segment(
+            segment,
+            video_path,
+            blackout_threshold,
+            min_match_duration,
+            min_blackout_duration,
+            src_resolution,
+            workers,
+            audio_hits,
+        )
+        if len(sub_segments) > 1:
+            logger.info(
+                "REFINE [%.1f-%.1f] (%.1fs): split into %d sub-segments",
+                segment["start"],
+                segment["end"],
+                segment["end"] - segment["start"],
+                len(sub_segments),
+            )
+            refined[idx : idx + 1] = sub_segments
+        else:
+            logger.warning(
+                "REFINE [%.1f-%.1f] (%.1fs): no additional boundaries found "
+                "despite exceeding %ds threshold",
+                segment["start"],
+                segment["end"],
+                segment["end"] - segment["start"],
+                _SUSPICIOUS_MATCH_MAX_DURATION,
+            )
+
+    # One-level guard: warn if any refined segment still exceeds the threshold
+    for b in refined:
+        if b["end"] - b["start"] > _SUSPICIOUS_MATCH_MAX_DURATION:
+            logger.warning(
+                "REFINE result still > %ds: [%.1f-%.1f] (%.1fs) -- "
+                "not recursing further",
+                _SUSPICIOUS_MATCH_MAX_DURATION,
+                b["start"],
+                b["end"],
+                b["end"] - b["start"],
+            )
+
+    return refined
+
+
+def _refine_one_segment(
+    segment: MatchBoundary,
+    video_path: Path,
+    blackout_threshold: float,
+    min_match_duration: float,
+    min_blackout_duration: float,
+    src_resolution: tuple[int, int] | None,
+    workers: int | None,
+    audio_hits: Sequence[BgmHit] | None,
+) -> list[MatchBoundary]:
+    """Re-scan one suspicious segment at finer interval and re-extract.
+
+    Returns a list of sub-segments that should replace the original one.
+    Returns ``[segment]`` (the original) when no additional structure is
+    found.
+    """
+    seg_start = segment["start"]
+    seg_end = segment["end"]
+
+    # Pass 1 fine: probe the segment range at _REFINEMENT_SAMPLE_INTERVAL
+    timestamps: list[float] = []
+    t = seg_start
+    while t < seg_end:
+        timestamps.append(round(t, 4))
+        t += _REFINEMENT_SAMPLE_INTERVAL
+
+    if not timestamps:
+        return [segment]
+
+    fine_results = _decode_chunk_cpu(
+        video_path,
+        timestamps,
+        seg_start,
+        seg_end,
+        _REFINEMENT_SAMPLE_INTERVAL,
+    )
+
+    blackout_times = sorted(
+        t for t, b in fine_results.items() if b < blackout_threshold
+    )
+    if not blackout_times:
+        return [segment]
+
+    blackout_regions = _group_blackout_regions(
+        blackout_times, _REFINEMENT_SAMPLE_INTERVAL
+    )
+    blackout_regions = _expand_regions_with_transitions(
+        blackout_regions,
+        fine_results,
+        _REFINEMENT_SAMPLE_INTERVAL,
+        _TRANSITION_THRESHOLD,
+    )
+
+    refined_regions = _refine_blackout_regions(
+        video_path, blackout_regions, blackout_threshold, seg_end, workers
+    )
+
+    region_classifications: list[str] | None = None
+    if src_resolution is not None and refined_regions:
+        from allaganeye.video.scorebar import filter_blackouts_with_scorebar
+
+        height = _scaled_height(src_resolution[0], src_resolution[1])
+        refined_regions, region_classifications = filter_blackouts_with_scorebar(
+            video_path,
+            refined_regions,
+            seg_end,
+            height,
+            workers,
+            audio_hits=audio_hits,
+        )
+
+    if not refined_regions:
+        return [segment]
+
+    effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)
+    sub_segments = _extract_subsegments(
+        refined_regions,
+        region_classifications,
+        seg_start,
+        seg_end,
+        min_match_duration,
+        effective_min,
+        original_type=segment.get("type", "unknown"),
+    )
+
+    return sub_segments if sub_segments else [segment]
+
+
+def _extract_subsegments(
+    blackout_regions: list[tuple[float, float]],
+    classifications: list[str] | None,
+    range_start: float,
+    range_end: float,
+    min_match_duration: float,
+    min_blackout_duration: float,
+    original_type: str = "unknown",
+) -> list[MatchBoundary]:
+    """Extract sub-segments within [range_start, range_end] (#317).
+
+    Mirrors ``_filter_and_extract_segments`` but operates on a sub-range.
+    Boundaries that lie entirely outside the range are ignored.  The
+    first and last sub-segments are anchored to ``range_start`` /
+    ``range_end`` (no leading/trailing segments are produced).
+    """
+    if classifications is not None:
+        paired = [
+            (r, c)
+            for r, c in zip(blackout_regions, classifications, strict=True)
+            if r[1] - r[0] >= min_blackout_duration
+            and r[1] >= range_start
+            and r[0] <= range_end
+        ]
+        regions = [r for r, _ in paired]
+        cls: list[str] | None = [c for _, c in paired]
+    else:
+        regions = [
+            r
+            for r in blackout_regions
+            if r[1] - r[0] >= min_blackout_duration
+            and r[1] >= range_start
+            and r[0] <= range_end
+        ]
+        cls = None
+
+    if not regions:
+        return []
+
+    # Sort regions and corresponding classifications together
+    if cls is not None:
+        order = sorted(range(len(regions)), key=lambda i: regions[i])
+        regions = [regions[i] for i in order]
+        cls = [cls[i] for i in order]
+    else:
+        regions.sort()
+
+    segments: list[MatchBoundary] = []
+    cur_start = range_start
+
+    for i, region in enumerate(regions):
+        seg_end = _padded_end(region)
+        seg_end = min(seg_end, range_end)
+        if seg_end - cur_start >= min_match_duration:
+            if cls is not None and i > 0:
+                seg_type = _infer_segment_type(cls[i - 1], cls[i])
+            else:
+                seg_type = original_type if i == 0 else "unknown"
+            segments.append({"start": cur_start, "end": seg_end, "type": seg_type})
+        cur_start = _padded_start(region)
+        cur_start = max(cur_start, range_start)
+        cur_start = min(cur_start, range_end)
+
+    if range_end - cur_start >= min_match_duration:
+        segments.append({"start": cur_start, "end": range_end, "type": original_type})
 
     return segments
 

--- a/tests/test_refinement.py
+++ b/tests/test_refinement.py
@@ -1,0 +1,306 @@
+"""Tests for two-pass long-segment refinement (#317)."""
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+from allaganeye.video.detector import (
+    MatchBoundary,
+    _REFINEMENT_SAMPLE_INTERVAL,
+    _SUSPICIOUS_MATCH_MAX_DURATION,
+    _extract_subsegments,
+    _refine_long_segments,
+    _refine_one_segment,
+)
+
+
+def _mb(start: float, end: float, type_: str = "fl_match") -> MatchBoundary:
+    """Build a MatchBoundary TypedDict for tests."""
+    return {"start": start, "end": end, "type": type_}
+
+
+# --- Constants sanity ---
+
+
+class TestConstants:
+    def test_threshold_is_28_min(self):
+        assert _SUSPICIOUS_MATCH_MAX_DURATION == 28 * 60
+
+    def test_refinement_interval_is_one_second(self):
+        assert _REFINEMENT_SAMPLE_INTERVAL == 1.0
+
+
+# --- _refine_long_segments ---
+
+
+class TestRefineLongSegments:
+    def test_no_suspicious_segments_returns_unchanged(self):
+        """All segments below threshold -> no refinement, return as-is."""
+        boundaries: list[MatchBoundary] = [
+            _mb(0.0, 1000.0),
+            _mb(1100.0, 2000.0),
+        ]
+        result = _refine_long_segments(
+            boundaries,
+            Path("test.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        assert result == boundaries
+
+    def test_empty_boundaries_returns_empty(self):
+        result = _refine_long_segments(
+            [],
+            Path("test.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        assert result == []
+
+    @patch("allaganeye.video.detector._refine_one_segment")
+    def test_long_segment_triggers_refine(self, mock_refine):
+        """Segment > 28min triggers refinement; result replaces it."""
+        original = _mb(100.0, 100.0 + 30 * 60)
+        boundaries: list[MatchBoundary] = [original]
+        mock_refine.return_value = [
+            _mb(100.0, 1100.0),
+            _mb(1300.0, 100.0 + 30 * 60),
+        ]
+        result = _refine_long_segments(
+            boundaries,
+            Path("test.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        assert len(result) == 2
+        mock_refine.assert_called_once()
+
+    @patch("allaganeye.video.detector._refine_one_segment")
+    def test_refine_returning_single_segment_keeps_original(self, mock_refine):
+        """If refinement finds no new structure, original segment is kept."""
+        original = _mb(100.0, 100.0 + 30 * 60)
+        boundaries: list[MatchBoundary] = [original]
+        mock_refine.return_value = [original]  # same single segment
+        result = _refine_long_segments(
+            boundaries,
+            Path("test.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        assert result == boundaries
+
+    @patch("allaganeye.video.detector._refine_one_segment")
+    def test_multiple_long_segments_each_refined_independently(self, mock_refine):
+        """Multiple segments above threshold are each processed once."""
+        long1 = _mb(0.0, 30 * 60)
+        short = _mb(35 * 60, 50 * 60)
+        long2 = _mb(60 * 60, 95 * 60)
+        boundaries: list[MatchBoundary] = [long1, short, long2]
+
+        def fake_refine(seg, *args, **kwargs):
+            mid = (seg["start"] + seg["end"]) / 2
+            return [
+                _mb(seg["start"], mid - 10),
+                _mb(mid + 10, seg["end"]),
+            ]
+
+        mock_refine.side_effect = fake_refine
+        result = _refine_long_segments(
+            boundaries,
+            Path("test.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        # 1 short + 2 sub-segments + 2 sub-segments = 5
+        assert len(result) == 5
+        assert result[2] == short  # untouched short segment in middle
+        assert mock_refine.call_count == 2
+
+    @patch("allaganeye.video.detector._refine_one_segment")
+    def test_no_recursion_when_refined_still_long(self, mock_refine, caplog):
+        """One-level guard: refined sub-segments still >threshold log warning,
+        no further refinement."""
+        original = _mb(0.0, 60 * 60)
+        # Refinement returns one still-long sub-segment + a normal one
+        mock_refine.return_value = [
+            _mb(0.0, 35 * 60),  # still > 28min
+            _mb(35 * 60 + 100, 60 * 60),
+        ]
+        with caplog.at_level(logging.WARNING, logger="allaganeye.video.detector"):
+            result = _refine_long_segments(
+                [original],
+                Path("test.mp4"),
+                blackout_threshold=15.0,
+                min_match_duration=300.0,
+                min_blackout_duration=1.5,
+                src_resolution=None,
+                workers=None,
+                audio_hits=None,
+            )
+        # _refine_one_segment called only once (no recursion)
+        assert mock_refine.call_count == 1
+        assert len(result) == 2
+        # Warning logged about residual long segment
+        assert any("still > " in r.message for r in caplog.records)
+
+
+# --- _refine_one_segment ---
+
+
+class TestRefineOneSegment:
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_no_blackouts_returns_original(self, mock_decode):
+        """No blackouts found in fine scan -> keep original segment."""
+        seg = _mb(100.0, 100.0 + 30 * 60)
+        mock_decode.return_value = {float(t): 200.0 for t in range(100, 100 + 30 * 60)}
+        result = _refine_one_segment(
+            seg,
+            Path("test.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        assert result == [seg]
+
+    @patch("allaganeye.video.detector._refine_blackout_regions")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_blackouts_found_split_into_subsegments(
+        self, mock_decode, mock_refine_regions
+    ):
+        """Fine scan finds blackouts -> sub-segments returned."""
+        seg = _mb(0.0, 30 * 60)
+        results = {float(t): 200.0 for t in range(0, 30 * 60)}
+        for t in (900.0, 901.0, 902.0):
+            results[t] = 3.0
+        mock_decode.return_value = results
+        mock_refine_regions.return_value = [(900.0, 902.0)]
+
+        result = _refine_one_segment(
+            seg,
+            Path("test.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        # Split into 2 sub-segments around the blackout
+        assert len(result) == 2
+        assert result[0]["start"] == 0.0
+        assert result[1]["end"] == 30 * 60
+
+
+# --- _extract_subsegments ---
+
+
+class TestExtractSubsegments:
+    def test_no_regions_returns_empty(self):
+        result = _extract_subsegments(
+            blackout_regions=[],
+            classifications=None,
+            range_start=100.0,
+            range_end=2000.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+        )
+        assert result == []
+
+    def test_one_blackout_splits_range_in_two(self):
+        result = _extract_subsegments(
+            blackout_regions=[(1000.0, 1003.0)],
+            classifications=None,
+            range_start=100.0,
+            range_end=2000.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+        )
+        assert len(result) == 2
+        assert result[0]["start"] == 100.0
+        assert result[-1]["end"] == 2000.0
+
+    def test_short_blackouts_filtered(self):
+        """Blackouts shorter than min_blackout_duration are ignored."""
+        result = _extract_subsegments(
+            blackout_regions=[(1000.0, 1000.5)],
+            classifications=None,
+            range_start=100.0,
+            range_end=2000.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+        )
+        assert result == []
+
+    def test_blackouts_outside_range_ignored(self):
+        result = _extract_subsegments(
+            blackout_regions=[(50.0, 55.0), (1000.0, 1003.0), (3000.0, 3003.0)],
+            classifications=None,
+            range_start=100.0,
+            range_end=2000.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+        )
+        assert len(result) == 2
+
+    def test_subsegments_below_min_duration_filtered(self):
+        """Sub-segments shorter than min_match_duration are dropped."""
+        result = _extract_subsegments(
+            blackout_regions=[(150.0, 153.0)],
+            classifications=None,
+            range_start=100.0,
+            range_end=2000.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+        )
+        # Leading sub-segment [100, ~150] < 300s -> filtered
+        assert len(result) == 1
+        assert result[0]["end"] == 2000.0
+
+    def test_classifications_inferred_for_inner_segments(self):
+        result = _extract_subsegments(
+            blackout_regions=[(1000.0, 1003.0)],
+            classifications=["match_boundary"],
+            range_start=100.0,
+            range_end=2000.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            original_type="fl_match",
+        )
+        assert result[0]["type"] == "fl_match"
+
+    def test_preserves_original_type_when_no_split(self):
+        """When no boundary present, segment type preserved via original_type."""
+        result = _extract_subsegments(
+            blackout_regions=[(1000.0, 1003.0)],
+            classifications=None,
+            range_start=100.0,
+            range_end=2000.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            original_type="fl_match",
+        )
+        assert result[0]["type"] == "fl_match"
+        assert result[-1]["type"] == "fl_match"

--- a/tests/test_refinement_additional.py
+++ b/tests/test_refinement_additional.py
@@ -1,0 +1,383 @@
+"""Additional tester-1 tests for two-pass long-segment refinement (#317).
+
+Complements ``tests/test_refinement.py`` (engineer-1) by covering:
+- Threshold boundary conditions (exactly-at vs. just-over 28min)
+- Log message content (info split / warning no-op)
+- ``_refine_one_segment`` scorebar path (src_resolution != None)
+- ``_refine_one_segment`` fallback when refined_regions filtered out
+- ``_extract_subsegments`` with multiple blackouts / range-boundary regions
+- ``_extract_subsegments`` classification propagation across multiple regions
+- Integration: ``detect_match_boundaries`` invokes ``_refine_long_segments``
+"""
+
+import logging
+from itertools import pairwise
+from pathlib import Path
+from unittest.mock import patch
+
+from allaganeye.video.detector import (
+    MatchBoundary,
+    _SUSPICIOUS_MATCH_MAX_DURATION,
+    _extract_subsegments,
+    _refine_long_segments,
+    _refine_one_segment,
+)
+
+DETECTOR = "allaganeye.video.detector"
+
+
+def _mb(start: float, end: float, type_: str = "fl_match") -> MatchBoundary:
+    return {"start": start, "end": end, "type": type_}
+
+
+# ---------------------------------------------------------------------------
+# Threshold boundary conditions
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdBoundary:
+    """The threshold check is strict > (see detector.py:1072).
+
+    Segments exactly at the threshold must NOT trigger refinement;
+    segments one second over must.
+    """
+
+    @patch(f"{DETECTOR}._refine_one_segment")
+    def test_exactly_at_threshold_does_not_trigger(self, mock_refine):
+        """Duration == 28*60s -- strict > means not suspicious."""
+        seg = _mb(0.0, float(_SUSPICIOUS_MATCH_MAX_DURATION))
+        result = _refine_long_segments(
+            [seg],
+            Path("t.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        assert result == [seg]
+        mock_refine.assert_not_called()
+
+    @patch(f"{DETECTOR}._refine_one_segment")
+    def test_one_second_over_triggers(self, mock_refine):
+        """Duration == 28*60 + 1s -- triggers refinement."""
+        seg = _mb(0.0, float(_SUSPICIOUS_MATCH_MAX_DURATION) + 1.0)
+        mock_refine.return_value = [seg]
+        _refine_long_segments(
+            [seg],
+            Path("t.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=None,
+            workers=None,
+            audio_hits=None,
+        )
+        mock_refine.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Log message content
+# ---------------------------------------------------------------------------
+
+
+class TestRefineLogging:
+    @patch(f"{DETECTOR}._refine_one_segment")
+    def test_info_log_on_split(self, mock_refine, caplog):
+        """Split result logs INFO 'REFINE ... split into N sub-segments'."""
+        seg = _mb(0.0, 30 * 60)
+        mock_refine.return_value = [_mb(0.0, 1000.0), _mb(1100.0, 30 * 60)]
+        with caplog.at_level(logging.INFO, logger=DETECTOR):
+            _refine_long_segments(
+                [seg],
+                Path("t.mp4"),
+                blackout_threshold=15.0,
+                min_match_duration=300.0,
+                min_blackout_duration=1.5,
+                src_resolution=None,
+                workers=None,
+                audio_hits=None,
+            )
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("split into 2 sub-segments" in m for m in msgs)
+
+    @patch(f"{DETECTOR}._refine_one_segment")
+    def test_warning_log_on_no_op(self, mock_refine, caplog):
+        """When refinement returns same single segment, WARNING is logged."""
+        seg = _mb(0.0, 30 * 60)
+        mock_refine.return_value = [seg]
+        with caplog.at_level(logging.WARNING, logger=DETECTOR):
+            _refine_long_segments(
+                [seg],
+                Path("t.mp4"),
+                blackout_threshold=15.0,
+                min_match_duration=300.0,
+                min_blackout_duration=1.5,
+                src_resolution=None,
+                workers=None,
+                audio_hits=None,
+            )
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("no additional boundaries found" in m for m in msgs)
+
+
+# ---------------------------------------------------------------------------
+# _refine_one_segment: scorebar path (src_resolution provided)
+# ---------------------------------------------------------------------------
+
+
+class TestRefineOneSegmentScorebarPath:
+    @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
+    @patch(f"{DETECTOR}._refine_blackout_regions")
+    @patch(f"{DETECTOR}._decode_chunk_cpu")
+    def test_scorebar_filter_invoked_when_src_resolution_provided(
+        self, mock_decode, mock_refine_regions, mock_filter
+    ):
+        """src_resolution != None -> filter_blackouts_with_scorebar called."""
+        seg = _mb(0.0, 30 * 60)
+        results = {float(t): 200.0 for t in range(0, 30 * 60)}
+        for t in (900.0, 901.0, 902.0):
+            results[t] = 3.0
+        mock_decode.return_value = results
+        mock_refine_regions.return_value = [(900.0, 902.0)]
+        mock_filter.return_value = ([(900.0, 902.0)], ["match_boundary"])
+
+        sub = _refine_one_segment(
+            seg,
+            Path("t.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=(1920, 1080),
+            workers=None,
+            audio_hits=None,
+        )
+        mock_filter.assert_called_once()
+        # Sub-segments created
+        assert len(sub) == 2
+
+    @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
+    @patch(f"{DETECTOR}._refine_blackout_regions")
+    @patch(f"{DETECTOR}._decode_chunk_cpu")
+    def test_scorebar_filters_out_all_regions_returns_original(
+        self, mock_decode, mock_refine_regions, mock_filter
+    ):
+        """Scorebar classifier rejects all regions -> fall back to [segment]."""
+        seg = _mb(0.0, 30 * 60)
+        results = {float(t): 200.0 for t in range(0, 30 * 60)}
+        for t in (900.0, 901.0, 902.0):
+            results[t] = 3.0
+        mock_decode.return_value = results
+        mock_refine_regions.return_value = [(900.0, 902.0)]
+        # Scorebar filter drops everything (e.g. all classified as non_fl)
+        mock_filter.return_value = ([], [])
+
+        sub = _refine_one_segment(
+            seg,
+            Path("t.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=(1920, 1080),
+            workers=None,
+            audio_hits=None,
+        )
+        assert sub == [seg]
+
+    @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
+    @patch(f"{DETECTOR}._refine_blackout_regions")
+    @patch(f"{DETECTOR}._decode_chunk_cpu")
+    def test_audio_hits_forwarded_to_scorebar_filter(
+        self, mock_decode, mock_refine_regions, mock_filter
+    ):
+        """audio_hits plumbed through to filter_blackouts_with_scorebar."""
+        seg = _mb(0.0, 30 * 60)
+        results = {float(t): 200.0 for t in range(0, 30 * 60)}
+        for t in (900.0, 901.0, 902.0):
+            results[t] = 3.0
+        mock_decode.return_value = results
+        mock_refine_regions.return_value = [(900.0, 902.0)]
+        mock_filter.return_value = ([(900.0, 902.0)], ["match_boundary"])
+
+        hits = [{"timestamp": 910.0, "similarity": 0.8}]
+        _refine_one_segment(
+            seg,
+            Path("t.mp4"),
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+            src_resolution=(1920, 1080),
+            workers=None,
+            audio_hits=hits,
+        )
+        # audio_hits passed as kwarg per detector.py:1193
+        _, kwargs = mock_filter.call_args
+        assert kwargs.get("audio_hits") == hits
+
+
+# ---------------------------------------------------------------------------
+# _extract_subsegments: uncovered cases
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSubsegmentsAdditional:
+    def test_three_blackouts_yield_four_subsegments(self):
+        """3 blackouts inside range -> 4 sub-segments."""
+        result = _extract_subsegments(
+            blackout_regions=[
+                (500.0, 503.0),
+                (1000.0, 1003.0),
+                (1500.0, 1503.0),
+            ],
+            classifications=None,
+            range_start=0.0,
+            range_end=2000.0,
+            min_match_duration=100.0,
+            min_blackout_duration=1.5,
+        )
+        assert len(result) == 4
+        assert result[0]["start"] == 0.0
+        assert result[-1]["end"] == 2000.0
+        # Strictly monotonic
+        for prev, cur in pairwise(result):
+            assert prev["end"] <= cur["start"]
+
+    def test_blackout_straddling_range_start_included(self):
+        """Region spanning [r0<range_start, r1>range_start] -> kept (r1 >= range_start)."""
+        result = _extract_subsegments(
+            blackout_regions=[(50.0, 105.0)],  # r0=50 < range_start=100, r1=105
+            classifications=None,
+            range_start=100.0,
+            range_end=2000.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+        )
+        # The region is kept; since r0=50 < range_start the leading sub-segment
+        # collapses -- only the trailing segment survives.
+        assert len(result) == 1
+        assert result[0]["end"] == 2000.0
+
+    def test_unsorted_regions_are_sorted(self):
+        """Regions passed in reverse order still yield correct sub-segments."""
+        result = _extract_subsegments(
+            blackout_regions=[(1500.0, 1503.0), (500.0, 503.0)],  # reverse order
+            classifications=None,
+            range_start=0.0,
+            range_end=2000.0,
+            min_match_duration=100.0,
+            min_blackout_duration=1.5,
+        )
+        assert len(result) == 3
+        # Middle segment spans between the two blackouts
+        assert result[0]["end"] <= result[1]["start"]
+        assert result[1]["end"] <= result[2]["start"]
+
+    def test_unsorted_regions_keep_classifications_aligned(self):
+        """Sort must move classifications alongside regions."""
+        result = _extract_subsegments(
+            blackout_regions=[(1500.0, 1503.0), (500.0, 503.0)],
+            classifications=["match_boundary", "unknown"],
+            range_start=0.0,
+            range_end=2000.0,
+            min_match_duration=100.0,
+            min_blackout_duration=1.5,
+            original_type="fl_match",
+        )
+        # 3 sub-segments: [0..500], [500..1500], [1500..2000]
+        assert len(result) == 3
+
+    def test_multiple_classifications_infer_inner_type(self):
+        """With 2 regions -> middle segment's type is inferred from both classes."""
+        result = _extract_subsegments(
+            blackout_regions=[(500.0, 503.0), (1500.0, 1503.0)],
+            classifications=["match_boundary", "match_boundary"],
+            range_start=0.0,
+            range_end=2000.0,
+            min_match_duration=100.0,
+            min_blackout_duration=1.5,
+            original_type="fl_match",
+        )
+        assert len(result) == 3
+        # Middle segment (between two match_boundary blackouts): fl_match
+        assert result[1]["type"] == "fl_match"
+
+    def test_all_regions_filtered_by_short_duration(self):
+        """All regions shorter than min_blackout -> empty result."""
+        result = _extract_subsegments(
+            blackout_regions=[(500.0, 500.5), (1500.0, 1500.5)],
+            classifications=None,
+            range_start=0.0,
+            range_end=2000.0,
+            min_match_duration=100.0,
+            min_blackout_duration=1.5,
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: detect_match_boundaries wiring
+# ---------------------------------------------------------------------------
+
+
+class TestDetectIntegration:
+    """Guard the wiring in detect_match_boundaries (#317 regression risk).
+
+    If someone refactors detect_match_boundaries and drops the call to
+    _refine_long_segments, these tests should fail immediately.
+    """
+
+    @patch(f"{DETECTOR}._refine_long_segments")
+    @patch(f"{DETECTOR}._filter_and_extract_segments")
+    @patch(f"{DETECTOR}._refine_blackout_regions")
+    @patch(f"{DETECTOR}._scan_cpu")
+    def test_refine_long_segments_called_from_detect(
+        self, mock_scan, mock_refine_regions, mock_filter, mock_refine_long
+    ):
+        """detect_match_boundaries pipes output through _refine_long_segments."""
+        from allaganeye.video.detector import detect_match_boundaries
+
+        mock_scan.return_value = {0.0: 200.0, 10.0: 200.0, 20.0: 200.0}
+        mock_refine_regions.return_value = []
+        base_boundaries = [_mb(0.0, 1800.0)]
+        mock_filter.return_value = base_boundaries
+        # Simulate refinement pass-through (no split)
+        mock_refine_long.return_value = base_boundaries
+
+        out = detect_match_boundaries(
+            Path("t.mp4"),
+            duration_hint=2000.0,
+            sample_interval=1.0,
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+        )
+        mock_refine_long.assert_called_once()
+        assert out == base_boundaries
+
+    @patch(f"{DETECTOR}._refine_long_segments")
+    @patch(f"{DETECTOR}._filter_and_extract_segments")
+    @patch(f"{DETECTOR}._refine_blackout_regions")
+    @patch(f"{DETECTOR}._scan_cpu")
+    def test_detect_returns_refinement_output(
+        self, mock_scan, mock_refine_regions, mock_filter, mock_refine_long
+    ):
+        """Split produced by _refine_long_segments propagates out."""
+        from allaganeye.video.detector import detect_match_boundaries
+
+        mock_scan.return_value = {0.0: 200.0}
+        mock_refine_regions.return_value = []
+        mock_filter.return_value = [_mb(0.0, 3000.0)]
+        # Refinement splits into 2
+        split = [_mb(0.0, 1400.0), _mb(1500.0, 3000.0)]
+        mock_refine_long.return_value = split
+
+        out = detect_match_boundaries(
+            Path("t.mp4"),
+            duration_hint=3500.0,
+            sample_interval=1.0,
+            blackout_threshold=15.0,
+            min_match_duration=300.0,
+            min_blackout_duration=1.5,
+        )
+        assert out == split

--- a/tests/test_refinement_additional.py
+++ b/tests/test_refinement_additional.py
@@ -15,6 +15,7 @@ from itertools import pairwise
 from pathlib import Path
 from unittest.mock import patch
 
+from allaganeye.audio.matcher import BgmHit
 from allaganeye.video.detector import (
     MatchBoundary,
     _SUSPICIOUS_MATCH_MAX_DURATION,
@@ -200,7 +201,7 @@ class TestRefineOneSegmentScorebarPath:
         mock_refine_regions.return_value = [(900.0, 902.0)]
         mock_filter.return_value = ([(900.0, 902.0)], ["match_boundary"])
 
-        hits = [{"timestamp": 910.0, "similarity": 0.8}]
+        hits: list[BgmHit] = [{"timestamp": 910.0, "similarity": 0.8}]
         _refine_one_segment(
             seg,
             Path("t.mp4"),


### PR DESCRIPTION
## Summary

- 長時間動画 (>2h) で sample_interval が 3.0s に auto-adjust される際に、1.5-2.0s の短い試合間暗転を Pass1 が取りこぼす問題に対応 (#317)
- 検出済 segment が **28 分** を超える場合、その範囲のみ **1.0s 間隔で再スキャン** して新規 blackout を発見、scorebar 分類経由で sub-segment に分割
- 1 レベル限定 (再帰なし)、残存長 segment は warning ログのみ

## 設計 (lead-1 採用方針 C 案)

| 定数 | 値 | 根拠 |
|---|---|---|
| `_SUSPICIOUS_MATCH_MAX_DURATION` | 28 * 60 | FL 試合典型 15-20 分、最大 25 分 + 安全マージン 3 分 |
| `_REFINEMENT_SAMPLE_INTERVAL` | 1.0 | 1.5s 暗転を 1 サンプル以上で確実に捕捉 |

## 変更内容

### `allaganeye/video/detector.py`

- `_refine_long_segments(boundaries, ...)`: トップレベルエントリ。28分超の segment を抽出して `_refine_one_segment` に委譲、結果を list の slice 置換で統合。1レベル限定の再帰防止と warning ログ
- `_refine_one_segment(segment, ...)`: 単一 segment の精密再スキャン。`_decode_chunk_cpu` で 1.0s 間隔プローブ → group/transition expand → `_refine_blackout_regions` → scorebar 分類 → `_extract_subsegments`
- `_extract_subsegments(...)`: `_filter_and_extract_segments` の sub-range 版。`[range_start, range_end]` 内のみで blackout 判定、segment 抽出
- `detect_match_boundaries`: `_filter_and_extract_segments` 直後に `_refine_long_segments` 呼出

### `tests/test_refinement.py` (新規 17 テスト)

- 定数 sanity (2)
- `_refine_long_segments`: 不発火/発火/no-op/複数 segment/1 レベル制約 (5)
- `_refine_one_segment`: 暗転なし/分割成功 (2)
- `_extract_subsegments`: 各種境界条件 (8)

## 検証結果

| 録画 | 手動 | V2 (PR#313) | V2 + refinement | 退行 |
|---|---|---|---|---|
| 0408 (2:50:29) | - | 8 | **8** | 改善維持 (refinement 不発火) |
| 0116 (2:01:43) | 7 | 7 | **7** | なし |
| 0118 (2:17:14) | 6 | 5 | **6** | **改善** (#317 解消) |
| 0119 (2:31:40) | 9 | 9 | **9** | なし |

### 0118 詳細 (本 issue 主因)

refinement ログ: `REFINE [177.2-2608.6] (2431.4s): split into 2 sub-segments`

- 元: 1 segment [02:57 - 43:28] (40.5min)
- 再スキャン発見: 1218 (M1 end), 1687 (M2 start) (各 1.5-2.0s 暗転)
- 結果: [02:57 - 20:21] (M1) + [28:06 - 43:28] (M2) ✓ 手動分割と一致

### 0408 (refinement 不発火確認)

最大 segment 17.8min、25.8min 待機 gap が segment 内にないため refinement 発火せず。誤発火なし ✓

## Test plan

- [x] `ruff check .` / `ruff format --check .` / `pyright` 全パス
- [x] `pytest -q` 451 テスト全パス (新規 17 含む)
- [x] 4 録画退行テスト: 0408=8 / 0116=7 / 0118=5->**6** / 0119=9
- [x] refinement 不発火 segment への影響なし確認

## 関連

- Issue #317
- PR #313 (V2 scorebar 検出) — V2 後の残存課題として lead-1 がスピンオフ

🤖 Generated with [Claude Code](https://claude.com/claude-code)