### PR TITLE
fix: 凍結中の音声スキャンをデフォルトで無効化 #327

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ allaganeye split <video_path> -o <output_dir>
 | `--workers` | auto | 検知の並列ワーカー数（デフォルト: 自動=CPU コア数、最大24） |
 | `--gpu` / `--no-gpu` | `--no-gpu` | GPU アクセラレーション検知（チャンク並列デコード）。GPU が利用不可の場合は CPU にフォールバック |
 | `--no-cache` | - | キャッシュを無視して再検知 |
-| `--no-audio` | - | 音声昇格（Fanfare スキャン）を無効化 |
 | `--dry-run` | - | 検知のみ実行し、分割しない |
 | `-v`, `--verbose` | - | 詳細ログ出力 |
 | `-q`, `--quiet` | - | 進捗出力を抑制（最終結果のみ） |

--- a/allaganeye/audio/__init__.py
+++ b/allaganeye/audio/__init__.py
@@ -5,6 +5,7 @@ detection.  See ``allaganeye/video/`` for visual signals and the high-level
 ``commands/split_matches.py`` for orchestration.
 
 Public API:
+    AUDIO_FROZEN -- whether the audio module is frozen (True = skip scan)
     extract_pcm -- pull mono PCM from a video via ffmpeg
     LogMelConfig / log_mel_spectrogram -- compute reference/target features
     save_features / load_features -- persist/load .npz feature files
@@ -24,6 +25,8 @@ Removal (director Q3 compliance, #284):
        it is used only inside this module (STFT and FFT convolution)
 """
 
+from typing import Final
+
 from allaganeye.audio.extract import extract_pcm
 from allaganeye.audio.features import (
     LogMelConfig,
@@ -38,7 +41,14 @@ from allaganeye.audio.matcher import (
 )
 from allaganeye.audio.scan import scan_fanfare_hits
 
+# Audio module freeze flag (#327, l1-detection-redesign.md).
+# Fanfare scan alone produces false positives (#303); the module is
+# frozen until compound-signal integration is ready.  Set to False
+# to re-enable audio promotion as the default behaviour.
+AUDIO_FROZEN: Final[bool] = True
+
 __all__ = [
+    "AUDIO_FROZEN",
     "BgmHit",
     "LogMelConfig",
     "extract_pcm",

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -79,7 +79,8 @@ def split(
         bool,
         typer.Option(
             "--no-audio",
-            help="Disable audio-based match boundary promotion (Fanfare scan)",
+            help="Disable audio-based match boundary promotion (Fanfare scan). "
+            "Currently frozen: audio scan is always skipped regardless of this flag.",
         ),
     ] = False,
     verbose: Annotated[

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -176,10 +176,17 @@ def _run_audio_scan(
 ) -> list[BgmHit] | None:
     """Scan the video for Fanfare peaks, returning hits or None.
 
-    Returns ``None`` when audio promotion is disabled (``--no-audio``) or
-    when the scan fails for a recoverable reason (missing audio track,
-    ffmpeg error).  Callers then proceed with scorebar-only filtering.
+    Returns ``None`` when audio promotion is disabled (``--no-audio``),
+    when the audio module is frozen (``AUDIO_FROZEN``), or when the scan
+    fails for a recoverable reason (missing audio track, ffmpeg error).
+    Callers then proceed with scorebar-only filtering.
     """
+    from allaganeye.audio import AUDIO_FROZEN
+
+    if AUDIO_FROZEN:
+        logger.debug("Audio module frozen (#327) -- skipping Fanfare scan")
+        return None
+
     if config.no_audio:
         return None
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -691,6 +691,53 @@ class TestAudioScanIntegration:
         assert result is None
 
     @pytest.mark.real_audio_scan
+    @patch("allaganeye.audio.scan.scan_fanfare_hits")
+    def test_run_audio_scan_frozen_does_not_call_scan_fanfare_hits(
+        self, mock_scan, tmp_path
+    ):
+        """Frozen path must short-circuit before invoking scan_fanfare_hits (#327).
+
+        This guards the performance/side-effect contract: the whole point of
+        freezing is that no ffmpeg audio extraction or correlation runs.
+        Returning None alone would not catch a bug where the scan still
+        executes but its result is discarded.
+        """
+        from allaganeye.commands.split_matches import _run_audio_scan
+
+        # AUDIO_FROZEN True (default) AND no_audio False -- scan must still skip
+        config = SplitConfig(
+            output_dir=tmp_path, min_match_duration=60.0, no_audio=False
+        )
+        result = _run_audio_scan(Path("input.mp4"), config, show=False, verbose=False)
+        assert result is None
+        mock_scan.assert_not_called()
+
+    @pytest.mark.real_audio_scan
+    def test_run_audio_scan_frozen_suppresses_progress_message(self, tmp_path, capsys):
+        """Frozen path must not print 'Scanning audio for Fanfare peaks' (#327).
+
+        The freeze check sits before the typer.echo, so show=True should still
+        produce silent output when frozen (no confusing message to the user).
+        """
+        from allaganeye.commands.split_matches import _run_audio_scan
+
+        config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+        result = _run_audio_scan(Path("input.mp4"), config, show=True, verbose=True)
+        captured = capsys.readouterr()
+        assert result is None
+        assert "Fanfare" not in captured.out
+        assert "Scanning audio" not in captured.out
+
+    def test_audio_frozen_flag_exported(self):
+        """AUDIO_FROZEN is part of the public audio API (#327)."""
+        import allaganeye.audio as audio_mod
+
+        assert hasattr(audio_mod, "AUDIO_FROZEN")
+        assert "AUDIO_FROZEN" in audio_mod.__all__
+        # Default state: frozen until compound-signal integration ships
+        assert audio_mod.AUDIO_FROZEN is True
+
+    @pytest.mark.real_audio_scan
     @patch("allaganeye.audio.AUDIO_FROZEN", False)
     def test_run_audio_scan_returns_none_when_disabled(self, tmp_path):
         """config.no_audio=True skips audio scan without invoking scan_fanfare_hits."""

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -681,6 +681,17 @@ class TestAudioScanIntegration:
         assert detect_kwargs["audio_hits"] == hits
 
     @pytest.mark.real_audio_scan
+    def test_run_audio_scan_returns_none_when_frozen(self, tmp_path):
+        """AUDIO_FROZEN=True skips scan without invoking scan_fanfare_hits (#327)."""
+        from allaganeye.commands.split_matches import _run_audio_scan
+
+        config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+        # AUDIO_FROZEN is True by default -- scan should be skipped
+        result = _run_audio_scan(Path("input.mp4"), config, show=False, verbose=False)
+        assert result is None
+
+    @pytest.mark.real_audio_scan
+    @patch("allaganeye.audio.AUDIO_FROZEN", False)
     def test_run_audio_scan_returns_none_when_disabled(self, tmp_path):
         """config.no_audio=True skips audio scan without invoking scan_fanfare_hits."""
         from allaganeye.commands.split_matches import _run_audio_scan
@@ -692,6 +703,7 @@ class TestAudioScanIntegration:
         assert result is None
 
     @pytest.mark.real_audio_scan
+    @patch("allaganeye.audio.AUDIO_FROZEN", False)
     @patch("allaganeye.audio.scan.scan_fanfare_hits")
     def test_run_audio_scan_returns_hits_on_success(self, mock_scan, tmp_path):
         """Successful scan returns hits verbatim."""
@@ -706,6 +718,7 @@ class TestAudioScanIntegration:
         mock_scan.assert_called_once()
 
     @pytest.mark.real_audio_scan
+    @patch("allaganeye.audio.AUDIO_FROZEN", False)
     @patch("allaganeye.audio.scan.scan_fanfare_hits")
     def test_run_audio_scan_falls_back_on_video_processing_error(
         self, mock_scan, tmp_path


### PR DESCRIPTION
## Summary

- `AUDIO_FROZEN: Final[bool] = True` フラグを `audio/__init__.py` に導入し、凍結期間中は Fanfare スキャンを自動スキップ
- `_run_audio_scan` で `AUDIO_FROZEN` チェック→早期 return（`config.no_audio` より優先）
- `--no-audio` CLI オプションは残すが help テキストに凍結注記を追加
- `README.md` のオプション表から `--no-audio` 行を削除（凍結中は非公開）
- テスト: frozen 状態の None 返却テスト追加、既存 real_audio_scan テストに `@patch("allaganeye.audio.AUDIO_FROZEN", False)` を追加

## Test plan

- [x] `pytest tests/test_split_matches.py` -- 43 passed
- [x] `pytest` (全テスト) -- 435 passed, 34 deselected
- [x] `ruff check .` / `ruff format --check .` -- all passed
- [x] `pyright` -- 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)