### PR TITLE
docs: --gpu デフォルト off の理由を補足 #332

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ allaganeye split <video_path> -o <output_dir>
 | `--min-match-duration` | `300.0` | 最小試合時間（秒）。短いセグメントを除外 |
 | `--min-blackout-duration` | `3.0` | 最小暗転時間（秒）。短い暗転を無視 |
 | `--workers` | auto | 検知の並列ワーカー数（デフォルト: 自動=CPU コア数、最大24） |
-| `--gpu` / `--no-gpu` | `--no-gpu` | GPU アクセラレーション検知（チャンク並列デコード）。GPU が利用不可の場合は CPU にフォールバック |
+| `--gpu` / `--no-gpu` | `--no-gpu` | GPU デコードで検知。CPU モードが十分高速なためデフォルトは off。GPU が利用不可の場合は CPU にフォールバック |
 | `--no-cache` | - | キャッシュを無視して再検知 |
 | `--no-audio` | - | 音声昇格（Fanfare スキャン）を無効化 |
 | `--dry-run` | - | 検知のみ実行し、分割しない |

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -68,6 +68,7 @@ def split(
         typer.Option(
             "--gpu/--no-gpu",
             help="Use GPU-accelerated detection (chunked parallel decode). "
+            "CPU mode is fast enough for most recordings, so GPU is off by default. "
             "Falls back to CPU if GPU is unavailable.",
         ),
     ] = False,


### PR DESCRIPTION
## Summary

- README オプション表: `--gpu` の説明に「CPU モードが十分高速なためデフォルトは off」を追記
- CLI `--gpu` ヘルプ: 同趣旨の補足を追加

## Test plan

- [x] doc のみの変更のため、lint チェック (`ruff check`) のみ実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)