### PR TITLE
feat: -V/--version short flag and verbose pipeline stats (#336 #337)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ allaganeye split <video_path> --workers 8  # ワーカー数指定
 allaganeye split <video_path> --no-cache   # キャッシュ無視で再検知
 allaganeye split <video_path> --no-audio   # 音声昇格を無効化（視覚のみ）
 allaganeye split <video_path> --quiet      # 進捗抑制（出力ファイルのみ）
+allaganeye split <video_path> -v           # verbose（環境情報・パイプライン統計を表示、#336）
+allaganeye --version                       # バージョン表示（短縮形: -V、#337）
 allaganeye debug-brightness <video_path>   # フレーム輝度 CSV 出力
 ```
 

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -26,7 +26,13 @@ def version_callback(value: bool) -> None:
 def main(
     version: Annotated[
         bool | None,
-        typer.Option("--version", callback=version_callback, is_eager=True),
+        typer.Option(
+            "--version",
+            "-V",
+            callback=version_callback,
+            is_eager=True,
+            help="Show version and exit.",
+        ),
     ] = None,
 ) -> None:
     """Allagan Eye - FF14 Frontline video auto-highlight extraction tool."""

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -119,12 +119,11 @@ def run_split(
 
     if show:
         if verbose:
-            mode = "GPU" if config.use_gpu else "CPU"
             workers_str = str(config.workers) if config.workers is not None else "auto"
             audio_str = "off" if config.no_audio else "on"
             typer.echo(
                 f"Detecting match boundaries "
-                f"(mode={mode}, interval={effective_interval}s, "
+                f"(interval={effective_interval}s, "
                 f"threshold={config.blackout_threshold}, workers={workers_str}, "
                 f"min_match={config.min_match_duration}s, "
                 f"min_blackout={config.min_blackout_duration}s, "

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import time
 from pathlib import Path
 from typing import TypedDict
 
@@ -10,7 +11,11 @@ import typer
 from allaganeye.audio.matcher import BgmHit
 from allaganeye.config import SplitConfig
 from allaganeye.exceptions import AllaganEyeError, DetectionError, VideoProcessingError
-from allaganeye.video.detector import MatchBoundary, detect_match_boundaries
+from allaganeye.video.detector import (
+    DetectionStats,
+    MatchBoundary,
+    detect_match_boundaries,
+)
 from allaganeye.video.probe import ProbeResult, probe_video
 from allaganeye.video.splitter import split_video
 
@@ -44,6 +49,11 @@ def run_split(
     """
     show = not quiet
 
+    total_start = time.monotonic()
+
+    if verbose and show:
+        _print_environment_header()
+
     # Step 1: Probe video metadata
     if show:
         typer.echo(f"Probing: {video_path}")
@@ -52,7 +62,8 @@ def run_split(
         typer.echo(
             f"  Duration: {metadata['duration']:.1f}s, "
             f"Resolution: {metadata['width']}x{metadata['height']}, "
-            f"FPS: {metadata['fps']:.2f}"
+            f"FPS: {metadata['fps']:.2f}, "
+            f"Codec: {metadata.get('codec', 'unknown')}"
         )
 
     # Auto-adjust sample_interval for long videos (C strategy from #68)
@@ -107,11 +118,26 @@ def run_split(
     audio_hits = _run_audio_scan(video_path, config, show=show, verbose=verbose)
 
     if show:
-        typer.echo(
-            f"Detecting match boundaries "
-            f"(interval={effective_interval}s, "
-            f"threshold={config.blackout_threshold})"
-        )
+        if verbose:
+            mode = "GPU" if config.use_gpu else "CPU"
+            workers_str = str(config.workers) if config.workers is not None else "auto"
+            audio_str = "off" if config.no_audio else "on"
+            typer.echo(
+                f"Detecting match boundaries "
+                f"(mode={mode}, interval={effective_interval}s, "
+                f"threshold={config.blackout_threshold}, workers={workers_str}, "
+                f"min_match={config.min_match_duration}s, "
+                f"min_blackout={config.min_blackout_duration}s, "
+                f"audio={audio_str})"
+            )
+        else:
+            typer.echo(
+                f"Detecting match boundaries "
+                f"(interval={effective_interval}s, "
+                f"threshold={config.blackout_threshold})"
+            )
+
+    detect_stats: DetectionStats | None = {} if verbose else None
 
     boundaries = _run_detection(
         video_path,
@@ -120,6 +146,7 @@ def run_split(
         config,
         audio_hits=audio_hits,
         quiet=quiet,
+        stats=detect_stats,
     )
 
     if not boundaries:
@@ -127,6 +154,10 @@ def run_split(
             "No match boundaries detected. "
             "Try adjusting --blackout-threshold or --min-match-duration."
         )
+
+    # Display pipeline statistics (verbose only)
+    if verbose and show and detect_stats is not None:
+        _print_detection_stats(detect_stats)
 
     # Display detection results
     if show:
@@ -162,9 +193,13 @@ def run_split(
     # Step 3: Split (unless dry-run)
     if config.dry_run:
         typer.echo("\nDry run: skipping split")
+        if verbose and show:
+            typer.echo(f"Total: {_format_duration(time.monotonic() - total_start)}")
         return
 
     _split_and_write_metadata(video_path, boundaries, gaps, metadata, config)
+    if verbose and show:
+        typer.echo(f"Total: {_format_duration(time.monotonic() - total_start)}")
 
 
 def _run_audio_scan(
@@ -208,6 +243,7 @@ def _run_detection(
     *,
     audio_hits: list[BgmHit] | None = None,
     quiet: bool = False,
+    stats: DetectionStats | None = None,
 ) -> list[MatchBoundary]:
     """Run detection with optional progress bar."""
     detect_kwargs = {
@@ -221,6 +257,7 @@ def _run_detection(
         "src_resolution": (metadata["width"], metadata["height"]),
         "codec": metadata.get("codec"),
         "audio_hits": audio_hits,
+        "stats": stats,
     }
 
     if not quiet:
@@ -307,6 +344,96 @@ def _split_and_write_metadata(
     for f in output_files:
         typer.echo(f"  {f.name}")
     typer.echo(f"Metadata: {metadata_path}")
+
+
+def _print_environment_header() -> None:
+    """Print environment info header (allaganeye / Python / OS) for -v mode.
+
+    Hardware details (CPU/GPU/memory/disk) are deferred to Phase 2
+    (issue #336).  This Phase 1 header covers the essentials needed
+    for bug reports.
+    """
+    import platform
+
+    from allaganeye import __version__
+
+    ffmpeg_version = _probe_ffmpeg_version()
+    typer.echo(
+        f"allaganeye {__version__} "
+        f"(ffmpeg {ffmpeg_version}, "
+        f"Python {platform.python_version()}, "
+        f"{platform.system()} {platform.release()})"
+    )
+
+
+def _probe_ffmpeg_version() -> str:
+    """Return ffmpeg version string, or '(unknown)' on failure."""
+    import subprocess
+
+    from allaganeye.ffmpeg_path import find_ffmpeg
+
+    try:
+        result = subprocess.run(
+            [find_ffmpeg(), "-version"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "(unknown)"
+
+    first_line = result.stdout.splitlines()[0] if result.stdout else ""
+    # "ffmpeg version 8.1-essentials_build-www.gyan.dev Copyright ..."
+    parts = first_line.split()
+    if len(parts) >= 3 and parts[0] == "ffmpeg" and parts[1] == "version":
+        return parts[2]
+    return "(unknown)"
+
+
+def _print_detection_stats(stats: DetectionStats) -> None:
+    """Emit pipeline statistics in verbose mode (issue #336 Phase 1)."""
+    mode = stats.get("mode")
+    if mode is not None:
+        pass1_samples = stats.get("pass1_samples", 0)
+        pass1_blackouts = stats.get("pass1_blackout_frames", 0)
+        pass1_elapsed = stats.get("pass1_elapsed_s", 0.0)
+        blackout_pct = 100.0 * pass1_blackouts / pass1_samples if pass1_samples else 0.0
+        typer.echo(
+            f"  Pass 1 ({mode}): {pass1_samples} samples, "
+            f"{pass1_blackouts} blackout frames ({blackout_pct:.1f}%), "
+            f"{_format_duration(pass1_elapsed)}"
+        )
+
+    if "pass2_regions" in stats:
+        pass2_elapsed = stats.get("pass2_elapsed_s", 0.0)
+        typer.echo(
+            f"  Pass 2: {stats['pass2_regions']} regions refined, "
+            f"{_format_duration(pass2_elapsed)}"
+        )
+
+    if any(
+        k in stats
+        for k in (
+            "scorebar_match_boundary",
+            "scorebar_in_match",
+            "scorebar_non_fl",
+            "scorebar_unknown",
+        )
+    ):
+        parts = [
+            f"{stats.get('scorebar_match_boundary', 0)} match_boundary",
+            f"{stats.get('scorebar_in_match', 0)} in_match",
+            f"{stats.get('scorebar_non_fl', 0)} non_fl",
+        ]
+        unknown = stats.get("scorebar_unknown", 0)
+        if unknown:
+            parts.append(f"{unknown} unknown")
+        typer.echo(f"  Scorebar: {', '.join(parts)}")
+
+    promotions = stats.get("audio_promotions")
+    if promotions is not None and promotions > 0:
+        typer.echo(f"  Audio promotion: {promotions} in_match -> match_boundary")
 
 
 def _format_timestamp(seconds: float) -> str:

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -21,6 +22,27 @@ class MatchBoundary(TypedDict):
     start: float
     end: float
     type: str
+
+
+class DetectionStats(TypedDict, total=False):
+    """Pipeline statistics populated by :func:`detect_match_boundaries`.
+
+    All keys are optional; callers pass an empty dict which the detector
+    populates as each phase completes.  Used for ``--verbose`` output
+    (issue #336 Phase 1).
+    """
+
+    mode: str  # "CPU" or "GPU"
+    pass1_samples: int
+    pass1_blackout_frames: int
+    pass1_elapsed_s: float
+    pass2_regions: int
+    pass2_elapsed_s: float
+    scorebar_match_boundary: int
+    scorebar_in_match: int
+    scorebar_non_fl: int
+    scorebar_unknown: int
+    audio_promotions: int
 
 
 logger = logging.getLogger(__name__)
@@ -51,6 +73,7 @@ def detect_match_boundaries(
     codec: str | None = None,
     progress_callback: Callable[[int, int, int], None] | None = None,
     audio_hits: Sequence[BgmHit] | None = None,
+    stats: DetectionStats | None = None,
 ) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
 
@@ -77,6 +100,8 @@ def detect_match_boundaries(
         )
 
     # Pass 1: scan for blackout frames
+    pass1_start = time.monotonic()
+    resolved_mode = "CPU"
     if use_gpu:
         from allaganeye.video.gpu_detector import scan_gpu
 
@@ -89,6 +114,7 @@ def detect_match_boundaries(
                 progress_callback,
                 codec=codec,
             )
+            resolved_mode = "GPU"
         except VideoProcessingError:
             # GPU failed -- fall back to CPU
             results = _scan_cpu(
@@ -99,6 +125,7 @@ def detect_match_boundaries(
                 workers,
                 progress_callback,
             )
+            resolved_mode = "CPU (GPU fallback)"
     else:
         results = _scan_cpu(
             video_path,
@@ -108,6 +135,15 @@ def detect_match_boundaries(
             workers,
             progress_callback,
         )
+    pass1_elapsed = time.monotonic() - pass1_start
+
+    if stats is not None:
+        stats["mode"] = resolved_mode
+        stats["pass1_samples"] = len(results)
+        stats["pass1_blackout_frames"] = sum(
+            1 for b in results.values() if b < blackout_threshold
+        )
+        stats["pass1_elapsed_s"] = pass1_elapsed
 
     # Collect blackout timestamps in chronological order
     blackout_times = sorted(t for t, b in results.items() if b < blackout_threshold)
@@ -119,9 +155,14 @@ def detect_match_boundaries(
     )
 
     # 2nd pass: refine blackout regions at fine interval (#77)
+    pass2_start = time.monotonic()
     refined_regions = _refine_blackout_regions(
         video_path, blackout_regions, blackout_threshold, duration_hint, workers
     )
+    pass2_elapsed = time.monotonic() - pass2_start
+    if stats is not None:
+        stats["pass2_regions"] = len(refined_regions)
+        stats["pass2_elapsed_s"] = pass2_elapsed
 
     # Scorebar-based filtering: remove in-match and non-FL blackouts (#111)
     region_classifications: list[str] | None = None
@@ -129,6 +170,7 @@ def detect_match_boundaries(
         from allaganeye.video.scorebar import filter_blackouts_with_scorebar
 
         height = _scaled_height(src_resolution[0], src_resolution[1])
+        scorebar_stats: dict[str, int] | None = {} if stats is not None else None
         refined_regions, region_classifications = filter_blackouts_with_scorebar(
             video_path,
             refined_regions,
@@ -136,7 +178,11 @@ def detect_match_boundaries(
             height,
             workers,
             audio_hits=audio_hits,
+            stats=scorebar_stats,
         )
+        if stats is not None and scorebar_stats is not None:
+            for key, value in scorebar_stats.items():
+                stats[key] = value  # type: ignore[literal-required]
 
     effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)
     return _filter_and_extract_segments(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -170,7 +170,6 @@ def detect_match_boundaries(
         from allaganeye.video.scorebar import filter_blackouts_with_scorebar
 
         height = _scaled_height(src_resolution[0], src_resolution[1])
-        scorebar_stats: dict[str, int] | None = {} if stats is not None else None
         refined_regions, region_classifications = filter_blackouts_with_scorebar(
             video_path,
             refined_regions,
@@ -178,11 +177,8 @@ def detect_match_boundaries(
             height,
             workers,
             audio_hits=audio_hits,
-            stats=scorebar_stats,
+            stats=stats,
         )
-        if stats is not None and scorebar_stats is not None:
-            for key, value in scorebar_stats.items():
-                stats[key] = value  # type: ignore[literal-required]
 
     effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)
     return _filter_and_extract_segments(

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -11,6 +11,7 @@ import numpy as np
 from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
+    DetectionStats,
     _SAMPLE_WIDTH,
     _SCOREBAR_METHOD,
     _SCOREBAR_ROI_X_END,
@@ -336,7 +337,7 @@ def filter_blackouts_with_scorebar(
     workers: int | None = None,
     *,
     audio_hits: Sequence[BgmHit] | None = None,
-    stats: dict[str, int] | None = None,
+    stats: DetectionStats | None = None,
 ) -> tuple[list[tuple[float, float]], list[str]]:
     """Filter blackout regions using scorebar context and duration.
 

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -336,6 +336,7 @@ def filter_blackouts_with_scorebar(
     workers: int | None = None,
     *,
     audio_hits: Sequence[BgmHit] | None = None,
+    stats: dict[str, int] | None = None,
 ) -> tuple[list[tuple[float, float]], list[str]]:
     """Filter blackout regions using scorebar context and duration.
 
@@ -364,11 +365,19 @@ def filter_blackouts_with_scorebar(
     """
     kept: list[tuple[float, float]] = []
     classifications: list[str] = []
+    raw_counts: dict[str, int] = {
+        "match_boundary": 0,
+        "in_match": 0,
+        "non_fl": 0,
+        "unknown": 0,
+    }
+    audio_promotions = 0
     for region in blackout_regions:
         classification = classify_blackout(
             video_path, region, duration, height, workers
         )
         region_duration = region[1] - region[0]
+        raw_counts[classification if classification in raw_counts else "unknown"] += 1
 
         if classification == "in_match" and audio_hits is not None:
             hit = _has_nearby_fanfare_hit(region, audio_hits)
@@ -383,6 +392,7 @@ def filter_blackouts_with_scorebar(
                     hit["similarity"],
                 )
                 classification = "match_boundary"
+                audio_promotions += 1
 
         if classification == "in_match" and region_duration < _IN_MATCH_MAX_DURATION:
             logger.info(
@@ -412,6 +422,13 @@ def filter_blackouts_with_scorebar(
         )
         kept.append(region)
         classifications.append(classification)
+
+    if stats is not None:
+        stats["scorebar_match_boundary"] = raw_counts["match_boundary"]
+        stats["scorebar_in_match"] = raw_counts["in_match"]
+        stats["scorebar_non_fl"] = raw_counts["non_fl"]
+        stats["scorebar_unknown"] = raw_counts["unknown"]
+        stats["audio_promotions"] = audio_promotions
 
     return _merge_boundary_pairs(
         video_path, kept, classifications, duration, height, workers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,26 @@ def test_version():
     assert "allaganeye" in result.stdout
 
 
+def test_version_short_flag():
+    """-V should be an alias for --version (issue #337)."""
+    result = runner.invoke(app, ["-V"])
+    assert result.exit_code == 0
+    assert "allaganeye" in result.stdout
+
+
+def test_verbose_short_flag_unchanged():
+    """-v must still map to --verbose (not --version) on the split command.
+
+    Breaking-change policy for v0.1.x: we add -V for --version but keep
+    -v = --verbose to avoid disrupting existing preview users (issue #337).
+    """
+    result = runner.invoke(app, ["split", "--help"])
+    assert result.exit_code == 0
+    # -v appears in the verbose flag help
+    assert "-v" in result.stdout
+    assert "verbose" in result.stdout.lower()
+
+
 def test_help():
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -701,6 +701,67 @@ class TestDetectMatchBoundaries:
             detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
 
     @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_stats_populated_cpu(self, mock_chunk):
+        """Verbose callers receive pipeline statistics (issue #336 Phase 1)."""
+        from allaganeye.video.detector import DetectionStats
+
+        mock_chunk.side_effect = lambda vp, ts, cs, ce, si: {t: 128.0 for t in ts}
+        stats: DetectionStats = {}
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=10.0,
+            sample_interval=1.0,
+            min_match_duration=1.0,
+            stats=stats,
+        )
+        assert stats.get("mode") == "CPU"
+        assert stats.get("pass1_samples") == 10
+        assert stats.get("pass1_blackout_frames") == 0
+        assert "pass1_elapsed_s" in stats
+        assert "pass2_regions" in stats
+        assert "pass2_elapsed_s" in stats
+
+    @patch("allaganeye.video.detector._probe_single_frame")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_stats_scorebar_counts(self, mock_chunk, mock_probe):
+        """Scorebar classification counts flow through to stats."""
+        from allaganeye.video.detector import DetectionStats
+
+        mock_chunk.side_effect = lambda vp, ts, cs, ce, si: {
+            t: 5.0 if 598.0 <= t <= 602.0 else 128.0 for t in ts
+        }
+        mock_probe.side_effect = lambda path, t: 5.0 if 593.0 <= t <= 607.0 else 128.0
+        with patch(
+            "allaganeye.video.scorebar.filter_blackouts_with_scorebar"
+        ) as mock_filter:
+
+            def filter_side_effect(
+                video_path, regions, duration, height, workers, *, audio_hits, stats
+            ):
+                if stats is not None:
+                    stats["scorebar_match_boundary"] = 1
+                    stats["scorebar_in_match"] = 2
+                    stats["scorebar_non_fl"] = 3
+                    stats["scorebar_unknown"] = 0
+                    stats["audio_promotions"] = 1
+                return regions, ["match_boundary"] * len(regions)
+
+            mock_filter.side_effect = filter_side_effect
+            stats: DetectionStats = {}
+            detect_match_boundaries(
+                Path("test.mp4"),
+                duration_hint=1800.0,
+                sample_interval=1.0,
+                min_match_duration=300.0,
+                src_resolution=(1920, 1080),
+                stats=stats,
+            )
+        assert stats.get("scorebar_match_boundary") == 1
+        assert stats.get("scorebar_in_match") == 2
+        assert stats.get("scorebar_non_fl") == 3
+        assert stats.get("audio_promotions") == 1
+
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
     def test_progress_callback(self, mock_chunk):
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si: {t: 128.0 for t in ts}
         calls = []

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -386,6 +386,27 @@ class TestFilterBlackouts:
         assert cls == []
 
     @patch(f"{SCOREBAR_MODULE}.classify_blackout")
+    def test_stats_records_raw_counts(self, mock_classify):
+        """stats dict receives raw classification counts (issue #336).
+
+        Non-FL and short in_match regions are dropped from the return but
+        must still appear in the stats counters so verbose output shows
+        the full picture.
+        """
+        mock_classify.side_effect = ["match_boundary", "in_match", "non_fl"]
+        regions = [(100.0, 105.0), (200.0, 201.0), (300.0, 302.0)]
+        stats: dict[str, int] = {}
+        result, _ = filter_blackouts_with_scorebar(
+            Path("v.mp4"), regions, 400.0, _HEIGHT, stats=stats
+        )
+        assert stats["scorebar_match_boundary"] == 1
+        assert stats["scorebar_in_match"] == 1
+        assert stats["scorebar_non_fl"] == 1
+        assert stats["audio_promotions"] == 0
+        # Short in_match and non_fl dropped from return
+        assert result == [(100.0, 105.0)]
+
+    @patch(f"{SCOREBAR_MODULE}.classify_blackout")
     def test_removes_non_fl(self, mock_classify):
         mock_classify.return_value = "non_fl"
         regions = [(100.0, 102.0)]

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -393,16 +393,18 @@ class TestFilterBlackouts:
         must still appear in the stats counters so verbose output shows
         the full picture.
         """
+        from allaganeye.video.detector import DetectionStats
+
         mock_classify.side_effect = ["match_boundary", "in_match", "non_fl"]
         regions = [(100.0, 105.0), (200.0, 201.0), (300.0, 302.0)]
-        stats: dict[str, int] = {}
+        stats: DetectionStats = {}
         result, _ = filter_blackouts_with_scorebar(
             Path("v.mp4"), regions, 400.0, _HEIGHT, stats=stats
         )
-        assert stats["scorebar_match_boundary"] == 1
-        assert stats["scorebar_in_match"] == 1
-        assert stats["scorebar_non_fl"] == 1
-        assert stats["audio_promotions"] == 0
+        assert stats.get("scorebar_match_boundary") == 1
+        assert stats.get("scorebar_in_match") == 1
+        assert stats.get("scorebar_non_fl") == 1
+        assert stats.get("audio_promotions") == 0
         # Short in_match and non_fl dropped from return
         assert result == [(100.0, 105.0)]
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -846,3 +846,120 @@ def test_non_verbose_does_not_print_stats(
     out = capsys.readouterr().out
     assert "Pass 1" not in out
     assert "Scorebar:" not in out
+    # Environment header is a verbose-only feature too
+    assert "Python" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_reports_gpu_fallback_mode(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose Pass 1 line distinguishes 'GPU' from 'CPU (GPU fallback)' (#336 / #335).
+
+    This is the core motivation for #336 Phase 1 -- the mode string is
+    what lets us diagnose the GPU/CPU +-2 discrepancy tracked in #335.
+    A bug here (e.g. always reporting 'CPU') would silently hide
+    whether the fallback actually fired.
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_fallback(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU (GPU fallback)"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 0
+            stats["pass1_elapsed_s"] = 1.0
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_fallback
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, use_gpu=True)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "Pass 1 (CPU (GPU fallback))" in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_detecting_line_shows_audio_off_when_no_audio(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose Detecting line reflects --no-audio (#336)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, no_audio=True)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "audio=off" in out
+    assert "audio=on" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_dry_run_emits_total(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose + dry-run still emits the Total: line (#336)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    config = SplitConfig(output_dir=tmp_path, dry_run=True, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "Dry run: skipping split" in out
+    assert "Total:" in out
+    mock_split.assert_not_called()
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_audio_promotion_line_suppressed_when_zero(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Audio promotion line is hidden when no promotions happened (#336)."""
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_no_promo(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 0
+            stats["pass1_elapsed_s"] = 1.0
+            stats["pass2_regions"] = 0
+            stats["pass2_elapsed_s"] = 0.1
+            stats["scorebar_match_boundary"] = 2
+            stats["scorebar_in_match"] = 0
+            stats["scorebar_non_fl"] = 0
+            stats["scorebar_unknown"] = 0
+            stats["audio_promotions"] = 0
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_no_promo
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "Scorebar:" in out  # scorebar line still shown
+    assert "Audio promotion" not in out  # but promo line hidden
+
+
+def test_probe_ffmpeg_version_returns_unknown_on_failure():
+    """ffmpeg -version failure yields '(unknown)' without raising (#336)."""
+    import subprocess
+
+    from allaganeye.commands.split_matches import _probe_ffmpeg_version
+
+    with patch("subprocess.run", side_effect=subprocess.SubprocessError("boom")):
+        result = _probe_ffmpeg_version()
+    assert result == "(unknown)"

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -761,10 +761,14 @@ def test_verbose_emits_codec_in_duration_line(
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
-def test_verbose_detecting_line_includes_mode_and_params(
+def test_verbose_detecting_line_includes_params(
     mock_probe, mock_detect, mock_split, tmp_path, capsys
 ):
-    """Verbose 'Detecting' line shows mode=CPU|GPU plus detailed params (issue #336)."""
+    """Verbose 'Detecting' line shows detailed params (issue #336).
+
+    Mode is shown in Pass 1 stats (post-detection) rather than in
+    the Detecting line, so that GPU fallback is accurately reported.
+    """
     mock_probe.return_value = PROBE_RESULT
     mock_detect.return_value = BOUNDARIES
     mock_split.return_value = _output_files(tmp_path)
@@ -774,7 +778,6 @@ def test_verbose_detecting_line_includes_mode_and_params(
 
     run_split(Path("input.mp4"), config, verbose=True)
     out = capsys.readouterr().out
-    assert "mode=GPU" in out
     assert "workers=8" in out
     assert "min_match=60.0s" in out
     assert "min_blackout=3.0s" in out

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -718,3 +718,128 @@ class TestAudioScanIntegration:
 
         result = _run_audio_scan(Path("input.mp4"), config, show=False, verbose=False)
         assert result is None
+
+
+# --- Verbose output (issue #336 Phase 1) ---
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_emits_environment_header(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose mode prints allaganeye version + Python/OS header (issue #336)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "allaganeye " in out
+    assert "Python" in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_emits_codec_in_duration_line(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose probe line includes video codec (issue #336)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "Codec: h264" in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_detecting_line_includes_mode_and_params(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose 'Detecting' line shows mode=CPU|GPU plus detailed params (issue #336)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(
+        output_dir=tmp_path, min_match_duration=60.0, use_gpu=True, workers=8
+    )
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "mode=GPU" in out
+    assert "workers=8" in out
+    assert "min_match=60.0s" in out
+    assert "min_blackout=3.0s" in out
+    assert "audio=on" in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_prints_pipeline_stats(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose mode emits Pass 1 / Pass 2 / Scorebar breakdown (issue #336)."""
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 1800
+            stats["pass1_blackout_frames"] = 42
+            stats["pass1_elapsed_s"] = 120.0
+            stats["pass2_regions"] = 12
+            stats["pass2_elapsed_s"] = 5.0
+            stats["scorebar_match_boundary"] = 4
+            stats["scorebar_in_match"] = 3
+            stats["scorebar_non_fl"] = 2
+            stats["scorebar_unknown"] = 0
+            stats["audio_promotions"] = 1
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "Pass 1 (CPU)" in out
+    assert "1800 samples" in out
+    assert "42 blackout frames" in out
+    assert "Pass 2" in out
+    assert "12 regions refined" in out
+    assert "Scorebar" in out
+    assert "4 match_boundary" in out
+    assert "3 in_match" in out
+    assert "2 non_fl" in out
+    assert "Audio promotion: 1" in out
+    assert "Total:" in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_non_verbose_does_not_print_stats(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Default (non-verbose) run must NOT pass stats into detect (avoid overhead)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=False)
+    _, detect_kwargs = mock_detect.call_args
+    assert detect_kwargs["stats"] is None
+    out = capsys.readouterr().out
+    assert "Pass 1" not in out
+    assert "Scorebar:" not in out


### PR DESCRIPTION
## Summary

Issues #336 (Phase 1) and #337 をまとめて対応。

### #337: `-V`/`--version` 追加
- `-V` を `--version` の短縮形として追加
- `-v` は `--verbose` のまま維持（preview ユーザーのマッスルメモリ保持、lead-1 方針コメント準拠）

### #336: verbose 出力拡充（Phase 1）
- 環境ヘッダ: `allaganeye <ver> (ffmpeg <ver>, Python <ver>, <OS>)`
- 入力行に `Codec: <name>` 追加
- Detecting 行に `workers`, `min_match`, `min_blackout`, `audio=on|off` 追加
- 新しいパイプライン統計ブロック:
  ```
    Pass 1 (CPU): 3410 samples, 156 blackout frames (4.6%), 7m12s
    Pass 2: 23 regions refined, 1m03s
    Scorebar: 12 match_boundary, 8 in_match, 3 non_fl
    Audio promotion: 2 in_match -> match_boundary
  ```
- 末尾に `Total: <duration>` 追加

### 実装ポイント
- `DetectionStats` TypedDict を追加。`detect_match_boundaries(stats=...)` / `filter_blackouts_with_scorebar(stats=...)` の out-param として populate
- 非 verbose 時は `stats=None` を渡してオーバーヘッドゼロ
- Scorebar カウントはフィルタ前の raw 値 → `non_fl` や短い `in_match` の drop 状況が可視化される（#335 調査の鍵）
- Phase 2（CPU/GPU モデル、メモリ、ディスク等の HW 情報）は本 PR では扱わない。`psutil` 非依存方針は lead-1 コメント通り維持

### レビュー差し戻し対応（infallible-thompson）
- **#3 GPU fallback 表示不整合**: Detecting 行から `mode=` を削除。mode は `Pass 1 ({mode})` 統計ブロックで正確に表示（`stats["mode"]` 使用）
- **#2 CI checklist**: テスター依頼をチェックボックスから分離

## Test plan (engineer)

- [x] `ruff check .` / `ruff format --check .` / `pyright` 通過
- [x] `pytest` 全 444 件 pass（新規 10 件を含む）
- [x] `allaganeye -V` / `allaganeye --version` 両方でバージョン表示を確認（test_version_short_flag）
- [x] `allaganeye split <v> -v` が verbose として機能することを確認（test_split_verbose_short）

## Tester verification required

- 実動画 `-v` 実行でトラブルシュート情報が揃うか確認

## 関連

- Issue #336 Phase 1（Phase 2 の HW 詳細は別 PR）
- Issue #337（破壊的変更なし。`-v` 意味は保持）
- Issue #335 調査の前提（mode / scorebar 内訳が CPU/GPU 乖離切り分けに使える）

作成: engineer-1 / レビュー修正: infallible-thompson