### PR TITLE
test: AUDIO_FROZEN の副作用契約テストを追加 #327 [tester-1]

### DIFF
--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -691,6 +691,53 @@ class TestAudioScanIntegration:
         assert result is None
 
     @pytest.mark.real_audio_scan
+    @patch("allaganeye.audio.scan.scan_fanfare_hits")
+    def test_run_audio_scan_frozen_does_not_call_scan_fanfare_hits(
+        self, mock_scan, tmp_path
+    ):
+        """Frozen path must short-circuit before invoking scan_fanfare_hits (#327).
+
+        This guards the performance/side-effect contract: the whole point of
+        freezing is that no ffmpeg audio extraction or correlation runs.
+        Returning None alone would not catch a bug where the scan still
+        executes but its result is discarded.
+        """
+        from allaganeye.commands.split_matches import _run_audio_scan
+
+        # AUDIO_FROZEN True (default) AND no_audio False -- scan must still skip
+        config = SplitConfig(
+            output_dir=tmp_path, min_match_duration=60.0, no_audio=False
+        )
+        result = _run_audio_scan(Path("input.mp4"), config, show=False, verbose=False)
+        assert result is None
+        mock_scan.assert_not_called()
+
+    @pytest.mark.real_audio_scan
+    def test_run_audio_scan_frozen_suppresses_progress_message(self, tmp_path, capsys):
+        """Frozen path must not print 'Scanning audio for Fanfare peaks' (#327).
+
+        The freeze check sits before the typer.echo, so show=True should still
+        produce silent output when frozen (no confusing message to the user).
+        """
+        from allaganeye.commands.split_matches import _run_audio_scan
+
+        config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+        result = _run_audio_scan(Path("input.mp4"), config, show=True, verbose=True)
+        captured = capsys.readouterr()
+        assert result is None
+        assert "Fanfare" not in captured.out
+        assert "Scanning audio" not in captured.out
+
+    def test_audio_frozen_flag_exported(self):
+        """AUDIO_FROZEN is part of the public audio API (#327)."""
+        import allaganeye.audio as audio_mod
+
+        assert hasattr(audio_mod, "AUDIO_FROZEN")
+        assert "AUDIO_FROZEN" in audio_mod.__all__
+        # Default state: frozen until compound-signal integration ships
+        assert audio_mod.AUDIO_FROZEN is True
+
+    @pytest.mark.real_audio_scan
     @patch("allaganeye.audio.AUDIO_FROZEN", False)
     def test_run_audio_scan_returns_none_when_disabled(self, tmp_path):
         """config.no_audio=True skips audio scan without invoking scan_fanfare_hits."""


### PR DESCRIPTION
## Summary

PR #339 のテスターレビューで発見した 3 つのテストギャップを補強します。既存テストは `_run_audio_scan` が `None` を返すことは検証していましたが、AUDIO_FROZEN の本質的契約（「音声処理が一切走らない」）を検証していませんでした。

### 追加テスト

- **`test_run_audio_scan_frozen_does_not_call_scan_fanfare_hits`**
  `scan_fanfare_hits` が呼ばれないことを `mock_scan.assert_not_called()` で明示。`None` を返す実装でも内部でスキャンが走っていたらバグ（凍結の目的であるパフォーマンス/副作用回避が崩れる）。`no_audio=False` を明示設定し AUDIO_FROZEN が優先する契約も同時に検証。
- **`test_run_audio_scan_frozen_suppresses_progress_message`**
  `show=True, verbose=True` でも "Scanning audio for Fanfare peaks" や "Fanfare" が出力されないことを `capsys` で検証。凍結中のユーザー体験契約（紛らわしい進捗表示を出さない — issue #327 の要件）を固定。
- **`test_audio_frozen_flag_exported`**
  `AUDIO_FROZEN` が `allaganeye.audio.__all__` に含まれ、デフォルト値が `True` であることを検証。将来の凍結解除時に `__all__` 更新漏れを防止。

## Test plan

- [x] `pytest tests/test_split_matches.py` -- 46 passed
- [x] `pytest` (全テスト) -- 435 passed（既存 + 新規 3 件）
- [x] `ruff check .` / `ruff format --check .` -- all passed
- [x] `pyright tests/test_split_matches.py` -- 0 errors

元 PR: #339 / Issue: #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)