### PR TITLE
fix: GPU mode progress bar label updates per chunk (#333)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -284,8 +284,22 @@ def _run_detection(
                     progress.update(advance)
                 last_pos[0] = completed
 
+            def on_chunk(done: int, total: int, eta_seconds: float) -> None:
+                # Update label so users see movement between chunk completions
+                # on GPU mode (otherwise the bar stays at 0% then jumps, #333).
+                if eta_seconds > 0:
+                    progress.label = (
+                        f"Detecting [chunk {done}/{total}, "
+                        f"ETA ~{_format_eta(eta_seconds)}]"
+                    )
+                else:
+                    progress.label = f"Detecting [chunk {done}/{total}]"
+
             return detect_match_boundaries(
-                video_path, **detect_kwargs, progress_callback=on_progress
+                video_path,
+                **detect_kwargs,
+                progress_callback=on_progress,
+                chunk_progress_callback=on_chunk,
             )
 
     return detect_match_boundaries(video_path, **detect_kwargs)
@@ -542,6 +556,22 @@ def _format_timestamp(seconds: float) -> str:
     if h:
         return f"{h}:{m:02d}:{s:02d}"
     return f"{m:02d}:{s:02d}"
+
+
+def _format_eta(seconds: float) -> str:
+    """Format an ETA for in-label display (compact, e.g. '45s' or '3m20s').
+
+    Designed for the GPU chunk progress label (#333).  Keeps width small
+    so the progress bar does not overflow typical terminal widths.
+    """
+    total = int(seconds)
+    if total < 60:
+        return f"{total}s"
+    m, s = divmod(total, 60)
+    if m < 60:
+        return f"{m}m{s:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h{m:02d}m"
 
 
 def _format_duration(seconds: float) -> str:

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -74,6 +74,7 @@ def detect_match_boundaries(
     progress_callback: Callable[[int, int, int], None] | None = None,
     audio_hits: Sequence[BgmHit] | None = None,
     stats: DetectionStats | None = None,
+    chunk_progress_callback: Callable[[int, int, float], None] | None = None,
 ) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
 
@@ -113,6 +114,7 @@ def detect_match_boundaries(
                 blackout_threshold,
                 progress_callback,
                 codec=codec,
+                chunk_progress_callback=chunk_progress_callback,
             )
             resolved_mode = "GPU"
         except VideoProcessingError:

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -34,6 +35,7 @@ def scan_gpu(
     blackout_threshold: float,
     progress_callback: Callable[[int, int, int], None] | None = None,
     codec: str | None = None,
+    chunk_progress_callback: Callable[[int, int, float], None] | None = None,
 ) -> dict[float, float]:
     """GPU mode: chunked parallel decode with cuvid hardware decoder.
 
@@ -43,6 +45,12 @@ def scan_gpu(
     from stdout and analyzed for brightness.
 
     Returns dict mapping timestamp -> brightness, same as CPU mode.
+
+    ``chunk_progress_callback`` is called as ``(done, total, eta_seconds)``
+    each time a chunk completes.  ETA is derived from the average
+    per-chunk wall time so it becomes accurate after the first few
+    completions.  Emitted BEFORE the per-frame ``progress_callback``
+    burst so the UI label updates before the bar jumps (#333).
 
     Raises VideoProcessingError if GPU decode fails for all chunks.
     """
@@ -63,6 +71,8 @@ def scan_gpu(
     fallback_checked = False
 
     cuvid_decoder = _CUVID_CODEC_MAP.get(codec or "")
+    scan_start = time.monotonic()
+    chunks_done = 0
 
     with ThreadPoolExecutor(max_workers=num_chunks) as pool:
         futures = {
@@ -89,6 +99,18 @@ def scan_gpu(
             if not fallback_checked:
                 fallback_checked = True
                 _check_gpu_usage(stderr_text, codec, cuvid_decoder)
+
+            chunks_done += 1
+            if chunk_progress_callback is not None:
+                elapsed = time.monotonic() - scan_start
+                remaining = num_chunks - chunks_done
+                # Linear extrapolation from completion ratio.  Chunks run
+                # in parallel but have similar sizes, so the rate at which
+                # they finish is a reasonable proxy for remaining wall
+                # time.  Conservative (overshoots slightly near the start,
+                # accurate near the end) -- users prefer that to overshoot.
+                eta = elapsed * remaining / chunks_done if remaining > 0 else 0.0
+                chunk_progress_callback(chunks_done, num_chunks, eta)
 
             for t, brightness in chunk_results.items():
                 results[t] = brightness

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -169,6 +169,52 @@ class TestScanGpu:
 
         assert len(calls) >= 1
 
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_chunk_progress_callback_fires_per_chunk(self, mock_decode):
+        """chunk_progress_callback fires once per chunk with (done, total, eta) (#333)."""
+        mock_decode.return_value = ({0.0: 128.0, 1.0: 5.0}, "")
+        chunk_calls: list[tuple[int, int, float]] = []
+
+        scan_gpu(
+            Path("test.mp4"),
+            10.0,
+            1.0,
+            15.0,
+            chunk_progress_callback=lambda d, t, eta: chunk_calls.append((d, t, eta)),
+        )
+
+        # One call per chunk -- exactly num_chunks total (lead review).
+        assert len(chunk_calls) >= 1
+        num_chunks = chunk_calls[-1][1]
+        assert len(chunk_calls) == num_chunks
+        # done is monotonically increasing 1..num_chunks
+        dones = [c[0] for c in chunk_calls]
+        assert dones == list(range(1, num_chunks + 1))
+        # total stays constant at num_chunks
+        assert all(c[1] == num_chunks for c in chunk_calls)
+        # Final ETA is 0 (no remaining chunks)
+        assert chunk_calls[-1][2] == 0.0
+        # Intermediate ETAs are non-negative
+        assert all(c[2] >= 0 for c in chunk_calls)
+
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_chunk_progress_not_called_on_failure(self, mock_decode):
+        """Callback must not fire for a failed chunk (#333)."""
+        mock_decode.side_effect = VideoProcessingError("fail")
+        chunk_calls: list[tuple[int, int, float]] = []
+
+        with pytest.raises(VideoProcessingError):
+            scan_gpu(
+                Path("test.mp4"),
+                10.0,
+                1.0,
+                15.0,
+                chunk_progress_callback=lambda d, t, eta: chunk_calls.append(
+                    (d, t, eta)
+                ),
+            )
+        assert chunk_calls == []
+
 
 class TestGpuFallbackIntegration:
     @patch("allaganeye.video.detector._scan_cpu")

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1232,3 +1232,27 @@ def test_probe_ffmpeg_version_returns_unknown_on_failure():
     with patch("subprocess.run", side_effect=subprocess.SubprocessError("boom")):
         result = _probe_ffmpeg_version()
     assert result == "(unknown)"
+
+
+# --- ETA formatter (issue #333) ---
+
+
+def test_format_eta_seconds():
+    from allaganeye.commands.split_matches import _format_eta
+
+    assert _format_eta(5) == "5s"
+    assert _format_eta(59) == "59s"
+
+
+def test_format_eta_minutes():
+    from allaganeye.commands.split_matches import _format_eta
+
+    assert _format_eta(60) == "1m00s"
+    assert _format_eta(125) == "2m05s"
+
+
+def test_format_eta_hours():
+    from allaganeye.commands.split_matches import _format_eta
+
+    assert _format_eta(3600) == "1h00m"
+    assert _format_eta(3700) == "1h01m"


### PR DESCRIPTION
## Summary

Issue #333 対応（lead-1 方針 案B）。

### 問題
`--gpu` で `Detecting` 進捗バーが長時間 0% 付近で停止し、チャンク完了が集中するタイミングで一気に 99% まで跳ねる。フリーズに見える。

### 修正
- `scan_gpu` に `chunk_progress_callback=(done, total, eta_seconds)` を追加。チャンク完了ごとに 1 回呼ぶ
- `detect_match_boundaries` が pass-through
- `_run_detection` で `progress.label` を `Detecting [chunk 3/16, ETA ~45s]` に書き換え
- ETA は wall-clock からの線形外挿（序盤はやや多め、終盤は正確）
- チャンク失敗時は callback を呼ばない（CPU フォールバック時の表示に整合）

### ベースブランチ

**PR #341 (#336/#337) の上に stack しています**（`engineer-1/issue-336-337-verbose-version` をベース）。#341 マージ後に自動的に `develop-0.1.1` ベースに切り替わります。

## Test plan (engineer)

- [x] `ruff check .` / `ruff format --check .` / `pyright` 通過
- [x] `pytest` 全 449 件 pass（新規 3 件追加）

## Tester verification required

- 実機 `--gpu` 実行でラベルが `[chunk X/16, ETA ~Ys]` に更新されるか確認
- CPU モードでは従来通りフレーム単位で進捗が上がることを確認（label は書き換わらない）

## 関連

- Issue #333（lead-1 方針 案B: チャンク完了ごとのラベル更新 + ETA 表示）
- PR #341（#336/#337）の後続

作成: engineer-1 / checklist 修正: infallible-thompson