### PR TITLE
test: ディスク容量チェックの UX 契約テストを追加 #338 [tester-1]

### DIFF
--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -779,6 +779,93 @@ class TestDiskSpaceCheck:
             # Path with space should be quoted
             assert '"' in str(exc_info.value)
 
+    @patch(f"{MODULE}.split_video")
+    @patch(f"{MODULE}.detect_match_boundaries")
+    @patch(f"{MODULE}.probe_video")
+    def test_match_list_displayed_before_disk_error(
+        self, mock_probe, mock_detect, mock_split, tmp_path, capsys
+    ):
+        """Match list is displayed before disk space error is raised (#338).
+
+        Core UX contract from issue #338: even when the split is aborted
+        for insufficient space, the user must see the detection results
+        first so they can confirm what was detected / was cached.
+        """
+        mock_probe.return_value = PROBE_RESULT
+        mock_detect.return_value = BOUNDARIES
+        config = SplitConfig(output_dir=tmp_path / "output", min_match_duration=60.0)
+
+        fake_usage = type("Usage", (), {"total": 10_000, "used": 9_000, "free": 1_000})
+        with (
+            patch(
+                "allaganeye.commands.split_matches.shutil.disk_usage",
+                return_value=fake_usage,
+            ),
+            patch(
+                f"{MODULE}._estimate_output_size",
+                return_value=100_000_000_000,  # 100GB vs 1KB free -> raises
+            ),
+        ):
+            with pytest.raises(AllaganEyeError, match="Not enough disk space"):
+                run_split(Path("input.mp4"), config)
+
+        output = capsys.readouterr().out
+        # Detected header + both Match lines must appear before the raise
+        assert "Detected 2 match(es)" in output
+        assert "Match 1:" in output
+        assert "Match 2:" in output
+        # Split must not be attempted
+        mock_split.assert_not_called()
+
+    def test_quiet_suppresses_tight_space_warning(self, tmp_path, capsys):
+        """show=False suppresses the tight-space warning (#338 + --quiet)."""
+        from allaganeye.commands.split_matches import _check_disk_space
+
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"\x00" * 1_000_000)
+        boundaries: list[MatchBoundary] = [
+            {"start": 0.0, "end": 900.0, "type": "unknown"},
+        ]
+        config = SplitConfig(output_dir=tmp_path / "output")
+
+        # Tight but sufficient: estimated 990_000, free 1_100_000 (>80% -> warn)
+        fake_usage = type(
+            "Usage", (), {"total": 2_000_000, "used": 900_000, "free": 1_100_000}
+        )
+        with patch(
+            "allaganeye.commands.split_matches.shutil.disk_usage",
+            return_value=fake_usage,
+        ):
+            _check_disk_space(video, boundaries, 1000.0, config, show=False)
+
+        stderr = capsys.readouterr().err
+        assert "Warning" not in stderr
+
+    @patch(f"{MODULE}.split_video")
+    @patch(f"{MODULE}.detect_match_boundaries")
+    @patch(f"{MODULE}.probe_video")
+    @patch(f"{MODULE}._load_cache")
+    def test_cached_path_enforces_disk_check(
+        self, mock_load, mock_probe, mock_detect, mock_split, tmp_path
+    ):
+        """Disk space check runs even when boundaries come from cache (#338).
+
+        The cached re-run is the primary recovery path from an earlier
+        disk-full failure; the check must re-validate that enough space
+        is available before splitting.
+        """
+        mock_probe.return_value = PROBE_RESULT
+        mock_load.return_value = BOUNDARIES  # simulate cache hit
+        mock_split.return_value = _output_files(tmp_path)
+        config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+        with patch(f"{MODULE}._check_disk_space") as mock_check:
+            run_split(Path("input.mp4"), config)
+
+        mock_check.assert_called_once()
+        # detect_match_boundaries must not be invoked (cache hit)
+        mock_detect.assert_not_called()
+
 
 class TestAudioScanIntegration:
     """Audio scan pipeline wiring in run_split and _run_audio_scan (#288)."""


### PR DESCRIPTION
## Summary

PR #344 のテスターレビューで発見した 3 件のテストギャップを補強します。既存テストは helper 単体の挙動（推定サイズ・raise 条件・警告表示）はカバーしていましたが、issue #338 の核心 UX 契約と経路網羅が欠けていました。

### 追加テスト

- **`test_match_list_displayed_before_disk_error`** — #338 核心 UX
  - 容量不足で raise される前に `Detected N match(es)` と全 Match 行が stdout に出力されることを検証
  - issue #338 の「検知結果は**通常通り表示した上で**エラーで中断」要件を固定
  - 回帰として最も起きやすいのは `_check_disk_space` を表示の**前**に移動してしまうケース

- **`test_quiet_suppresses_tight_space_warning`** — `--quiet` との組み合わせ
  - `show=False` で 80% 超の tight-space 警告が stderr に出ないことを検証
  - PR #344 Summary で明記された「`--quiet` 時は警告抑制」挙動が未テストだった

- **`test_cached_path_enforces_disk_check`** — キャッシュ経路
  - `_load_cache` がヒットした場合も `_check_disk_space` が呼ばれることを検証
  - キャッシュ再実行は #338 で想定する主要リカバリ経路のため、ここで分割前の再検証が抜けると「空けてから再実行したら途中でまた落ちる」事故が起きうる

## Test plan

- [x] `pytest tests/test_split_matches.py::TestDiskSpaceCheck` -- 9 passed (6 既存 + 3 新規)
- [x] `pytest` (全テスト) -- 443 passed, 34 deselected
- [x] `ruff check .` / `ruff format --check .` -- all passed

元 PR: #344 / Issue: #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)