### PR TITLE
fix: scan_fanfare_hits の FileNotFoundError を VideoProcessingError でラップ #350

### DIFF
--- a/allaganeye/audio/scan.py
+++ b/allaganeye/audio/scan.py
@@ -20,6 +20,7 @@ from allaganeye.audio.extract import extract_pcm
 from allaganeye.audio.features import load_features_multi, log_mel_spectrogram
 from allaganeye.audio.matcher import BgmHit, find_match_peaks, sliding_cosine_similarity
 from allaganeye.audio.refs import get_reference_path
+from allaganeye.exceptions import VideoProcessingError
 
 
 _DEFAULT_THRESHOLD = 0.65
@@ -49,15 +50,19 @@ def scan_fanfare_hits(
 
     Returns hits sorted by timestamp (seconds from video start).  Raises
     ``VideoProcessingError`` when audio extraction fails (e.g. missing
-    audio track); callers may catch this to fall back to audio-less
-    classification.
+    audio track) or when the bundled reference feature file is missing;
+    callers may catch this to fall back to audio-less classification.
 
     When the referenced feature file bundles multiple reference windows
     (#289, War Room spans BGM version differences), the per-frame max of
     all references' sliding similarity curves is used; peaks are then
     detected on that combined curve.
     """
-    features_list, config, _ = load_features_multi(get_reference_path(ref_name))
+    try:
+        ref_path = get_reference_path(ref_name)
+    except FileNotFoundError as e:
+        raise VideoProcessingError(f"fanfare reference feature missing: {e}") from e
+    features_list, config, _ = load_features_multi(ref_path)
     pcm = extract_pcm(video_path, sample_rate=config.sample_rate)
     target = log_mel_spectrogram(pcm, config)
 

--- a/tests/test_audio_scan.py
+++ b/tests/test_audio_scan.py
@@ -91,14 +91,29 @@ def test_scan_fanfare_hits_forwards_threshold(
 @patch(f"{_SCAN_MODULE}.get_reference_path")
 def test_scan_fanfare_hits_uses_custom_ref_name(mock_ref_path):
     """ref_name parameter is passed to get_reference_path."""
+    from allaganeye.exceptions import VideoProcessingError
+
     mock_ref_path.side_effect = FileNotFoundError("stop early")
 
     try:
         scan_fanfare_hits(Path("/fake/v.mkv"), ref_name="war_room")
-    except FileNotFoundError:
+    except VideoProcessingError:
         pass
 
     mock_ref_path.assert_called_once_with("war_room")
+
+
+@patch(f"{_SCAN_MODULE}.get_reference_path")
+def test_scan_fanfare_hits_missing_ref_raises_video_processing_error(mock_ref_path):
+    """FileNotFoundError from get_reference_path is wrapped as VideoProcessingError (#350)."""
+    import pytest
+
+    from allaganeye.exceptions import VideoProcessingError
+
+    mock_ref_path.side_effect = FileNotFoundError("fanfare.npz not found")
+
+    with pytest.raises(VideoProcessingError, match="fanfare reference feature missing"):
+        scan_fanfare_hits(Path("/fake/v.mkv"))
 
 
 @patch(f"{_SCAN_MODULE}.find_match_peaks")

--- a/tests/test_audio_scan.py
+++ b/tests/test_audio_scan.py
@@ -116,6 +116,30 @@ def test_scan_fanfare_hits_missing_ref_raises_video_processing_error(mock_ref_pa
         scan_fanfare_hits(Path("/fake/v.mkv"))
 
 
+@patch(f"{_SCAN_MODULE}.get_reference_path")
+def test_scan_fanfare_hits_missing_ref_preserves_cause(mock_ref_path):
+    """Wrapped VideoProcessingError preserves __cause__ chain for debugging (#350).
+
+    The PR summary documents that ``from e`` keeps ``__cause__`` so the
+    original FileNotFoundError (with its detail about which path was
+    missing) is visible in tracebacks.  Guards against a future refactor
+    dropping ``from e`` -- which would preserve CLI fallback behaviour
+    but lose the packaging diagnostic that makes this error actionable.
+    """
+    import pytest
+
+    from allaganeye.exceptions import VideoProcessingError
+
+    original = FileNotFoundError("fanfare.npz not found at expected path")
+    mock_ref_path.side_effect = original
+
+    with pytest.raises(VideoProcessingError) as excinfo:
+        scan_fanfare_hits(Path("/fake/v.mkv"))
+
+    assert excinfo.value.__cause__ is original
+    assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+
+
 @patch(f"{_SCAN_MODULE}.find_match_peaks")
 @patch(f"{_SCAN_MODULE}.log_mel_spectrogram")
 @patch(f"{_SCAN_MODULE}.extract_pcm")


### PR DESCRIPTION
## Summary

- `scan_fanfare_hits` 内で `get_reference_path` の `FileNotFoundError` を catch し `VideoProcessingError` に re-raise
- `from e` で `__cause__` 保持
- docstring の Raises セクション更新
- テスト: `FileNotFoundError` → `VideoProcessingError` 変換テスト追加
- 既存テスト (`test_scan_fanfare_hits_uses_custom_ref_name`) を `VideoProcessingError` catch に更新

## Test plan

- [x] `pytest tests/test_audio_scan.py` -- 5 passed (1 新規)
- [x] `pytest` (全テスト) -- 468 passed, 34 deselected
- [x] `ruff check .` / `ruff format --check .` -- all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)