### PR TITLE
test: VideoProcessingError の __cause__ 保持契約を追加 #350 [tester-1]

### DIFF
--- a/tests/test_audio_scan.py
+++ b/tests/test_audio_scan.py
@@ -116,6 +116,30 @@ def test_scan_fanfare_hits_missing_ref_raises_video_processing_error(mock_ref_pa
         scan_fanfare_hits(Path("/fake/v.mkv"))
 
 
+@patch(f"{_SCAN_MODULE}.get_reference_path")
+def test_scan_fanfare_hits_missing_ref_preserves_cause(mock_ref_path):
+    """Wrapped VideoProcessingError preserves __cause__ chain for debugging (#350).
+
+    The PR summary documents that ``from e`` keeps ``__cause__`` so the
+    original FileNotFoundError (with its detail about which path was
+    missing) is visible in tracebacks.  Guards against a future refactor
+    dropping ``from e`` -- which would preserve CLI fallback behaviour
+    but lose the packaging diagnostic that makes this error actionable.
+    """
+    import pytest
+
+    from allaganeye.exceptions import VideoProcessingError
+
+    original = FileNotFoundError("fanfare.npz not found at expected path")
+    mock_ref_path.side_effect = original
+
+    with pytest.raises(VideoProcessingError) as excinfo:
+        scan_fanfare_hits(Path("/fake/v.mkv"))
+
+    assert excinfo.value.__cause__ is original
+    assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+
+
 @patch(f"{_SCAN_MODULE}.find_match_peaks")
 @patch(f"{_SCAN_MODULE}.log_mel_spectrogram")
 @patch(f"{_SCAN_MODULE}.extract_pcm")


### PR DESCRIPTION
## Summary

PR #352 のテスターレビューで発見した 1 件のテストギャップを補強します。既存テストは FileNotFoundError → VideoProcessingError の変換とメッセージ一致を検証していましたが、PR Summary で明記された \`from e\` による \`__cause__\` 保持の契約が未テストでした。

### 追加テスト

- **\`test_scan_fanfare_hits_missing_ref_preserves_cause\`**
  - \`excinfo.value.__cause__ is original\` を identity check
  - \`__cause__\` が FileNotFoundError instance であることを確認
  - \`from e\` を誤って外しても CLI fallback は機能するため、既存テストではすり抜ける
  - traceback から欠落パス情報が消えるとパッケージング不備の診断が困難になる

## パイプライン全体の fallback 検証

本 PR では追加しませんが、エンドツーエンドの fallback 経路（\`_run_audio_scan\` が VideoProcessingError を catch して None 返却）は既存の \`test_run_audio_scan_falls_back_on_video_processing_error\` で既にカバーされています。VideoProcessingError として伝播する契約が本 PR で検証されるため、両者でカバレッジが完結します。

## Test plan

- [x] \`pytest tests/test_audio_scan.py\` -- 6 passed
- [x] \`pytest\` (全テスト) -- 469 passed, 34 deselected
- [x] \`ruff check .\` / \`ruff format --check .\` -- all passed

元 PR: #352 / Issue: #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)