### PR TITLE
feat: verbose error detail (traceback + ffmpeg stderr) #351

### DIFF
--- a/allaganeye/audio/extract.py
+++ b/allaganeye/audio/extract.py
@@ -54,9 +54,14 @@ def extract_pcm(
         ) from e
 
     if proc.returncode != 0:
-        stderr_tail = proc.stderr.decode(errors="replace")[-300:]
+        stderr_text = proc.stderr.decode(errors="replace")
         raise VideoProcessingError(
-            f"ffmpeg audio extraction failed for {video_path}: {stderr_tail}"
+            f"ffmpeg audio extraction failed for {video_path}",
+            context={
+                "command": " ".join(str(c) for c in cmd),
+                "return_code": proc.returncode,
+                "stderr_tail": stderr_text[-2000:],
+            },
         )
 
     if len(proc.stdout) == 0:

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -132,10 +132,10 @@ def split(
         run_split(video_path, config, verbose=verbose, quiet=quiet)
 
     except AllaganEyeError as e:
-        typer.echo(f"Error: {e}", err=True)
+        _report_app_error(e, verbose=verbose)
         raise typer.Exit(code=e.exit_code) from None
-    except Exception as e:
-        typer.echo(f"Unexpected error: {e}", err=True)
+    except Exception:
+        _report_unexpected_error(verbose=verbose)
         raise typer.Exit(code=1) from None
 
 
@@ -188,8 +188,35 @@ def debug_brightness(
         )
 
     except AllaganEyeError as e:
-        typer.echo(f"Error: {e}", err=True)
+        _report_app_error(e, verbose=False)
         raise typer.Exit(code=e.exit_code) from None
-    except Exception as e:
-        typer.echo(f"Unexpected error: {e}", err=True)
+    except Exception:
+        _report_unexpected_error(verbose=False)
         raise typer.Exit(code=1) from None
+
+
+def _report_app_error(exc: AllaganEyeError, *, verbose: bool) -> None:
+    """Render an ``AllaganEyeError`` to stderr, adding verbose detail (#351)."""
+    typer.echo(f"Error: {exc}", err=True)
+    if verbose:
+        detail = exc.verbose_detail()
+        if detail:
+            typer.echo(detail, err=True)
+
+
+def _report_unexpected_error(*, verbose: bool) -> None:
+    """Render an unexpected (non-``AllaganEyeError``) exception (#351).
+
+    Non-verbose: short one-liner.  Verbose: full traceback via
+    ``traceback.print_exc`` so ``__cause__`` / ``__context__`` chains are
+    preserved (we purposefully do not pass ``from None`` in this path).
+    """
+    if verbose:
+        import traceback
+
+        traceback.print_exc()
+    else:
+        import sys
+
+        exc = sys.exc_info()[1]
+        typer.echo(f"Unexpected error: {exc}", err=True)

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -133,9 +133,17 @@ def run_split(
     )
 
     if not boundaries:
+        det_context: dict[str, object] = {
+            "audio_hits": len(audio_hits) if audio_hits is not None else "disabled",
+        }
+        if detect_stats:
+            det_context.update(
+                {f"stats.{k}": v for k, v in detect_stats.items()}  # type: ignore[misc]
+            )
         raise DetectionError(
             "No match boundaries detected. "
-            "Try adjusting --blackout-threshold or --min-match-duration."
+            "Try adjusting --blackout-threshold or --min-match-duration.",
+            context=det_context,
         )
 
     # Display pipeline statistics (verbose only)

--- a/allaganeye/exceptions.py
+++ b/allaganeye/exceptions.py
@@ -1,10 +1,41 @@
 """Error classes with exit code mapping."""
 
+from typing import Any
+
 
 class AllaganEyeError(Exception):
-    """Base exception for Allagan Eye."""
+    """Base exception for Allagan Eye.
+
+    ``context`` carries optional diagnostic key/value pairs that are shown
+    only when the CLI runs with ``--verbose`` (issue #351).  Non-verbose
+    output stays short; verbose adds command lines, stderr tails, pipeline
+    stats, and similar details needed for bug reports.
+    """
 
     exit_code: int = 1
+
+    def __init__(self, message: str, *, context: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.context = context or {}
+
+    def verbose_detail(self) -> str:
+        """Return a multi-line detail string for verbose mode, or ``""``.
+
+        Each context entry is rendered as ``  key: value`` on its own line.
+        Multi-line string values (e.g. ffmpeg stderr tails) are indented
+        further so they visually belong to their key.
+        """
+        if not self.context:
+            return ""
+        lines: list[str] = []
+        for key, value in self.context.items():
+            text = str(value)
+            if "\n" in text:
+                indented = "\n".join(f"    {ln}" for ln in text.splitlines())
+                lines.append(f"  {key}:\n{indented}")
+            else:
+                lines.append(f"  {key}: {text}")
+        return "\n".join(lines)
 
 
 class InputFileError(AllaganEyeError):

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -198,7 +198,15 @@ def _decode_chunk(
     stderr_text = proc.stderr.decode(errors="replace")
 
     if proc.returncode != 0:
-        raise VideoProcessingError(f"GPU decode failed: {stderr_text[-500:]}")
+        raise VideoProcessingError(
+            "GPU decode failed",
+            context={
+                "command": " ".join(str(c) for c in cmd),
+                "return_code": proc.returncode,
+                "chunk": f"{chunk_start:.1f}-{chunk_end:.1f}",
+                "stderr_tail": stderr_text[-2000:],
+            },
+        )
 
     # Parse raw frames from stdout
     data = proc.stdout

--- a/allaganeye/video/probe.py
+++ b/allaganeye/video/probe.py
@@ -61,7 +61,15 @@ def probe_video(video_path: Path) -> ProbeResult:
             f"ffprobe timed out after 30s for {video_path}"
         ) from e
     except subprocess.CalledProcessError as e:
-        raise VideoProcessingError(f"ffprobe failed: {e.stderr}") from e
+        stderr_text = e.stderr if isinstance(e.stderr, str) else ""
+        raise VideoProcessingError(
+            "ffprobe failed",
+            context={
+                "command": " ".join(str(c) for c in e.cmd) if e.cmd else "",
+                "return_code": e.returncode,
+                "stderr_tail": stderr_text[-2000:] if stderr_text else "",
+            },
+        ) from e
 
     try:
         data = json.loads(result.stdout)

--- a/tests/test_audio_extract.py
+++ b/tests/test_audio_extract.py
@@ -104,8 +104,10 @@ def test_extract_pcm_nonzero_returncode(_mock_ffmpeg, mock_run, tmp_path):
     video.touch()
     mock_run.return_value = _mock_result(returncode=1, stderr=b"some ffmpeg error here")
 
-    with pytest.raises(VideoProcessingError, match="some ffmpeg error here"):
+    with pytest.raises(VideoProcessingError) as exc_info:
         extract_pcm(video)
+    # stderr tail is now on .context (verbose detail), not the message (#351)
+    assert "some ffmpeg error here" in exc_info.value.context["stderr_tail"]
 
 
 @patch("allaganeye.audio.extract.subprocess.run")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -394,6 +394,68 @@ def test_split_unexpected_error_exit_code(mock_run_split, fake_video):
     assert result.exit_code == 1
 
 
+# --- Verbose error detail tests (issue #351) ---
+
+
+@patch(MODULE)
+def test_split_verbose_shows_context_detail(mock_run_split, fake_video):
+    """VideoProcessingError with context emits 'stderr_tail:' in verbose mode."""
+    mock_run_split.side_effect = VideoProcessingError(
+        "ffmpeg failed",
+        context={
+            "command": "ffmpeg -i foo.mp4",
+            "return_code": 1,
+            "stderr_tail": "NAL unit type 12 not supported",
+        },
+    )
+    result = runner.invoke(app, ["split", str(fake_video), "-v"])
+    assert result.exit_code == 3
+    combined = result.stdout + (result.stderr or "")
+    assert "Error: ffmpeg failed" in combined
+    assert "command:" in combined
+    assert "return_code:" in combined
+    assert "stderr_tail:" in combined
+    assert "NAL unit type 12 not supported" in combined
+
+
+@patch(MODULE)
+def test_split_non_verbose_hides_context_detail(mock_run_split, fake_video):
+    """Without -v, context detail stays hidden (short error only)."""
+    mock_run_split.side_effect = VideoProcessingError(
+        "ffmpeg failed",
+        context={"stderr_tail": "NAL unit type 12 not supported"},
+    )
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 3
+    combined = result.stdout + (result.stderr or "")
+    assert "Error: ffmpeg failed" in combined
+    assert "stderr_tail" not in combined
+    assert "NAL unit type 12 not supported" not in combined
+
+
+@patch(MODULE)
+def test_split_verbose_shows_traceback_for_unexpected(mock_run_split, fake_video):
+    """Unexpected Exception emits traceback to stderr in verbose mode."""
+    mock_run_split.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["split", str(fake_video), "-v"])
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "Traceback" in combined
+    assert "RuntimeError: boom" in combined
+
+
+@patch(MODULE)
+def test_split_non_verbose_hides_traceback_for_unexpected(mock_run_split, fake_video):
+    """Without -v, unexpected error shows short one-liner (no traceback)."""
+    mock_run_split.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "Traceback" not in combined
+    assert "Unexpected error" in combined
+    assert "boom" in combined
+
+
 # --- Extension support tests ---
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -46,3 +46,113 @@ def test_str_message_independent_of_context():
     """The short message stays clean for non-verbose display."""
     exc = VideoProcessingError("ffmpeg failed", context={"stderr_tail": "junk"})
     assert str(exc) == "ffmpeg failed"
+
+
+# --- Raise-site context wiring (issue #351) ---
+
+
+def test_probe_video_error_attaches_command_and_stderr():
+    """ffprobe CalledProcessError is wrapped with command/return_code/stderr_tail (#351)."""
+    import subprocess
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import pytest
+
+    from allaganeye.video.probe import probe_video
+
+    err = subprocess.CalledProcessError(
+        returncode=2,
+        cmd=["ffprobe", "-i", "bad.mkv"],
+        stderr="Invalid data found when processing input",
+    )
+    with (
+        patch("allaganeye.video.probe.subprocess.run", side_effect=err),
+        patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe"),
+    ):
+        with pytest.raises(VideoProcessingError) as excinfo:
+            probe_video(Path("bad.mkv"))
+
+    ctx = excinfo.value.context
+    assert ctx["return_code"] == 2
+    assert "ffprobe" in ctx["command"]
+    assert "bad.mkv" in ctx["command"]
+    assert "Invalid data" in ctx["stderr_tail"]
+
+
+def test_stderr_tail_truncated_to_2000_chars():
+    """Long stderr output is truncated to last 2000 chars (#351).
+
+    Guards against silent bloat of context if someone changes
+    ``[-2000:]`` to a larger slice or removes it entirely.  Verified via
+    the probe.py raise site which is representative of all three (probe
+    / gpu / extract) that share the same cap.
+    """
+    import subprocess
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import pytest
+
+    from allaganeye.video.probe import probe_video
+
+    huge_stderr = "x" * 5000 + "END"
+    err = subprocess.CalledProcessError(
+        returncode=1, cmd=["ffprobe"], stderr=huge_stderr
+    )
+    with (
+        patch("allaganeye.video.probe.subprocess.run", side_effect=err),
+        patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe"),
+    ):
+        with pytest.raises(VideoProcessingError) as excinfo:
+            probe_video(Path("bad.mkv"))
+
+    tail = excinfo.value.context["stderr_tail"]
+    assert len(tail) == 2000
+    # Ensure we kept the tail (not the head): the final marker survives
+    assert tail.endswith("END")
+
+
+def test_detection_error_context_includes_audio_hits():
+    """DetectionError with empty boundaries carries audio_hits context (#351 / #335).
+
+    Debugging hook lead-1 wants for the #335 GPU/CPU discrepancy
+    investigation: when detection finds nothing the context must show
+    audio_hits status (= "disabled" when no_audio / frozen).  Guards
+    against a future refactor dropping the context dict.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import pytest
+
+    from allaganeye.commands.split_matches import run_split
+    from allaganeye.config import SplitConfig
+
+    PROBE_RESULT = {
+        "duration": 1800.0,
+        "width": 1920,
+        "height": 1080,
+        "fps": 30.0,
+        "codec": "h264",
+        "audio_codec": "aac",
+    }
+
+    with (
+        patch(
+            "allaganeye.commands.split_matches.probe_video",
+            return_value=PROBE_RESULT,
+        ),
+        patch(
+            "allaganeye.commands.split_matches.detect_match_boundaries",
+            return_value=[],
+        ),
+        patch("allaganeye.commands.split_matches._run_audio_scan", return_value=None),
+    ):
+        config = SplitConfig(min_match_duration=60.0)
+        with pytest.raises(DetectionError) as excinfo:
+            run_split(Path("v.mp4"), config)
+
+    ctx = excinfo.value.context
+    assert "audio_hits" in ctx
+    assert ctx["audio_hits"] == "disabled"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,48 @@
+"""Tests for AllaganEyeError context/verbose_detail (issue #351)."""
+
+from allaganeye.exceptions import (
+    AllaganEyeError,
+    DetectionError,
+    VideoProcessingError,
+)
+
+
+def test_context_defaults_to_empty():
+    exc = AllaganEyeError("boom")
+    assert exc.context == {}
+    assert exc.verbose_detail() == ""
+
+
+def test_context_stored_and_rendered():
+    exc = VideoProcessingError(
+        "ffmpeg failed",
+        context={"command": "ffmpeg -i x.mp4", "return_code": 1},
+    )
+    detail = exc.verbose_detail()
+    assert "command: ffmpeg -i x.mp4" in detail
+    assert "return_code: 1" in detail
+
+
+def test_multiline_value_is_indented():
+    """stderr tails span many lines; verbose_detail indents them."""
+    exc = VideoProcessingError(
+        "x",
+        context={"stderr_tail": "line1\nline2\nline3"},
+    )
+    detail = exc.verbose_detail()
+    assert "stderr_tail:" in detail
+    # Each continuation line gets deeper indentation
+    assert "    line1" in detail
+    assert "    line2" in detail
+
+
+def test_exit_code_preserved_with_context():
+    exc = DetectionError("nope", context={"stats": {"a": 1}})
+    assert exc.exit_code == 4
+    assert "stats: {'a': 1}" in exc.verbose_detail()
+
+
+def test_str_message_independent_of_context():
+    """The short message stays clean for non-verbose display."""
+    exc = VideoProcessingError("ffmpeg failed", context={"stderr_tail": "junk"})
+    assert str(exc) == "ffmpeg failed"


### PR DESCRIPTION
## Summary

Issue #351（#336 追加要件の後続）。\`-v\` / \`--verbose\` 指定時のみ、バグ報告に必要な詳細情報をエラー出力に追加する。非 verbose 時は従来どおり短いメッセージのみ。

### 実装（lead-1 方針準拠）

**\`AllaganEyeError\` 基底クラスに \`context\` を追加**:
- \`context: dict[str, Any]\` を \`__init__\` で受け取る
- \`verbose_detail()\` が複数行の詳細文字列を返す（context 空なら \`\"\"\`）
- 複数行値（stderr tail 等）は自動でインデント整形

**\`cli.py\` トップレベル except の verbose 分岐**:
\`\`\`python
except AllaganEyeError as e:
    _report_app_error(e, verbose=verbose)   # verbose 時のみ detail 追加
    raise typer.Exit(code=e.exit_code) from None
except Exception:
    _report_unexpected_error(verbose=verbose)  # verbose 時は traceback.print_exc
    raise typer.Exit(code=1) from None
\`\`\`

**raise 側に context 付与**:
- \`video/probe.py\` \`CalledProcessError\` → \`command\` / \`return_code\` / \`stderr_tail\`
- \`video/gpu_detector.py\` 非ゼロ returncode → \`command\` / \`return_code\` / \`chunk\` / \`stderr_tail\`
- \`audio/extract.py\` 非ゼロ returncode → 同上
- \`commands/split_matches.py\` \`DetectionError\` → \`audio_hits\` 件数 + \`detect_stats\` の全フィールド

### verbose 出力例

\`\`\`
Error: ffmpeg failed
  command: ffmpeg -hwaccel cuda -i recording.mkv ...
  return_code: 1
  stderr_tail:
    [h264_cuvid @ 0x...] decoder disconnect
    Conversion failed!
\`\`\`

## Test plan

- [x] \`ruff check\` / \`ruff format --check\` / \`pyright\`: pass
- [x] \`pytest\`: 484 passed, 34 deselected（新規 \`test_exceptions.py\` 5 件 + \`test_cli.py\` verbose/非 verbose 4 件）
- [x] 非 verbose 時は context 詳細・traceback が出ないことを検証
- [x] verbose 時は \`command:\` / \`stderr_tail:\` / \`Traceback\` が stderr に出ることを検証

## 関連

- #351（本 issue）
- #336 Phase 1 の「追加要件」後続
- #335（GPU/CPU 乖離調査）のデバッグ補助

作成: engineer-1