### PR TITLE
feat: コーデックに基づく GPU/CPU モード自動選択 #334

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ allaganeye split <video_path> -o <output_dir>
 | `--min-match-duration` | `300.0` | 最小試合時間（秒）。短いセグメントを除外 |
 | `--min-blackout-duration` | `3.0` | 最小暗転時間（秒）。短い暗転を無視 |
 | `--workers` | auto | 検知の並列ワーカー数（デフォルト: 自動=CPU コア数、最大24） |
-| `--gpu` / `--no-gpu` | `--no-gpu` | GPU デコードで検知。CPU モードが十分高速なためデフォルトは off。GPU が利用不可の場合は CPU にフォールバック |
+| `--gpu` / `--no-gpu` | auto | GPU デコードで検知。デフォルトはコーデックで自動選択（H.264/HEVC -> GPU、その他 -> CPU）。GPU が利用不可の場合は CPU にフォールバック |
 | `--no-cache` | - | キャッシュを無視して再検知 |
 | `--dry-run` | - | 検知のみ実行し、分割しない |
 | `-v`, `--verbose` | - | 詳細ログ出力 |

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -70,14 +70,14 @@ def split(
         bool, typer.Option("--dry-run", help="Detect only, do not split")
     ] = False,
     gpu: Annotated[
-        bool,
+        bool | None,
         typer.Option(
             "--gpu/--no-gpu",
-            help="Use GPU-accelerated detection (chunked parallel decode). "
-            "CPU mode is fast enough for most recordings, so GPU is off by default. "
+            help="Use GPU-accelerated detection. "
+            "Default: auto-select based on codec (H.264/HEVC -> GPU, others -> CPU). "
             "Falls back to CPU if GPU is unavailable.",
         ),
-    ] = False,
+    ] = None,
     no_cache: Annotated[
         bool,
         typer.Option("--no-cache", help="Ignore cached detection results"),

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -97,6 +97,9 @@ def run_split(
                 video_path, boundaries, gaps, metadata, config, quiet=quiet
             )
 
+    # Resolve GPU/CPU mode: auto-select based on codec when not explicit (#334)
+    use_gpu = _resolve_gpu_mode(config.use_gpu, metadata.get("codec"), show, verbose)
+
     # Step 2: Detect match boundaries
     if verbose and show:
         if effective_interval != config.sample_interval:
@@ -130,6 +133,7 @@ def run_split(
         audio_hits=audio_hits,
         quiet=quiet,
         stats=detect_stats,
+        use_gpu=use_gpu,
     )
 
     if not boundaries:
@@ -246,6 +250,32 @@ def _run_audio_scan(
     return hits
 
 
+# Codecs where GPU decode is typically faster than CPU parallel probing.
+_GPU_PREFERRED_CODECS = {"h264", "hevc"}
+
+
+def _resolve_gpu_mode(
+    use_gpu: bool | None,
+    codec: str | None,
+    show: bool,
+    verbose: bool,
+) -> bool:
+    """Resolve GPU/CPU mode from explicit flag or codec auto-detection (#334).
+
+    When *use_gpu* is ``None`` (no ``--gpu``/``--no-gpu`` given), selects
+    GPU for H.264/HEVC (mature GPU decode support) and CPU for everything
+    else (AV1, VP9, etc.).  Returns a concrete ``bool``.
+    """
+    if use_gpu is not None:
+        return use_gpu
+
+    selected = (codec or "").lower() in _GPU_PREFERRED_CODECS
+    if show and verbose:
+        mode = "GPU" if selected else "CPU"
+        typer.echo(f"  Auto-selected {mode} mode (codec: {codec or 'unknown'})")
+    return selected
+
+
 def _run_detection(
     video_path: Path,
     metadata: ProbeResult,
@@ -255,6 +285,7 @@ def _run_detection(
     audio_hits: list[BgmHit] | None = None,
     quiet: bool = False,
     stats: DetectionStats | None = None,
+    use_gpu: bool = False,
 ) -> list[MatchBoundary]:
     """Run detection with progress bars for each phase (#328, #329, #331)."""
     detect_kwargs = {
@@ -263,7 +294,7 @@ def _run_detection(
         "blackout_threshold": config.blackout_threshold,
         "min_match_duration": config.min_match_duration,
         "min_blackout_duration": config.min_blackout_duration,
-        "use_gpu": config.use_gpu,
+        "use_gpu": use_gpu,
         "workers": config.workers,
         "src_resolution": (metadata["width"], metadata["height"]),
         "codec": metadata.get("codec"),

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -16,7 +16,7 @@ class SplitConfig:
     min_match_duration: float = 300.0
     min_blackout_duration: float = 3.0
     dry_run: bool = False
-    use_gpu: bool = False
+    use_gpu: bool | None = None
     workers: int | None = None
     no_cache: bool = False
     no_audio: bool = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,7 +156,7 @@ def test_split_default_options(mock_run_split, fake_video):
     assert config.min_match_duration == 300.0
     assert config.min_blackout_duration == 3.0
     assert config.workers is None
-    assert config.use_gpu is False
+    assert config.use_gpu is None  # auto mode (#334)
     assert config.dry_run is False
     assert kwargs["verbose"] is False
     assert kwargs["quiet"] is False

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1147,6 +1147,50 @@ class TestResolveGpuMode:
         assert "Auto-selected GPU mode" in out
         assert "h264" in out
 
+    def test_auto_cpu_verbose_shows_cpu_message(self, capsys):
+        """CPU auto-selection also emits a verbose notice (#334).
+
+        Guards the else-branch of the mode resolution -- users on
+        AV1/VP9 recordings need to see that CPU mode was chosen
+        intentionally (not just because GPU failed).
+        """
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _resolve_gpu_mode(None, "av1", show=True, verbose=True)
+        out = capsys.readouterr().out
+        assert "Auto-selected CPU mode" in out
+        assert "av1" in out
+
+    def test_auto_non_verbose_suppresses_message(self, capsys):
+        """Non-verbose auto selection is silent (#334)."""
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _resolve_gpu_mode(None, "h264", show=True, verbose=False)
+        out = capsys.readouterr().out
+        assert "Auto-selected" not in out
+
+    def test_auto_quiet_suppresses_message(self, capsys):
+        """--quiet (show=False) silences auto-selection message even with verbose (#334)."""
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _resolve_gpu_mode(None, "h264", show=False, verbose=True)
+        out = capsys.readouterr().out
+        assert "Auto-selected" not in out
+
+    def test_auto_codec_matching_is_case_insensitive(self):
+        """Codec name matching is case-insensitive (#334).
+
+        ffprobe normally returns lowercase codec_name, but downstream
+        callers or manual ProbeResult construction may pass "H264" /
+        "HEVC".  The set is compared via ``.lower()``; guards against a
+        future refactor dropping that normalization.
+        """
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(None, "H264", show=False, verbose=False) is True
+        assert _resolve_gpu_mode(None, "HEVC", show=False, verbose=False) is True
+        assert _resolve_gpu_mode(None, "Hevc", show=False, verbose=False) is True
+
 
 class TestAudioScanIntegration:
     """Audio scan pipeline wiring in run_split and _run_audio_scan (#288)."""

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -105,7 +105,8 @@ def test_pipeline_happy_path(mock_probe, mock_detect, mock_split, tmp_path):
     assert detect_kwargs["blackout_threshold"] == config.blackout_threshold
     assert detect_kwargs["min_match_duration"] == config.min_match_duration
     assert detect_kwargs["min_blackout_duration"] == config.min_blackout_duration
-    assert detect_kwargs["use_gpu"] == config.use_gpu
+    # Auto-selected GPU for h264 codec (#334)
+    assert detect_kwargs["use_gpu"] is True
     assert detect_kwargs["workers"] == config.workers
     assert detect_kwargs["src_resolution"] == (
         PROBE_RESULT["width"],
@@ -1098,6 +1099,53 @@ class TestDiskSpaceCheck:
         mock_check.assert_called_once()
         # detect_match_boundaries must not be invoked (cache hit)
         mock_detect.assert_not_called()
+
+
+class TestResolveGpuMode:
+    """Codec-based GPU/CPU auto-selection (#334)."""
+
+    def test_explicit_gpu_true(self):
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(True, "av1", show=False, verbose=False) is True
+
+    def test_explicit_gpu_false(self):
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(False, "h264", show=False, verbose=False) is False
+
+    def test_auto_h264_selects_gpu(self):
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(None, "h264", show=False, verbose=False) is True
+
+    def test_auto_hevc_selects_gpu(self):
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(None, "hevc", show=False, verbose=False) is True
+
+    def test_auto_av1_selects_cpu(self):
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(None, "av1", show=False, verbose=False) is False
+
+    def test_auto_vp9_selects_cpu(self):
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(None, "vp9", show=False, verbose=False) is False
+
+    def test_auto_unknown_codec_selects_cpu(self):
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(None, None, show=False, verbose=False) is False
+
+    def test_auto_verbose_shows_message(self, capsys):
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _resolve_gpu_mode(None, "h264", show=True, verbose=True)
+        out = capsys.readouterr().out
+        assert "Auto-selected GPU mode" in out
+        assert "h264" in out
 
 
 class TestAudioScanIntegration:


### PR DESCRIPTION
## Summary

- `--gpu`/`--no-gpu` 未指定時にコーデックで GPU/CPU を自動選択
  - H.264/HEVC -> GPU（成熟した GPU デコード支援）
  - AV1/VP9/その他 -> CPU（並列プローブが効率的）
- `config.use_gpu` を `bool` -> `bool | None` に変更（`None` = auto）
- `_resolve_gpu_mode()` で probe 後のコーデック情報から判定
- verbose 時に `Auto-selected GPU mode (codec: h264)` を表示
- 明示的 `--gpu`/`--no-gpu` 指定時は従来通り指定に従う
- GPU 利用不可時の CPU フォールバックは既存機構を流用

### 前提条件充足

#335（GPU/CPU match 数 ±2 乖離）がクローズ済み。match 数差 ±0 で品質基準 §1 PASS。director-1 によりブロック解除承認済み。

## Test plan

- [x] `pytest` -- 483 passed, 34 deselected（新規 8 件含む）
- [x] `ruff check .` / `ruff format --check .` / `pyright` -- all passed
- [x] `_resolve_gpu_mode` ユニットテスト: explicit/auto 全コーデックパターン + verbose 表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)