### PR TITLE
test: verbose error detail の raise-site 配線契約を追加 #351 [tester-1]

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -46,3 +46,113 @@ def test_str_message_independent_of_context():
     """The short message stays clean for non-verbose display."""
     exc = VideoProcessingError("ffmpeg failed", context={"stderr_tail": "junk"})
     assert str(exc) == "ffmpeg failed"
+
+
+# --- Raise-site context wiring (issue #351) ---
+
+
+def test_probe_video_error_attaches_command_and_stderr():
+    """ffprobe CalledProcessError is wrapped with command/return_code/stderr_tail (#351)."""
+    import subprocess
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import pytest
+
+    from allaganeye.video.probe import probe_video
+
+    err = subprocess.CalledProcessError(
+        returncode=2,
+        cmd=["ffprobe", "-i", "bad.mkv"],
+        stderr="Invalid data found when processing input",
+    )
+    with (
+        patch("allaganeye.video.probe.subprocess.run", side_effect=err),
+        patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe"),
+    ):
+        with pytest.raises(VideoProcessingError) as excinfo:
+            probe_video(Path("bad.mkv"))
+
+    ctx = excinfo.value.context
+    assert ctx["return_code"] == 2
+    assert "ffprobe" in ctx["command"]
+    assert "bad.mkv" in ctx["command"]
+    assert "Invalid data" in ctx["stderr_tail"]
+
+
+def test_stderr_tail_truncated_to_2000_chars():
+    """Long stderr output is truncated to last 2000 chars (#351).
+
+    Guards against silent bloat of context if someone changes
+    ``[-2000:]`` to a larger slice or removes it entirely.  Verified via
+    the probe.py raise site which is representative of all three (probe
+    / gpu / extract) that share the same cap.
+    """
+    import subprocess
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import pytest
+
+    from allaganeye.video.probe import probe_video
+
+    huge_stderr = "x" * 5000 + "END"
+    err = subprocess.CalledProcessError(
+        returncode=1, cmd=["ffprobe"], stderr=huge_stderr
+    )
+    with (
+        patch("allaganeye.video.probe.subprocess.run", side_effect=err),
+        patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe"),
+    ):
+        with pytest.raises(VideoProcessingError) as excinfo:
+            probe_video(Path("bad.mkv"))
+
+    tail = excinfo.value.context["stderr_tail"]
+    assert len(tail) == 2000
+    # Ensure we kept the tail (not the head): the final marker survives
+    assert tail.endswith("END")
+
+
+def test_detection_error_context_includes_audio_hits():
+    """DetectionError with empty boundaries carries audio_hits context (#351 / #335).
+
+    Debugging hook lead-1 wants for the #335 GPU/CPU discrepancy
+    investigation: when detection finds nothing the context must show
+    audio_hits status (= "disabled" when no_audio / frozen).  Guards
+    against a future refactor dropping the context dict.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    import pytest
+
+    from allaganeye.commands.split_matches import run_split
+    from allaganeye.config import SplitConfig
+
+    PROBE_RESULT = {
+        "duration": 1800.0,
+        "width": 1920,
+        "height": 1080,
+        "fps": 30.0,
+        "codec": "h264",
+        "audio_codec": "aac",
+    }
+
+    with (
+        patch(
+            "allaganeye.commands.split_matches.probe_video",
+            return_value=PROBE_RESULT,
+        ),
+        patch(
+            "allaganeye.commands.split_matches.detect_match_boundaries",
+            return_value=[],
+        ),
+        patch("allaganeye.commands.split_matches._run_audio_scan", return_value=None),
+    ):
+        config = SplitConfig(min_match_duration=60.0)
+        with pytest.raises(DetectionError) as excinfo:
+            run_split(Path("v.mp4"), config)
+
+    ctx = excinfo.value.context
+    assert "audio_hits" in ctx
+    assert ctx["audio_hits"] == "disabled"


### PR DESCRIPTION
## Summary

PR #354 のテスターレビューで発見した 3 件のテストギャップを補強します。既存テスト（\`test_exceptions.py\` 5 件 + \`test_cli.py\` 4 件）は \`AllaganEyeError\` クラス単体と CLI エンドの verbose 分岐を十分にカバーしていましたが、実際に context を注入する raise-site（probe / gpu / split_matches）の配線が未検証でした。

### 追加テスト

- **\`test_probe_video_error_attaches_command_and_stderr\`**
  - \`probe.py\` の \`CalledProcessError\` → \`VideoProcessingError\` ラップで \`command\` / \`return_code\` / \`stderr_tail\` が実際に注入されることを検証
  - 配線の回帰を最前線で検出（単体テストだけでは raise 側が壊れても通る）

- **\`test_stderr_tail_truncated_to_2000_chars\`**
  - \`stderr_tail[-2000:]\` の truncate 契約を固定
  - 誰かが \`-2000\` を外したり別値に変えた場合に即発覚
  - probe / gpu_detector / audio.extract の 3 箇所で共有されるマジックナンバー

- **\`test_detection_error_context_includes_audio_hits\`**
  - \`run_split\` 統合経由で \`DetectionError.context\` に \`audio_hits\` が入ることを検証
  - #335（GPU/CPU 乖離）調査で lead-1 が明示的に要望した debug フックなので、これが壊れると #335 の原因特定が困難になる

## Test plan

- [x] \`pytest tests/test_exceptions.py\` -- 8 passed (5 既存 + 3 新規)
- [x] \`pytest\` (全テスト) -- 487 passed, 34 deselected
- [x] \`ruff check .\` / \`ruff format --check .\` -- all passed

元 PR: #354 / Issue: #351 / 関連: #335 #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)