### PR TITLE
test: GPU/CPU 自動選択の表示・正規化契約を追加 #334 [tester-1]

### DIFF
--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1147,6 +1147,50 @@ class TestResolveGpuMode:
         assert "Auto-selected GPU mode" in out
         assert "h264" in out
 
+    def test_auto_cpu_verbose_shows_cpu_message(self, capsys):
+        """CPU auto-selection also emits a verbose notice (#334).
+
+        Guards the else-branch of the mode resolution -- users on
+        AV1/VP9 recordings need to see that CPU mode was chosen
+        intentionally (not just because GPU failed).
+        """
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _resolve_gpu_mode(None, "av1", show=True, verbose=True)
+        out = capsys.readouterr().out
+        assert "Auto-selected CPU mode" in out
+        assert "av1" in out
+
+    def test_auto_non_verbose_suppresses_message(self, capsys):
+        """Non-verbose auto selection is silent (#334)."""
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _resolve_gpu_mode(None, "h264", show=True, verbose=False)
+        out = capsys.readouterr().out
+        assert "Auto-selected" not in out
+
+    def test_auto_quiet_suppresses_message(self, capsys):
+        """--quiet (show=False) silences auto-selection message even with verbose (#334)."""
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _resolve_gpu_mode(None, "h264", show=False, verbose=True)
+        out = capsys.readouterr().out
+        assert "Auto-selected" not in out
+
+    def test_auto_codec_matching_is_case_insensitive(self):
+        """Codec name matching is case-insensitive (#334).
+
+        ffprobe normally returns lowercase codec_name, but downstream
+        callers or manual ProbeResult construction may pass "H264" /
+        "HEVC".  The set is compared via ``.lower()``; guards against a
+        future refactor dropping that normalization.
+        """
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        assert _resolve_gpu_mode(None, "H264", show=False, verbose=False) is True
+        assert _resolve_gpu_mode(None, "HEVC", show=False, verbose=False) is True
+        assert _resolve_gpu_mode(None, "Hevc", show=False, verbose=False) is True
+
 
 class TestAudioScanIntegration:
     """Audio scan pipeline wiring in run_split and _run_audio_scan (#288)."""


### PR DESCRIPTION
## Summary

PR #355 のテスターレビューで発見した 4 件のテストギャップを補強します。既存テストは explicit/auto × 全コーデック（h264/hevc/av1/vp9/unknown）を網羅していましたが、表示分岐の片側（CPU auto メッセージ）と正規化契約が未検証でした。

### 追加テスト

- **\`test_auto_cpu_verbose_shows_cpu_message\`**
  - AV1/VP9 等で CPU モードが自動選択されたときの \`Auto-selected CPU mode (codec: av1)\` メッセージを検証
  - 既存は GPU 側のみカバーで else-branch が未検証

- **\`test_auto_non_verbose_suppresses_message\`**
  - \`verbose=False\` 時に \`Auto-selected\` が出ないことを検証（デフォルト出力の静粛性）

- **\`test_auto_quiet_suppresses_message\`**
  - \`--quiet\` (\`show=False\`) 時に verbose=True でもメッセージが抑制されることを検証
  - \`if show and verbose\` の \`show\` 側の短絡を固定

- **\`test_auto_codec_matching_is_case_insensitive\`**
  - \`H264\` / \`HEVC\` / \`Hevc\` で GPU auto 選択されることを検証
  - \`(codec or \"\").lower()\` の正規化が外れた場合の回帰防止
  - ffprobe は通常 lowercase を返すが、将来の正規化削除や手動 ProbeResult 構築時に壊れるリスク

## Test plan

- [x] \`pytest tests/test_split_matches.py::TestResolveGpuMode\` -- 12 passed (8 既存 + 4 新規)
- [x] \`pytest\` (全テスト) -- 487 passed, 34 deselected
- [x] \`ruff check .\` / \`ruff format --check .\` -- all passed

元 PR: #355 / Issue: #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)