### PR TITLE
docs: 出力ファイル一覧に .detection_cache.json を追記 #360

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ output/
 ├── match_001.mp4
 ├── match_002.mp4
 ├── match_003.mp4
-└── metadata.json
+├── metadata.json         # 分割結果（機械可読）
+└── .detection_cache.json # 検知結果キャッシュ（同一ソース・同一パラメータの再実行を高速化。--no-cache で無視）
 ```
 
 ### Exit Codes

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -49,7 +49,8 @@ allaganeye split <video_path> [OPTIONS]
 ### 出力
 
 - `output/match_001.mp4`, `match_002.mp4`, ...
-- `output/metadata.json`
+- `output/metadata.json` — 分割結果（機械可読）
+- `output/.detection_cache.json` — 検知結果キャッシュ（同一ソース・同一パラメータの再実行を高速化。`--no-cache` で無視）
 
 ### metadata.json
 


### PR DESCRIPTION
## 概要

`split` コマンドの出力ファイル一覧に `.detection_cache.json` が記載されておらず、実際の出力と不整合になっていた問題を修正。

Issue #360

## 変更内容

- `README.md`: `### 出力` の出力ツリーに `metadata.json` と `.detection_cache.json` を注釈付きで追記
- `docs/cli-spec.md`: `### 出力` の箇条書きに両ファイルを注釈付きで追記
- いずれも `--no-cache` による無視動作を一行で補足

## 統合しない方針（Issue 記載の通り）

- `metadata.json` は L3 パイプラインの入力契約。キャッシュ検証用メタ情報を混ぜると契約が肥大化する
- キャッシュ無効化時に metadata まで消える挙動は望ましくない
- `.` prefix による「内部成果物」の慣例を維持

## チェックリスト

- [x] README.md の出力ツリーに `.detection_cache.json` を追記
- [x] docs/cli-spec.md `### 出力` にも同様に追記
- [x] `--no-cache` オプションとの関係を一行で補足
- [x] ドキュメントのみの変更につき pytest / ruff / pyright は影響なし
- [x] CLAUDE.md の更新は不要（出力仕様は各ドキュメントが正）

セッション: engineer-1