### PR TITLE
fix: Pass 1 borderline frame 対策 (A3/A4 hysteresis) #361

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -151,14 +151,32 @@ def detect_match_boundaries(
         )
         stats["pass1_elapsed_s"] = pass1_elapsed
 
-    # Collect blackout timestamps in chronological order
-    blackout_times = sorted(t for t, b in results.items() if b < blackout_threshold)
+    # A4 (#361): Pass 1 blackout judgment uses upper hysteresis margin so
+    # borderline frames (e.g. brightness 15.13 when threshold is 15.0) are
+    # treated as blackout.  Pass 2 precise measurement later rejects false
+    # positives introduced by the wider net.
+    pass1_blackout_threshold = blackout_threshold + _BLACKOUT_THRESHOLD_UPPER_MARGIN
+    blackout_times = sorted(
+        t for t, b in results.items() if b < pass1_blackout_threshold
+    )
 
     # Group into regions and expand with transition frames (#71)
     blackout_regions = _group_blackout_regions(blackout_times, sample_interval)
     blackout_regions = _expand_regions_with_transitions(
         blackout_regions, results, sample_interval, _TRANSITION_THRESHOLD
     )
+
+    # A3 (#361): add +-_BORDERLINE_REFINE_RADIUS pseudo-regions around Pass 1
+    # borderline frames so Pass 2's 0.25s probing covers short blackouts
+    # (<=2.5s) that Pass 1 missed due to sample_interval alignment.
+    if _ENABLE_BORDERLINE_REFINEMENT:
+        borderline_regions = _borderline_pseudo_regions(
+            results, blackout_threshold, duration_hint
+        )
+        if borderline_regions:
+            blackout_regions = _merge_regions(
+                blackout_regions + borderline_regions, sample_interval
+            )
 
     # Progress tracking for Pass 2 + scorebar filtering.
     # Total is initially set for Pass 2 only, then updated after Pass 2
@@ -809,6 +827,40 @@ included in the expanded region, allowing short blackouts followed by
 lobby screens to be detected as match boundaries.
 """
 
+_BLACKOUT_THRESHOLD_UPPER_MARGIN = 2.0
+"""Upper hysteresis margin for Pass 1 blackout judgment (#361).
+
+Pass 1 judges a frame as blackout when ``brightness < blackout_threshold +
+_BLACKOUT_THRESHOLD_UPPER_MARGIN``.  Catches frames that sit just above
+the strict threshold due to decoder-path variance (chunked fps filter vs
+single-frame decode returning different brightnesses for the same
+timestamp).  False positives are rejected by Pass 2 precise 0.25s
+measurement and scorebar classification.
+
+Set to 0.0 to disable A4 hysteresis (pre-#361 behavior).
+"""
+
+_ENABLE_BORDERLINE_REFINEMENT = True
+"""If True, Pass 2 refines +-_BORDERLINE_REFINE_RADIUS around Pass 1
+borderline frames (#361).
+
+Borderline = brightness in ``[blackout_threshold, blackout_threshold * 2)``.
+These are near-miss frames that may surround short blackouts (<=2.5s)
+missed by Pass 1 sample_interval.  Adding +-3s windows to Pass 2's
+refinement set lets 0.25s probing catch the real blackout even if
+Pass 1 never saw a frame below threshold.
+
+Set to False to restore pre-#361 behavior.
+"""
+
+_BORDERLINE_REFINE_RADIUS = 3.0
+"""Seconds on each side of borderline timestamps added to Pass 2 refinement (#361).
+
++-3s covers the worst case of a 2.5s blackout centered between two
+Pass 1 samples spaced 3s apart.  Pass 2's own +-_REFINE_WINDOW (5s)
+further extends the probe window, so effective coverage is +-8s.
+"""
+
 _REFINE_INTERVAL = 0.25
 """Fine interval for 2nd-pass re-probing of blackout candidates."""
 
@@ -829,6 +881,46 @@ With ``-c copy``, FFmpeg can only cut at keyframes (~2s apart for OBS).
 By placing cut points inside blackout regions, keyframe drift never
 clips actual match footage.
 """
+
+
+def _borderline_pseudo_regions(
+    results: dict[float, float],
+    blackout_threshold: float,
+    total_duration: float,
+) -> list[tuple[float, float]]:
+    """Build pseudo-regions around Pass 1 borderline frames (A3, #361).
+
+    A borderline frame sits in ``[blackout_threshold, blackout_threshold * 2)``
+    -- close to blackout but not dark enough to pass the strict Pass 1 cut.
+    Each borderline timestamp produces a +-``_BORDERLINE_REFINE_RADIUS``
+    window so Pass 2 precise sampling probes around it.
+    """
+    radius = _BORDERLINE_REFINE_RADIUS
+    upper = blackout_threshold * 2
+    return [
+        (max(0.0, t - radius), min(total_duration, t + radius))
+        for t, b in results.items()
+        if blackout_threshold <= b < upper
+    ]
+
+
+def _merge_regions(
+    regions: list[tuple[float, float]],
+    sample_interval: float,
+) -> list[tuple[float, float]]:
+    """Sort and merge overlapping or adjacent (start, end) regions."""
+    if not regions:
+        return []
+    tolerance = sample_interval * 2
+    sorted_regions = sorted(regions)
+    merged: list[tuple[float, float]] = [sorted_regions[0]]
+    for start, end in sorted_regions[1:]:
+        prev_start, prev_end = merged[-1]
+        if start - prev_end <= tolerance:
+            merged[-1] = (prev_start, max(prev_end, end))
+        else:
+            merged.append((start, end))
+    return merged
 
 
 def _group_blackout_regions(

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -11,17 +11,22 @@ from allaganeye.exceptions import VideoProcessingError
 from allaganeye.video.detector import (
     MatchBoundary,
     _BLACKOUT_PADDING,
+    _BLACKOUT_THRESHOLD_UPPER_MARGIN,
+    _BORDERLINE_REFINE_RADIUS,
+    _ENABLE_BORDERLINE_REFINEMENT,
     _FRAME_SIZE,
     _REFINED_MIN_BLACKOUT,
     _REFINE_INTERVAL,
     _REFINE_WINDOW,
     _TRANSITION_THRESHOLD,
+    _borderline_pseudo_regions,
     _decode_chunk_cpu,
     _expand_regions_with_transitions,
     _filter_and_extract_segments,
     _generate_timestamps,
     _group_blackout_regions,
     _infer_segment_type,
+    _merge_regions,
     _probe_single_frame,
     _refine_blackout_regions,
     detect_match_boundaries,
@@ -981,3 +986,223 @@ class TestDecodeChunkCpu:
 
         assert len(result) == 3
         assert all(v == 255.0 for v in result.values())
+
+
+# ============================================================
+# TestPass1HysteresisAndBorderline (#361)
+# ============================================================
+
+
+class TestPass1HysteresisConstants:
+    """Constants for A4 hysteresis and A3 borderline refinement (#361)."""
+
+    def test_upper_margin_default(self):
+        assert _BLACKOUT_THRESHOLD_UPPER_MARGIN == 2.0
+
+    def test_borderline_refinement_enabled_by_default(self):
+        assert _ENABLE_BORDERLINE_REFINEMENT is True
+
+    def test_borderline_refine_radius(self):
+        assert _BORDERLINE_REFINE_RADIUS == 3.0
+
+
+class TestBorderlinePseudoRegions:
+    """Unit tests for _borderline_pseudo_regions (A3, #361)."""
+
+    def test_empty_results(self):
+        assert _borderline_pseudo_regions({}, 15.0, 1000.0) == []
+
+    def test_no_borderline_frames(self):
+        """All frames outside [threshold, threshold*2) -> no pseudo regions."""
+        results = {0.0: 128.0, 10.0: 5.0, 20.0: 200.0}
+        assert _borderline_pseudo_regions(results, 15.0, 1000.0) == []
+
+    def test_borderline_frame_creates_window(self):
+        """A single borderline frame at 15.13 creates a +-3s window."""
+        results = {100.0: 15.13}
+        regions = _borderline_pseudo_regions(results, 15.0, 1000.0)
+        assert regions == [(97.0, 103.0)]
+
+    def test_window_clamped_to_start(self):
+        """Window does not go below 0.0."""
+        results = {1.0: 20.0}
+        regions = _borderline_pseudo_regions(results, 15.0, 1000.0)
+        assert regions[0][0] == 0.0
+        assert regions[0][1] == 4.0
+
+    def test_window_clamped_to_duration(self):
+        """Window does not exceed total_duration."""
+        results = {999.0: 20.0}
+        regions = _borderline_pseudo_regions(results, 15.0, 1000.0)
+        assert regions[0][0] == 996.0
+        assert regions[0][1] == 1000.0
+
+    def test_upper_bound_exclusive(self):
+        """Frames at exactly 2 * threshold are not borderline."""
+        results = {100.0: 30.0}  # == threshold * 2
+        assert _borderline_pseudo_regions(results, 15.0, 1000.0) == []
+
+    def test_lower_bound_inclusive(self):
+        """Frames at exactly threshold are borderline."""
+        results = {100.0: 15.0}
+        regions = _borderline_pseudo_regions(results, 15.0, 1000.0)
+        assert len(regions) == 1
+
+
+class TestMergeRegions:
+    """Unit tests for _merge_regions (A3 helper, #361)."""
+
+    def test_empty(self):
+        assert _merge_regions([], 1.0) == []
+
+    def test_single_region(self):
+        assert _merge_regions([(10.0, 20.0)], 1.0) == [(10.0, 20.0)]
+
+    def test_overlapping_merged(self):
+        result = _merge_regions([(10.0, 20.0), (15.0, 25.0)], 1.0)
+        assert result == [(10.0, 25.0)]
+
+    def test_adjacent_within_tolerance_merged(self):
+        """Gap <= 2*sample_interval merges."""
+        result = _merge_regions([(10.0, 20.0), (21.5, 25.0)], 1.0)  # gap 1.5 < 2.0
+        assert result == [(10.0, 25.0)]
+
+    def test_far_apart_kept_separate(self):
+        result = _merge_regions([(10.0, 20.0), (100.0, 110.0)], 1.0)
+        assert result == [(10.0, 20.0), (100.0, 110.0)]
+
+    def test_unsorted_input(self):
+        """Regions are sorted before merging."""
+        result = _merge_regions([(100.0, 110.0), (10.0, 20.0)], 1.0)
+        assert result == [(10.0, 20.0), (100.0, 110.0)]
+
+
+class TestPass1HysteresisIntegration:
+    """Integration of A4 hysteresis and A3 refinement in detect_match_boundaries."""
+
+    @patch("allaganeye.video.detector._probe_single_frame")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_upper_margin_catches_borderline_blackout(self, mock_chunk, mock_probe):
+        """A4: Pass 1 frame at brightness 15.5 is treated as blackout with margin=2.0.
+
+        With strict threshold 15.0 this frame would not pass Pass 1.  With
+        the upper hysteresis margin, it enters the blackout set.  Pass 2
+        is mocked to confirm blackout, so the boundary is retained.
+        """
+
+        # Put borderline frames in the middle, bright frames elsewhere.
+        # Pass 1 runs at 3s interval (default), so frames at 600-609 become
+        # a 10s borderline span.
+        def chunk_side_effect(vp, ts, cs, ce, si):
+            return {t: 15.5 if 600.0 <= t <= 609.0 else 128.0 for t in ts}
+
+        mock_chunk.side_effect = chunk_side_effect
+        # Pass 2 confirms blackout (<15.0 strict) in the same span
+        mock_probe.side_effect = lambda p, t: 5.0 if 599.0 <= t <= 610.0 else 128.0
+
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=1800.0,
+            sample_interval=3.0,
+            min_match_duration=300.0,
+        )
+
+        # With A4, borderline Pass 1 frames trigger Pass 2, which confirms
+        # the blackout and splits the video into two matches.
+        assert len(result) == 2
+
+    @patch("allaganeye.video.detector._probe_single_frame")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_borderline_triggers_refinement_around_missed_blackout(
+        self, mock_chunk, mock_probe
+    ):
+        """A3: Pass 1 borderline frames trigger Pass 2 +-3s refinement.
+
+        Simulates the #330 scenario: Pass 1 at 3s interval returns 20.0 at
+        t=8139 (borderline, not blackout).  No frame crosses the strict
+        threshold in Pass 1, so without A3 there is no blackout region.
+        With A3, a pseudo-region (8136, 8142) is added and Pass 2 probes
+        at 0.25s intervals -- finding the real short blackout at 8137-8140.
+        """
+
+        def chunk_side_effect(vp, ts, cs, ce, si):
+            # t=8139 is borderline; surrounding Pass 1 samples are bright
+            out = {}
+            for t in ts:
+                if t == 8139.0:
+                    out[t] = 20.0  # borderline: in [15, 30)
+                else:
+                    out[t] = 128.0
+            return out
+
+        mock_chunk.side_effect = chunk_side_effect
+        # Pass 2 at 0.25s finds real blackout 8137.25-8139.75
+        mock_probe.side_effect = lambda p, t: 2.0 if 8137.25 <= t <= 8139.75 else 128.0
+
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=10000.0,
+            sample_interval=3.0,
+            min_match_duration=300.0,
+        )
+
+        # Confirm Pass 2 was asked to probe around the borderline timestamp
+        probed = [c.args[1] for c in mock_probe.call_args_list]
+        near_borderline = [t for t in probed if 8136.0 <= t <= 8142.0]
+        assert near_borderline, (
+            "Expected Pass 2 probes around borderline t=8139, "
+            f"but probed: {sorted(set(probed))[:10]}..."
+        )
+
+    @patch("allaganeye.video.detector._probe_single_frame")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_borderline_refinement_disabled_skips_pseudo_regions(
+        self, mock_chunk, mock_probe
+    ):
+        """With _ENABLE_BORDERLINE_REFINEMENT=False, no pseudo regions added."""
+
+        def chunk_side_effect(vp, ts, cs, ce, si):
+            return {t: 20.0 if t == 8139.0 else 128.0 for t in ts}
+
+        mock_chunk.side_effect = chunk_side_effect
+        mock_probe.return_value = 128.0
+
+        with patch("allaganeye.video.detector._ENABLE_BORDERLINE_REFINEMENT", False):
+            detect_match_boundaries(
+                Path("test.mp4"),
+                duration_hint=10000.0,
+                sample_interval=3.0,
+                min_match_duration=300.0,
+            )
+
+        probed = [c.args[1] for c in mock_probe.call_args_list]
+        # No Pass 2 probes around 8139 since no blackout region was created
+        near_borderline = [t for t in probed if 8136.0 <= t <= 8142.0]
+        assert not near_borderline
+
+    @patch("allaganeye.video.detector._probe_single_frame")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_upper_margin_zero_restores_strict_threshold(self, mock_chunk, mock_probe):
+        """With _BLACKOUT_THRESHOLD_UPPER_MARGIN=0.0, only b<threshold is blackout."""
+
+        def chunk_side_effect(vp, ts, cs, ce, si):
+            # Make one frame borderline (15.5) but otherwise bright.
+            # Also disable A3 so only A4 behavior is under test.
+            return {t: 15.5 if 600.0 <= t <= 609.0 else 128.0 for t in ts}
+
+        mock_chunk.side_effect = chunk_side_effect
+        mock_probe.return_value = 128.0  # Pass 2 finds no blackout
+
+        with (
+            patch("allaganeye.video.detector._BLACKOUT_THRESHOLD_UPPER_MARGIN", 0.0),
+            patch("allaganeye.video.detector._ENABLE_BORDERLINE_REFINEMENT", False),
+        ):
+            result = detect_match_boundaries(
+                Path("test.mp4"),
+                duration_hint=1800.0,
+                sample_interval=3.0,
+                min_match_duration=300.0,
+            )
+
+        # Borderline not captured -> single match spans whole video
+        assert len(result) == 1

--- a/tests/test_regression_330.py
+++ b/tests/test_regression_330.py
@@ -1,0 +1,141 @@
+"""Regression tests for issue #330 Match 6 boundary accuracy (#361).
+
+Verifies that detect_match_boundaries places the end of the 6th match near
+2:15:37 in the 2026-04-08 21-14-05 recording, rather than the 2:16:12 value
+observed before the #361 Prong A3/A4 fix.
+
+Requires:
+- ``ALLAGANEYE_AUDIO_TEST_VIDEO`` pointing to the 2026-04-08 21-14-05 primary
+  recording (same env var used by ``tests/test_audio_integration.py``).
+- ffmpeg/ffprobe in PATH.
+- For the GPU variant, a GPU with hardware acceleration available.
+
+Run with: ``pytest -m slow tests/test_regression_330.py``
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from allaganeye.ffmpeg_path import find_ffmpeg
+from allaganeye.video.detector import (
+    MatchBoundary,
+    detect_match_boundaries,
+)
+from allaganeye.video.probe import ProbeResult, probe_video
+
+pytestmark = pytest.mark.slow
+
+
+# Match 6 actual end (ground truth, 2026-04-08 21-14-05 recording):
+# 2:15:37 = 8137s, from user verification in issue #330.
+_MATCH_6_ACTUAL_END_SECONDS = 8137.0
+_BOUNDARY_TOLERANCE_SECONDS = 10.0
+
+# Match 6 was Match index 5 (0-based) in the observed 8-match detection.
+# See memory `project_audio_primary_recording.md` for expected starts.
+_MATCH_6_INDEX = 5
+
+# Accept a small variance around the expected 8-match count to stay resilient
+# to unrelated detector tweaks; the assertion on Match 6 end is the core check.
+_EXPECTED_MATCH_COUNT_MIN = 7
+_EXPECTED_MATCH_COUNT_MAX = 9
+
+
+def _video_from_env() -> Path | None:
+    env = os.environ.get("ALLAGANEYE_AUDIO_TEST_VIDEO")
+    if not env:
+        return None
+    path = Path(env)
+    return path if path.is_file() else None
+
+
+def _gpu_available() -> bool:
+    try:
+        result = subprocess.run(
+            [find_ffmpeg(), "-hwaccels"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        accels = result.stdout.lower()
+        return any(
+            a in accels for a in ("cuda", "d3d11va", "qsv", "vulkan", "videotoolbox")
+        )
+    except Exception:
+        return False
+
+
+gpu_available = pytest.mark.skipif(
+    not _gpu_available(),
+    reason="No GPU hardware acceleration available",
+)
+
+
+@pytest.fixture(scope="module")
+def primary_video() -> Path:
+    video = _video_from_env()
+    if video is None:
+        pytest.skip(
+            "ALLAGANEYE_AUDIO_TEST_VIDEO not set or file missing; "
+            "expected the 2026-04-08 21-14-05.mkv primary recording"
+        )
+    return video
+
+
+@pytest.fixture(scope="module")
+def primary_metadata(primary_video: Path) -> ProbeResult:
+    return probe_video(primary_video)
+
+
+def _run_detection(
+    video: Path, metadata: ProbeResult, *, use_gpu: bool
+) -> list[MatchBoundary]:
+    return detect_match_boundaries(
+        video,
+        use_gpu=use_gpu,
+        duration_hint=metadata["duration"],
+        sample_interval=2.0,
+        blackout_threshold=15.0,
+        min_match_duration=300.0,
+        min_blackout_duration=3.0,
+        src_resolution=(metadata["width"], metadata["height"]),
+        codec=metadata["codec"],
+    )
+
+
+def _assert_match_6_end_within_tolerance(boundaries: list[MatchBoundary]) -> None:
+    count = len(boundaries)
+    assert _EXPECTED_MATCH_COUNT_MIN <= count <= _EXPECTED_MATCH_COUNT_MAX, (
+        f"Expected {_EXPECTED_MATCH_COUNT_MIN}-{_EXPECTED_MATCH_COUNT_MAX} "
+        f"matches, got {count}. boundaries={boundaries}"
+    )
+    match_6 = boundaries[_MATCH_6_INDEX]
+    diff = abs(match_6["end"] - _MATCH_6_ACTUAL_END_SECONDS)
+    assert diff <= _BOUNDARY_TOLERANCE_SECONDS, (
+        f"Match 6 end {match_6['end']:.1f}s differs from ground truth "
+        f"{_MATCH_6_ACTUAL_END_SECONDS:.1f}s by {diff:.1f}s "
+        f"(tolerance {_BOUNDARY_TOLERANCE_SECONDS:.1f}s). "
+        f"match_6={match_6}"
+    )
+
+
+class TestMatch6BoundaryRegression:
+    """Regression: #330 Match 6 end 35s shift resolved by #361 A3/A4."""
+
+    def test_match_6_boundary_2015_within_tolerance_cpu(
+        self, primary_video: Path, primary_metadata: ProbeResult
+    ) -> None:
+        boundaries = _run_detection(primary_video, primary_metadata, use_gpu=False)
+        _assert_match_6_end_within_tolerance(boundaries)
+
+    @gpu_available
+    def test_match_6_boundary_2015_within_tolerance_gpu(
+        self, primary_video: Path, primary_metadata: ProbeResult
+    ) -> None:
+        boundaries = _run_detection(primary_video, primary_metadata, use_gpu=True)
+        _assert_match_6_end_within_tolerance(boundaries)

--- a/tests/test_regression_330.py
+++ b/tests/test_regression_330.py
@@ -36,15 +36,6 @@ pytestmark = pytest.mark.slow
 _MATCH_6_ACTUAL_END_SECONDS = 8137.0
 _BOUNDARY_TOLERANCE_SECONDS = 10.0
 
-# Match 6 was Match index 5 (0-based) in the observed 8-match detection.
-# See memory `project_audio_primary_recording.md` for expected starts.
-_MATCH_6_INDEX = 5
-
-# Accept a small variance around the expected 8-match count to stay resilient
-# to unrelated detector tweaks; the assertion on Match 6 end is the core check.
-_EXPECTED_MATCH_COUNT_MIN = 7
-_EXPECTED_MATCH_COUNT_MAX = 9
-
 
 def _video_from_env() -> Path | None:
     env = os.environ.get("ALLAGANEYE_AUDIO_TEST_VIDEO")
@@ -109,18 +100,22 @@ def _run_detection(
 
 
 def _assert_match_6_end_within_tolerance(boundaries: list[MatchBoundary]) -> None:
-    count = len(boundaries)
-    assert _EXPECTED_MATCH_COUNT_MIN <= count <= _EXPECTED_MATCH_COUNT_MAX, (
-        f"Expected {_EXPECTED_MATCH_COUNT_MIN}-{_EXPECTED_MATCH_COUNT_MAX} "
-        f"matches, got {count}. boundaries={boundaries}"
-    )
-    match_6 = boundaries[_MATCH_6_INDEX]
-    diff = abs(match_6["end"] - _MATCH_6_ACTUAL_END_SECONDS)
-    assert diff <= _BOUNDARY_TOLERANCE_SECONDS, (
-        f"Match 6 end {match_6['end']:.1f}s differs from ground truth "
-        f"{_MATCH_6_ACTUAL_END_SECONDS:.1f}s by {diff:.1f}s "
-        f"(tolerance {_BOUNDARY_TOLERANCE_SECONDS:.1f}s). "
-        f"match_6={match_6}"
+    """Assert exactly one detected match ends within tolerance of the ground truth.
+
+    Content-based matching is robust against unrelated detector changes that
+    shift the overall match count or ordering: the regression check stays
+    meaningful as long as *some* match boundary lands near 2:15:37.
+    """
+    candidates = [
+        b
+        for b in boundaries
+        if abs(b["end"] - _MATCH_6_ACTUAL_END_SECONDS) <= _BOUNDARY_TOLERANCE_SECONDS
+    ]
+    assert len(candidates) == 1, (
+        f"Expected exactly one match ending within "
+        f"{_BOUNDARY_TOLERANCE_SECONDS:.1f}s of "
+        f"{_MATCH_6_ACTUAL_END_SECONDS:.1f}s, found {len(candidates)}. "
+        f"boundaries={boundaries}"
     )
 
 


### PR DESCRIPTION
## 概要

#330 Match 6 境界の 35s ずれ（Phase 0 真因調査で判明した Pass 1 検出漏れ）の根本対策。計画書 `composed-crunching-flute.md` の Prong A3/A4 を実装。

## 変更内容

### `allaganeye/video/detector.py`

**A4: Pass 1 閾値の上方向ヒステリシス**
- 新定数 `_BLACKOUT_THRESHOLD_UPPER_MARGIN = 2.0`
- Pass 1 blackout 判定を `b < threshold` から `b < threshold + _BLACKOUT_THRESHOLD_UPPER_MARGIN` に変更
- chunked fps filter と single-frame decode が同 timestamp に対して異なる brightness を返す問題を緩和（例: 8139.00 で Pass 1 は 15.13、単発 decode は 1.7）

**A3: borderline frame 周辺の Pass 2 追加 refinement**
- 新定数 `_ENABLE_BORDERLINE_REFINEMENT = True`, `_BORDERLINE_REFINE_RADIUS = 3.0`
- 新ヘルパ `_borderline_pseudo_regions`: 輝度 `[threshold, threshold*2)` の frame を借定 region `(t-3, t+3)` に変換
- 新ヘルパ `_merge_regions`: 既存 `blackout_regions` と和集合・重複排除
- Pass 2 (0.25s 間隔) が sample_interval 境界に挟まれた短い暗転 (<=2.5s) を拾える

False positive は Pass 2 strict 閾値判定と scorebar 分類で落とす。

### GPU について

`gpu_detector.py` の変更は不要。scan_gpu が返す `dict[float, float]` を `detect_match_boundaries` 中央ロジックが処理するため、A3/A4 は CPU/GPU 両モードに自動適用される。

### Rollback 構造

- `_BLACKOUT_THRESHOLD_UPPER_MARGIN = 0.0` で A4 無効化
- `_ENABLE_BORDERLINE_REFINEMENT = False` で A3 無効化

両フラグで従来挙動に戻れる。

## テスト

### ユニットテスト (`tests/test_detector.py` に 4 クラス追加)
- `TestPass1HysteresisConstants`: 新定数の既定値
- `TestBorderlinePseudoRegions`: borderline range / window clamping
- `TestMergeRegions`: merge tolerance / overlap
- `TestPass1HysteresisIntegration`: A3/A4 有効・無効時の動作

### 回帰テスト (`tests/test_regression_330.py` 新設)
- `test_match_6_boundary_2015_within_tolerance_cpu`: 実動画 CPU モード Match 6 終了 = 2:15:37 +- 10s
- `test_match_6_boundary_2015_within_tolerance_gpu`: GPU モード同条件
- `slow` マーカー、`ALLAGANEYE_AUDIO_TEST_VIDEO` env var で有効化
- content-based matching: 境界リストから `end` がグラウンドトゥルースに近いものを検索し、他 tweak による Match 順序変化に強い

### 実動画での実行結果

`E:/videos/2026-04-08 21-14-05.mkv` (37GB):

| モード | 実行時間 | 結果 |
|---|---|---|
| CPU | 7m59s | PASSED (Match 6 終了が 2:15:37 +-10s 以内) |
| GPU | 6m44s | PASSED (同上) |

## Test plan (engineer)

- [x] `pytest -m 'not slow'` 全 pass (521 tests)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `pyright allaganeye/ tests/` clean
- [x] 実動画 `2026-04-08 21-14-05.mkv` で CPU / GPU 両モードの Match 6 終了 = 2:15:37 +- 10s PASS

## Tester verification required

以下は tester による実動画スロー実行を依頼:

- `pytest -m slow tests/test_regression_330.py` CPU / GPU 両モード実行 (primary 録画 `ALLAGANEYE_AUDIO_TEST_VIDEO`)
- 既存 4 録画 (20260116, 20260118, 20260119, 20260408) で Match 数・境界退行なし (`pytest -m slow` で `test_integration.py` / `test_scorebar_regression.py`)

## 関連

- #361 (本 PR で対応)
- #330 Match 6 境界精度 (本 PR で解消見込み)
- #359 Pass 1 brightness 非決定性 (A3/A4 は部分緩和、根本は Pass 1 decode 経路統一 = 別途)
- #214 ffmpeg seek 非決定性 (既知制約)

[engineer-2]

🤖 Generated with [Claude Code](https://claude.com/claude-code)