### PR TITLE
fix(detector): Pass 2 中に Refining 進捗を発火 (Refs #366)

### DIFF
--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -179,9 +179,9 @@ def detect_match_boundaries(
             )
 
     # Progress tracking for Pass 2 + scorebar filtering.
-    # Total is initially set for Pass 2 only, then updated after Pass 2
-    # when the actual refined_regions count is known for scorebar.
-    refine_total = len(blackout_regions)
+    # Pass 2 publishes the actual probe count via its progress_callback;
+    # scorebar bumps the total later when refined_regions is known.
+    refine_total = 0
     refine_completed = 0
 
     def _refine_step() -> None:
@@ -190,18 +190,29 @@ def detect_match_boundaries(
         if refine_progress_callback is not None:
             refine_progress_callback(refine_completed, refine_total)
 
-    # 2nd pass: refine blackout regions at fine interval (#77)
+    def _on_refine_probe(completed: int, total: int) -> None:
+        nonlocal refine_completed, refine_total
+        refine_total = total
+        refine_completed = completed
+        if refine_progress_callback is not None:
+            refine_progress_callback(refine_completed, refine_total)
+
+    # 2nd pass: refine blackout regions at fine interval (#77).
+    # progress_callback fires per probe so the Refining bar advances during
+    # the long ThreadPoolExecutor wait (#366).
     pass2_start = time.monotonic()
     refined_regions = _refine_blackout_regions(
-        video_path, blackout_regions, blackout_threshold, duration_hint, workers
+        video_path,
+        blackout_regions,
+        blackout_threshold,
+        duration_hint,
+        workers,
+        progress_callback=_on_refine_probe,
     )
     pass2_elapsed = time.monotonic() - pass2_start
     if stats is not None:
         stats["pass2_regions"] = len(refined_regions)
         stats["pass2_elapsed_s"] = pass2_elapsed
-    # Report Pass 2 completion (one step per original region)
-    for _ in blackout_regions:
-        _refine_step()
 
     # Scorebar-based filtering: remove in-match and non-FL blackouts (#111)
     region_classifications: list[str] | None = None
@@ -1012,12 +1023,18 @@ def _refine_blackout_regions(
     blackout_threshold: float,
     total_duration: float,
     workers: int | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> list[tuple[float, float]]:
     """Re-probe blackout regions at fine interval for precise duration.
 
     For each region, probes +-_REFINE_WINDOW seconds at _REFINE_INTERVAL
     to get an accurate measurement of the blackout duration.  Returns
     updated regions with refined start/end times.
+
+    *progress_callback* fires once before probing with ``(0, total_probes)``
+    to publish the total, then once per completed probe with the running
+    ``(completed, total)``.  This lets callers drive a progress bar during
+    the long ThreadPoolExecutor wait (#366).
     """
     if not blackout_regions:
         return blackout_regions
@@ -1037,17 +1054,25 @@ def _refine_blackout_regions(
     # Parallel probes
     results: dict[float, float] = {}
     sorted_probes = sorted(probe_timestamps)
+    total_probes = len(sorted_probes)
+
+    if progress_callback is not None:
+        progress_callback(0, total_probes)
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = {
             pool.submit(_probe_single_frame, video_path, t): t for t in sorted_probes
         }
+        completed = 0
         for future in as_completed(futures):
             t = futures[future]
             try:
                 results[t] = future.result()
             except VideoProcessingError:
                 results[t] = 255.0
+            completed += 1
+            if progress_callback is not None:
+                progress_callback(completed, total_probes)
 
     # Re-extract blackout regions from fine-grained data
     fine_blackout_times = sorted(

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -253,6 +253,51 @@ class TestRefineBlackoutRegions:
         assert all(0.0 <= t <= 8.0 for t in probed_times)
 
     @patch("allaganeye.video.detector._probe_single_frame")
+    def test_progress_callback_fires_per_probe(self, mock_probe):
+        """progress_callback is called per probe completion (#366).
+
+        Before #366 the Refining bar froze for the entire Pass 2 wait
+        because progress was only reported after the function returned.
+        """
+        mock_probe.return_value = 128.0
+        regions = [(100.0, 102.0)]
+        calls: list[tuple[int, int]] = []
+
+        _refine_blackout_regions(
+            Path("test.mp4"),
+            regions,
+            15.0,
+            1000.0,
+            progress_callback=lambda c, t: calls.append((c, t)),
+        )
+
+        # Initial publish + one call per probe
+        probe_count = mock_probe.call_count
+        assert probe_count > 0
+        assert calls[0] == (0, probe_count)
+        assert len(calls) == probe_count + 1
+        # Monotonically non-decreasing completed counts
+        completed_seq = [c for c, _ in calls]
+        assert completed_seq == sorted(completed_seq)
+        # Total stays constant; final completed equals total
+        assert all(t == probe_count for _, t in calls)
+        assert calls[-1] == (probe_count, probe_count)
+
+    @patch("allaganeye.video.detector._probe_single_frame")
+    def test_progress_callback_not_called_for_empty_regions(self, mock_probe):
+        """Empty input short-circuits before any progress is published."""
+        calls: list[tuple[int, int]] = []
+        _refine_blackout_regions(
+            Path("test.mp4"),
+            [],
+            15.0,
+            1000.0,
+            progress_callback=lambda c, t: calls.append((c, t)),
+        )
+        assert calls == []
+        mock_probe.assert_not_called()
+
+    @patch("allaganeye.video.detector._probe_single_frame")
     def test_video_processing_error_treated_as_non_blackout(self, mock_probe):
         """VideoProcessingError from a future is caught and treated as 255.0."""
         from allaganeye.exceptions import VideoProcessingError
@@ -814,9 +859,10 @@ class TestDetectMatchBoundaries:
         )
         # At least one refine callback for the detected region
         assert len(refine_calls) >= 1
-        # completed counts are monotonically non-decreasing and bounded by total
+        # completed counts are bounded by total.  The initial probe publish
+        # uses (0, total) before any probe completes (#366), so 0 is allowed.
         for completed, total in refine_calls:
-            assert 1 <= completed <= total
+            assert 0 <= completed <= total
         # final completed == total (all refine steps reported)
         assert refine_calls[-1][0] == refine_calls[-1][1]
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -774,6 +774,23 @@ class TestRefineProgressBar:
         def on_refine(completed: int, total: int) -> None:
             calls.append((completed, total))
 
+        def refine_side_effect(
+            video_path,
+            blackout_regions,
+            blackout_threshold,
+            duration_hint,
+            workers,
+            *,
+            progress_callback=None,
+        ):
+            # Mimic Pass 2: publish total then advance per probe (#366)
+            total_probes = 4
+            if progress_callback is not None:
+                progress_callback(0, total_probes)
+                for i in range(1, total_probes + 1):
+                    progress_callback(i, total_probes)
+            return [(0.0, 5.0)]
+
         # Use a minimal mock: scan_cpu returns a blackout region so Pass 2 fires
         with (
             patch(
@@ -782,7 +799,7 @@ class TestRefineProgressBar:
             ),
             patch(
                 "allaganeye.video.detector._refine_blackout_regions",
-                return_value=[(0.0, 5.0)],
+                side_effect=refine_side_effect,
             ),
             patch(
                 "allaganeye.video.scorebar.filter_blackouts_with_scorebar",
@@ -811,6 +828,23 @@ class TestRefineProgressBar:
         def on_refine(completed: int, total: int) -> None:
             calls.append((completed, total))
 
+        def refine_side_effect(
+            video_path,
+            blackout_regions,
+            blackout_threshold,
+            duration_hint,
+            workers,
+            *,
+            progress_callback=None,
+        ):
+            # Mimic Pass 2: publish total then advance per probe (#366)
+            total_probes = 6
+            if progress_callback is not None:
+                progress_callback(0, total_probes)
+                for i in range(1, total_probes + 1):
+                    progress_callback(i, total_probes)
+            return [(0.0, 5.0), (15.0, 20.0), (25.0, 30.0)]
+
         # 2 blackout regions from Pass 1, 3 refined regions for scorebar
         with (
             patch(
@@ -819,7 +853,7 @@ class TestRefineProgressBar:
             ),
             patch(
                 "allaganeye.video.detector._refine_blackout_regions",
-                return_value=[(0.0, 5.0), (15.0, 20.0), (25.0, 30.0)],
+                side_effect=refine_side_effect,
             ),
             patch(
                 "allaganeye.video.scorebar.filter_blackouts_with_scorebar",


### PR DESCRIPTION
## 概要

`_refine_blackout_regions` に `progress_callback` を追加し、`ThreadPoolExecutor` の `as_completed` ループ内で発火するよう変更。これにより Pass 2 (Refining) 進捗バーが実進捗で進むようになる。

## 背景

これまでは Pass 2 完了後に呼び出し側が `len(blackout_regions)` 回ダミーステップを発火していたため、長時間動画で Pass 2 中に進捗が完全停止して見え「フリーズ?」と誤解される実害があった (#328 の不完全修正 → #366)。

## 変更内容

- `allaganeye/video/detector.py`
  - `_refine_blackout_regions` に `progress_callback: Callable[[int, int], None] | None = None` を追加
  - 開始時に `progress_callback(0, total_probes)` で総数を publish
  - `as_completed` ループ内で `progress_callback(completed, total_probes)` を発火
  - `detect_match_boundaries` の呼び出し側で `_on_refine_probe` アダプタを定義し、`refine_progress_callback` に転送
  - 旧 `for _ in blackout_regions: _refine_step()` ダミーループを削除
  - scorebar フェーズの total 更新ロジックは互換 (`refine_completed + len(refined_regions)`)
- `tests/test_detector.py`
  - 新規: `test_progress_callback_fires_per_probe` (per-probe 発火を検証)
  - 新規: `test_progress_callback_not_called_for_empty_regions`
  - 既存 `test_refine_progress_callback` の境界条件を `0 <=` に更新 (初期 publish 対応)
- `tests/test_split_matches.py`
  - 既存テストのモックが新しい `progress_callback` を発火するよう side_effect 化

## チェックリスト

- [x] `python -m ruff check` 通過
- [x] `python -m ruff format --check` 通過
- [x] `python -m pyright allaganeye/video/detector.py allaganeye/commands/split_matches.py` 通過
- [x] `python -m pytest` 通過 (523 passed, 36 deselected)
- [x] base = `develop-0.1.1`
- [x] `Refs #366`
- [x] session-id 記載

## 関連 Issue

- Refs #366 (本 PR)
- 後続: #368 (Detecting バー上書き問題) — 本 PR マージ後に engineer が着手予定

## レビューワ

`role:director` (Lead Engineer 作成 PR のため)

## session-id

lead-2