### PR TITLE
fix(split): metadata.json output_file を POSIX 区切りで出力 (Refs #371) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -545,7 +545,7 @@ def _split_and_write_metadata(
                 "duration": b["end"] - b["start"],
                 "duration_display": _format_duration(b["end"] - b["start"]),
                 "type": b.get("type", "unknown"),
-                "output_file": str(f),
+                "output_file": f.as_posix(),
             }
             for i, (b, f) in enumerate(zip(boundaries, output_files, strict=True))
         ],

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -79,7 +79,7 @@ allaganeye split <video_path> [OPTIONS]
 | `duration` | float | 試合時間（秒） |
 | `duration_display` | string | 試合時間の表示形式 |
 | `type` | string | セグメントの種別（`"fl_match"` / `"unknown"`） |
-| `output_file` | string | 出力ファイルパス |
+| `output_file` | string | 出力ファイルパス（POSIX 区切り、例: `output/match_001.mp4`）。Windows 実行時も `/` で記録される |
 
 **gaps[]:**
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -123,7 +123,7 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
       "duration": 842.0,
       "duration_display": "14m02s",
       "type": "fl_match",
-      "output_file": "match_001.mp4"
+      "output_file": "output/match_001.mp4"
     }
   ],
   "gaps": [

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -146,6 +146,38 @@ def test_pipeline_metadata_json_content(mock_probe, mock_detect, mock_split, tmp
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_metadata_output_file_uses_posix_separator(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """metadata.json output_file uses POSIX '/' separator on all platforms (#371).
+
+    JSON is a cross-platform data-interchange format; backslashes in paths
+    break Linux/macOS consumers of metadata.json (e.g. the L2/L3 pipeline).
+    """
+    nested = tmp_path / "sub" / "output"
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = [
+        nested / "match_001.mp4",
+        nested / "match_002.mp4",
+    ]
+    config = SplitConfig(output_dir=nested, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+
+    data = json.loads((nested / "metadata.json").read_text(encoding="utf-8"))
+    for m in data["matches"]:
+        assert "\\" not in m["output_file"], (
+            f"output_file must not contain backslashes: {m['output_file']!r}"
+        )
+        assert "/" in m["output_file"], (
+            f"output_file must contain forward slashes: {m['output_file']!r}"
+        )
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_pipeline_output_dir_created(mock_probe, mock_detect, mock_split, tmp_path):
     """Output directory is created if it doesn't exist."""
     output = tmp_path / "subdir" / "output"


### PR DESCRIPTION
## Summary

Windows 環境で `metadata.json` の `matches[].output_file` がバックスラッシュ区切り (例: `output\match_001.mp4`) で記録されており、Linux/macOS で共有・パイプライン読み込みする際に破綻する問題を修正。

`Path.as_posix()` で POSIX 互換のフォワードスラッシュに正規化する。

## 変更点

- `allaganeye/commands/split_matches.py` — `_split_and_write_metadata` の matches 生成で `str(f)` → `f.as_posix()`
- `tests/test_split_matches.py` — 回帰防止テスト `test_metadata_output_file_uses_posix_separator` 追加。**書き出された metadata.json を再 parse** し、`\` が含まれず `/` を含むことを assert
- `docs/cli-spec.md` — `output_file` の説明を「POSIX 区切り（Windows でも `/`）」と明記
- `docs/design-overview.md` — サンプル JSON を `"output/match_001.mp4"` に更新

## スコープ外

`source` パス側も同様の問題があるが、本 PR のスコープは `output_file` のみ (#372 で別対応)。

## 再発防止

従来のテストは metadata 出力を部分文字列 (`"match_001" in output_file`) で見ていたため、区切り文字の変化を捕捉できていなかった。本 PR のテストは **書き出された JSON を実ファイル経由で再 parse** し、`\` の非存在 / `/` の存在を構造的に検証する。

## 手動検証

```
$ allaganeye split "E:/royalstraightflesh/videos/20260116/20260116_1.mp4" -o /tmp/verify-371
$ python -m json.tool /tmp/verify-371/metadata.json
...
    "output_file": "C:/Users/idios/AppData/Local/Temp/verify-371/match_001.mp4"
...
```

Windows の絶対パスでも `/` 区切りで出力されることを確認。

## Test plan

- [x] コード修正 (split_matches.py)
- [x] テスト追加 (test_metadata_output_file_uses_posix_separator)
- [x] docs 同期 (cli-spec.md / design-overview.md)
- [x] `pytest` 522 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors
- [x] 実動画で手動検証し metadata.json の `output_file` が `/` 区切りになることを確認

Refs #371

session-id: engineer-1