### PR TITLE
docs(quickstart): venv の終了 / 再 activate 手順を追記 (Refs #364) [engineer-1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ rem まず検知結果を確認
 allaganeye split your_recording.mkv --dry-run
 rem 結果が正しければ本実行
 allaganeye split your_recording.mkv
+
+rem 使い終わったら仮想環境を抜ける (Windows/Linux/macOS 共通)
+deactivate
 ```
 
 > 上記は Windows コマンドプロンプトでの例です。PowerShell・Git Bash・Linux・macOS での手順は [Quick Start Guide](docs/quickstart.md) を参照してください。
+>
+> 新しいターミナルで再度作業する場合は、`.venv` を再 activate してから `allaganeye` を実行してください（詳細は [Quick Start Guide §4](docs/quickstart.md#4-動画を分割する)）。
 
 ## 使い方
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -196,6 +196,16 @@ pip install -e .
 
 > **注意**: 仮想環境を使わずに `pip install -e .` すると、`allaganeye` コマンドが PATH の通らないディレクトリにインストールされることがあります（特に Microsoft Store 版 Python）。仮想環境の使用を推奨します。
 
+### 仮想環境を抜ける
+
+作業が終わって仮想環境から抜けるときは、どのシェル・OS でも共通で `deactivate` と入力します。
+
+```bash
+deactivate
+```
+
+`deactivate` は venv が提供する組み込みコマンドで、Windows (コマンドプロンプト / PowerShell / Git Bash) ・Linux ・macOS のいずれでも同じ一語で動作します。ターミナル自体を閉じれば自動的に抜けます。
+
 ## 3. 更新
 
 ```bash
@@ -228,6 +238,8 @@ editable install (`pip install -e .`) のため、通常は `git pull` だけで
 依存パッケージが追加・変更された場合のみ `pip install -e .` の再実行が必要です。
 
 ## 4. 動画を分割する
+
+> **新しいターミナルで作業を再開する場合**: 仮想環境を `deactivate` した、あるいはターミナルを閉じてから戻ってきた場合は、[§2 インストール](#2-インストール) に載っているコマンドで `.venv` を再 activate してから `allaganeye` を実行してください。再 activate せずに実行すると `command not found` （Windows では `コマンドが見つかりません` / `not recognized`）になります。
 
 ### 対応する録画
 


### PR DESCRIPTION
## Summary

ユーザーテストで `deactivate` の案内・新しいターミナルでの `.venv` 再 activate 手順が Quick Start に無く、「ターミナルを閉じてから戻って `allaganeye split ...` を打つと command not found」という詰まり方をする導線が判明。これを解消する docs-only 修正。

## 変更点

- `README.md` Quick Start:
  - コマンド例末尾に `deactivate` を 1 行追加（Windows/Linux/macOS 共通と明記）
  - 新しいターミナルで再 activate する必要性への参照リンクを追加
- `docs/quickstart.md` §2（インストール）末尾:
  - 「仮想環境を抜ける」段落を新設。`deactivate` は venv 組み込みコマンドで全 OS/シェル共通であることを説明
- `docs/quickstart.md` §4（動画を分割する）冒頭:
  - 「新しいターミナルでは §2 と同じ手順で `.venv` を再 activate」ガイドを追加。`command not found` 相当メッセージの例も記載

## Test plan

- [x] `pytest` 521 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] §2 → §3 → §4 を頭から読み、導線が自然か目視確認
- [x] 既存 §3（更新）の再 activate パターンと文言の重複をチェック（§2 への参照リンクで冗長を回避）

## 関連

- 依存: なし（他 PR と並行可）

Refs #364

session-id: engineer-1