### PR TITLE
fix(split): metadata.json gaps に raw 秒値を追加 (Refs #369) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -551,8 +551,11 @@ def _split_and_write_metadata(
         ],
         "gaps": [
             {
+                "start_time": g["start"],
+                "end_time": g["end"],
                 "start_display": _format_timestamp(g["start"]),
                 "end_display": _format_timestamp(g["end"]),
+                "duration": g["duration"],
                 "duration_display": _format_duration(g["duration"]),
             }
             for g in gaps

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -85,9 +85,12 @@ allaganeye split <video_path> [OPTIONS]
 
 | フィールド | 型 | 説明 |
 |---|---|---|
-| `start_display` | string | ギャップ開始時刻 |
-| `end_display` | string | ギャップ終了時刻 |
-| `duration_display` | string | ギャップ時間 |
+| `start_time` | float | ギャップ開始時刻（秒） |
+| `end_time` | float | ギャップ終了時刻（秒） |
+| `start_display` | string | ギャップ開始時刻の表示形式 |
+| `end_display` | string | ギャップ終了時刻の表示形式 |
+| `duration` | float | ギャップ時間（秒） |
+| `duration_display` | string | ギャップ時間の表示形式 |
 
 ## debug-brightness コマンド
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -127,7 +127,14 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
     }
   ],
   "gaps": [
-    {"start_display": "50:12", "end_display": "75:39", "duration_display": "25m27s"}
+    {
+      "start_time": 3012.0,
+      "end_time": 4539.0,
+      "start_display": "50:12",
+      "end_display": "75:39",
+      "duration": 1527.0,
+      "duration_display": "25m27s"
+    }
   ]
 }
 ```

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -178,6 +178,45 @@ def test_metadata_output_file_uses_posix_separator(
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_metadata_gaps_have_raw_seconds(mock_probe, mock_detect, mock_split, tmp_path):
+    """metadata.json gaps carry raw start_time/end_time/duration (#369).
+
+    L2/L3 pipelines need machine-readable raw seconds to avoid re-parsing
+    display strings. Shape must match matches[] (raw + display pairs).
+    """
+    boundaries_with_gap: list[MatchBoundary] = [
+        {"start": 0.0, "end": 600.0, "type": "unknown"},
+        {"start": 1200.5, "end": 1800.0, "type": "unknown"},
+    ]
+    mock_probe.return_value = {**PROBE_RESULT, "duration": 2000.0}
+    mock_detect.return_value = boundaries_with_gap
+    mock_split.return_value = [
+        tmp_path / "match_001.mp4",
+        tmp_path / "match_002.mp4",
+    ]
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+
+    data = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    assert len(data["gaps"]) == 1, "expected one significant gap >= 300s"
+    gap = data["gaps"][0]
+
+    for key in ("start_time", "end_time", "duration"):
+        assert key in gap, f"gaps[] missing raw key {key!r}: {list(gap)!r}"
+        assert isinstance(gap[key], float), (
+            f"gaps[0].{key} must be float, got {type(gap[key]).__name__}"
+        )
+
+    # Raw fields must agree with display fields (same event, same value).
+    assert gap["start_time"] == 600.0
+    assert gap["end_time"] == 1200.5
+    assert abs(gap["duration"] - (gap["end_time"] - gap["start_time"])) < 1e-6
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_pipeline_output_dir_created(mock_probe, mock_detect, mock_split, tmp_path):
     """Output directory is created if it doesn't exist."""
     output = tmp_path / "subdir" / "output"


### PR DESCRIPTION
## Summary

`metadata.json` の `gaps` 配列が display 文字列 (`start_display` / `end_display` / `duration_display`) のみを持ち raw 秒値を欠いていたため、L2/L3 パイプラインで機械処理する際に文字列再パースが必要だった。`matches` と同じ shape (raw + display 両方) に揃える。

## 変更点

- `allaganeye/commands/split_matches.py` — `_split_and_write_metadata` の gaps 生成に `start_time` / `end_time` / `duration` (float 秒) を追加。キー順は matches と一貫させる
- `Gap` TypedDict (L24) は既に `start` / `end` / `duration` を持つので**定義変更不要**
- `tests/test_split_matches.py` — `test_metadata_gaps_have_raw_seconds` を追加。書き出された JSON を再 parse し、raw キー存在・型 float・`duration == end_time - start_time` の整合性を構造検証
- `docs/cli-spec.md` — gaps[] スキーマ表に `start_time` / `end_time` / `duration` を追加
- `docs/design-overview.md` — サンプル JSON を raw + display 両方持つ形に更新

## 出力イメージ

```json
"gaps": [
  {
    "start_time": 2091.0,
    "end_time": 2437.5,
    "start_display": "34:51",
    "end_display": "40:37",
    "duration": 346.5,
    "duration_display": "5m46s"
  }
]
```

## 再発防止

テストは dict を直接見るのではなく **書き出された metadata.json を再 parse** し構造検証する方針を #371 に続き踏襲。display だけが出力されていた以前の実装でもテストが通ってしまう substring マッチを避ける。

## Test plan

- [x] コード修正 (split_matches.py)
- [x] テスト追加 (test_metadata_gaps_have_raw_seconds)
- [x] docs 同期 (cli-spec.md / design-overview.md)
- [x] `pytest` 523 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors
- [x] 単独試合の実動画で実 JSON を確認（gaps は空配列、型と shape は OK）。multi-match での raw 値整合はユニットテストで検証

## 関連

- 依存: PR #378 (#371) マージ済みブランチから作成
- 次順: #370 (detection_params 追加)

Refs #369

session-id: engineer-1