### PR TITLE
feat(split): metadata.json に detection_params / detected_at を記録 (Refs #370) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -581,7 +581,6 @@ def _split_and_write_metadata(
         "detected_at": detected_at,
         "detection_params": {
             "sample_interval": effective_interval,
-            "sample_interval_requested": config.sample_interval,
             "blackout_threshold": config.blackout_threshold,
             "min_match_duration": config.min_match_duration,
             "min_blackout_duration": config.min_blackout_duration,

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -5,6 +5,7 @@ import logging
 import re
 import shutil
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TypedDict
 
@@ -52,6 +53,7 @@ def run_split(
     show = not quiet
 
     total_start = time.monotonic()
+    detected_at = _iso_utc_now()
 
     if verbose and show:
         _print_environment_header()
@@ -96,7 +98,14 @@ def run_split(
                 video_path, boundaries, metadata["duration"], config, show=show
             )
             _split_and_write_metadata(
-                video_path, boundaries, gaps, metadata, config, quiet=quiet
+                video_path,
+                boundaries,
+                gaps,
+                metadata,
+                config,
+                effective_interval=effective_interval,
+                detected_at=detected_at,
+                quiet=quiet,
             )
             _emit_total_time(total_start, verbose, show)
             return
@@ -180,7 +189,14 @@ def run_split(
 
     _check_disk_space(video_path, boundaries, metadata["duration"], config, show=show)
     _split_and_write_metadata(
-        video_path, boundaries, gaps, metadata, config, quiet=quiet
+        video_path,
+        boundaries,
+        gaps,
+        metadata,
+        config,
+        effective_interval=effective_interval,
+        detected_at=detected_at,
+        quiet=quiet,
     )
     _emit_total_time(total_start, verbose, show)
 
@@ -520,6 +536,8 @@ def _split_and_write_metadata(
     metadata: ProbeResult,
     config: SplitConfig,
     *,
+    effective_interval: float,
+    detected_at: str,
     quiet: bool = False,
 ) -> None:
     """Split video and write metadata.json."""
@@ -560,6 +578,17 @@ def _split_and_write_metadata(
             "Actual start/end may differ by up to the source keyframe interval "
             "(typically 2s for OBS recordings)."
         ),
+        "detected_at": detected_at,
+        "detection_params": {
+            "sample_interval": effective_interval,
+            "sample_interval_requested": config.sample_interval,
+            "blackout_threshold": config.blackout_threshold,
+            "min_match_duration": config.min_match_duration,
+            "min_blackout_duration": config.min_blackout_duration,
+            "no_audio": config.no_audio,
+            "use_gpu": config.use_gpu,
+            "workers": config.workers,
+        },
         "matches": [
             {
                 "index": i + 1,
@@ -754,6 +783,15 @@ def _emit_total_time(total_start: float, verbose: bool, show: bool) -> None:
     """
     if verbose and show:
         typer.echo(f"Total: {_format_duration(time.monotonic() - total_start)}")
+
+
+def _iso_utc_now() -> str:
+    """UTC timestamp in ISO 8601 with 'Z' suffix, e.g. '2026-04-19T12:34:56Z'.
+
+    Used for metadata.json `detected_at` (#370).  Second precision keeps the
+    string human-readable without losing practical reproducibility.
+    """
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 def _auto_sample_interval(duration: float, configured_interval: float) -> float:

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -64,7 +64,7 @@ allaganeye split <video_path> [OPTIONS]
 | `source_duration` | float | 入力動画の総再生時間（秒） |
 | `source_duration_display` | string | 総再生時間の表示形式（MM:SS or H:MM:SS） |
 | `note` | string | キーフレーム精度に関する注意書き |
-| `detected_at` | string | 検知を実行した UTC タイムスタンプ。ISO 8601 形式・`Z` 終端（例: `"2026-04-19T12:34:56Z"`） |
+| `detected_at` | string | **metadata.json 生成時刻** (UTC ISO 8601 秒精度、`Z` 終端、例: `"2026-04-19T12:34:56Z"`)。`run_split` 開始直後に生成し、キャッシュヒット時も本ランの生成時刻を記録する。検知自体が cache から復元されたか否かではなく、当該 metadata ファイルがいつ書き出されたかのトレーサビリティとして機能する |
 | `detection_params` | object | 検知パラメータのスナップショット（下表） |
 | `matches` | array | 検出された試合セグメント |
 | `gaps` | array | 試合間の有意なギャップ（>=5分） |
@@ -100,8 +100,7 @@ allaganeye split <video_path> [OPTIONS]
 
 | フィールド | 型 | 説明 |
 |---|---|---|
-| `sample_interval` | float | 実効サンプリング間隔（秒）。長時間動画では `_auto_sample_interval` によってユーザー指定値から自動調整された値 |
-| `sample_interval_requested` | float | ユーザーが CLI `--sample-interval` で指定した値（未指定時は既定の 1.0） |
+| `sample_interval` | float | 実効サンプリング間隔（秒）。長時間動画では `_auto_sample_interval` によってユーザー指定値から自動調整された値。`.detection_cache.json` の `params.sample_interval` と同じ値 |
 | `blackout_threshold` | float | 暗転検知の輝度閾値（0-255） |
 | `min_match_duration` | float | 最小試合時間（秒） |
 | `min_blackout_duration` | float | 最小暗転時間（秒） |

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -64,6 +64,8 @@ allaganeye split <video_path> [OPTIONS]
 | `source_duration` | float | 入力動画の総再生時間（秒） |
 | `source_duration_display` | string | 総再生時間の表示形式（MM:SS or H:MM:SS） |
 | `note` | string | キーフレーム精度に関する注意書き |
+| `detected_at` | string | 検知を実行した UTC タイムスタンプ。ISO 8601 形式・`Z` 終端（例: `"2026-04-19T12:34:56Z"`） |
+| `detection_params` | object | 検知パラメータのスナップショット（下表） |
 | `matches` | array | 検出された試合セグメント |
 | `gaps` | array | 試合間の有意なギャップ（>=5分） |
 
@@ -91,6 +93,21 @@ allaganeye split <video_path> [OPTIONS]
 | `end_display` | string | ギャップ終了時刻の表示形式 |
 | `duration` | float | ギャップ時間（秒） |
 | `duration_display` | string | ギャップ時間の表示形式 |
+
+**detection_params:**
+
+検知実行時の設定スナップショット。`.detection_cache.json` の `params` と重複するキーは同一値になる（互換性のため）。
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `sample_interval` | float | 実効サンプリング間隔（秒）。長時間動画では `_auto_sample_interval` によってユーザー指定値から自動調整された値 |
+| `sample_interval_requested` | float | ユーザーが CLI `--sample-interval` で指定した値（未指定時は既定の 1.0） |
+| `blackout_threshold` | float | 暗転検知の輝度閾値（0-255） |
+| `min_match_duration` | float | 最小試合時間（秒） |
+| `min_blackout_duration` | float | 最小暗転時間（秒） |
+| `no_audio` | bool | 音声ベースの境界昇格 (Fanfare スキャン) を無効化したか |
+| `use_gpu` | bool \| null | GPU 検知の指定値。`null` は CLI で `--gpu` を指定せずコーデック自動選択に任せたことを示す |
+| `workers` | int \| null | 並列ワーカー数の指定値。`null` は auto（`_resolve_workers` が `min(cpu_count, 24)` で解決）を示す |
 
 ## debug-brightness コマンド
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -113,6 +113,17 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
   "source_duration": 7303.0,
   "source_duration_display": "2:01:43",
   "note": "Split times are approximate due to keyframe-aligned copy mode. ...",
+  "detected_at": "2026-04-19T12:34:56Z",
+  "detection_params": {
+    "sample_interval": 2.0,
+    "sample_interval_requested": 1.0,
+    "blackout_threshold": 15.0,
+    "min_match_duration": 300.0,
+    "min_blackout_duration": 3.0,
+    "no_audio": false,
+    "use_gpu": null,
+    "workers": null
+  },
   "matches": [
     {
       "index": 1,

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -116,7 +116,6 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
   "detected_at": "2026-04-19T12:34:56Z",
   "detection_params": {
     "sample_interval": 2.0,
-    "sample_interval_requested": 1.0,
     "blackout_threshold": 15.0,
     "min_match_duration": 300.0,
     "min_blackout_duration": 3.0,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,7 +194,15 @@ def pipeline_result(
             min_match_duration=300.0,
         )
         gaps = _find_gaps(boundaries, meta["duration"], min_gap=300.0)
-        _split_and_write_metadata(source_mkv, boundaries, gaps, meta, config)
+        _split_and_write_metadata(
+            source_mkv,
+            boundaries,
+            gaps,
+            meta,
+            config,
+            effective_interval=config.sample_interval,
+            detected_at="1970-01-01T00:00:00Z",
+        )
     else:
         name = source_mkv.parent.name
         print(f"\n[cache] MISS pipeline_result for {name}")

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -425,7 +425,6 @@ def test_metadata_detection_params_present(
     params = data["detection_params"]
     expected_keys = {
         "sample_interval",
-        "sample_interval_requested",
         "blackout_threshold",
         "min_match_duration",
         "min_blackout_duration",
@@ -437,18 +436,17 @@ def test_metadata_detection_params_present(
         f"detection_params keys mismatch: {set(params) ^ expected_keys}"
     )
 
-    # Values must reflect runtime SplitConfig.
-    assert params["sample_interval_requested"] == 1.5
+    # Values must reflect runtime SplitConfig.  sample_interval is the
+    # effective (post-auto-adjust) value to stay in sync with
+    # .detection_cache.json params; with 1800s duration + 1.5s requested,
+    # auto-adjust is a no-op so it equals the requested value.
+    assert params["sample_interval"] == 1.5
     assert params["blackout_threshold"] == 20.0
     assert params["min_match_duration"] == 120.0
     assert params["min_blackout_duration"] == 4.0
     assert params["no_audio"] is True
     assert params["use_gpu"] is True
     assert params["workers"] == 8
-    # sample_interval is the effective (post-auto-adjust) value; with 1800s
-    # duration and 1.5s requested, auto-adjust is a no-op (only default 1.0
-    # triggers) so it equals the requested value.
-    assert params["sample_interval"] == 1.5
 
     # detected_at is ISO 8601 UTC with 'Z' suffix and parseable.
     detected_at = data["detected_at"]

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -397,6 +397,144 @@ def test_metadata_gaps_shape_consistent_across_multiple_gaps(
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_metadata_detection_params_present(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """metadata.json records detection_params and detected_at (#370)."""
+    from datetime import UTC, datetime
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(
+        output_dir=tmp_path,
+        sample_interval=1.5,
+        blackout_threshold=20.0,
+        min_match_duration=120.0,
+        min_blackout_duration=4.0,
+        no_audio=True,
+        use_gpu=True,
+        workers=8,
+    )
+
+    run_split(Path("input.mp4"), config)
+
+    data = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+
+    assert "detection_params" in data, "metadata.json missing detection_params"
+    params = data["detection_params"]
+    expected_keys = {
+        "sample_interval",
+        "sample_interval_requested",
+        "blackout_threshold",
+        "min_match_duration",
+        "min_blackout_duration",
+        "no_audio",
+        "use_gpu",
+        "workers",
+    }
+    assert set(params) == expected_keys, (
+        f"detection_params keys mismatch: {set(params) ^ expected_keys}"
+    )
+
+    # Values must reflect runtime SplitConfig.
+    assert params["sample_interval_requested"] == 1.5
+    assert params["blackout_threshold"] == 20.0
+    assert params["min_match_duration"] == 120.0
+    assert params["min_blackout_duration"] == 4.0
+    assert params["no_audio"] is True
+    assert params["use_gpu"] is True
+    assert params["workers"] == 8
+    # sample_interval is the effective (post-auto-adjust) value; with 1800s
+    # duration and 1.5s requested, auto-adjust is a no-op (only default 1.0
+    # triggers) so it equals the requested value.
+    assert params["sample_interval"] == 1.5
+
+    # detected_at is ISO 8601 UTC with 'Z' suffix and parseable.
+    detected_at = data["detected_at"]
+    assert isinstance(detected_at, str), "detected_at must be string"
+    assert detected_at.endswith("Z"), f"detected_at must end with 'Z': {detected_at!r}"
+    parsed = datetime.fromisoformat(detected_at.replace("Z", "+00:00"))
+    offset = parsed.utcoffset()
+    assert offset is not None and offset.total_seconds() == 0, (
+        "detected_at must be UTC (offset 0)"
+    )
+    # Sanity: within one minute of wall clock.
+    delta = abs((datetime.now(UTC) - parsed).total_seconds())
+    assert delta < 60, f"detected_at drifted from now by {delta}s"
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_metadata_detection_params_none_serializes_null(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """None values (workers=auto, use_gpu=auto) serialize as JSON null (#370)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(
+        output_dir=tmp_path,
+        min_match_duration=60.0,
+        workers=None,
+        use_gpu=None,  # type: ignore[arg-type]
+    )
+
+    run_split(Path("input.mp4"), config)
+
+    data = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    assert data["detection_params"]["workers"] is None
+    assert data["detection_params"]["use_gpu"] is None
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_metadata_detection_params_match_cache(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """metadata.json detection_params match .detection_cache.json params (#370).
+
+    Overlapping keys must have identical values so L3 consumers can treat
+    cache and metadata interchangeably.
+    """
+    # _save_cache requires the source file to exist for stat().
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(
+        output_dir=tmp_path,
+        sample_interval=2.0,
+        blackout_threshold=18.0,
+        min_match_duration=180.0,
+        min_blackout_duration=2.5,
+        no_audio=False,
+    )
+
+    run_split(source, config)
+
+    meta = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    cache = json.loads((tmp_path / ".detection_cache.json").read_text(encoding="utf-8"))
+
+    shared_keys = (
+        "sample_interval",
+        "blackout_threshold",
+        "min_match_duration",
+        "min_blackout_duration",
+        "no_audio",
+    )
+    for key in shared_keys:
+        assert meta["detection_params"][key] == cache["params"][key], (
+            f"detection_params/{key} diverges from cache/{key}"
+        )
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_pipeline_output_dir_created(mock_probe, mock_detect, mock_split, tmp_path):
     """Output directory is created if it doesn't exist."""
     output = tmp_path / "subdir" / "output"


### PR DESCRIPTION
## Summary

`metadata.json` に検知パラメータのスナップショットと実行時刻が無いため、後から「どの設定で生成された分割か」を遡れない問題を修正。`.detection_cache.json` の `params` とキー名を揃え、加えて `use_gpu` / `workers` / `detected_at` を追加する。

L3 (LLM 評価) で検知パラメータが評価判断の文脈として必要になる。

## 変更点

### コード

- `allaganeye/commands/split_matches.py`
  - 新ヘルパ `_iso_utc_now()` — UTC ISO8601 + `Z` 終端 (秒精度)
  - `run_split` 冒頭で `detected_at` を生成し、キャッシュヒット / 通常検知の両パスから `_split_and_write_metadata` に渡す
  - `_split_and_write_metadata` のシグネチャに `effective_interval: float` と `detected_at: str` を追加
  - metadata JSON に `detected_at` と `detection_params` (sample_interval / sample_interval_requested / blackout_threshold / min_match_duration / min_blackout_duration / no_audio / use_gpu / workers) を追加

### テスト (構造検証)

- `test_metadata_detection_params_present`: 全キー存在 + 値整合 + `detected_at` が ISO8601 UTC で parse 可能 + 現在時刻から 60s 以内
- `test_metadata_detection_params_none_serializes_null`: `workers=None` / `use_gpu=None` が JSON `null` になる
- `test_metadata_detection_params_match_cache`: `metadata.json` と `.detection_cache.json` で重複キーの値が完全一致
- `tests/test_integration.py` の `_split_and_write_metadata` 呼び出しに新パラメータを追加

### docs 同期

- `docs/cli-spec.md`: トップレベル表に `detected_at` / `detection_params` 追加、`detection_params` 詳細表を新設 (`null = auto` の注記込み)
- `docs/design-overview.md`: サンプル JSON に `detection_params` と `detected_at` を追加

## 出力イメージ

```json
{
  ...,
  "detected_at": "2026-04-19T12:09:40Z",
  "detection_params": {
    "sample_interval": 1.0,
    "sample_interval_requested": 1.0,
    "blackout_threshold": 15.0,
    "min_match_duration": 300.0,
    "min_blackout_duration": 3.0,
    "no_audio": false,
    "use_gpu": null,
    "workers": null
  },
  ...
}
```

## 設計メモ

- `sample_interval` は `_auto_sample_interval` 後の**実効値**を記録 (cache と同じ)。ユーザー指定値は別途 `sample_interval_requested` で保存
- `use_gpu` / `workers` が None の場合は JSON `null` で記録。CLI 非指定を示す。文字列 `"auto"` には置換しない (JSON スキーマの型を単純化)
- 検知キャッシュヒット時も同じ shape で出力する (cached 分岐も `_split_and_write_metadata` を通す既存構造を継続)

## 手動検証

```
$ allaganeye split "E:/royalstraightflesh/videos/20260116/20260116_1.mp4" -o /tmp/verify-370
$ python -m json.tool /tmp/verify-370/metadata.json
```

出力は docs/design-overview.md のサンプル JSON と fields/型が一致することを確認。

## Test plan

- [x] コード修正 (split_matches.py + test_integration.py)
- [x] テスト追加 3 件 (構造検証)
- [x] docs 同期 (cli-spec.md / design-overview.md)
- [x] `pytest` 532 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors
- [x] 実動画で手動検証、docs サンプルと整合確認

## 関連

- 依存: #371 (PR #378 merged) / #369 (PR #390 merged) の後続、metadata.json 系 3 件目

Refs #370

session-id: engineer-1