### PR TITLE
fix(split): verbose で全パスが Total: 時間を出力するよう統一 (Refs #381) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -89,13 +89,16 @@ def run_split(
                 _display_gaps(gaps)
             if config.dry_run:
                 typer.echo("\nDry run: skipping split")
+                _emit_total_time(total_start, verbose, show)
                 return
             _check_disk_space(
                 video_path, boundaries, metadata["duration"], config, show=show
             )
-            return _split_and_write_metadata(
+            _split_and_write_metadata(
                 video_path, boundaries, gaps, metadata, config, quiet=quiet
             )
+            _emit_total_time(total_start, verbose, show)
+            return
 
     # Resolve GPU/CPU mode: auto-select based on codec when not explicit (#334)
     use_gpu = _resolve_gpu_mode(config.use_gpu, metadata.get("codec"), show, verbose)
@@ -171,16 +174,14 @@ def run_split(
     # Step 3: Split (unless dry-run)
     if config.dry_run:
         typer.echo("\nDry run: skipping split")
-        if verbose and show:
-            typer.echo(f"Total: {_format_duration(time.monotonic() - total_start)}")
+        _emit_total_time(total_start, verbose, show)
         return
 
     _check_disk_space(video_path, boundaries, metadata["duration"], config, show=show)
     _split_and_write_metadata(
         video_path, boundaries, gaps, metadata, config, quiet=quiet
     )
-    if verbose and show:
-        typer.echo(f"Total: {_format_duration(time.monotonic() - total_start)}")
+    _emit_total_time(total_start, verbose, show)
 
 
 def _display_results(
@@ -698,6 +699,17 @@ def _format_duration(seconds: float) -> str:
     if h:
         return f"{h}h{m:02d}m"
     return f"{m}m{s:02d}s"
+
+
+def _emit_total_time(total_start: float, verbose: bool, show: bool) -> None:
+    """Print ``Total: HH:MM:SS`` wall-clock for the split pipeline (#381).
+
+    Emitted on every verbose-visible exit path (cache hit + split, cache hit
+    + dry-run, cache miss + split, cache miss + dry-run) so users always see
+    how long the run took regardless of which branch executed.
+    """
+    if verbose and show:
+        typer.echo(f"Total: {_format_duration(time.monotonic() - total_start)}")
 
 
 def _auto_sample_interval(duration: float, configured_interval: float) -> float:

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1744,6 +1744,86 @@ def test_verbose_dry_run_emits_total(
     mock_split.assert_not_called()
 
 
+def _seed_cache(source: Path, output_dir: Path, config: SplitConfig) -> None:
+    """Write a .detection_cache.json entry matching ``config`` so ``_load_cache``
+    hits.  Helper for cache-hit tests (#381)."""
+    source.write_bytes(b"")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _save_cache(
+        output_dir / ".detection_cache.json",
+        source,
+        PROBE_RESULT,
+        config.sample_interval,
+        config,
+        BOUNDARIES,
+    )
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_hit_split_emits_total(mock_probe, mock_split, tmp_path, capsys):
+    """Verbose + cache-hit + split path must emit the Total: line (#381).
+
+    Previously only the cache-miss paths emitted Total:, so users who ran
+    repeatedly saw "split done, no timing" which broke the UX symmetry.
+    """
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    _seed_cache(source, tmp_path, config)
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    run_split(source, config, verbose=True)
+
+    out = capsys.readouterr().out
+    assert "(cached)" in out, "cache hit path expected"
+    assert "Total:" in out, (
+        f"verbose+cache+split must emit Total: line (#381)\n--- captured ---\n{out}"
+    )
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_hit_dry_run_emits_total(
+    mock_probe, mock_split, tmp_path, capsys
+):
+    """Verbose + cache-hit + dry-run path must also emit Total: (#381)."""
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(output_dir=tmp_path, dry_run=True, min_match_duration=60.0)
+    _seed_cache(source, tmp_path, config)
+
+    mock_probe.return_value = PROBE_RESULT
+
+    run_split(source, config, verbose=True)
+
+    out = capsys.readouterr().out
+    assert "Dry run: skipping split" in out
+    assert "Total:" in out
+    mock_split.assert_not_called()
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_cache_hit_quiet_suppresses_total(mock_probe, mock_split, tmp_path, capsys):
+    """Quiet mode suppresses Total: even on cache-hit split path (#381).
+
+    _emit_total_time gates on both verbose and show, so quiet (show=False)
+    must still hide Total: regardless of verbose setting.
+    """
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    _seed_cache(source, tmp_path, config)
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    run_split(source, config, verbose=True, quiet=True)
+
+    out = capsys.readouterr().out
+    assert "Total:" not in out
+
+
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")


### PR DESCRIPTION
## Summary

`-v` (verbose) モードで cache-hit + split / cache-hit + dry-run の 2 パスが `Total: HH:MM:SS` 行を出力しない非対称があった。キャッシュヒット時は `run_split` が `_split_and_write_metadata` で return するため末尾の Total: 出力に到達しない。

`_emit_total_time(total_start, verbose, show)` ヘルパに切り出し、4 パス全て (cache hit/miss × dry-run/split) の exit 直前で必ず呼ぶように統一。

## 変更点

- `allaganeye/commands/split_matches.py`
  - 新ヘルパ `_emit_total_time` 追加 (verbose/show ゲートをヘルパ内で一元化)
  - cached 分岐 (dry-run / split 両方) で return 直前にヘルパを呼ぶ
  - cache miss 分岐の既存 2 箇所 (L175, L183) をヘルパ呼び出しに置換
- `tests/test_split_matches.py` 追加 3 件:
  - `test_verbose_cache_hit_split_emits_total` — cache hit + split で Total: が出ることを assert
  - `test_verbose_cache_hit_dry_run_emits_total` — cache hit + dry-run でも Total:
  - `test_cache_hit_quiet_suppresses_total` — quiet モードでは非表示のまま (ヘルパのゲート確認)

## 再発防止

PR #343 の類似問題と同じく「ユーザーに見える出力を substring で見るだけでなく、条件ごとの有無を構造的に assert」する方針を徹底。本 PR のテストは cache hit 系 2 パスを個別に回して Total: 行の存在を検証する。

`_emit_total_time` ヘルパ化により今後 verbose の時間表示を変える際も 1 箇所修正で全パスに反映されるようにした (DRY)。

## docs 同期

cli-spec.md / design-overview.md 等に `Total:` の言及は無く、スキーマ情報でもないため docs 同期対象外。

## Test plan

- [x] コード修正 (split_matches.py)
- [x] テスト追加 3 件
- [x] `pytest` 535 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors

## 関連

- B グループ頭 (Lead 指示): 他の B グループ issue (#380) の rebase 起点となる
- 依存なし、並列投下可

Refs #381

session-id: engineer-1