### PR TITLE
fix(split): verbose summary の audio 表示が frozen 実態と乖離 (Refs #384) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -116,7 +116,6 @@ def run_split(
     audio_hits = _run_audio_scan(video_path, config, show=show, verbose=verbose)
 
     if show and verbose:
-        audio_str = "off" if config.no_audio else "on"
         typer.echo(
             f"Detecting match boundaries "
             f"(interval={effective_interval}s, "
@@ -124,7 +123,7 @@ def run_split(
             f"workers={_workers_summary_str(config.workers)}, "
             f"min_match={config.min_match_duration}s, "
             f"min_blackout={config.min_blackout_duration}s, "
-            f"audio={audio_str})"
+            f"audio={_audio_status_str(config.no_audio)})"
         )
 
     detect_stats: DetectionStats | None = {} if verbose else None
@@ -241,6 +240,21 @@ def _workers_summary_str(workers: int | None) -> str:
 
     resolved = _resolve_workers(None)
     return f"auto ({resolved})"
+
+
+def _audio_status_str(no_audio: bool) -> str:
+    """Return audio-scan status string for verbose summary (#384).
+
+    Must stay in sync with ``_run_audio_scan``: if the audio module is
+    frozen, the scan is skipped regardless of ``--no-audio``, and the
+    verbose summary must reflect that instead of reading ``config.no_audio``
+    blindly.
+    """
+    from allaganeye.audio import AUDIO_FROZEN
+
+    if AUDIO_FROZEN:
+        return "frozen"
+    return "off" if no_audio else "on"
 
 
 def _run_audio_scan(

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -41,7 +41,7 @@ allaganeye split <video_path> [OPTIONS]
 | `--workers` | auto | 検知の並列ワーカー数（デフォルト: 自動=`min(cpu_count, 24)`） |
 | `--gpu` / `--no-gpu` | `false` | GPU アクセラレーション検知（チャンク並列デコード）。利用不可時は CPU フォールバック |
 | `--no-cache` | `false` | キャッシュされた検知結果を無視して再検知する |
-| `--no-audio` | `false` | 音声ベースの試合境界昇格（Fanfare スキャン）を無効化する |
+| `--no-audio` | `false` | 音声ベースの試合境界昇格（Fanfare スキャン）を無効化する。**現在は音声モジュールが凍結中（#327）のため、本フラグの値に関わらずスキャンは常にスキップされる。verbose 出力では `audio=frozen` と表示される (#384)** |
 | `--dry-run` | `false` | 検知のみ実行し分割しない（検知結果はキャッシュに保存される） |
 | `-v`, `--verbose` | `false` | 詳細出力（メタデータ詳細、gap 情報） |
 | `-q`, `--quiet` | `false` | 進捗出力を抑制（出力ファイル一覧のみ） |

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1655,7 +1655,11 @@ def test_verbose_detecting_line_includes_params(
         output_dir=tmp_path, min_match_duration=60.0, use_gpu=True, workers=8
     )
 
-    run_split(Path("input.mp4"), config, verbose=True)
+    # Force AUDIO_FROZEN=False so this test verifies the on/off branch of
+    # _audio_status_str (the frozen branch is covered by a dedicated test
+    # below).
+    with patch("allaganeye.audio.AUDIO_FROZEN", False):
+        run_split(Path("input.mp4"), config, verbose=True)
     out = capsys.readouterr().out
     assert "workers=8" in out
     assert "min_match=60.0s" in out
@@ -1768,16 +1772,91 @@ def test_verbose_reports_gpu_fallback_mode(
 def test_verbose_detecting_line_shows_audio_off_when_no_audio(
     mock_probe, mock_detect, mock_split, tmp_path, capsys
 ):
-    """Verbose Detecting line reflects --no-audio (#336)."""
+    """Verbose Detecting line reflects --no-audio (#336).
+
+    Exercises the non-frozen branch of _audio_status_str (#384); with
+    AUDIO_FROZEN=True in production, the frozen branch dominates, so this
+    test patches it off to assert the config.no_audio-driven flip.
+    """
     mock_probe.return_value = PROBE_RESULT
     mock_detect.return_value = BOUNDARIES
     mock_split.return_value = _output_files(tmp_path)
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, no_audio=True)
 
-    run_split(Path("input.mp4"), config, verbose=True)
+    with patch("allaganeye.audio.AUDIO_FROZEN", False):
+        run_split(Path("input.mp4"), config, verbose=True)
     out = capsys.readouterr().out
     assert "audio=off" in out
     assert "audio=on" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_detecting_line_shows_audio_frozen_when_module_frozen(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose Detecting line shows 'audio=frozen' when AUDIO_FROZEN is True (#384).
+
+    The audio module is currently frozen (#327), so regardless of the
+    ``--no-audio`` flag the scan is skipped.  verbose output must reflect
+    that reality instead of reading ``config.no_audio`` blindly, which
+    previously printed misleading ``audio=on``.
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+
+    # no_audio=False would previously have produced audio=on; with
+    # AUDIO_FROZEN=True we expect audio=frozen.
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, no_audio=False)
+
+    with patch("allaganeye.audio.AUDIO_FROZEN", True):
+        run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "audio=frozen" in out, f"expected audio=frozen in: {out!r}"
+    assert "audio=on" not in out
+    assert "audio=off" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_audio_frozen_overrides_no_audio_flag(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """When frozen, the verbose status stays 'frozen' even with --no-audio (#384).
+
+    Prevents regression to config.no_audio taking precedence over the
+    frozen module state (the original bug).
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, no_audio=True)
+
+    with patch("allaganeye.audio.AUDIO_FROZEN", True):
+        run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "audio=frozen" in out
+    assert "audio=off" not in out
+
+
+def test_audio_status_str_helper_matches_run_audio_scan_contract():
+    """_audio_status_str output stays in sync with _run_audio_scan behaviour (#384).
+
+    Direct unit coverage of the helper.  If this test passes but the
+    verbose output still shows wrong values, the helper isn't being called.
+    """
+    from allaganeye.commands.split_matches import _audio_status_str
+
+    with patch("allaganeye.audio.AUDIO_FROZEN", True):
+        assert _audio_status_str(no_audio=False) == "frozen"
+        assert _audio_status_str(no_audio=True) == "frozen"
+
+    with patch("allaganeye.audio.AUDIO_FROZEN", False):
+        assert _audio_status_str(no_audio=False) == "on"
+        assert _audio_status_str(no_audio=True) == "off"
 
 
 @patch(f"{MODULE}.split_video")


### PR DESCRIPTION
## Summary

`-v` (verbose) モードの検知パラメータ summary で `audio=on/off` が `config.no_audio` 直読みで表示されていたが、実コードは `AUDIO_FROZEN=True` (#327) のため `--no-audio` フラグの値に関わらず audio scan は常時 skip される挙動。verbose 表示が実態と乖離していた。

`_audio_status_str` ヘルパを新設し、`AUDIO_FROZEN` を見て `'frozen'` / `'on'` / `'off'` を返すようにして表示と挙動を同一ソースから派生させる。

## 変更点

- `allaganeye/commands/split_matches.py`
  - 新ヘルパ `_audio_status_str(no_audio: bool) -> str` — `AUDIO_FROZEN` 優先の 3 値 (frozen / on / off)
  - verbose summary の `audio=` 値を config 直読みからヘルパ経由に変更
- `tests/test_split_matches.py`
  - 既存 `audio=on` / `audio=off` を見る 2 テストを `AUDIO_FROZEN=False` パッチ下で回すよう修正 (on/off 分岐の意図を保持)
  - 新規 `test_verbose_detecting_line_shows_audio_frozen_when_module_frozen`: frozen 時 `audio=frozen` 出力確認
  - 新規 `test_verbose_audio_frozen_overrides_no_audio_flag`: frozen が `--no-audio` より優先 (元バグ回帰防止)
  - 新規 `test_audio_status_str_helper_matches_run_audio_scan_contract`: ヘルパ単体 parametric カバー
- `docs/cli-spec.md`: `--no-audio` 説明に現在の frozen 状態と verbose `audio=frozen` 表示を追記

## 出力イメージ

frozen 時 (現状):
```
Detecting match boundaries (interval=3.0s, threshold=15.0, workers=auto, min_match=300.0s, min_blackout=3.0s, audio=frozen)
```

frozen 解除後 (audio 再統合後):
```
Detecting match boundaries (... audio=on)       # デフォルト
Detecting match boundaries (... audio=off)      # --no-audio
```

## 再発防止

ヘルパを経由させることで「verbose 表示と実挙動の源」が 1 箇所に集約される。`_run_audio_scan` が `AUDIO_FROZEN` の処理を先頭で行っているのに合わせて、summary 側も同じ順序で分岐を評価する (frozen -> no_audio -> 通常)。

ヘルパ単体テストも追加して、今後 frozen 解除時にどこを直せば良いか明確化。

## 関連

- B グループ並列 (独立)
- `_audio_status_str` は #380 で cache hit verbose にも再利用予定 (Lead 指示)

Refs #384

session-id: engineer-1