### PR TITLE
fix(split): verbose ヘッダの ffmpeg version を major.minor[.patch] に短縮 (Refs #383) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import shutil
 import time
 from pathlib import Path
@@ -595,8 +596,26 @@ def _print_environment_header() -> None:
     )
 
 
+_FFMPEG_VERSION_RE = re.compile(r"^[nv]?(\d+\.\d+(?:\.\d+)?)")
+"""Strip ``n`` / ``v`` / ``git-`` prefixes and build-metadata suffixes from
+ffmpeg version strings, keeping only ``major.minor[.patch]`` (#383).
+
+Handles common shapes:
+  - ``8.1-full_build-www.gyan.dev``  -> ``8.1``
+  - ``n7.1``                          -> ``7.1``
+  - ``4.4.2-0ubuntu0.22.04.1``        -> ``4.4.2``
+  - ``git-2023-01-01-abcdef``         -> no match, caller keeps raw
+"""
+
+
 def _probe_ffmpeg_version() -> str:
-    """Return ffmpeg version string, or '(unknown)' on failure."""
+    """Return ffmpeg ``major.minor[.patch]`` version, or '(unknown)' on failure.
+
+    Build-metadata and distributor suffixes (``-full_build-www.gyan.dev``,
+    ``-0ubuntu0.22.04.1``, etc.) are stripped so the verbose header stays
+    concise (#383).  If the prefix doesn't match the expected numeric
+    pattern, the raw token is returned as a fallback.
+    """
     import subprocess
 
     from allaganeye.ffmpeg_path import find_ffmpeg
@@ -616,7 +635,9 @@ def _probe_ffmpeg_version() -> str:
     # "ffmpeg version 8.1-essentials_build-www.gyan.dev Copyright ..."
     parts = first_line.split()
     if len(parts) >= 3 and parts[0] == "ffmpeg" and parts[1] == "version":
-        return parts[2]
+        raw = parts[2]
+        match = _FFMPEG_VERSION_RE.match(raw)
+        return match.group(1) if match else raw
     return "(unknown)"
 
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1790,6 +1790,67 @@ def test_probe_ffmpeg_version_returns_unknown_on_failure():
     assert result == "(unknown)"
 
 
+# --- ffmpeg version string trimming (#383) ---
+
+
+@pytest.mark.parametrize(
+    ("raw_first_line", "expected"),
+    [
+        # Windows Gyan full build: the original #383 reproduction
+        (
+            "ffmpeg version 8.1-full_build-www.gyan.dev Copyright (c) 2000-2025",
+            "8.1",
+        ),
+        # Linux distribution build with Ubuntu patch metadata
+        (
+            "ffmpeg version 4.4.2-0ubuntu0.22.04.1 Copyright (c) 2000-2021",
+            "4.4.2",
+        ),
+        # BtbN 'n' prefix (common on nightly CI builds)
+        ("ffmpeg version n7.1 Copyright (c) 2000-2024", "7.1"),
+        # essentials_build variant
+        ("ffmpeg version 6.0-essentials_build-www.gyan.dev", "6.0"),
+        # Bare version (macOS Homebrew style)
+        ("ffmpeg version 5.1.4 Copyright (c) 2000-2023", "5.1.4"),
+    ],
+)
+def test_probe_ffmpeg_version_trims_build_metadata(raw_first_line, expected):
+    """_probe_ffmpeg_version returns major.minor[.patch] only (#383)."""
+    from unittest.mock import MagicMock
+
+    from allaganeye.commands.split_matches import _probe_ffmpeg_version
+
+    mock_result = MagicMock(stdout=raw_first_line + "\n")
+    with patch("subprocess.run", return_value=mock_result):
+        result = _probe_ffmpeg_version()
+    assert result == expected
+
+
+def test_probe_ffmpeg_version_falls_back_to_raw_when_regex_misses():
+    """Unparseable tokens return raw string rather than (unknown) (#383)."""
+    from unittest.mock import MagicMock
+
+    from allaganeye.commands.split_matches import _probe_ffmpeg_version
+
+    # "git-" style dev build has no numeric prefix after the regex.
+    mock_result = MagicMock(stdout="ffmpeg version git-2023-01-01-abcdef Copyright\n")
+    with patch("subprocess.run", return_value=mock_result):
+        result = _probe_ffmpeg_version()
+    assert result == "git-2023-01-01-abcdef"
+
+
+def test_probe_ffmpeg_version_unknown_when_format_unexpected():
+    """Malformed first line (no 'ffmpeg version' prefix) yields (unknown)."""
+    from unittest.mock import MagicMock
+
+    from allaganeye.commands.split_matches import _probe_ffmpeg_version
+
+    mock_result = MagicMock(stdout="not ffmpeg output at all\n")
+    with patch("subprocess.run", return_value=mock_result):
+        result = _probe_ffmpeg_version()
+    assert result == "(unknown)"
+
+
 # --- ETA formatter (issue #333) ---
 
 


### PR DESCRIPTION
## Summary

verbose ヘッダの ffmpeg バージョン表示に gyan.dev のビルド配布元や Ubuntu patchlevel 等の冗長なメタデータが含まれていた。正規表現で `major.minor[.patch]` のみを抽出し、先頭の `n` / `v` プレフィックスも剥がす。

Before:
```
allaganeye 0.1.1 (ffmpeg 8.1-full_build-www.gyan.dev, Python 3.12.10, Windows 11)
```

After:
```
allaganeye 0.1.1 (ffmpeg 8.1, Python 3.12.10, Windows 11)
```

## 変更点

- `allaganeye/commands/split_matches.py`
  - `_FFMPEG_VERSION_RE = re.compile(r"^[nv]?(\d+\.\d+(?:\.\d+)?)")` — 先頭マッチで major.minor[.patch] 抽出
  - `_probe_ffmpeg_version` で regex を適用、unmatch 時は raw token fallback (形式外でも (unknown) に落とさず情報を保持)
- `tests/test_split_matches.py`
  - `test_probe_ffmpeg_version_trims_build_metadata`: 5 パターン parametric (gyan full/essentials, Ubuntu patchlevel, BtbN n7.1, bare 5.1.4)
  - `test_probe_ffmpeg_version_falls_back_to_raw_when_regex_misses`: git-YYYY-MM-DD 等でも raw を保持
  - `test_probe_ffmpeg_version_unknown_when_format_unexpected`: ffmpeg prefix 無しなら従来どおり (unknown)

## 再発防止

`parametrize` で 5 ディストリビュータのバリエーションをまとめて検証。将来的に ffmpeg 側の version 出力フォーマットが変わっても、テストを 1 行追加するだけで網羅できる構造にした。

## Test plan

- [x] コード修正 (split_matches.py — import re + regex + 適用)
- [x] テスト追加 (5 パラメトリック + 2 fallback/unknown)
- [x] `pytest` 539 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors

## 関連

- B グループ並列 (独立)

Refs #383

session-id: engineer-1