### PR TITLE
fix(split): verbose summary の workers=auto に解決後の数を併記 (Refs #389) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -112,12 +112,12 @@ def run_split(
     audio_hits = _run_audio_scan(video_path, config, show=show, verbose=verbose)
 
     if show and verbose:
-        workers_str = str(config.workers) if config.workers is not None else "auto"
         audio_str = "off" if config.no_audio else "on"
         typer.echo(
             f"Detecting match boundaries "
             f"(interval={effective_interval}s, "
-            f"threshold={config.blackout_threshold}, workers={workers_str}, "
+            f"threshold={config.blackout_threshold}, "
+            f"workers={_workers_summary_str(config.workers)}, "
             f"min_match={config.min_match_duration}s, "
             f"min_blackout={config.min_blackout_duration}s, "
             f"audio={audio_str})"
@@ -216,6 +216,23 @@ def _display_gaps(gaps: list[Gap]) -> None:
             f"{_format_timestamp(gap['end'])} "
             f"({_format_duration(gap['duration'])})"
         )
+
+
+def _workers_summary_str(workers: int | None) -> str:
+    """Format workers count for verbose summary, resolving ``auto`` (#389).
+
+    When ``config.workers is None`` the CLI delegates to
+    ``_resolve_workers`` which picks ``min(cpu_count, 24)``.  Users with
+    performance issues need to see the *resolved* number to diagnose
+    under-parallelised runs, not just the ``auto`` placeholder.
+    """
+    if workers is not None:
+        return str(workers)
+
+    from allaganeye.video.detector import _resolve_workers
+
+    resolved = _resolve_workers(None)
+    return f"auto ({resolved})"
 
 
 def _run_audio_scan(

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1779,6 +1779,68 @@ def test_audio_promotion_line_suppressed_when_zero(
     assert "Audio promotion" not in out  # but promo line hidden
 
 
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_workers_auto_shows_resolved_count(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose summary resolves workers=auto to the actual count (#389).
+
+    ``workers=auto`` alone doesn't let users diagnose CPU under-utilisation
+    or hit the right number for their box; the resolved ``min(cpu_count,
+    24)`` must be shown alongside.
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, workers=None)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    # Line must contain "workers=auto (<number>)" with the number >= 1.
+    import re as _re
+
+    m = _re.search(r"workers=auto \((\d+)\)", out)
+    assert m is not None, f"expected 'workers=auto (<n>)' in: {out!r}"
+    assert int(m.group(1)) >= 1
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_workers_explicit_shows_plain_number(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Explicit workers=N is printed as the number without '(auto)' (#389)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, workers=8)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "workers=8" in out
+    assert "workers=auto" not in out
+    assert "(auto)" not in out  # no parentheses suffix for explicit values
+
+
+def test_workers_summary_str_helper_contract():
+    """_workers_summary_str unit coverage (#389).
+
+    Ensures future changes to _resolve_workers fallback (e.g. cpu_count
+    detection tweaks) stay reflected in the verbose output.
+    """
+    from allaganeye.commands.split_matches import _workers_summary_str
+
+    assert _workers_summary_str(1) == "1"
+    assert _workers_summary_str(16) == "16"
+
+    with patch("allaganeye.video.detector._resolve_workers", return_value=12):
+        assert _workers_summary_str(None) == "auto (12)"
+
+
 def test_probe_ffmpeg_version_returns_unknown_on_failure():
     """ffmpeg -version failure yields '(unknown)' without raising (#336)."""
     import subprocess


### PR DESCRIPTION
## Summary

`-v` (verbose) summary が `workers=auto` と表示するだけで、`_resolve_workers` が CPU コア数から解決した実際の並列度が見えず、CPU 利用率不足などのパフォーマンストラブルシュートに必要な情報が欠落していた。新ヘルパ `_workers_summary_str` で auto 時は `auto (N)` 形式、明示値時は数値のみを返す。

## 変更点

- `allaganeye/commands/split_matches.py`
  - 新ヘルパ `_workers_summary_str(workers: int | None) -> str`
    - `workers=None` → `_resolve_workers(None)` を呼んで `auto (12)` 等
    - `workers=8` → `"8"` (parenthesis なし)
  - verbose summary の workers 表示をヘルパ経由に変更
- `tests/test_split_matches.py`
  - `test_verbose_workers_auto_shows_resolved_count`: `workers=None` で `workers=auto (<n>)` が regex マッチし n>=1
  - `test_verbose_workers_explicit_shows_plain_number`: `workers=8` で `workers=8` のみ、`(auto)` 非出現
  - `test_workers_summary_str_helper_contract`: ヘルパ単体 (明示 + `_resolve_workers=12` patch で auto)

## 出力イメージ

auto (未指定時):
```
Detecting match boundaries (interval=3.0s, threshold=15.0, workers=auto (16), min_match=300.0s, min_blackout=3.0s, audio=on)
```

明示指定時 (`--workers 8`):
```
Detecting match boundaries (..., workers=8, ...)
```

## 再発防止

ヘルパ化することで、将来 `_resolve_workers` の実装 (cpu_count 取得方法 / 上限 24 の変更) が変わっても verbose 出力に確実に追従する。ヘルパ単体テストでパッチ可能な契約を確認。

## Test plan

- [x] コード修正 (split_matches.py)
- [x] テスト追加 3 件
- [x] `pytest` 535 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors

## 関連

- B グループ並列 (独立、1 行の修正 + ヘルパ)

Refs #389

session-id: engineer-1