### PR TITLE
fix(stats): verbose の Scorebar 行に elapsed time を併記 (Refs #386) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -658,6 +658,12 @@ def _print_detection_stats(stats: DetectionStats) -> None:
         unknown = stats.get("scorebar_unknown", 0)
         if unknown:
             parts.append(f"{unknown} unknown")
+        # Append elapsed time when available (#386) for symmetry with
+        # Pass 1 / Pass 2.  Gate on presence so tests that don't populate
+        # the key still render a clean "X match_boundary, ..." line.
+        scorebar_elapsed = stats.get("scorebar_elapsed_s")
+        if scorebar_elapsed is not None:
+            parts.append(_format_duration(scorebar_elapsed))
         typer.echo(f"  Scorebar: {', '.join(parts)}")
 
     promotions = stats.get("audio_promotions")

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -42,6 +42,7 @@ class DetectionStats(TypedDict, total=False):
     scorebar_in_match: int
     scorebar_non_fl: int
     scorebar_unknown: int
+    scorebar_elapsed_s: float
     audio_promotions: int
 
 
@@ -223,6 +224,7 @@ def detect_match_boundaries(
         refine_total = refine_completed + len(refined_regions)
 
         height = _scaled_height(src_resolution[0], src_resolution[1])
+        scorebar_start = time.monotonic()
         refined_regions, region_classifications = filter_blackouts_with_scorebar(
             video_path,
             refined_regions,
@@ -233,6 +235,9 @@ def detect_match_boundaries(
             stats=stats,
             progress_callback=lambda c, t: _refine_step(),
         )
+        scorebar_elapsed = time.monotonic() - scorebar_start
+        if stats is not None:
+            stats["scorebar_elapsed_s"] = scorebar_elapsed
 
     effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)
     return _filter_and_extract_segments(

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1656,6 +1656,95 @@ def test_verbose_prints_pipeline_stats(
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_verbose_scorebar_line_includes_elapsed(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Scorebar line includes an elapsed-time token (#386).
+
+    Pass 1 and Pass 2 already print elapsed; the scorebar line previously
+    showed only counts, breaking symmetry and hiding scorebar-specific
+    performance regressions from troubleshoot reports.
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 5
+            stats["pass1_elapsed_s"] = 10.0
+            stats["pass2_regions"] = 3
+            stats["pass2_elapsed_s"] = 2.0
+            stats["scorebar_match_boundary"] = 2
+            stats["scorebar_in_match"] = 1
+            stats["scorebar_non_fl"] = 0
+            stats["scorebar_unknown"] = 0
+            stats["scorebar_elapsed_s"] = 12.0
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    scorebar_line = next(
+        (line for line in out.splitlines() if line.strip().startswith("Scorebar:")),
+        None,
+    )
+    assert scorebar_line is not None, f"Scorebar line missing in: {out!r}"
+    # _format_duration(12.0) -> "0m12s"
+    assert "0m12s" in scorebar_line, f"Scorebar line missing elapsed: {scorebar_line!r}"
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_scorebar_line_without_elapsed_still_prints(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """When scorebar_elapsed_s is absent, the line still renders counts (#386).
+
+    Backwards-compat safety: downstream code (or an older detector) that
+    doesn't populate the new key must not break the stats output.
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 5
+            stats["pass1_elapsed_s"] = 10.0
+            stats["pass2_regions"] = 3
+            stats["pass2_elapsed_s"] = 2.0
+            stats["scorebar_match_boundary"] = 1
+            stats["scorebar_in_match"] = 0
+            stats["scorebar_non_fl"] = 0
+            stats["scorebar_unknown"] = 0
+            # intentionally NOT setting scorebar_elapsed_s
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    scorebar_line = next(
+        (line for line in out.splitlines() if line.strip().startswith("Scorebar:")),
+        None,
+    )
+    assert scorebar_line is not None
+    assert "1 match_boundary" in scorebar_line
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_non_verbose_does_not_print_stats(
     mock_probe, mock_detect, mock_split, tmp_path, capsys
 ):


### PR DESCRIPTION
## Summary

Pass 1 / Pass 2 の verbose stats には elapsed time があるのに、Scorebar 行はカウントのみで所要時間が見えない非対称があった。Pass 1 / Pass 2 と同じ `time.monotonic()` pattern で計測し、`DetectionStats` に `scorebar_elapsed_s` を追加、`_print_detection_stats` で末尾に表示。

## 変更点

- `allaganeye/video/detector.py`
  - `DetectionStats` TypedDict に `scorebar_elapsed_s: float` を追加
  - `filter_blackouts_with_scorebar` 呼び出しを `time.monotonic()` で挟み、`stats["scorebar_elapsed_s"]` に記録
- `allaganeye/commands/split_matches.py`
  - `_print_detection_stats` の Scorebar 行で elapsed が存在する場合のみ `_format_duration(...)` を parts に追加 (後方互換)
- `tests/test_split_matches.py`
  - `test_verbose_scorebar_line_includes_elapsed`: elapsed=12.0 で "0m12s" 表示確認
  - `test_verbose_scorebar_line_without_elapsed_still_prints`: 旧 stats (elapsed 未設定) で counts のみで描画される後方互換を assert

## 出力イメージ

Before:
```
  Scorebar: 15 match_boundary, 2 in_match, 1 non_fl
```

After:
```
  Scorebar: 15 match_boundary, 2 in_match, 1 non_fl, 12s
```

## 再発防止

- elapsed を optional (`scorebar_elapsed_s`) で設計、描画側も `if ... is not None` で gate → 将来 stats キー追加時に他所を壊さない
- 行単位テストで Scorebar 行のみ抽出して assert、他行に影響しないことを保証

## Test plan

- [x] コード修正 (detector.py DetectionStats + 計測 / split_matches.py 描画)
- [x] テスト追加 2 件 (elapsed 有無両パス)
- [x] `pytest` 534 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors

## 関連

- C グループ並列 (#387 と独立)

Refs #386

session-id: engineer-1