### PR TITLE
fix(stats): verbose で Splitting 行の elapsed time を出力 (Refs #387) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -97,6 +97,7 @@ def run_split(
             _check_disk_space(
                 video_path, boundaries, metadata["duration"], config, show=show
             )
+            split_start = time.monotonic()
             _split_and_write_metadata(
                 video_path,
                 boundaries,
@@ -107,6 +108,7 @@ def run_split(
                 detected_at=detected_at,
                 quiet=quiet,
             )
+            _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
             _emit_total_time(total_start, verbose, show)
             return
 
@@ -187,6 +189,7 @@ def run_split(
         return
 
     _check_disk_space(video_path, boundaries, metadata["duration"], config, show=show)
+    split_start = time.monotonic()
     _split_and_write_metadata(
         video_path,
         boundaries,
@@ -197,6 +200,7 @@ def run_split(
         detected_at=detected_at,
         quiet=quiet,
     )
+    _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
     _emit_total_time(total_start, verbose, show)
 
 
@@ -741,6 +745,21 @@ def _probe_ffmpeg_version() -> str:
         match = _FFMPEG_VERSION_RE.match(raw)
         return match.group(1) if match else raw
     return "(unknown)"
+
+
+def _emit_splitting_elapsed(
+    split_start: float, match_count: int, verbose: bool, show: bool
+) -> None:
+    """Emit ``  Splitting: N matches, Xs`` for verbose stats (#387).
+
+    Called from ``run_split`` after ``_split_and_write_metadata`` returns so
+    users can see the split phase's standalone cost instead of inferring it
+    from ``Total - (Pass 1 + Pass 2 + Scorebar)``.  Printed on both the
+    cached and cache-miss paths so the number is always surfaced.
+    """
+    if verbose and show:
+        elapsed = time.monotonic() - split_start
+        typer.echo(f"  Splitting: {match_count} matches, {_format_duration(elapsed)}")
 
 
 def _print_detection_stats(stats: DetectionStats) -> None:

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -2256,6 +2256,85 @@ def test_audio_status_str_helper_matches_run_audio_scan_contract():
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_verbose_emits_splitting_elapsed_with_match_count(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose mode emits 'Splitting: N matches, Xs' after split (#387).
+
+    Pass 1 / Pass 2 / Scorebar already report elapsed; Splitting was the
+    only hidden phase, forcing users to do arithmetic on Total to infer
+    its cost.
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES  # 2 matches
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    splitting_line = next(
+        (line for line in out.splitlines() if line.strip().startswith("Splitting:")),
+        None,
+    )
+    assert splitting_line is not None, f"Splitting: line missing in: {out!r}"
+    assert "2 matches" in splitting_line, (
+        f"Splitting line should report count=2: {splitting_line!r}"
+    )
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_non_verbose_does_not_emit_splitting_line(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Splitting elapsed is verbose-only; default runs stay terse (#387)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=False)
+    out = capsys.readouterr().out
+    assert "Splitting:" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_hit_also_emits_splitting_line(
+    mock_probe, mock_split, tmp_path, capsys
+):
+    """Cache-hit + split path also emits the Splitting line (#387).
+
+    Symmetry with the non-cache path so users see the same breakdown
+    whether or not Pass 1/2 ran.
+    """
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    _save_cache(
+        tmp_path / ".detection_cache.json",
+        source,
+        PROBE_RESULT,
+        config.sample_interval,
+        config,
+        BOUNDARIES,
+    )
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    run_split(source, config, verbose=True)
+    out = capsys.readouterr().out
+    assert "(cached)" in out
+    assert "Splitting:" in out, f"cache+split path must show Splitting: {out!r}"
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_verbose_dry_run_emits_total(
     mock_probe, mock_detect, mock_split, tmp_path, capsys
 ):


### PR DESCRIPTION
## Summary

Pass 1 / Pass 2 / Scorebar は verbose stats に elapsed を表示するのに Splitting だけ非表示で、ユーザーは Total から逆算して Splitting 単独時間を割り出す必要があった。`run_split` の `_split_and_write_metadata` 呼び出し前後で `time.monotonic()` を挟み、新ヘルパ `_emit_splitting_elapsed` から verbose 時のみ ``  Splitting: <N> matches, <duration>`` を出力する。

## 変更点

- `allaganeye/commands/split_matches.py`
  - 新ヘルパ `_emit_splitting_elapsed(split_start, match_count, verbose, show)`
  - cache-hit + split 分岐と cache-miss + split 分岐の両方で `split_start = time.monotonic()` → `_split_and_write_metadata(...)` → ヘルパ呼び出しの順で配置
- `tests/test_split_matches.py`
  - `test_verbose_emits_splitting_elapsed_with_match_count`: 2 matches mock で行抽出し `"2 matches"` 確認
  - `test_non_verbose_does_not_emit_splitting_line`: verbose=False で非出力
  - `test_verbose_cache_hit_also_emits_splitting_line`: cache hit path でも Splitting 行が出る (対称性)

## 出力イメージ

Before:
```
  Pass 1 (CPU): 3410 samples, 31 blackout frames (0.9%), 5m50s
  Pass 2: 18 regions refined, 1m03s
  Scorebar: 15 match_boundary, 2 in_match, 1 non_fl
Splitting  #################################### 100%
...
Total: 8m07s
```

After:
```
  Pass 1 (CPU): 3410 samples, 31 blackout frames (0.9%), 5m50s
  Pass 2: 18 regions refined, 1m03s
  Scorebar: 15 match_boundary, 2 in_match, 1 non_fl, 12s
Splitting  #################################### 100%
  Splitting: 8 matches, 1m02s
...
Total: 8m07s
```

(注: Scorebar 行の elapsed は [#386](https://github.com/Idios/kobutachan-allaganeye/pull/403) で別途追加済)

## 設計メモ

`_split_and_write_metadata` のシグネチャは**変更しない** (#370 で既に `effective_interval` / `detected_at` を追加しており、これ以上積み上げたくない)。Splitting 時間は呼び出し側で計測する方が責務分離として自然 — タイミングは "split 呼び出しの前後" という run_split レベルの関心事。

## 再発防止

- 行単位抽出 (`startswith("Splitting:")`) で assert、他行を汚染しない
- cache hit 側も明示的にテスト (#381 の Total: と同じパターン — cache 分岐が after-split 出力から取りこぼすリスクを構造的に防ぐ)

## Test plan

- [x] コード修正 (split_matches.py)
- [x] テスト追加 3 件 (verbose / non-verbose / cache-hit)
- [x] `pytest` 535 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors

## 関連

- C グループ並列 (#386 と独立)

Refs #387

session-id: engineer-1