### PR TITLE
test(split): B グループ追加カバレッジ (#397 #398 optional gap) (Refs #382 #383)

### DIFF
--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -200,6 +200,37 @@ def test_match_list_no_marker_when_all_fl_match(
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_match_list_handles_missing_type_key(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Boundary dict without ``type`` key yields no marker and no error (#382).
+
+    Legacy cache / older metadata payloads may ship MatchBoundary-shaped
+    dicts that omit ``type``.  The display code uses ``b.get("type")``
+    defensively; this test pins that contract so a future refactor to
+    ``b["type"]`` fails loudly here rather than KeyError-ing at runtime.
+    """
+    no_type_boundaries: list[MatchBoundary] = [
+        {"start": 0.0, "end": 600.0},  # type: ignore[typeddict-item]
+        {"start": 610.0, "end": 1200.0},  # type: ignore[typeddict-item]
+    ]
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = no_type_boundaries
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+    out = capsys.readouterr().out
+
+    # No marker, no crash, and the Match lines still render.
+    assert "[unknown]" not in out
+    match_lines = [ln for ln in out.splitlines() if ln.strip().startswith("Match ")]
+    assert len(match_lines) == 2
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_metadata_output_file_uses_posix_separator(
     mock_probe, mock_detect, mock_split, tmp_path
 ):
@@ -2045,6 +2076,32 @@ def test_probe_ffmpeg_version_unknown_when_format_unexpected():
     with patch("subprocess.run", return_value=mock_result):
         result = _probe_ffmpeg_version()
     assert result == "(unknown)"
+
+
+@pytest.mark.parametrize(
+    ("raw_first_line", "expected"),
+    [
+        # 'v' prefix is less common than 'n' but the regex supports both.
+        # Pin this so a future regex narrowing to ``^n?`` surfaces here.
+        ("ffmpeg version v7.0 Copyright (c) 2000-2024", "7.0"),
+        ("ffmpeg version v6.1.1-custom Copyright (c) 2000-2023", "6.1.1"),
+    ],
+)
+def test_probe_ffmpeg_version_handles_v_prefix(raw_first_line, expected):
+    """'v' prefix variant is trimmed just like 'n' (#383).
+
+    The parametric coverage in the PR focuses on ``n`` (BtbN nightly style)
+    and bare numerics.  ``^[nv]?`` in the regex also accepts ``v`` -- pin
+    that explicitly so a narrowing to ``^n?`` would fail loudly.
+    """
+    from unittest.mock import MagicMock
+
+    from allaganeye.commands.split_matches import _probe_ffmpeg_version
+
+    mock_result = MagicMock(stdout=raw_first_line + "\n")
+    with patch("subprocess.run", return_value=mock_result):
+        result = _probe_ffmpeg_version()
+    assert result == expected
 
 
 # --- ETA formatter (issue #333) ---


### PR DESCRIPTION
## 概要

PR #397 / #398 のレビューで検出した optional gap に対する追加テスト 3 件（parametric 含む）。

## 依存関係

**Depends on #397 AND #398** — 現在のブランチは #398 ベースに #397 を cherry-pick した状態。両 PR マージ後に `git rebase origin/develop-0.1.1` で diff を純粋なテスト追加分のみに収束させる。

## 追加テスト

| # | テスト | 対応 PR | 検出リスク |
|---|---|---|---|
| 1 | `test_match_list_handles_missing_type_key` | #397 | `.get("type")` → `b["type"]` への将来の narrowing |
| 2 | `test_probe_ffmpeg_version_handles_v_prefix` (parametric × 2) | #398 | 正規表現 `^[nv]?` の `v` 対応削除 |

## 有効性検証

- PR #397 + #398 適用後: **3/3 PASS**
- develop-0.1.1 ベースライン:
  - `test_probe_ffmpeg_version_handles_v_prefix`: **2 FAIL** (raw `v7.0` / `v6.1.1-custom` そのまま返却)
  - `test_match_list_handles_missing_type_key`: PASS (develop では marker logic 自体が無い、前向き回帰ガード)

→ v prefix 2 件は有効な回帰ガード、missing_type は将来的なコード変更に対する前向きガード。

## チェックリスト

- [x] `python -m ruff check` 通過
- [x] `python -m ruff format --check` 通過
- [x] `python -m pyright tests/test_split_matches.py` 通過 (0 errors)
- [x] `python -m pytest` 通過 (544 passed, 36 deselected)
- [x] 旧実装で v-prefix 2 件が FAIL することを確認
- [x] base = `develop-0.1.1`
- [x] `Refs #382 #383`
- [x] session-id 記載

## 関連

- Refs #382 (#397 depends)
- Refs #383 (#398 depends)

## レビューワ

`role:lead-engineer` (Tester 作成 PR のため)

## session-id

tester-1