### PR TITLE
feat(verbose): 検知候補の filter drop 内訳を表示 (Refs #388) [engineer-1]

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -807,6 +807,32 @@ def _print_detection_stats(stats: DetectionStats) -> None:
     if promotions is not None and promotions > 0:
         typer.echo(f"  Audio promotion: {promotions} in_match -> match_boundary")
 
+    # Filter drop breakdown (#388): why candidates -> matches shrank.
+    # scorebar in_match / non_fl counts stay on the Scorebar line above;
+    # this section captures duration-based drops (below_min_match_duration
+    # and residual "other") so users can tune --min-match-duration.
+    candidates = stats.get("filter_candidates")
+    drops = stats.get("filter_drops")
+    # Skip the section entirely when there are no real candidates *and*
+    # no drops: the match came from the whole-video fallback path, so
+    # ``Filter: 0 candidates -> 0 matches`` would be misleading noise.
+    if (
+        candidates is not None
+        and drops is not None
+        and (candidates > 0 or sum(drops.values()) > 0)
+    ):
+        kept = candidates - sum(drops.values())
+        typer.echo(f"  Filter: {candidates} candidates -> {kept} matches")
+        # Emit only non-zero categories so the output stays terse on
+        # healthy runs; zero-row lines would be noise.
+        if drops.get("below_min_match_duration", 0) > 0:
+            typer.echo(
+                f"    {drops['below_min_match_duration']} dropped "
+                f"(below min_match_duration)"
+            )
+        if drops.get("other", 0) > 0:
+            typer.echo(f"    {drops['other']} dropped (other)")
+
 
 def _format_timestamp(seconds: float) -> str:
     """Format seconds as MM:SS or H:MM:SS."""

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -44,6 +44,11 @@ class DetectionStats(TypedDict, total=False):
     scorebar_unknown: int
     scorebar_elapsed_s: float
     audio_promotions: int
+    # Refined-region count entering _filter_and_extract_segments (#388).
+    # Paired with filter_drops so verbose can report
+    # ``<candidates> -> <final matches>`` with breakdown.
+    filter_candidates: int
+    filter_drops: dict[str, int]  # keys: below_min_match_duration, other
 
 
 logger = logging.getLogger(__name__)
@@ -235,6 +240,7 @@ def detect_match_boundaries(
         min_match_duration,
         effective_min,
         classifications=region_classifications,
+        stats=stats,
     )
 
 
@@ -1091,6 +1097,7 @@ def _filter_and_extract_segments(
     min_match_duration: float,
     min_blackout_duration: float = 3.0,
     classifications: list[str] | None = None,
+    stats: DetectionStats | None = None,
 ) -> list[MatchBoundary]:
     """Filter blackout regions by duration and extract match segments.
 
@@ -1102,10 +1109,39 @@ def _filter_and_extract_segments(
 
     When *classifications* is provided, each segment receives a ``"type"``
     field inferred from adjacent blackout classifications.
+
+    When *stats* is provided, the candidate count entering this function
+    and the per-reason drop counts are recorded under
+    ``stats["filter_candidates"]`` and ``stats["filter_drops"]`` (#388).
+    ``filter_drops`` keys: ``"below_min_match_duration"`` (segment length
+    short of the threshold) and ``"other"`` (whole-video candidate also
+    below the threshold when no valid blackout remains).  scorebar-based
+    drops (``in_match`` / ``non_fl``) stay in the dedicated
+    ``scorebar_*`` fields -- this counter is strictly for the duration-
+    based filters that happen inside this function.
     """
+    # Candidate count reported as "the number of refined regions fed in";
+    # scorebar filtering has already shrunk this above.  Pass 2 numbers
+    # still live in ``pass2_regions``.
+    if stats is not None:
+        stats["filter_candidates"] = len(blackout_regions)
+        # Reuse an existing dict if the caller pre-populated it (future
+        # multi-stage increments), otherwise start fresh.
+        drops = stats.get("filter_drops") or {}
+        drops.setdefault("below_min_match_duration", 0)
+        drops.setdefault("other", 0)
+        stats["filter_drops"] = drops
+
+    def _record_drop(key: str) -> None:
+        if stats is not None:
+            stats["filter_drops"][key] = stats["filter_drops"].get(key, 0) + 1
+
     if not blackout_regions:
         if total_duration >= min_match_duration:
             return [{"start": 0.0, "end": total_duration, "type": "unknown"}]
+        # Whole video was shorter than min_match_duration -- count the
+        # implicit whole-video candidate as dropped.
+        _record_drop("other")
         return []
 
     # Filter out short blackout regions (e.g. respawn blackouts 1-2s)
@@ -1131,6 +1167,7 @@ def _filter_and_extract_segments(
     if not blackout_regions:
         if total_duration >= min_match_duration:
             return [{"start": 0.0, "end": total_duration, "type": "unknown"}]
+        _record_drop("other")
         return []
 
     # Extract segments between blackout regions
@@ -1149,6 +1186,8 @@ def _filter_and_extract_segments(
                     "type": "unknown",
                 }
             )
+        else:
+            _record_drop("below_min_match_duration")
 
     # Between blackout regions
     for i in range(len(blackout_regions) - 1):
@@ -1169,6 +1208,8 @@ def _filter_and_extract_segments(
                     "type": seg_type,
                 }
             )
+        else:
+            _record_drop("below_min_match_duration")
 
     # After last blackout
     seg_start = _padded_start(blackout_regions[-1])
@@ -1181,6 +1222,8 @@ def _filter_and_extract_segments(
                 "type": "unknown",
             }
         )
+    else:
+        _record_drop("below_min_match_duration")
 
     return segments
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -95,6 +95,30 @@ HW 情報は全て best-effort。取得失敗しても `(unavailable)` を返す
 
 各バーは前のバーが 100% 到達 → 改行して確定 → 次のバーが新しい行で開始する。過去のバーが `\r` で上書きされたり、単位切替で 100% → 99% に逆戻りしたりすることはない。
 
+### verbose stats の内訳行 (#386 / #387 / #388)
+
+検知完了後、verbose は以下の順でパイプライン統計を出力する:
+
+```
+  Pass 1 (CPU): 3410 samples, 31 blackout frames (0.9%), 5m50s
+  Pass 2: 18 regions refined, 1m03s
+  Scorebar: 15 match_boundary, 2 in_match, 1 non_fl, 0m12s
+  Filter: 15 candidates -> 8 matches
+    6 dropped (below min_match_duration)
+    1 dropped (other)
+  Splitting: 8 matches, 1m02s
+```
+
+| 行 | 内容 |
+|---|---|
+| `Pass 1` | Pass 1 のサンプル数・暗転フレーム数・所要時間 |
+| `Pass 2` | Pass 2 精密計測の region 数・所要時間 (#366) |
+| `Scorebar` | Scorebar 分類 (match_boundary / in_match / non_fl / unknown) のカウントと所要時間 (#386) |
+| `Filter` | Scorebar 通過後の候補数 → 最終 match 数。`below_min_match_duration` / `other` が 0 より大きい場合のみ内訳を追加出力 (#388) |
+| `Splitting` | 分割フェーズの match 数・所要時間 (#387) |
+
+`Filter` セクションは候補数がゼロかつドロップがゼロの場合 (whole-video fallback により match が生成されたケース) は出力を省略する。`dropped (below min_match_duration)` は **セグメント長が `min_match_duration` に満たなかった数**、`dropped (other)` は短尺動画の whole-video 候補不適合等の残余カウント。`in_match` / `non_fl` はここに含まれず、上の Scorebar 行がそのカウントを担う (重複防止)。
+
 ### metadata.json
 
 分割結果の機械可読な記録。外部ツールやスクリプトから参照可能。L3（メタデータ化）パイプラインの入力として使用予定。L3 未着手のため、フィールド構造は暫定であり破壊的変更の可能性がある。

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -677,6 +677,137 @@ class TestExtractSegments:
 
 
 # ============================================================
+# _filter_and_extract_segments: filter_drops stats wiring (#388)
+# ============================================================
+
+
+class TestFilterDropsStats:
+    """Verify the stats param captures drop breakdown (#388)."""
+
+    def test_candidates_count_matches_input(self):
+        """filter_candidates == len(blackout_regions) entering the filter."""
+        stats: dict = {}
+        regions = [(100.0, 105.0), (500.0, 505.0), (1200.0, 1205.0)]
+        _filter_and_extract_segments(
+            regions,
+            1800.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert stats["filter_candidates"] == 3
+
+    def test_no_drops_when_all_segments_pass(self):
+        """Every segment >= min_match_duration -> zero drops."""
+        stats: dict = {}
+        # Two blackouts spaced to give 3 segments each >= 300s.
+        regions = [(400.0, 405.0), (800.0, 805.0)]
+        _filter_and_extract_segments(
+            regions,
+            1500.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert stats["filter_drops"] == {
+            "below_min_match_duration": 0,
+            "other": 0,
+        }
+
+    def test_below_min_match_duration_increments_on_short_segment(self):
+        """Segments shorter than min_match_duration bump the counter."""
+        stats: dict = {}
+        # First segment 0-100 (100s), second 150-400 (250s), last 450-500 (50s).
+        # All three < min_match_duration=300 -> 3 drops.
+        regions = [(100.0, 150.0), (400.0, 450.0)]
+        result = _filter_and_extract_segments(
+            regions,
+            500.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert result == []
+        assert stats["filter_drops"]["below_min_match_duration"] == 3
+        assert stats["filter_drops"]["other"] == 0
+
+    def test_mixed_pass_and_drop(self):
+        """One segment passes, two fail -> candidates=2, drops=2, kept=1."""
+        stats: dict = {}
+        # seg1: 0-100 (100s, drop), seg2: 150-900 (750s, pass),
+        # seg3: 950-1000 (50s, drop).
+        regions = [(100.0, 150.0), (900.0, 950.0)]
+        result = _filter_and_extract_segments(
+            regions,
+            1000.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert len(result) == 1
+        assert stats["filter_drops"]["below_min_match_duration"] == 2
+
+    def test_empty_regions_whole_video_short_counts_as_other(self):
+        """No blackouts + video shorter than min_match -> 'other' drop."""
+        stats: dict = {}
+        result = _filter_and_extract_segments(
+            [],
+            100.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert result == []
+        assert stats["filter_drops"]["other"] == 1
+
+    def test_empty_regions_whole_video_long_no_drop(self):
+        """No blackouts + video >= min_match -> whole-video match, no drop."""
+        stats: dict = {}
+        result = _filter_and_extract_segments(
+            [],
+            1800.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert len(result) == 1
+        assert stats["filter_drops"] == {
+            "below_min_match_duration": 0,
+            "other": 0,
+        }
+
+    def test_stats_none_runs_without_raising(self):
+        """When stats is None the function behaves exactly as before."""
+        # Sanity: existing callers / tests that don't pass stats must
+        # continue to work (backwards-compatibility with the pre-#388
+        # signature).
+        result = _filter_and_extract_segments([(100.0, 105.0)], 1800.0, 300.0, 3.0)
+        assert len(result) >= 1
+
+    def test_below_min_blackout_regions_rolled_into_candidate_count(self):
+        """Regions below min_blackout_duration are not candidates.
+
+        They get filtered before the segment loop and don't contribute to
+        filter_drops (those live on the Scorebar / min-blackout path above
+        this function). The candidate count reflects what's left after
+        scorebar but before min-blackout trimming.
+        """
+        stats: dict = {}
+        # 3 regions incoming; one is 1s (< 3s min_blackout) so it gets
+        # trimmed, leaving 2 effective blackouts that make 3 segments
+        # (0-100 short, 100-900 pass, 900-1000 short).
+        regions = [(100.0, 101.0), (100.0, 105.0), (900.0, 905.0)]
+        _filter_and_extract_segments(
+            regions,
+            1000.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert stats["filter_candidates"] == 3
+
+
+# ============================================================
 # TestInferSegmentType
 # ============================================================
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -2108,6 +2108,176 @@ def test_verbose_scorebar_line_without_elapsed_still_prints(
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_verbose_prints_filter_drop_breakdown(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Verbose stats show Filter section with drop breakdown (#388).
+
+    Troubleshoot scenario: Pass 2 refined 18 candidates, scorebar removed
+    some, filter dropped 6 for min_match_duration -> only 8 final. Users
+    need to see the drop counts to tune --min-match-duration.
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 3410
+            stats["pass1_blackout_frames"] = 31
+            stats["pass1_elapsed_s"] = 350.0
+            stats["pass2_regions"] = 18
+            stats["pass2_elapsed_s"] = 63.0
+            stats["scorebar_match_boundary"] = 15
+            stats["scorebar_in_match"] = 2
+            stats["scorebar_non_fl"] = 1
+            stats["scorebar_unknown"] = 0
+            stats["filter_candidates"] = 15
+            stats["filter_drops"] = {
+                "below_min_match_duration": 6,
+                "other": 1,
+            }
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=300.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    lines = out.splitlines()
+    filter_header = next(
+        (line for line in lines if line.strip().startswith("Filter:")),
+        None,
+    )
+    assert filter_header is not None, f"Filter: line missing in: {out!r}"
+    # 15 candidates - (6 + 1) = 8 kept
+    assert "15 candidates" in filter_header
+    assert "8 matches" in filter_header
+
+    # Breakdown lines appear as indented entries after the header.
+    assert "6 dropped (below min_match_duration)" in out
+    assert "1 dropped (other)" in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_filter_breakdown_hides_zero_categories(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Zero-count drop categories stay hidden to keep output terse (#388)."""
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 3
+            stats["pass1_elapsed_s"] = 5.0
+            stats["pass2_regions"] = 2
+            stats["pass2_elapsed_s"] = 1.0
+            stats["filter_candidates"] = 2
+            stats["filter_drops"] = {
+                "below_min_match_duration": 0,
+                "other": 0,
+            }
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    assert "Filter: 2 candidates -> 2 matches" in out
+    # No breakdown rows when every category is 0.
+    assert "0 dropped" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_filter_breakdown_absent_when_stats_missing_keys(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Legacy stats without filter_candidates / filter_drops render safely (#388).
+
+    Backwards-compat: older detect fixtures (or tests that mock
+    detect_match_boundaries) may not populate the new keys.  Filter
+    section must simply be skipped rather than raising.
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 3
+            stats["pass1_elapsed_s"] = 5.0
+            stats["pass2_regions"] = 2
+            stats["pass2_elapsed_s"] = 1.0
+            # intentionally NOT setting filter_candidates / filter_drops
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "Filter:" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_filter_section_skipped_on_whole_video_fallback(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Whole-video fallback produces ``candidates=0, drops=0`` -> hide Filter (#388).
+
+    When every refined region is removed at the scorebar stage, the
+    filter function still returns one whole-video match via the fallback
+    path.  Emitting ``Filter: 0 candidates -> 0 matches`` in that case
+    would contradict the ``Detected 1 match(es)`` line and confuse users.
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 3
+            stats["pass1_elapsed_s"] = 5.0
+            stats["pass2_regions"] = 2
+            stats["pass2_elapsed_s"] = 1.0
+            stats["filter_candidates"] = 0
+            stats["filter_drops"] = {
+                "below_min_match_duration": 0,
+                "other": 0,
+            }
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "Filter:" not in out, (
+        f"Filter: section should be hidden on whole-video fallback: {out!r}"
+    )
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_non_verbose_does_not_print_stats(
     mock_probe, mock_detect, mock_split, tmp_path, capsys
 ):


### PR DESCRIPTION
## Summary

verbose stats に Pass 2 refined 数と最終 match 数の間の差分内訳が表示されず、`--min-match-duration` チューニングができない問題を修正。`DetectionStats` に `filter_candidates` / `filter_drops` を追加し、`_print_detection_stats` に Filter セクションを挿入する。scorebar 分類 (in_match / non_fl) との重複を避けるため、filter_drops は duration 系 (below_min_match_duration / other) のみ記録する。

## 要因分析

- **直接原因**: `_filter_and_extract_segments` 内の「seg_end - seg_start < min_match_duration で continue」分岐に drop カウンタが無く、stats から最終 match 数の差分理由を復元できない
- **検出漏れ**: 既存 verbose stats は Pass 1 / Pass 2 / Scorebar / Splitting の 4 行構造だったが Filter 段階のみカウンタが存在せず、実 L1 ユーザーテストで `Pass 2: 18 regions` → `Detected 8 matches` の差分 10 の理由が推測になっていた
- **再発防止**: 本 PR のテストは `_filter_and_extract_segments` の各 drop 経路 (3 種セグメント + whole-video fallback) を網羅し、将来 filter 条件を追加・変更しても drop 数の記録が壊れないことを構造検証

## 類似バグ調査

verbose stats 5 行構造 (Pass 1 / Pass 2 / Scorebar / Filter / Splitting) のうち、本 PR 以前は Filter 行だけが空白地帯だった。本セッションで #386 (Scorebar elapsed) / #387 (Splitting elapsed) / 本 PR の 3 件で verbose stats は完全網羅される。scorebar の in_match / non_fl との重複リスクは Lead コメントで指摘されていた通り、filter_drops は duration 系ドロップのみに限定する。

## Lead 方針との差異

issue 本文と Lead 最新コメントにわずかな齟齬 (issue body サンプル例は 4 キー表示、Lead コメントは `continue  # 既に scorebar カウント済み` で 2 キーのみ) があったため、**Lead コメント** (スコープ指示) に厳密に従い:

- `filter_drops` キーは `below_min_match_duration` / `other` の 2 キーに限定
- scorebar 系 drop は既存 `scorebar_in_match` / `scorebar_non_fl` のまま (重複させない)
- issue body の `2 dropped (in_match)` / `1 dropped (non_fl)` は scorebar 行と重複するため本 PR では省略
- `below_min_blackout` は `_filter_and_extract_segments` 内で先にフィルタされるため候補数に含めつつ drop カテゴリには立てない

方針の異同について lead 判断が必要なら再調整します (別 issue で `in_match` / `non_fl` の「実除外数」表示を要望する形等)。

## 変更点

### コード

- `allaganeye/video/detector.py`
  - `DetectionStats` TypedDict に `filter_candidates` / `filter_drops` を追加
  - `_filter_and_extract_segments` に `stats: DetectionStats | None = None` パラメータ追加
  - 関数冒頭で `filter_candidates = len(blackout_regions)` を記録、`filter_drops` 初期化
  - 各 drop 経路 (before-first / between / after-last segment が min_match 未満) / whole-video fallback の 4 経路で increment
  - `detect_match_boundaries` 呼び出し側で `stats=stats` を渡す
  - stats=None の経路はそのまま動作する backwards-compat

- `allaganeye/commands/split_matches.py`
  - `_print_detection_stats` に Filter セクション追加
  - `Filter: <N> candidates -> <M> matches` + 内訳 2 行 (非ゼロ時のみ)
  - candidates=0 かつ drops=0 のケース (whole-video fallback で match 生成) ではセクション全体を省略 (`Detected 1 match(es)` と矛盾する `0 matches` 表示を回避)

### テスト

- `tests/test_detector.py` 新規 `TestFilterDropsStats` クラス 8 件: candidates カウント / 全通過 / mixed / whole-video fallback / backwards-compat 全経路
- `tests/test_split_matches.py` 追加 4 件: Filter 行の行単位構造検証 / ゼロカテゴリ非出力 / 旧 stats backwards-compat / whole-video fallback スキップ

### docs

- `docs/cli-spec.md` に「verbose stats の内訳行 (#386 / #387 / #388)」節新設。5 行構造 + 各行意味 + 表示条件を表で明記

## 出力イメージ

```
  Pass 1 (CPU): 3410 samples, 31 blackout frames (0.9%), 5m50s
  Pass 2: 18 regions refined, 1m03s
  Scorebar: 15 match_boundary, 2 in_match, 1 non_fl, 0m12s
  Filter: 15 candidates -> 8 matches
    6 dropped (below min_match_duration)
    1 dropped (other)
  Splitting: 8 matches, 1m02s
```

## 手動検証

実動画 (`20260116_1.mp4`, scorebar ですべて in_match filter され whole-video fallback する短尺動画) で Filter セクション非表示、`Detected 1 match(es)` と整合することを確認。多 match ケースは mock 経由の単体 / 表示テストで網羅。

## Test plan

- [x] コード修正 (detector.py + split_matches.py)
- [x] 単体テスト 8 件 + 表示テスト 4 件
- [x] docs 同期 (cli-spec.md)
- [x] `pytest` 603 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors
- [x] 実動画で whole-video fallback 経路の非表示挙動確認

Refs #388

session-id: engineer-1