### PR TITLE
fix(split): -q モードで dry-run 通知を出力しないよう gate (Refs #418)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -91,7 +91,8 @@ def run_split(
             if show and verbose and gaps:
                 _display_gaps(gaps)
             if config.dry_run:
-                typer.echo("\nDry run: skipping split")
+                if show:
+                    typer.echo("\nDry run: skipping split")
                 _emit_total_time(total_start, verbose, show)
                 return
             _check_disk_space(
@@ -184,7 +185,8 @@ def run_split(
 
     # Step 3: Split (unless dry-run)
     if config.dry_run:
-        typer.echo("\nDry run: skipping split")
+        if show:
+            typer.echo("\nDry run: skipping split")
         _emit_total_time(total_start, verbose, show)
         return
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -2699,7 +2699,7 @@ def test_quiet_dry_run_cache_hit_stdout_empty(mock_probe, mock_split, tmp_path, 
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.probe_video")
 def test_quiet_cache_hit_only_output_listing(mock_probe, mock_split, tmp_path, capsys):
-    """-q cache-hit emits ONLY the output listing — no '(cached)' (#418 M)."""
+    """-q cache-hit emits ONLY the output listing -- no '(cached)' (#418 M)."""
     source = tmp_path / "input.mp4"
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
     _seed_cache(source, tmp_path, config)

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -2647,3 +2647,97 @@ def test_format_eta_hours():
 
     assert _format_eta(3600) == "1h00m"
     assert _format_eta(3700) == "1h01m"
+
+
+# --- Quiet strict-silent (#418) ---
+#
+# Per user-confirmed matrix v2 spec, ``-q`` (quiet) emits ONLY the output
+# file listing (``Output:`` / filenames / ``Metadata:``) on stdout.  Every
+# dry-run / cache notice / verbose line must stay hidden, on every branch
+# (cache-hit vs cache-miss, dry-run vs split).  The regression was that
+# ``Dry run: skipping split`` was echoed without a ``show`` gate so
+# ``-q --dry-run`` leaked the notice on both paths.
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_quiet_dry_run_cache_miss_stdout_empty(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """-q --dry-run (cache-miss) emits nothing on stdout (#418 L)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    config = SplitConfig(output_dir=tmp_path, dry_run=True, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config, quiet=True)
+
+    captured = capsys.readouterr()
+    assert captured.out == "", f"stdout leaked under -q --dry-run: {captured.out!r}"
+    mock_split.assert_not_called()
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_quiet_dry_run_cache_hit_stdout_empty(mock_probe, mock_split, tmp_path, capsys):
+    """-q --dry-run (cache-hit) emits nothing on stdout (#418 L)."""
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(output_dir=tmp_path, dry_run=True, min_match_duration=60.0)
+    _seed_cache(source, tmp_path, config)
+
+    mock_probe.return_value = PROBE_RESULT
+
+    run_split(source, config, quiet=True)
+
+    captured = capsys.readouterr()
+    assert captured.out == "", (
+        f"stdout leaked under -q --dry-run cache-hit: {captured.out!r}"
+    )
+    mock_split.assert_not_called()
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_quiet_cache_hit_only_output_listing(mock_probe, mock_split, tmp_path, capsys):
+    """-q cache-hit emits ONLY the output listing — no '(cached)' (#418 M)."""
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    _seed_cache(source, tmp_path, config)
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    run_split(source, config, quiet=True)
+
+    out = capsys.readouterr().out
+    assert "(cached)" not in out
+    assert "Probing:" not in out
+    assert "Detected" not in out
+    assert "Dry run" not in out
+    assert f"Output: {tmp_path}" in out
+    assert "match_001.mp4" in out
+    assert "Metadata:" in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_quiet_no_cache_only_output_listing(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """-q --no-cache emits ONLY the output listing (#418)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, no_cache=True)
+
+    run_split(Path("input.mp4"), config, quiet=True)
+
+    out = capsys.readouterr().out
+    assert "Probing:" not in out
+    assert "Detected" not in out
+    assert "Dry run" not in out
+    assert "(cached)" not in out
+    assert f"Output: {tmp_path}" in out
+    assert "match_001.mp4" in out
+    assert "Metadata:" in out


### PR DESCRIPTION
## 概要

[issue#418](https://github.com/Idios/kobutachan-allaganeye/issues/418) 対応。`-q` (quiet) モードで `Dry run: skipping split` 通知が stdout に leak していた問題を修正。

## 根本原因分析

`show = not quiet` gate は個別 `typer.echo` に逐次追加されてきた経緯があり、dry-run 終了直前の 2 箇所だけ gate 漏れしていた:

- [allaganeye/commands/split_matches.py:94](allaganeye/commands/split_matches.py:94) (cache-hit + dry-run)
- [allaganeye/commands/split_matches.py:187](allaganeye/commands/split_matches.py:187) (cache-miss + dry-run)

その他の `typer.echo` は全て audit 済みで、`_display_results` / `(cached)` サフィックス / Probing / stats 等はいずれも `if show:` 内で emit されており仕様 (#405 マトリクス v2) と整合。

## 類似バグ調査

- 他に ungated `typer.echo` (非 stderr) なし
- O (quiet モードのエラー stderr) は現状確認: `_report_app_error` が default / `-q` 双方で `Error: <msg>` のみ stderr emit、マトリクス v2 19c 仕様と合致 → **新規 issue 起票不要** (#405 に別途コメント予定)
- N (cache 生成パス通知) は現行実装に存在せず (logger.debug は stdout に出ない) → regression test で `-q` 時に出ないことを保証

## 変更点

- `split_matches.py` の dry-run 通知 2 箇所を `if show:` でラップ
- `tests/test_split_matches.py` に回帰テスト 4 本追加:
  - `test_quiet_dry_run_cache_miss_stdout_empty`
  - `test_quiet_dry_run_cache_hit_stdout_empty`
  - `test_quiet_cache_hit_only_output_listing`
  - `test_quiet_no_cache_only_output_listing`

## 受け入れ基準 (issue #418 より)

- [x] `-q --dry-run` で stdout が空
- [x] `-q` で `(cached)` サフィックスが stdout に出ない (既に gate 済みを regression で保証)
- [x] `-q` で Probing / dry-run 通知 / cache 生成パス通知が stdout に出ない
- [x] `-q` で出力ファイル一覧 (Output / ファイル / Metadata) は stdout に出る
- [x] 新規テスト: 各パスで stdout 厳密 silent 検証 (`-q --dry-run` 2 系統, `-q --no-cache`, cache hit + `-q`)
- [x] `docs/output-spec.md` との整合 — 本 PR では対象外 (#405 Phase 2 別 PR で対応予定)

## PR チェックリスト

- [x] 全テスト通過: `pytest tests/test_split_matches.py tests/test_cli.py` → 177 passed
- [x] Lint 通過: `ruff check . && ruff format --check .`
- [x] 型チェック通過: `pyright`
- [x] 関連ドキュメント更新: 本 PR スコープは実装修正のみ。`docs/output-spec.md` 新設 (#405 Phase 2 タスク 4) は別 PR
- [x] CLAUDE.md の更新不要

## 関連

- Refs #418 / #405 (CLI 出力マトリクス)
- Base: `develop-0.1.1`
- Session: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)