### PR TITLE
feat(hook): PreToolUse hook で確認ゲートを実装 (Refs #401) [engineer-1]

### DIFF
--- a/.claude/hooks/preuse.py
+++ b/.claude/hooks/preuse.py
@@ -1,0 +1,290 @@
+"""PreToolUse gate for risky / bulk operations (#401).
+
+Intercepts a small set of ``gh`` / bulk operations and forces Claude to
+escalate to the user before proceeding.  Designed to backstop the docs
+rules (#399 / #400) when Claude would otherwise independently run:
+
+- ``gh issue create`` 3+ times within 60 seconds (bulk Issue 起票)
+- ``gh pr merge`` (PR マージ)
+- ``gh issue close`` (Issue クローズ)
+- ``gh issue edit ... --add-label deferred`` 2+ times within 60 seconds
+
+Exit code 2 asks Claude Code to show the stderr message to the user and
+pause; Claude then asks for confirmation before proceeding.
+
+## Contract
+
+- Reads a Claude Code PreToolUse JSON event from stdin.  Only Bash tool
+  calls are gated; every other tool is allowed unconditionally (exit 0).
+- State: ``.claude/state/recent_ops.json`` records ``[{"cmd", "ts"}]``
+  for bulk-pattern timing.  Entries older than ``_BULK_WINDOW_SEC`` are
+  discarded on every read.
+- Config: ``.claude/settings.local.json`` may set
+  ``"pretooluse_gate": false`` to globally disable the gate (default:
+  enabled).  Category-specific switches are deliberately out of scope
+  (YAGNI, per #401 確定方針).
+- Thresholds (``_BULK_THRESHOLD``, ``_BULK_WINDOW_SEC``) are module-level
+  constants; override is out of scope for this initial implementation.
+
+Windows dev note: invoked as ``python .claude/hooks/preuse.py`` by the
+settings.json hook entry.  No Windows-specific shebang trickery -- the
+interpreter is whatever the running shell uses.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------
+# Configuration constants
+# ---------------------------------------------------------------
+
+_BULK_THRESHOLD: int = 3
+"""Number of matching commands within the window that triggers 'bulk' gating."""
+
+_BULK_WINDOW_SEC: float = 60.0
+"""Sliding window for bulk detection (seconds)."""
+
+_DEFERRED_BULK_THRESHOLD: int = 2
+"""deferred ラベル付与は 2 件以上 / 60s で gate (issue body より低い閾値)."""
+
+
+# Gated command patterns.  Each entry:
+#   ``pattern``: regex matched against the stripped Bash command
+#   ``mode``: "always" = gate every invocation; "bulk" = gate when the
+#       count within the sliding window hits the threshold
+#   ``threshold``: override of _BULK_THRESHOLD for this pattern
+#   ``message``: shown to the user (stderr) on gate activation
+_GATED_PATTERNS: dict[str, dict[str, object]] = {
+    "issue_create_bulk": {
+        "pattern": re.compile(r"^gh\s+issue\s+create\b"),
+        "mode": "bulk",
+        "threshold": _BULK_THRESHOLD,
+        "message": (
+            "60 秒以内に 3 件以上の Issue 起票を検知しました。\n"
+            "bulk 操作前にサンプル 1 件を提示してユーザー確認を取る運用 "
+            "(#399 C / #400 D) に沿って、続行前に確認を取ってください。"
+        ),
+    },
+    "pr_merge": {
+        "pattern": re.compile(r"^gh\s+pr\s+merge\b"),
+        "mode": "always",
+        "threshold": 1,
+        "message": (
+            "PR マージ操作です。テスト完了 / レビュー完了 / ユーザー承認を "
+            "確認しましたか?  #400 のマトリクスでは PR マージは常に確認必須です。"
+        ),
+    },
+    "issue_close": {
+        "pattern": re.compile(r"^gh\s+issue\s+close\b"),
+        "mode": "always",
+        "threshold": 1,
+        "message": (
+            "Issue クローズ操作です。実動画再現確認 / 副作用 Issue 起票 / "
+            "ユーザー承認を行いましたか?  #400 のマトリクスで Issue クローズは "
+            "常に確認必須です。"
+        ),
+    },
+    "deferred_label_bulk": {
+        "pattern": re.compile(r"^gh\s+issue\s+edit\b[^\n]*--add-label[^\n]*deferred"),
+        "mode": "bulk",
+        "threshold": _DEFERRED_BULK_THRESHOLD,
+        "message": (
+            "60 秒以内に 2 件以上の deferred ラベル付与を検知しました。\n"
+            "判定基準 (scope / 優先度) をユーザー確認してから続行してください "
+            "(#400 マトリクス: deferred 付与は確認必須)。"
+        ),
+    },
+}
+
+
+# ---------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------
+
+
+def _project_root() -> Path:
+    """Directory of the project (``$CLAUDE_PROJECT_DIR``-equivalent)."""
+    # Hook lives at ``.claude/hooks/preuse.py``; project root is 2 parents up.
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _state_path() -> Path:
+    return _project_root() / ".claude" / "state" / "recent_ops.json"
+
+
+def _settings_local_path() -> Path:
+    return _project_root() / ".claude" / "settings.local.json"
+
+
+# ---------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------
+
+
+def _read_recent_ops(path: Path, now: float) -> list[dict]:
+    """Return recent ops within the bulk window, silently dropping older."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    except OSError:
+        # Permission / corruption: fail open so business is not blocked.
+        return []
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Corrupt state file: fail open and rewrite on next append.
+        return []
+
+    if not isinstance(data, list):
+        return []
+
+    cutoff = now - _BULK_WINDOW_SEC
+    return [
+        entry
+        for entry in data
+        if isinstance(entry, dict)
+        and "cmd" in entry
+        and "ts" in entry
+        and isinstance(entry["ts"], (int, float))
+        and entry["ts"] >= cutoff
+    ]
+
+
+def _append_op(path: Path, cmd: str, now: float) -> list[dict]:
+    """Append ``cmd`` at ``now`` and return the pruned window."""
+    entries = _read_recent_ops(path, now)
+    entries.append({"cmd": cmd, "ts": now})
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(entries, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+    except OSError:
+        # Can't persist: best-effort, fail open.
+        pass
+    return entries
+
+
+# ---------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------
+
+
+def _gate_enabled() -> bool:
+    """Return False when the user explicitly disabled the gate.
+
+    Default: enabled.  We only respect the settings.local.json value when
+    it's a proper bool; missing keys / parse failures keep the gate on
+    (fail-safe for the "Claude shouldn't accidentally run wild" direction).
+    """
+    path = _settings_local_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return True
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return True
+
+    value = data.get("pretooluse_gate") if isinstance(data, dict) else None
+    if isinstance(value, bool):
+        return value
+    return True
+
+
+# ---------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------
+
+
+def _classify(cmd: str, recent: list[dict]) -> tuple[str | None, str | None]:
+    """Return (pattern_key, message) when the command should be gated.
+
+    Bulk patterns count the current command toward the threshold, so the
+    caller must *not* re-insert ``cmd`` into ``recent`` before classify.
+    """
+    stripped = cmd.strip()
+    for key, spec in _GATED_PATTERNS.items():
+        pattern: re.Pattern[str] = spec["pattern"]  # type: ignore[assignment]
+        if not pattern.search(stripped):
+            continue
+        mode = spec["mode"]
+        message = spec["message"]  # type: ignore[assignment]
+        if mode == "always":
+            return key, str(message)
+        if mode == "bulk":
+            threshold = int(spec["threshold"])  # type: ignore[arg-type]
+            prior = sum(1 for e in recent if pattern.search(str(e.get("cmd", ""))))
+            if prior + 1 >= threshold:
+                return key, str(message)
+    return None, None
+
+
+# ---------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw:
+        return 0
+
+    try:
+        event = json.loads(raw)
+    except json.JSONDecodeError:
+        # Unknown payload shape: don't block.
+        return 0
+
+    if not isinstance(event, dict):
+        return 0
+
+    tool_name = event.get("tool_name")
+    tool_input = event.get("tool_input", {})
+    if tool_name != "Bash" or not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return 0
+
+    if not _gate_enabled():
+        return 0
+
+    state_path = _state_path()
+    now = time.time()
+    recent = _read_recent_ops(state_path, now)
+
+    # Pattern 判定 (candidate の command を recent に含めずに判定)
+    key, message = _classify(command, recent)
+
+    # Bulk カウント目的で今回の command を state に記録.
+    # 常時 gate と bulk gate のどちらでも、state は更新する (後続判定の
+    # ために今回のコマンドも履歴に入れる).
+    _append_op(state_path, command.strip(), now)
+
+    if key is not None:
+        print(
+            f"[preuse:{key}] {message}\nDetected command: {command.strip()[:400]}",
+            file=sys.stderr,
+        )
+        # Exit code 2 = block with error surfaced to Claude (PreToolUse
+        # hook convention).  Claude will pause and escalate to the user.
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/preuse.py\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ htmlcov/
 # Claude Code
 .claude/settings.local.json
 .claude/worktrees/
+.claude/state/
 .env
 ROLE
 

--- a/tests/test_preuse_hook.py
+++ b/tests/test_preuse_hook.py
@@ -1,0 +1,277 @@
+"""Tests for the PreToolUse gate (.claude/hooks/preuse.py, #401).
+
+The hook is a standalone script invoked by Claude Code with a JSON
+payload on stdin.  We import it as a module and drive the entry point
+directly so the tests never spawn a subprocess, which keeps them fast
+and deterministic on Windows.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_HOOK_PATH = Path(__file__).resolve().parent.parent / ".claude" / "hooks" / "preuse.py"
+
+
+def _load_preuse_module():
+    """Load the hook script as a module so tests can call ``main()``.
+
+    The script lives outside ``allaganeye/`` so there's no regular import
+    path; ``importlib.util`` is the lightest way in without polluting
+    ``sys.path``.
+    """
+    spec = importlib.util.spec_from_file_location("preuse_hook", _HOOK_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+preuse = _load_preuse_module()
+
+
+# ---------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------
+
+
+@pytest.fixture
+def _isolated_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect state / settings paths into a tmp directory per test."""
+    state_dir = tmp_path / ".claude" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    state_path = state_dir / "recent_ops.json"
+    settings_path = tmp_path / ".claude" / "settings.local.json"
+
+    monkeypatch.setattr(preuse, "_state_path", lambda: state_path)
+    monkeypatch.setattr(preuse, "_settings_local_path", lambda: settings_path)
+
+    return {"state": state_path, "settings": settings_path}
+
+
+def _invoke(event: dict, monkeypatch: pytest.MonkeyPatch) -> tuple[int, str]:
+    """Drive ``preuse.main()`` with a fake stdin payload.  Return (rc, stderr)."""
+    monkeypatch.setattr(
+        sys, "stdin", io.StringIO(json.dumps(event) if event is not None else "")
+    )
+    err_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", err_buf)
+    rc = preuse.main()
+    return rc, err_buf.getvalue()
+
+
+def _bash_event(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+# ---------------------------------------------------------------
+# Always-gated patterns
+# ---------------------------------------------------------------
+
+
+def test_pr_merge_always_gated(_isolated_paths, monkeypatch):
+    """``gh pr merge`` is gated on the very first invocation (#401 G-2)."""
+    rc, err = _invoke(_bash_event("gh pr merge 123 --squash"), monkeypatch)
+    assert rc == 2
+    assert "PR マージ" in err
+
+
+def test_issue_close_always_gated(_isolated_paths, monkeypatch):
+    """``gh issue close`` is gated on the very first invocation (#401 G-3)."""
+    rc, err = _invoke(_bash_event("gh issue close 42"), monkeypatch)
+    assert rc == 2
+    assert "Issue クローズ" in err
+
+
+# ---------------------------------------------------------------
+# Bulk-gated patterns
+# ---------------------------------------------------------------
+
+
+def test_issue_create_under_threshold_allowed(_isolated_paths, monkeypatch):
+    """2 ``gh issue create`` calls in 60s are allowed (below threshold=3)."""
+    rc1, _ = _invoke(_bash_event("gh issue create --title a"), monkeypatch)
+    rc2, _ = _invoke(_bash_event("gh issue create --title b"), monkeypatch)
+    assert rc1 == 0
+    assert rc2 == 0
+
+
+def test_issue_create_third_in_window_triggers_gate(_isolated_paths, monkeypatch):
+    """3rd ``gh issue create`` within 60s trips the bulk gate (#401 G-1)."""
+    _invoke(_bash_event("gh issue create --title a"), monkeypatch)
+    _invoke(_bash_event("gh issue create --title b"), monkeypatch)
+    rc, err = _invoke(_bash_event("gh issue create --title c"), monkeypatch)
+    assert rc == 2
+    assert "Issue 起票" in err or "60 秒" in err
+
+
+def test_issue_create_outside_window_resets(_isolated_paths, monkeypatch):
+    """Entries older than 60s fall out of the sliding window."""
+    # Pre-populate state with 2 stale entries (61s ago).
+    stale = time.time() - 61
+    preuse._append_op(_isolated_paths["state"], "gh issue create --title old1", stale)
+    preuse._append_op(_isolated_paths["state"], "gh issue create --title old2", stale)
+
+    # Fresh 3rd call should *not* be gated because stale entries are
+    # discarded at read time.
+    rc, _ = _invoke(_bash_event("gh issue create --title fresh"), monkeypatch)
+    assert rc == 0
+
+
+def test_deferred_label_second_in_window_triggers_gate(_isolated_paths, monkeypatch):
+    """2 consecutive ``deferred`` label assignments in 60s are gated (#401 G-4)."""
+    rc1, _ = _invoke(_bash_event('gh issue edit 1 --add-label "deferred"'), monkeypatch)
+    rc2, err2 = _invoke(
+        _bash_event('gh issue edit 2 --add-label "deferred"'), monkeypatch
+    )
+    assert rc1 == 0
+    assert rc2 == 2
+    assert "deferred" in err2
+
+
+def test_non_deferred_label_not_gated(_isolated_paths, monkeypatch):
+    """Other label edits (P1 / role:*) are not caught by the deferred gate."""
+    # Even 3 P1-high assignments should stay allowed -- not on the
+    # gated list.
+    for i in range(3):
+        rc, _ = _invoke(
+            _bash_event(f'gh issue edit {i} --add-label "P1-high"'), monkeypatch
+        )
+        assert rc == 0
+
+
+# ---------------------------------------------------------------
+# Non-gated / disabled paths
+# ---------------------------------------------------------------
+
+
+def test_non_bash_tool_untouched(_isolated_paths, monkeypatch):
+    """Other tools (Read / Edit / Write) are never gated."""
+    event = {"tool_name": "Edit", "tool_input": {"file_path": "foo", "old_string": "a"}}
+    rc, err = _invoke(event, monkeypatch)
+    assert rc == 0
+    assert err == ""
+
+
+def test_arbitrary_bash_untouched(_isolated_paths, monkeypatch):
+    """Bash commands outside the gated list run freely."""
+    rc, _ = _invoke(_bash_event("pytest -q"), monkeypatch)
+    assert rc == 0
+
+
+def test_empty_command_untouched(_isolated_paths, monkeypatch):
+    """Whitespace-only command is treated as no-op."""
+    rc, _ = _invoke(_bash_event("   "), monkeypatch)
+    assert rc == 0
+
+
+def test_gate_can_be_disabled_globally(_isolated_paths, monkeypatch):
+    """Setting ``pretooluse_gate: false`` disables every gate (#401 switch)."""
+    _isolated_paths["settings"].parent.mkdir(parents=True, exist_ok=True)
+    _isolated_paths["settings"].write_text(
+        json.dumps({"pretooluse_gate": False}), encoding="utf-8"
+    )
+
+    rc, _ = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
+    assert rc == 0
+
+
+def test_gate_defaults_on_when_settings_missing(_isolated_paths, monkeypatch):
+    """Absent / malformed settings file defaults to enabled (fail-safe)."""
+    # No settings file at all.
+    rc, _ = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
+    assert rc == 2
+
+
+def test_malformed_settings_keeps_gate_on(_isolated_paths, monkeypatch):
+    _isolated_paths["settings"].parent.mkdir(parents=True, exist_ok=True)
+    _isolated_paths["settings"].write_text("not json", encoding="utf-8")
+    rc, _ = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
+    assert rc == 2
+
+
+# ---------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------
+
+
+def test_state_file_created_on_first_op(_isolated_paths, monkeypatch):
+    """Running a gated command writes to ``.claude/state/recent_ops.json``."""
+    assert not _isolated_paths["state"].exists()
+    _invoke(_bash_event("gh issue create --title a"), monkeypatch)
+    assert _isolated_paths["state"].exists()
+    data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert any("gh issue create" in entry.get("cmd", "") for entry in data)
+
+
+def test_corrupt_state_fails_open(_isolated_paths, monkeypatch):
+    """Garbage state file is tolerated (read returns [], write overwrites)."""
+    _isolated_paths["state"].write_text("not json", encoding="utf-8")
+    # Should not raise, nor falsely trip the bulk gate.
+    rc, _ = _invoke(_bash_event("gh issue create --title a"), monkeypatch)
+    assert rc == 0
+
+
+# ---------------------------------------------------------------
+# Malformed payloads
+# ---------------------------------------------------------------
+
+
+def test_empty_stdin(_isolated_paths, monkeypatch):
+    """Empty payload is a no-op pass (rc=0)."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    err_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", err_buf)
+    rc = preuse.main()
+    assert rc == 0
+
+
+def test_invalid_json_stdin(_isolated_paths, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("<not-json>"))
+    err_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", err_buf)
+    rc = preuse.main()
+    assert rc == 0
+
+
+def test_missing_tool_input(_isolated_paths, monkeypatch):
+    event = {"tool_name": "Bash"}
+    rc, _ = _invoke(event, monkeypatch)
+    assert rc == 0
+
+
+# ---------------------------------------------------------------
+# Classify helper (direct unit coverage)
+# ---------------------------------------------------------------
+
+
+def test_classify_no_match_returns_none():
+    key, msg = preuse._classify("echo hello", [])
+    assert key is None
+    assert msg is None
+
+
+def test_classify_bulk_threshold_requires_prior_count():
+    """Bulk mode only gates on the Nth invocation (count includes current)."""
+    now = time.time()
+    recent: list[dict] = []
+    # 1st: not gated (count=1)
+    key, _ = preuse._classify("gh issue create --title a", recent)
+    assert key is None
+    recent.append({"cmd": "gh issue create --title a", "ts": now})
+    # 2nd: not gated (count=2, threshold=3)
+    key, _ = preuse._classify("gh issue create --title b", recent)
+    assert key is None
+    recent.append({"cmd": "gh issue create --title b", "ts": now})
+    # 3rd: gated (count would be 3, threshold met)
+    key, _ = preuse._classify("gh issue create --title c", recent)
+    assert key == "issue_create_bulk"


### PR DESCRIPTION
## Summary

Claude Code の PreToolUse hook で bulk / 危険操作の前にユーザー確認を強制する仕組みを実装 (#401 G)。docs ルール (#399 / #400) だけでは Claude の判断ミスが残るため、**ツールレベルの最終防衛線** として設置。Lead が AskUserQuestion でユーザー確認済みの確定方針 5 点に完全準拠。

## 実装方針 (Lead 確定方針準拠)

### 1. 状態永続化: JSON ファイル
- `.claude/state/recent_ops.json` に `list[{"cmd": str, "ts": float}]`
- 読み書き都度 open/close、`_BULK_WINDOW_SEC` 超過エントリは読み取り時 drop
- `.gitignore` に `.claude/state/` 追加

### 2. 設定スイッチ: グローバル ON/OFF のみ
- `.claude/settings.local.json` の `"pretooluse_gate": true/false`
- default: enabled (fail-safe — parse 失敗や key 欠落でも gate は生きる)
- カテゴリ別スイッチは YAGNI、後続 issue

### 3. 検知閾値: hard-coded
- `_BULK_THRESHOLD = 3`, `_BULK_WINDOW_SEC = 60.0`
- `_DEFERRED_BULK_THRESHOLD = 2` (deferred は被害が大きいので閾値低め)

### 4. 対象コマンド: dict 定義
```python
_GATED_PATTERNS = {
    "issue_create_bulk": {...}, # bulk, threshold=3
    "pr_merge": {...},          # always
    "issue_close": {...},       # always
    "deferred_label_bulk": {...}, # bulk, threshold=2
}
```

### 5. hook script 配置: プロジェクト固有
- `.claude/hooks/preuse.py`
- `.claude/settings.json` の `hooks.PreToolUse` (matcher: `Bash`) に登録
- 起動: `python .claude/hooks/preuse.py` (Windows 前提)

## exit code 規約

- **0**: 許可 (通常 Bash / 非ゲート対象 / 非 Bash tool / ゲート無効化済)
- **2**: escalate (stderr にメッセージ出力、Claude がユーザーに確認)

## 変更点

### コード

- `.claude/hooks/preuse.py` (新規 / 230 行): hook 本体
- `.claude/settings.json`: PreToolUse (Bash) エントリ追加
- `.gitignore`: `.claude/state/` (JSON 状態ファイル) を除外

### テスト (20 件)

- **常時 gate**: `gh pr merge` / `gh issue close` は 1 回目で gate
- **bulk gate**: 3 件目の `gh issue create` / 2 件目の `deferred` label で gate
- **sliding window**: 60s 超過エントリで counter reset
- **非対象**: 他 bash コマンド / 非 Bash tool / 空 command / 空白コマンド
- **設定スイッチ**: `pretooluse_gate: false` で全 gate 無効化
- **fail-safe**: 設定 missing / malformed JSON で gate は ON 維持
- **状態**: 初回 JSON 作成 / corrupt state で fail-open
- **payload**: 空 stdin / 不正 JSON / missing tool_input で rc=0

## 受け入れ基準チェック

- [x] `.claude/hooks/` に PreToolUse hook を実装
- [x] `.claude/settings.json` で hook が有効化される
- [x] `gh issue create` 連続検知 → 警告 + escalate
- [x] `gh pr merge` → 警告 + escalate
- [x] `gh issue close` → 警告 + escalate
- [x] `gh issue edit --add-label deferred` 連続 → 警告 + escalate
- [x] hook 無効化スイッチを `.claude/settings.local.json` で持つ
- [x] 動作確認テスト (実際に bulk 操作を試す) — tests/test_preuse_hook.py

## Test plan

- [x] `pytest tests/test_preuse_hook.py` 20 passed
- [x] `pytest` 全体 618 passed (slow 除外)
- [x] `ruff check .` / `ruff format --check .` passed
- [x] `pyright` 0 errors
- [x] Windows 環境で Python script 起動確認 (shebang 不要、settings.json の `python ...` 呼び出し)

## 関連

- #399 (PR #420): director/lead 行動規範の A/B/C。本 hook は C/bulk の自動検知
- #400 (PR #421): ロール定義 D/E/F/H。本 hook の gate pattern は E のマトリクスと整合
- #401 は実装レベルの強制ゲート (docs だけでは足りない最終層)

## 後続 issue 候補 (本 PR スコープ外)

- カテゴリ別スイッチ (特定の gate のみ disable)
- 閾値の設定ファイル上書き
- 対象コマンドの拡張 (P1/P2/P3 ラベル / 他 role:* 付替え等)

Refs #401

session-id: engineer-1