### PR TITLE
test(cli): CLI オプション組合せの網羅テスト追加

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
 from allaganeye.cli import app
@@ -666,3 +667,169 @@ def test_split_neither_gpu_flag_preserves_auto(mock_run_split, fake_video):
     assert result.exit_code == 0
     config = mock_run_split.call_args[0][1]
     assert config.use_gpu is None
+
+
+# --- CLI option combination tests ---
+#
+# The existing per-option tests verify each flag in isolation.  Users run
+# the CLI with *combinations* (e.g. ``--dry-run --no-cache -v`` when
+# troubleshooting), and individual-flag tests don't guarantee that
+# pairwise and three-way interactions still wire through to SplitConfig
+# correctly.
+#
+# Full 2^N cartesian coverage is infeasible (~16k cases for ~14 options).
+# Instead we cover three bounded axes:
+#
+#   1. Real usecase patterns - the combinations a user actually types
+#   2. Risk-high pairs - flags that interact via the same code path
+#      (cache + dry-run, GPU + cache, etc.)
+#   3. Order-independence - Typer should not care about flag order
+#
+# All cases mock ``run_split`` so a full parametrize sweep is < 1 second.
+
+
+class TestCliOptionCombinations:
+    """Representative CLI flag combinations forward to SplitConfig."""
+
+    @pytest.mark.parametrize(
+        ("argv_extras", "expected_config"),
+        [
+            # --- Real usecase patterns ---
+            # Inspect mode: check what would be detected without splitting.
+            (["--dry-run", "-v"], {"dry_run": True}),
+            # Force fresh inspect: ignore cache and dry-run.
+            (
+                ["--dry-run", "--no-cache", "-v"],
+                {"dry_run": True, "no_cache": True},
+            ),
+            # Silent bulk processing with audio disabled.
+            (["-q", "--no-audio"], {"no_audio": True}),
+            # CPU debugging: verbose, force CPU, limit workers.
+            (
+                ["-v", "--no-gpu", "--workers", "4"],
+                {"use_gpu": False, "workers": 4},
+            ),
+            # Custom output + GPU + workers (typical batch script).
+            (
+                ["--gpu", "--workers", "8"],
+                {"use_gpu": True, "workers": 8},
+            ),
+            # Tuned detection parameters (no flags).
+            (
+                [
+                    "--sample-interval",
+                    "1.0",
+                    "--blackout-threshold",
+                    "20.0",
+                    "--min-match-duration",
+                    "180",
+                ],
+                {
+                    "sample_interval": 1.0,
+                    "blackout_threshold": 20.0,
+                    "min_match_duration": 180.0,
+                },
+            ),
+            # --- Risk-high pairs (shared code paths) ---
+            # dry-run writes cache; --no-cache invalidates on read.
+            (
+                ["--dry-run", "--no-cache"],
+                {"dry_run": True, "no_cache": True},
+            ),
+            # Force fresh GPU detection.
+            (
+                ["--gpu", "--no-cache"],
+                {"use_gpu": True, "no_cache": True},
+            ),
+            # Full debug invocation.
+            (
+                ["-v", "--no-cache", "--dry-run"],
+                {"no_cache": True, "dry_run": True},
+            ),
+            # Silent dry-run with fresh detection.
+            (
+                ["-q", "--dry-run", "--no-cache"],
+                {"dry_run": True, "no_cache": True},
+            ),
+            # --- Three-way flag interaction ---
+            # All three boolean flags with GPU.
+            (
+                ["--no-cache", "--dry-run", "--no-audio", "--gpu"],
+                {
+                    "no_cache": True,
+                    "dry_run": True,
+                    "no_audio": True,
+                    "use_gpu": True,
+                },
+            ),
+            # Value options + flag combination.
+            (
+                ["--sample-interval", "2.0", "--no-gpu", "--no-audio"],
+                {
+                    "sample_interval": 2.0,
+                    "use_gpu": False,
+                    "no_audio": True,
+                },
+            ),
+        ],
+    )
+    @patch(MODULE)
+    def test_cli_combination_forwards_to_config(
+        self, mock_run_split, fake_video, argv_extras, expected_config
+    ):
+        """Combination of CLI flags forwards expected values to SplitConfig."""
+        result = runner.invoke(app, ["split", str(fake_video), *argv_extras])
+        assert result.exit_code == 0, (
+            f"exit code {result.exit_code} for argv={argv_extras!r}: {result.stdout}"
+        )
+        config = mock_run_split.call_args[0][1]
+        for key, expected in expected_config.items():
+            actual = getattr(config, key)
+            assert actual == expected, (
+                f"argv={argv_extras!r}: expected {key}={expected!r}, got {actual!r}"
+            )
+
+    @pytest.mark.parametrize(
+        "argv_order",
+        [
+            ["--dry-run", "-v"],
+            ["-v", "--dry-run"],
+            ["--no-gpu", "--no-audio", "-v"],
+            ["-v", "--no-audio", "--no-gpu"],
+            ["--no-audio", "-v", "--no-gpu"],
+        ],
+    )
+    @patch(MODULE)
+    def test_flag_order_is_independent(self, mock_run_split, fake_video, argv_order):
+        """Flag order does not alter which config fields end up set."""
+        result = runner.invoke(app, ["split", str(fake_video), *argv_order])
+        assert result.exit_code == 0
+        config = mock_run_split.call_args[0][1]
+        # Regardless of order, presence of each flag flips its field.
+        if "--dry-run" in argv_order:
+            assert config.dry_run is True
+        if "--no-gpu" in argv_order:
+            assert config.use_gpu is False
+        if "--no-audio" in argv_order:
+            assert config.no_audio is True
+
+    @patch(MODULE)
+    def test_verbose_routed_as_kwarg_not_config_in_combo(
+        self, mock_run_split, fake_video
+    ):
+        """Combinations containing -v route verbose as run_split kwarg.
+
+        ``verbose`` is not a SplitConfig field -- it's a display-side
+        kwarg for ``run_split``.  Any combination including ``-v`` must
+        preserve that routing.
+        """
+        result = runner.invoke(
+            app,
+            ["split", str(fake_video), "--dry-run", "--no-cache", "-v"],
+        )
+        assert result.exit_code == 0
+        assert mock_run_split.call_args[1]["verbose"] is True
+        # Config still holds the flag values.
+        config = mock_run_split.call_args[0][1]
+        assert config.dry_run is True
+        assert config.no_cache is True


### PR DESCRIPTION
## 概要

既存 `test_cli.py` は各 option を個別に検証するのみで、ユーザが実際に使う 2-3 flag 組合せ (例: `--dry-run --no-cache -v`) の pairwise / three-way 相互作用は `test_split_all_options_combined` 1 件しかカバーされていませんでした。実ユースケースで頻出する組合せに対し代表パターン + リスク高ペアを bounded に追加します。

## 設計方針

`2^14 ≈ 16384` の完全直積は不可能なので、以下 3 軸で**件数と実行時間を抑制**:

| 軸 | 件数 | 目的 |
|---|---|---|
| 1. Real usecase patterns | 6 | ユーザが実際に打つコマンド組合せ |
| 2. Risk-high pairs | 4 | 同一コード経路を共有する相互作用 (cache + dry-run 等) |
| 3. Three-way 組合せ | 2 | 3 連相互作用の smoke |
| 4. Flag order independence | 5 | 順序不変性を parametric |
| 5. Verbose kwarg routing | 1 | `-v` が config ではなく run_split kwarg に行くこと |

**合計 18 ケース、実行時間 1.24s** (`run_split` 全 mock)。

## 追加テスト詳細

### `test_cli_combination_forwards_to_config` (parametric × 12)

```python
# Real usecase
(["--dry-run", "-v"], {"dry_run": True})
(["--dry-run", "--no-cache", "-v"], {...})
(["-q", "--no-audio"], {...})
(["-v", "--no-gpu", "--workers", "4"], {...})
(["--gpu", "--workers", "8"], {...})
(["--sample-interval", "1.0", "--blackout-threshold", "20.0", ...], {...})

# Risk-high pairs
(["--dry-run", "--no-cache"], {...})
(["--gpu", "--no-cache"], {...})
(["-v", "--no-cache", "--dry-run"], {...})
(["-q", "--dry-run", "--no-cache"], {...})

# Three-way
(["--no-cache", "--dry-run", "--no-audio", "--gpu"], {...})
(["--sample-interval", "2.0", "--no-gpu", "--no-audio"], {...})
```

各ケースで `SplitConfig` に期待値が forward されることを `getattr(config, key) == expected` で厳密検証。

### `test_flag_order_is_independent` (parametric × 5)

```python
["--dry-run", "-v"]
["-v", "--dry-run"]
["--no-gpu", "--no-audio", "-v"]
["-v", "--no-audio", "--no-gpu"]
["--no-audio", "-v", "--no-gpu"]
```

順序違いで config 同一を確認 (Typer / Click の parse 仕様への依存を pin)。

### `test_verbose_routed_as_kwarg_not_config_in_combo`

`--dry-run --no-cache -v` 組合せで `-v` が **`SplitConfig` ではなく `run_split` の kwarg** に渡ることを担保 (既存の個別 verbose テストが組合せ下でも維持されているか)。

## 検証

- 18 新規テストすべて **PASS** (develop-0.1.1 ベース)
- `pytest`: 624 passed (既存 606 + 追加 18), 36 deselected
- `ruff check` / `format` / `pyright` 通過
- **実行時間: 1.24s** (`run_split` 全 mock、full suite への影響 < 2%)

## 爆発抑制の根拠

| オプション数 | 完全直積 | 本 PR カバー | 倍率 |
|---|---|---|---|
| ~14 | 16384 | 18 | 0.11% |

完全直積の 0.11% だが、実ユースケース + リスク高ペア + 順序依存を網羅するため**実効カバー率**は高い。pairwise 完全 (~25-30 件) は行わず、「エンジニアが実際に踏むバグ箇所」優先で件数を絞っています。

## チェックリスト

- [x] `python -m ruff check` 通過
- [x] `python -m ruff format --check` 通過
- [x] `python -m pyright tests/test_cli.py` 通過 (0 errors)
- [x] `python -m pytest` 通過 (624 passed)
- [x] base = `develop-0.1.1`
- [x] session-id 記載
- [x] 実行時間 < 2 秒 / full suite 影響 < 2%

## 依存関係

**依存なし** — 既存 CLI 実装のみに依存、develop-0.1.1 で直接動作。

## レビューワ

`role:lead-engineer` (Tester 作成 PR のため)

## session-id

tester-1