### PR TITLE
fix(cli): エラー表示を matrix v2 19a/19b/19c に整合 (Refs #428) [engineer-1]

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -1,5 +1,7 @@
 """CLI entry point for Allagan Eye."""
 
+import sys
+import traceback
 from pathlib import Path
 from typing import Annotated
 
@@ -12,6 +14,8 @@ from allaganeye.exceptions import (
     ConfigValidationError,
     InputFileError,
 )
+
+_VERBOSE_HINT = "  (Run with -v / --verbose for full details)"
 
 app = typer.Typer(
     name="allaganeye",
@@ -163,10 +167,10 @@ def split(
         run_split(video_path, config, verbose=verbose, quiet=quiet)
 
     except AllaganEyeError as e:
-        _report_app_error(e, verbose=verbose)
+        _report_app_error(e, verbose=verbose, quiet=quiet)
         raise typer.Exit(code=e.exit_code) from None
     except Exception:
-        _report_unexpected_error(verbose=verbose)
+        _report_unexpected_error(verbose=verbose, quiet=quiet)
         raise typer.Exit(code=1) from None
 
 
@@ -219,35 +223,78 @@ def debug_brightness(
         )
 
     except AllaganEyeError as e:
-        _report_app_error(e, verbose=False)
+        # debug-brightness has no -v / -q, so it maps to matrix 19b's
+        # "default" row but without a -v hint (the option doesn't exist
+        # for this command).
+        _report_app_error(e, verbose=False, quiet=False, show_hint=False)
         raise typer.Exit(code=e.exit_code) from None
     except Exception:
-        _report_unexpected_error(verbose=False)
+        _report_unexpected_error(verbose=False, quiet=False, show_hint=False)
         raise typer.Exit(code=1) from None
 
 
-def _report_app_error(exc: AllaganEyeError, *, verbose: bool) -> None:
-    """Render an ``AllaganEyeError`` to stderr, adding verbose detail (#351)."""
+def _report_app_error(
+    exc: AllaganEyeError,
+    *,
+    verbose: bool,
+    quiet: bool = False,
+    show_hint: bool = True,
+) -> None:
+    """Render an ``AllaganEyeError`` per matrix v2 19a/19b/19c (#428, #351).
+
+    - 19a (verbose=True):  ``Error: <msg>`` + ``verbose_detail()`` context
+      lines + full traceback (exceptions are raised ``from None`` in the
+      CLI handlers but the traceback is emitted here *before* re-raise,
+      so the stack is still the original error's).
+    - 19b (default):       ``Error: <msg>`` + one-line hint directing to
+      ``-v``.  Suppressed when ``show_hint=False`` (commands with no
+      verbose option, e.g. ``debug-brightness``, still take this branch
+      but skip the misleading hint).
+    - 19c (quiet=True):    ``Error: <msg>`` only.  No hint, no context,
+      no traceback.  Keeps the -q contract of "error message only"
+      intact even when verbose_detail would otherwise be available.
+    """
     typer.echo(f"Error: {exc}", err=True)
+
+    if quiet:
+        return
+
     if verbose:
         detail = exc.verbose_detail()
         if detail:
             typer.echo(detail, err=True)
+        tb = "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        ).rstrip()
+        typer.echo(tb, err=True)
+        return
+
+    if show_hint:
+        typer.echo(_VERBOSE_HINT, err=True)
 
 
-def _report_unexpected_error(*, verbose: bool) -> None:
-    """Render an unexpected (non-``AllaganEyeError``) exception (#351).
+def _report_unexpected_error(
+    *, verbose: bool, quiet: bool = False, show_hint: bool = True
+) -> None:
+    """Render an unexpected (non-``AllaganEyeError``) exception per matrix v2.
 
-    Non-verbose: short one-liner.  Verbose: full traceback via
-    ``traceback.print_exc`` so ``__cause__`` / ``__context__`` chains are
-    preserved (we purposefully do not pass ``from None`` in this path).
+    - 19a (verbose=True):  full traceback via ``traceback.print_exc`` so
+      ``__cause__`` / ``__context__`` chains are preserved (the CLI
+      handlers deliberately skip ``from None`` for this path).
+    - 19b (default):       ``Unexpected error: <exc>`` + -v hint (when
+      ``show_hint=True``).  No traceback so the default noise level
+      stays low.
+    - 19c (quiet=True):    ``Unexpected error: <exc>`` only.
     """
     if verbose:
-        import traceback
-
         traceback.print_exc()
-    else:
-        import sys
+        return
 
-        exc = sys.exc_info()[1]
-        typer.echo(f"Unexpected error: {exc}", err=True)
+    exc = sys.exc_info()[1]
+    typer.echo(f"Unexpected error: {exc}", err=True)
+
+    if quiet:
+        return
+
+    if show_hint:
+        typer.echo(_VERBOSE_HINT, err=True)

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -276,3 +276,45 @@ timestamp,brightness
 | 3 | FFmpeg / ffprobe エラー |
 | 4 | 試合境界が見つからない |
 | 5 | 設定値不正（パラメータの範囲外等） |
+
+### エラー表示 (#428 / #405 matrix v2)
+
+`split` コマンドのエラーは `-v` / `-q` によって出力量が変わる。すべてのエラーは stderr に出力される (stdout は壊れたデータを残さないよう空のまま)。
+
+| モード | 出力形式 (AllaganEyeError 系) | 出力形式 (予期せぬ例外) |
+|---|---|---|
+| `-v` (19a) | `Error: <msg>` + `verbose_detail()` コンテキスト (ffmpeg stderr_tail 等) + full traceback | full traceback (``__cause__`` / ``__context__`` 含む) |
+| default (19b) | `Error: <msg>` + `  (Run with -v / --verbose for full details)` 1 行 hint | `Unexpected error: <exc>` + 1 行 hint |
+| `-q` (19c) | `Error: <msg>` のみ | `Unexpected error: <exc>` のみ |
+
+`debug-brightness` には `-v` / `-q` がないため、エラーは上表の default 形式に準じるが、**存在しないオプションを誘導しないよう -v hint は出さない** (対応オプションがない場合は `show_hint=False`)。
+
+verbose モードの traceback は CLI ハンドラが `raise typer.Exit(...) from None` で上位に抜ける直前、元の例外が `sys.exc_info()` に残っている段階で `traceback.format_exception(type(exc), exc, exc.__traceback__)` により生成される。`from None` で traceback 自体を抑制しているわけではなく、典型的なユーザーには邪魔になるため default / -q では出さない設計。
+
+出力例 (ffmpeg 失敗 + `-v`):
+
+```
+Error: ffmpeg failed
+  command: ffmpeg -i recording.mkv ...
+  return_code: 1
+  stderr_tail:
+    NAL unit type 12 not supported
+Traceback (most recent call last):
+  File "...\allaganeye\cli.py", line 163, in split
+    run_split(video_path, config, verbose=verbose, quiet=quiet)
+  ...
+allaganeye.exceptions.VideoProcessingError: ffmpeg failed
+```
+
+出力例 (同じエラー / default):
+
+```
+Error: ffmpeg failed
+  (Run with -v / --verbose for full details)
+```
+
+出力例 (同じエラー / `-q`):
+
+```
+Error: ffmpeg failed
+```

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -457,6 +457,150 @@ def test_split_non_verbose_hides_traceback_for_unexpected(mock_run_split, fake_v
     assert "boom" in combined
 
 
+# --- Matrix v2 19a/19b/19c error display tests (issue #428) ---
+
+
+@patch(MODULE)
+def test_matrix_19a_verbose_emits_traceback_for_app_error(mock_run_split, fake_video):
+    """19a: -v shows Error + verbose_detail + full traceback for AllaganEyeError.
+
+    The traceback must be emitted even though the CLI handler re-raises
+    via ``raise typer.Exit from None``: we print the traceback *before*
+    the re-raise, when the original exception stack is still attached.
+    """
+    mock_run_split.side_effect = VideoProcessingError(
+        "ffmpeg failed",
+        context={
+            "command": "ffmpeg -i foo.mp4",
+            "return_code": 1,
+            "stderr_tail": "NAL unit type 12 not supported",
+        },
+    )
+    result = runner.invoke(app, ["split", str(fake_video), "-v"])
+    assert result.exit_code == 3
+    combined = result.stdout + (result.stderr or "")
+    # Error line + verbose detail + traceback lines all present.
+    assert "Error: ffmpeg failed" in combined
+    assert "stderr_tail:" in combined
+    assert "NAL unit type 12 not supported" in combined
+    assert "Traceback" in combined
+    assert "VideoProcessingError" in combined
+    # Hint must NOT appear in verbose mode (hint is 19b's signal).
+    assert "--verbose for full details" not in combined
+
+
+@patch(MODULE)
+def test_matrix_19b_default_emits_hint_for_app_error(mock_run_split, fake_video):
+    """19b: default shows Error + 1-line hint (no context, no traceback)."""
+    mock_run_split.side_effect = VideoProcessingError(
+        "ffmpeg failed",
+        context={"stderr_tail": "NAL unit type 12 not supported"},
+    )
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 3
+    combined = result.stdout + (result.stderr or "")
+    assert "Error: ffmpeg failed" in combined
+    # Hint is the defining 19b signal.
+    assert "Run with -v / --verbose for full details" in combined
+    # Neither context detail nor traceback leak into default mode.
+    assert "stderr_tail" not in combined
+    assert "NAL unit type" not in combined
+    assert "Traceback" not in combined
+
+
+@patch(MODULE)
+def test_matrix_19c_quiet_emits_error_only_for_app_error(mock_run_split, fake_video):
+    """19c: -q shows Error only.  No context, no hint, no traceback."""
+    mock_run_split.side_effect = VideoProcessingError(
+        "ffmpeg failed",
+        context={"stderr_tail": "NAL unit type 12 not supported"},
+    )
+    result = runner.invoke(app, ["split", str(fake_video), "-q"])
+    assert result.exit_code == 3
+    combined = result.stdout + (result.stderr or "")
+    assert "Error: ffmpeg failed" in combined
+    assert "--verbose for full details" not in combined
+    assert "stderr_tail" not in combined
+    assert "NAL unit type" not in combined
+    assert "Traceback" not in combined
+
+
+@patch(MODULE)
+def test_matrix_19b_default_emits_hint_for_unexpected(mock_run_split, fake_video):
+    """19b applies to non-AllaganEyeError too: one-liner + hint."""
+    mock_run_split.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "Unexpected error: boom" in combined
+    assert "Run with -v / --verbose for full details" in combined
+    assert "Traceback" not in combined
+
+
+@patch(MODULE)
+def test_matrix_19c_quiet_emits_error_only_for_unexpected(mock_run_split, fake_video):
+    """19c for non-AllaganEyeError: one-liner only (no hint, no traceback)."""
+    mock_run_split.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["split", str(fake_video), "-q"])
+    assert result.exit_code == 1
+    combined = result.stdout + (result.stderr or "")
+    assert "Unexpected error: boom" in combined
+    assert "--verbose for full details" not in combined
+    assert "Traceback" not in combined
+
+
+@patch(MODULE)
+def test_matrix_traceback_includes_exception_class_name(mock_run_split, fake_video):
+    """-v traceback must surface the concrete AllaganEyeError subclass.
+
+    Bug reports lean on the subclass name to classify failures; a bare
+    base-class ``AllaganEyeError`` would lose the signal.
+    """
+    mock_run_split.side_effect = DetectionError("no boundaries")
+    result = runner.invoke(app, ["split", str(fake_video), "-v"])
+    assert result.exit_code == 4
+    combined = result.stdout + (result.stderr or "")
+    assert "Traceback" in combined
+    assert "DetectionError" in combined
+
+
+@patch(MODULE)
+def test_matrix_config_error_follows_matrix(mock_run_split, fake_video):
+    """ConfigValidationError (pre-run_split path) still follows the matrix.
+
+    The CLI raises ConfigValidationError itself when -v and -q conflict
+    (#419); the reporter must use the correct mode for the *successful*
+    option -- i.e. when only -v is passed, -v wins and 19a applies.
+    """
+    # Invalid threshold raises during SplitConfig.__post_init__ -> CVE.
+    # Run with -v so we assert 19a's output shape.
+    result = runner.invoke(
+        app,
+        ["split", str(fake_video), "--blackout-threshold", "-5", "-v"],
+    )
+    assert result.exit_code == 5
+    combined = result.stdout + (result.stderr or "")
+    assert "Error:" in combined
+    assert "Traceback" in combined
+    assert "ConfigValidationError" in combined
+
+
+def test_matrix_debug_brightness_hint_suppressed(tmp_path):
+    """debug-brightness has no -v option; do not show the -v hint on error.
+
+    Input-validation error path triggers InputFileError without -v / -q
+    flags available.  The hint would be misleading ("Run with -v" is not
+    a valid option here), so ``show_hint=False`` is passed in the
+    debug-brightness handler.  Exit code must stay at 2 (InputFileError).
+    """
+    missing = tmp_path / "does_not_exist.mp4"
+    result = runner.invoke(app, ["debug-brightness", str(missing)])
+    assert result.exit_code == 2
+    combined = result.stdout + (result.stderr or "")
+    assert "Error:" in combined
+    assert "--verbose for full details" not in combined
+
+
 # --- Extension support tests ---
 
 


### PR DESCRIPTION
## 概要

[issue#428](https://github.com/Idios/kobutachan-allaganeye/issues/428) 対応。#405 matrix v2 の 19a/19b 行が現実装と不整合だった問題を修正。

## 問題

| # | モード | 仕様 | 修正前の挙動 |
|---|---|---|---|
| 19a | `-v` | `Error:` + verbose_detail + full traceback + ffmpeg stderr | traceback なし (`from None` で抑制)、context のみ |
| 19b | default | `Error:` + 1 行 hint | hint なし、error line だけ |
| 19c | `-q` | `Error:` のみ | 一致 ✓ |

## 根本原因

- [allaganeye/cli.py:165-167](allaganeye/cli.py:165) / [:221-223](allaganeye/cli.py:221) で `raise typer.Exit from None` により traceback 抑制
- `_report_app_error` が quiet をそもそも受け取らないため、`-q` でも `-v` と同等の情報量になりうる (実際は verbose=False で呼ばれていたので副次的に 19c は一致していた)
- default と verbose の差分が「verbose_detail の有無」だけで、hint / traceback が設計に無かった

## 修正内容

### `allaganeye/cli.py`

- `_report_app_error(exc, *, verbose, quiet=False, show_hint=True)`:
  - 常に `Error: <msg>` を stderr に出す
  - **19c** (quiet): 以降 return
  - **19a** (verbose): `verbose_detail()` + `traceback.format_exception(type(exc), exc, exc.__traceback__)`
  - **19b** (default): `show_hint` True なら 1 行 hint (`Run with -v / --verbose for full details`)
- `_report_unexpected_error(*, verbose, quiet=False, show_hint=True)`:
  - 19a: `traceback.print_exc` (既存)
  - 19b: `Unexpected error: <exc>` + hint
  - 19c: `Unexpected error: <exc>` のみ
- `split` コマンドで `quiet=quiet` を両ヘルパに透過
- `debug-brightness` は `-v` / `-q` を持たないため `show_hint=False` を渡し、存在しないオプションへの誘導を防止

### 類似バグ調査

- 他の `raise typer.Exit from None` 箇所 (2 コマンド × 2 パス = 4 箇所) を全て audit 済み。debug-brightness も同じ reporter を使っているため一貫した挙動に揃えた (hint 抑制)
- `AllaganEyeError` のサブクラス (VideoProcessingError / DetectionError / ConfigValidationError / InputFileError) は全て `verbose_detail` を継承するため、reporter 経由で自動的に matrix 適用される
- ffmpeg stderr は既存 `stderr_tail` context 経由で `verbose_detail()` が出すため追加実装不要

### 再発防止

- `docs/cli-spec.md` に「エラー表示 (#428 / #405 matrix v2)」節を新設し、各モードの出力形式を表 + 出力例 3 パターンで明示 (PR #343 系の「docs に出力例が書かれていない」問題を継続対策)
- テストは stdout/stderr を parse して構造検証 (hint 行・Traceback 有無・class name 有無を個別 assert)

## テスト追加 (`tests/test_cli.py`, 7 件)

| テスト | 検証対象 |
|---|---|
| `test_matrix_19a_verbose_emits_traceback_for_app_error` | 19a AllaganEyeError: context + traceback + class name |
| `test_matrix_19b_default_emits_hint_for_app_error` | 19b: hint 行あり、context / traceback なし |
| `test_matrix_19c_quiet_emits_error_only_for_app_error` | 19c: Error のみ、hint なし |
| `test_matrix_19b_default_emits_hint_for_unexpected` | 19b 非 AllaganEyeError: one-liner + hint |
| `test_matrix_19c_quiet_emits_error_only_for_unexpected` | 19c 非 AllaganEyeError: one-liner のみ |
| `test_matrix_traceback_includes_exception_class_name` | -v + DetectionError で subclass 名が stack に出る |
| `test_matrix_config_error_follows_matrix` | ConfigValidationError (pre-run_split) も matrix 適用 |
| `test_matrix_debug_brightness_hint_suppressed` | debug-brightness は hint 非出力 |

既存の `test_split_verbose_shows_context_detail` / `test_split_non_verbose_hides_context_detail` / `test_split_verbose_shows_traceback_for_unexpected` / `test_split_non_verbose_hides_traceback_for_unexpected` は仕様変更なしで継続 pass。

## 受け入れ基準 (issue #428 より)

- [x] `-v` 時に AllaganEyeError でも full traceback が stderr に出る
- [x] default 時に hint 行が stderr に出る
- [x] 既存 19c (`-q`) 仕様は完全保持
- [x] エラー出力テスト追加: 各モード (-v / default / -q) で stderr フォーマット検証
- [x] AllaganEyeError 各サブクラス (VideoProcessingError / ConfigValidationError / DetectionError) で同じ挙動になることを確認

## PR チェックリスト

- [x] 全テスト通過: `pytest` → 686 passed
- [x] Lint 通過: `ruff check . && ruff format --check .`
- [x] 型チェック通過: `pyright`
- [x] 関連ドキュメント更新: `docs/cli-spec.md` (エラー表示節新設)
- [x] CLAUDE.md の更新不要 (既存記述と整合)
- [x] `docs/cli-spec.md` の出力例・マトリクスが本 PR の実装と整合

## 関連

- Refs #428 / #405 (CLI 出力マトリクス v2)
- Base: `develop-0.1.1`

session-id: engineer-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)