### PR TITLE
chore(setup): develop-0.2.0 init (version bump + tools relocation)

### DIFF
--- a/allaganeye/tools/__init__.py
+++ b/allaganeye/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Maintenance utilities bundled with allaganeye (non-CLI tools)."""

--- a/allaganeye/tools/regen_audio_refs.py
+++ b/allaganeye/tools/regen_audio_refs.py
@@ -1,0 +1,159 @@
+"""Regenerate bundled audio reference feature files from source recordings.
+
+Reference features are short BGM segments captured from recordings the
+maintainer owns.  The script extracts one or more windows via ffmpeg,
+computes the log-mel spectrogram, and writes a compressed ``.npz`` to
+the bundled ``allaganeye/audio/refs/`` directory.
+
+Single-reference mode (Fanfare, #287):
+    python -m allaganeye.tools.regen_audio_refs \\
+        --video "E:/videos/2026-04-08 21-14-05.mkv" \\
+        --start 50 --duration 5 --name fanfare
+
+Multi-reference mode (War Room, #289):
+    # WR plays differently in pre-patch 20260116-era recordings vs. the
+    # canonical ogg / 2026-04-08 recording.  We bundle two windows; the
+    # scanner takes the per-frame max of their sliding similarities.
+    python -m allaganeye.tools.regen_audio_refs \\
+        --name war_room \\
+        --window "path/to/WarRoom.ogg" 0 1.5 \\
+        --window "path/to/recording.mkv" 6520 3
+
+The output is ``allaganeye/audio/refs/<name>.npz`` (relative to repo root).
+Existing files are overwritten.  Single-reference mode writes format v2;
+multi-reference mode writes format v3 (backward-compatible loader).
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from allaganeye.audio.extract import extract_pcm
+from allaganeye.audio.features import (
+    LogMelConfig,
+    log_mel_spectrogram,
+    save_features,
+    save_features_multi,
+)
+
+# Project root: allaganeye/tools/<this file> -> parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Regenerate a bundled audio reference feature file."
+    )
+    parser.add_argument(
+        "--video", type=Path, help="Source recording path (single-ref mode)"
+    )
+    parser.add_argument(
+        "--start",
+        type=float,
+        help="Start time of the BGM window in seconds (single-ref mode)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=5.0,
+        help="Window duration in seconds, default 5 (single-ref mode)",
+    )
+    parser.add_argument(
+        "--window",
+        action="append",
+        nargs=3,
+        metavar=("VIDEO", "START", "DURATION"),
+        default=[],
+        help=(
+            "Multi-ref mode: repeat to add a reference window. "
+            "Each window takes 3 args: video path, start sec, duration sec. "
+            "Mutually exclusive with --video/--start."
+        ),
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Reference name (e.g. 'fanfare'). Output: allaganeye/audio/refs/<name>.npz",
+    )
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        default=22050,
+        help="Sample rate for STFT (default: 22050)",
+    )
+    parser.add_argument(
+        "--n-mels", type=int, default=80, help="Number of mel bands (default: 80)"
+    )
+    return parser.parse_args()
+
+
+def _extract_window(
+    video: Path, start: float, duration: float, config: LogMelConfig
+) -> tuple:
+    if not video.exists():
+        raise FileNotFoundError(f"video not found: {video}")
+    print(f"Extracting from {video.name}: start={start}s duration={duration}s")
+    pcm = extract_pcm(
+        video, sample_rate=config.sample_rate, start=start, duration=duration
+    )
+    print(f"  PCM samples: {len(pcm)} ({len(pcm) / config.sample_rate:.2f}s)")
+    features = log_mel_spectrogram(pcm, config)
+    print(f"  features shape: {features.shape}")
+    return features, {
+        "source_filename": video.name,
+        "source_start": start,
+        "source_duration": duration,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+
+    single_mode = args.video is not None
+    multi_mode = len(args.window) > 0
+    if single_mode and multi_mode:
+        print(
+            "ERROR: --video/--start and --window are mutually exclusive",
+            file=sys.stderr,
+        )
+        return 1
+    if not single_mode and not multi_mode:
+        print(
+            "ERROR: provide either --video/--start or at least one --window",
+            file=sys.stderr,
+        )
+        return 1
+    if single_mode and args.start is None:
+        print("ERROR: --start is required in single-ref mode", file=sys.stderr)
+        return 1
+
+    config = LogMelConfig(sample_rate=args.sample_rate, n_mels=args.n_mels)
+    out_path = ROOT / "allaganeye" / "audio" / "refs" / f"{args.name}.npz"
+
+    if single_mode:
+        features, window_meta = _extract_window(
+            args.video, args.start, args.duration, config
+        )
+        save_features(out_path, features, config, window_meta)
+    else:
+        features_list = []
+        windows_meta = []
+        for video_str, start_str, dur_str in args.window:
+            f, meta = _extract_window(
+                Path(video_str), float(start_str), float(dur_str), config
+            )
+            features_list.append(f)
+            windows_meta.append(meta)
+        save_features_multi(
+            out_path,
+            features_list,
+            config,
+            {"windows": windows_meta, "n_windows": len(windows_meta)},
+        )
+
+    print(f"Wrote {out_path} ({out_path.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -72,9 +72,8 @@ lead-1/work     → PR → (director-1 レビュー) → develop-0.1.1 へマー
 
 1. `develop-x.x.0` 上で全 PR がマージ済み、テスト通過を確認
 2. `deferred` ラベル付き issue を全件レビューし、次バージョンのスコープに含めるか判断する
-3. `pyproject.toml` の `version` を更新する PR を `develop-x.x.0` に作成・マージ
-4. `develop-x.x.0 → main` のリリース PR を作成・マージ
-5. `main` にタグを打つ (`v0.x.0`)
-6. GitHub Release を作成（変更内容サマリ付き）
-7. `main` から次バージョンの `develop-x.x.0` ブランチを作成
-8. 次レイヤーの Issue を作成し、作業開始
+3. `develop-x.x.0 → main` のリリース PR を作成・マージ
+4. `main` にタグを打つ (`v0.x.0`)
+5. GitHub Release を作成（変更内容サマリ付き）
+6. `main` から次バージョンの `develop-x.x.0` ブランチを作成し、その時点で `pyproject.toml` の `version` を `x.y.0` に更新（`.dev` 等の pre-release 識別子は付けない。PyPI 未公開のため不要）
+7. 次レイヤーの Issue を作成し、作業開始

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kobutachan-allaganeye"
-version = "0.1.1"
+version = "0.2.0"
 description = "FF14 Frontline video auto-highlight extraction tool"
 license = {text = "MIT"}
 requires-python = ">=3.11"


### PR DESCRIPTION
## 概要

L2 開発開始に伴う `develop-0.2.0` ブランチ初期セットアップ。Step 0 相当。

- `pyproject.toml` の version: `0.1.1` → `0.2.0` (PyPI 未公開のため pre-release 識別子なし)
- `scripts/regen_audio_refs.py` を `allaganeye/tools/regen_audio_refs.py` に移設
  - 実行方法変更: `python -m allaganeye.tools.regen_audio_refs ...`
  - `allaganeye/tools/__init__.py` を新設しパッケージ化
- `docs/release-strategy.md` の「レイヤー間の移行手順」を修正
  - 旧: L2 完了直前に version bump PR を作成
  - 新: `develop-x.x.0` ブランチ作成時に version を `x.y.0` に更新（`.dev` 等の pre-release 識別子なし）

## 背景

- 2026-04-20 に L1 v0.1.1 リリース済み、次フェーズ L2 移行のための初期化
- `engineer-1/issue-307-scorebar-v2` ブランチ (放棄済み実験) 処分の一環で `scripts/` 配下を整理
  - 画像データ (Square Enix 権利物) は `_archive/scorebar-v2/` にバックアップ済み
  - 保存価値のある `regen_audio_refs.py` のみパッケージ内に移設

## テスト

- [x] `ruff check .` 全件パス
- [x] `ruff format --check .` 全件パス
- [x] `pytest` 全件パス (685 passed, 37 deselected)

## 関連

- 計画: `plans/deffere-issue-l2-deffered-1-l1-issue-2-graceful-clover.md`
- 後続: Issue A (L1 状態 + ロードマップ更新)、Issue B (L2 再定義)、Issue C (L2-0 ワークフロー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)