### PR TITLE
docs(skills): empirical-prompt-tuning で 5 スキル改善

### DIFF
--- a/.claude/skills/create-task/SKILL.md
+++ b/.claude/skills/create-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-task
-description: issue-policy.md に沿ったタスク issue を対話的に作成する
+description: issue-policy.md に沿って GitHub issue を対話的に作成する（全 prefix: bug/doc/refactor/task/question/risk 対応）
 user-invocable: true
 argument-hint: <タスクの概要（自然言語）>
 ---
@@ -11,13 +11,20 @@ argument-hint: <タスクの概要（自然言語）>
 
 1. ユーザーの指示（`$ARGUMENTS`）からタスクの内容を把握する
 2. 適切な prefix を選択する（`[bug]`, `[doc]`, `[refactor]`, `[question]`, `[risk]`, `[task]`）
-3. `docs/issue-policy.md` §3 の対応テンプレートに沿って本文を作成する
-4. 作成前にユーザーにタイトルと本文を提示し、確認を得る
-5. ユーザーが承認したら `gh issue create` で作成する:
+3. `docs/issue-policy.md` §3 の対応テンプレートに沿ってタイトルと本文を作成する
+4. 重複チェック: `gh issue list --search "<主題を表す名詞 2-3 個>" --state all --repo Idios/kobutachan-allaganeye` を実行し、類似 issue がないか確認する（キーワードはタイトルから名詞を優先抽出、必要なら本文から補足）
+5. 作成前にユーザーに以下の要素を提示して確認を得る:
+   - タイトル（文字数表示付き、例: "33/40 文字"）
+   - assignee / ラベル一覧（スコープラベル・優先度ラベル含む）
+   - 重複チェック結果（ヒット件数と代表 issue）
+   - 本文全文
+   - 選択肢: 「はい / 修正箇所を指摘 / やめる」
+6. ユーザーが承認したら以下のコマンドで作成する（Windows + Git Bash での日本語本文破損回避のため `printf | --body-file -` 方式）:
    ```bash
-   gh issue create \
+   printf '%s\n' "<本文>" | gh issue create \
+     --repo Idios/kobutachan-allaganeye \
      --title "<prefix> <概要>" \
-     --body "<テンプレートに沿った本文>" \
+     --body-file - \
      --assignee "Idios" \
      --label "<prefix に対応するラベル（該当する場合）>" \
      --label "<スコープラベル（l2a-gui / l2b-installer / l2c-guard / l2-workflow / l2-decision / l1-residual 等、該当する場合）>"
@@ -26,9 +33,9 @@ argument-hint: <タスクの概要（自然言語）>
 ## 注意事項
 
 - 1 issue = 1 つの問題・タスク。複数の問題をまとめない
-- 作成前に `gh issue list` で重複がないか確認する
 - ラベルは prefix に応じて設定する（`[risk]` は prefix ラベルなし）
 - 対応スコープが明確な場合はスコープラベル（`l2a-gui` / `l2b-installer` / `l2c-guard` / `l2-workflow` / `l2-decision` / `l1-residual` 等）を付ける（`docs/issue-policy.md` §2 参照）
 - 優先度が明確な場合は `P1-high` / `P2-medium` / `P3-low` ラベルを付ける（`docs/issue-policy.md` §2 参照）
 - タイトルは日本語で 40 文字以内
 - 本文の末尾に `作成: <session-id>` を記載する
+- `Closes` / `Fixes` / `Resolves` キーワードは本文中で使わない（クローズは手動）

--- a/.claude/skills/enforce-acceptance-criteria/SKILL.md
+++ b/.claude/skills/enforce-acceptance-criteria/SKILL.md
@@ -53,6 +53,8 @@ gh issue view <ISSUE番号> --json body | python -c "import json,sys;b=json.load
 - [ ] 各条件に対応する diff の具体的なファイル:行範囲を特定した
 - [ ] 各条件に対応するテストケース名を特定した
 - [ ] テストが実際に通過していることを確認した (`gh pr checks` or 手動 pytest)
+- [ ] baseline FAIL → FIX 検証テストがある場合、baseline FAIL の実証（修正前コミットの test 失敗ログ、または PR 本文での明記）が確認できた
+- [ ] 参照ファイル追加を伴う条件がある場合、`gh pr diff --name-only` で追加ファイルの実体（拡張子・サイズ等）を確認した
 - [ ] UI/出力変更の場合、実サンプル (CLI 出力・スクショ) が PR 本文に添付されているか確認した
 - [ ] 複数 issue を束ねている PR の場合、全 issue の条件を逐条処理した
 - [ ] 「Phase 2 は別途」等の先送りがある場合、子 issue 番号が PR 本文と親 issue 本文の両方に記載されているか確認した

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: バージョンバンプとリリースPRの作成を自動化する
+description: deferred issue レビュー → バージョンバンプ → リリース PR 作成を自動化する
 ---
 
 # リリーススキル
@@ -14,6 +14,8 @@ description: バージョンバンプとリリースPRの作成を自動化す�
 - `minor`: 新機能追加
 - `major`: 破壊的変更
 
+自動判定ルール（引数省略時）: 前回タグ以降のコミット prefix から判定。`feat:` / `feat(...)` があれば minor、`!` または `BREAKING CHANGE` があれば major、それ以外（`fix` / `docs` / `refactor` / `chore` / `test` のみ）は patch。判断が曖昧な場合はユーザーに確認する。
+
 ## 手順
 
 ### Step 1: deferred issue のレビュー（必須）
@@ -24,10 +26,13 @@ description: バージョンバンプとリリースPRの作成を自動化す�
 gh issue list --repo Idios/kobutachan-allaganeye --state open --label "deferred" --json number,title,labels
 ```
 
-- 各 issue について、次バージョンのスコープに含めるか・引き続き deferred かをユーザーに確認する
-- スコープに含める場合: `deferred` を外し、適切なスコープラベル + 優先度ラベルに変更
+- 各 issue について、以下の 3 択をユーザーに確認する:
+  - **[A] 次バージョンのスコープに含める**: `deferred` を外し、適切なスコープラベル + 優先度ラベル（`P1-high` / `P2-medium` / `P3-low`、ユーザーに選択を求める）に変更
+  - **[B] 引き続き deferred**: ラベル変更なし。理由を PR 本文に記載
+  - **[C] クローズ**: `gh issue close <番号> --comment "<理由>"` でクローズ
 - deferred issue が 0 件の場合のみ自動で次ステップに進む
 - 1 件以上ある場合: **必ずユーザーに判断を求めてから** 次に進む
+- 3 件以上の bulk 操作になる場合は CLAUDE.md §「自律判断マトリクス」に従い、実行前にサンプル 1 件を提示してユーザー確認を取る
 
 ### Step 2: リリース準備
 
@@ -36,37 +41,65 @@ gh issue list --repo Idios/kobutachan-allaganeye --state open --label "deferred"
    ```bash
    git log $(git describe --tags --abbrev=0 2>/dev/null || echo "HEAD~50")..HEAD --oneline
    ```
-3. バージョン種別を決定（引数指定 or コミット内容から自動判定）
+3. バージョン種別を決定（引数指定 or 上記「自動判定ルール」）
+4. ベースブランチを特定:
+   - **minor/major**: 現在の `develop-<新バージョン>` （既存 develop ブランチ）
+   - **patch**: ホットフィックス扱い。現在の `develop-<新バージョン>` がある場合はそこへ、無ければ `main` へ PR。判断が曖昧な場合は `git branch -r | grep -E 'origin/develop-|origin/main'` の結果を提示してユーザー確認
 
 ### Step 3: バージョンバンプと PR 作成
 
-4. `pyproject.toml` の `version` を更新
-5. リリースブランチを作成:
+5. **事前品質チェック** (CLAUDE.md PR 作成ルール):
    ```bash
+   ruff check .
+   ruff format --check .
+   pytest
+   pyright
+   ```
+   いずれか失敗したら修正してから以下に進む
+6. `pyproject.toml` の `version` を更新（他にバージョン参照箇所があれば `grep -r '<旧バージョン>' --include='*.py' --include='*.toml'` で確認し同時更新）
+7. リリースブランチを作成（Step 2-4 で特定したベースブランチから分岐）:
+   ```bash
+   git checkout <ベースブランチ>
+   git pull
    git checkout -b release/v<新バージョン>
    ```
-6. 変更をコミット:
+8. 変更をコミット（session-id を含める、CLAUDE.md PR 作成ルール）:
    ```bash
    git add pyproject.toml
-   git commit -m "chore: bump version to <新バージョン>"
+   git commit -m "chore: bump version to <新バージョン> [<session-id>]"
    ```
-7. リリース PR を作成:
+9. リリースブランチを push:
    ```bash
-   gh pr create --title "Release v<新バージョン>" --body "$(cat <<'EOF'
-   ## Release v<新バージョン>
-
-   ### 変更内容
-   <コミット分析結果のサマリー>
-
-   ### deferred issue レビュー結果
-   <Step 1 の判断結果を記載>
-
-   ### チェックリスト
-   - [ ] バージョン番号が正しい
-   - [ ] 全テスト通過
-   - [ ] deferred issue を全件レビュー済み
-   - [ ] CLAUDE.md の更新が必要な変更はない
-   EOF
-   )" --label "release" --assignee Idios
+   git push -u origin release/v<新バージョン>
    ```
-8. ユーザーに PR URL とバージョン変更内容を報告
+10. リリース PR を作成（base は Step 2-4 で特定したベースブランチ、Windows + Git Bash での日本語本文破損回避のため `printf | --body-file -` 方式）:
+    ```bash
+    printf '%s\n' "## Release v<新バージョン>
+
+    ### 変更内容
+    <コミット分析結果のサマリー>
+
+    ### deferred issue レビュー結果
+    <Step 1 の判断結果を記載>
+
+    ### チェックリスト
+    - [ ] バージョン番号が正しい
+    - [ ] 全テスト通過 (\`pytest\`, \`ruff check .\`, \`ruff format --check .\`, \`pyright\`)
+    - [ ] deferred issue を全件レビュー済み
+    - [ ] CLAUDE.md の更新が必要な変更はない
+
+    作成: <session-id>" | gh pr create \
+      --title "Release v<新バージョン>" \
+      --body-file - \
+      --base <ベースブランチ> \
+      --label "release" \
+      --assignee Idios
+    ```
+11. ユーザーに PR URL とバージョン変更内容を報告
+
+### タグ打ち・GitHub Release 作成
+
+リリース PR マージ後の手順（本スキル範囲外、`docs/release-strategy.md` §タグ運用 を参照）:
+- patch リリース: マージされたブランチで `git tag v<新バージョン>` → `git push origin v<新バージョン>`
+- minor/major リリース: `develop-<新バージョン>` を `main` にマージしてから `main` でタグ打ち
+- `gh release create v<新バージョン> --notes-from-tag` で GitHub Release 作成

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: PR をレビューし、受け入れ条件チェックリストで検証。懸念点があればコメント、なければ LGTM してユーザーにマージを提案
+description: PR をレビュー（base ブランチ確認・受け入れ条件ゲート・CI・ロジック/ドキュメント整合性）し、懸念があれば修正依頼、なければ LGTM とマージ提案、マージ後は紐づく issue を処理する。修正は同セッションで継続
 user-invocable: true
 argument-hint: <PR番号>
 ---
@@ -34,7 +34,7 @@ gh pr diff $ARGUMENTS
   - UI/出力変更: スナップショットテストまたは contract テスト
 - [ ] **複数 issue 束ね時の合理性**: 1 PR で複数 issue を閉じる場合、束ねる理由が PR 本文に明記されているか
 - [ ] **Phase 分割時の子 issue 起票**: 「Phase 2 は別途」等で残タスクを先送りする場合、子 issue 番号が親 issue に記載されているか
-- [ ] **`Closes` / `Fixes` / `Resolves` キーワードが使われていない**: issue クローズは手動で行う
+- [ ] **`Closes` / `Fixes` / `Resolves` キーワードが使われていない**: issue クローズは手動で行う（`/enforce-acceptance-criteria` が verified を返していればこの項目は自動 PASS。二重チェックになるため明示スキップ可）
 
 ### 4. CI / Lint / Test ステータス確認
 
@@ -63,6 +63,7 @@ PR の変更種別に応じて以下を確認する:
 
 **コード / テスト変更 PR の場合**:
 - 関連ドキュメント (`docs/cli-spec.md`, `docs/design-overview.md`, `README.md`, `CLAUDE.md` 等) が更新されているか
+- **特に CLAUDE.md / docs に「追加予定」「今後実装」等の予告記述があり、本 PR がその実装に該当する場合、予告文を実装済み記述に更新すること。更新漏れは Step 6 で修正依頼対象**
 - コード変更がドキュメント記述と矛盾していないか
 - 出力形式変更の場合、`docs/cli-spec.md` の出力例も更新されているか (#343 系の再発防止)
 

--- a/.claude/skills/scope-guard/SKILL.md
+++ b/.claude/skills/scope-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope-guard
-description: 実装中の「ついでに直した」スコープ逸脱を検知し、別 issue 起票または revert を強制する。Iron Law 3 の執行機構。
+description: 実装中の「ついでに直した」スコープ逸脱を検知し、(a) 別 issue 起票 / (b) revert / (c) スコープ拡大 の 3 択をユーザー判断で強制する。Iron Law 3 の執行機構。
 user-invocable: true
 ---
 
@@ -41,10 +41,19 @@ AskUserQuestion: 現在の作業ブランチはどの issue に対応します�
 
 ### Step 2: 変更範囲の確認
 
+現行 develop ブランチを特定してから実行:
+
 ```bash
-git diff --stat develop-0.2.0...HEAD
-git diff develop-0.2.0...HEAD --name-only
+# 現行 develop ブランチを特定（origin の develop-* から最新版を選択）
+DEVELOP_BRANCH=$(git branch -r | grep -E 'origin/develop-[0-9]+' | sed 's|.*origin/||' | sort -V | tail -1)
+echo "base: $DEVELOP_BRANCH"  # 例: develop-0.2.0
+
+# 変更範囲を確認
+git diff --stat "$DEVELOP_BRANCH"...HEAD
+git diff "$DEVELOP_BRANCH"...HEAD --name-only
 ```
+
+ブランチ特定が不明瞭な場合は `AskUserQuestion` でユーザー確認。
 
 変更ファイル一覧を issue スコープと照合:
 
@@ -63,6 +72,8 @@ git diff develop-0.2.0...HEAD --name-only
    - **(c) スコープ拡大を認める**: 元 issue の scope を編集し、変更を正当化 (ユーザー判断必須)
 
 2. 上記いずれかを実行、**独断で (a)/(b)/(c) を選ばない**
+
+**フロー**: (b) revert を選択した場合は本スキル終了（作業ブランチから逸脱変更が消えたため Step 4 不要）。(a)/(c) を選択した場合は Step 4 に進み PR 本文への記載事項を確認する。
 
 ### Step 4: PR 作成前の最終確認
 


### PR DESCRIPTION
## Summary
5 スキル (create-task, release, review-pr, enforce-acceptance-criteria, scope-guard) の曖昧さを [mizchi/chezmoi-dotfiles の empirical-prompt-tuning](https://github.com/mizchi/chezmoi-dotfiles/blob/main/dot_claude/skills/empirical-prompt-tuning/SKILL.md) に従って反復検証し改善しました。

## ワークフロー
- Iter 0: description ↔ body の静的整合チェック (5 スキル全件で乖離検出・修正)
- Iter 1: 新規 subagent 5 並列で白紙評価、各スキルのシナリオ + 要件チェックリスト ([critical] 付き) で採点
- Iter 2: 1 スキル 1 テーマの最小修正 + 再評価 (別 subagent 5 並列)

## 改善内容

### create-task
- 重複チェックに具体的な `gh issue list --search` コマンドとキーワード抽出ルールを明記
- 確認プロンプトで提示すべき要素 5 点 (タイトル文字数 / ラベル / 重複結果 / 本文 / 選択肢) をリスト化
- `printf | --body-file -` 方式で日本語本文破損回避 (memory feedback_gh_command_ja_heredoc.md 準拠)
- `--repo Idios/kobutachan-allaganeye` を明示
- `Closes` / `Fixes` / `Resolves` 禁止を注意事項に追加

### release
- Step 1 で 3 択化 ([A] 含める / [B] deferred 据え置き / [C] クローズ)
- bulk 操作 (3 件以上) の事前確認を追記
- 自動判定ルール (feat → minor, ! / BREAKING → major, その他 → patch) を明示
- Step 2-4 にベースブランチ特定ルール (minor/major は develop, patch はホットフィックス扱いでユーザー確認) を追加
- Step 3 に事前品質チェック (ruff / pytest / pyright) / push step / session-id コミット / `--base <新バージョン>` を追加
- タグ打ち・GitHub Release 作成手順を末尾に追加 (本スキルは PR 作成で終了と明記)

### review-pr
- Step 3 補助チェック 5 項目の `Closes` 検査を `/enforce-acceptance-criteria` verified 時はスキップ可と明記 (二重チェック排除)
- Step 5 コード変更 PR 観点に「CLAUDE.md/docs の予告記述が本 PR で実装された場合は更新必須、漏れは修正依頼対象」を追加

### enforce-acceptance-criteria
- Verification Checklist に 2 項目追加:
  - baseline FAIL → FIX 検証テストがある場合、baseline FAIL の実証 (修正前コミットでの失敗ログ or PR 本文明記) を確認
  - 参照ファイル追加を伴う条件がある場合、`gh pr diff --name-only` で追加ファイルの実体確認

### scope-guard
- Step 2 の `develop-0.2.0` ハードコードを `git branch -r | grep 'origin/develop-[0-9]+' | sort -V | tail -1` での動的特定に置換
- Step 3 に (b) revert 選択時は Step 4 不要、(a)/(c) は Step 4 へ進むというフロー分岐を明示

## Metrics (Iter 1 → Iter 2)
| Skill | 精度 | 不明瞭点 | 備考 |
|---|---|---|---|
| create-task | 100% → 100% | 3 → 4 | 残は優先度フロー / 依存 issue 欄 (scope 外) |
| release | **86% → 100%** | 8 → 6 | 最大改善 (base branch / pre-flight / session-id) |
| review-pr | 100% → 100% | 2 → 5 | スコープ広がり、残は meta 仕様 |
| enforce-acceptance-criteria | 100% → 100% | 3 → 2 | baseline / 参照ファイル項目追加が効いた |
| scope-guard | 100% → 100% | **5 → 2** | ハードコード解消が大きい |

5 スキル × 2 iter 全てで [critical] 要件 全 ○。

## 残る不明瞭点 (follow-up 候補、本 PR scope 外)
- create-task: engineer ロール起票時の優先度確認フロー / 依存 issue 記載欄
- release: 2 件 bulk 閾値の扱い / `pyproject.toml` 以外の version 参照箇所探索 / develop-x.x.x 同期 PR 手順
- review-pr: 予告記述 grep 対象スコープの明示
- enforce-acceptance-criteria: 日本語平文 `#N` 記法に対する正規表現フォールバック

## Test plan
- [x] ruff check . (All checks passed)
- [x] ruff format --check . (57 files already formatted)
- [x] pytest (686 passed)
- [x] 5 スキル × 2 iter の新規 subagent 評価で [critical] 要件 全 ○
