### PR TITLE
feat(exceptions): SecurityVerificationError (exit 6) 追加 (Refs #454)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | 3 | FFmpeg / ffprobe エラー |
 | 4 | 検知失敗（試合境界が見つからない） |
 | 5 | 設定値不正（パラメータの範囲外等） |
+| 6 | セキュリティ検査失敗（`allaganeye-guard verify` が FAIL を返した場合） |
 
 ### 外部依存
 

--- a/allaganeye/exceptions.py
+++ b/allaganeye/exceptions.py
@@ -60,3 +60,9 @@ class DetectionError(AllaganEyeError):
     """No match boundaries detected in the video."""
 
     exit_code = 4
+
+
+class SecurityVerificationError(AllaganEyeError):
+    """allaganeye-guard verification reported FAIL for the input file."""
+
+    exit_code = 6

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -278,6 +278,7 @@ timestamp,brightness
 | 3 | FFmpeg / ffprobe エラー |
 | 4 | 試合境界が見つからない |
 | 5 | 設定値不正（パラメータの範囲外等） |
+| 6 | セキュリティ検査失敗（`allaganeye-guard verify` が FAIL を返した場合） |
 
 ### エラー表示 (#428 / #405 matrix v2)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from allaganeye.exceptions import (
     AllaganEyeError,
     DetectionError,
     InputFileError,
+    SecurityVerificationError,
     VideoProcessingError,
 )
 
@@ -384,6 +385,22 @@ def test_split_base_error_exit_code(mock_run_split, fake_video):
 
     result = runner.invoke(app, ["split", str(fake_video)])
     assert result.exit_code == 1
+
+
+@patch(MODULE)
+def test_split_security_verification_error_exit_code(mock_run_split, fake_video):
+    """SecurityVerificationError produces exit code 6 via base handler (#454).
+
+    allaganeye-guard verify 失敗を表す例外は `AllaganEyeError` 基底クラスの
+    汎用ハンドラを通じて exit 6 に写像される。`--verify` CLI 実装 (後続 issue)
+    より先に exit code 契約を確立し、guard 統合時の互換性を保証する。
+    """
+    mock_run_split.side_effect = SecurityVerificationError(
+        "allaganeye-guard reported FAIL for input"
+    )
+
+    result = runner.invoke(app, ["split", str(fake_video)])
+    assert result.exit_code == 6
 
 
 @patch(MODULE)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,6 +3,7 @@
 from allaganeye.exceptions import (
     AllaganEyeError,
     DetectionError,
+    SecurityVerificationError,
     VideoProcessingError,
 )
 
@@ -40,6 +41,30 @@ def test_exit_code_preserved_with_context():
     exc = DetectionError("nope", context={"stats": {"a": 1}})
     assert exc.exit_code == 4
     assert "stats: {'a': 1}" in exc.verbose_detail()
+
+
+def test_security_verification_error_exit_code():
+    """SecurityVerificationError must map to exit code 6 (#454)."""
+    exc = SecurityVerificationError("guard verification failed")
+    assert exc.exit_code == 6
+    assert isinstance(exc, AllaganEyeError)
+
+
+def test_security_verification_error_exit_code_is_unique():
+    """Exit code 6 must not collide with any other AllaganEyeError subclass."""
+    from allaganeye.exceptions import (
+        ConfigValidationError,
+        InputFileError,
+    )
+
+    other_codes = {
+        AllaganEyeError.exit_code,
+        InputFileError.exit_code,
+        VideoProcessingError.exit_code,
+        DetectionError.exit_code,
+        ConfigValidationError.exit_code,
+    }
+    assert SecurityVerificationError.exit_code not in other_codes
 
 
 def test_str_message_independent_of_context():


### PR DESCRIPTION
## 概要

L2c allaganeye-guard 統合の先行タスク (`docs/guard-integration.md` §10 タスク 1, Refs [#454](https://github.com/Idios/kobutachan-allaganeye/issues/454))。

guard の `verify` 検査で FAIL が返った場合に allaganeye 本体が exit 6 で終了する契約を確立する。`--verify` CLI 実装 (後続 issue) より先に例外クラスと exit code を合意しておくことで、guard 側との互換性を保証する。

## 変更点

- `allaganeye/exceptions.py`: `SecurityVerificationError` (exit_code=6) を追加 (L5 insertions)
- `allaganeye/cli.py`: **無改変** — 既存の `AllaganEyeError` 基底クラス経路ハンドラ (`raise typer.Exit(code=e.exit_code)`) が自動的に exit 6 に写像するため
- `docs/cli-spec.md`: Exit Codes 表に行 6 を追記
- `CLAUDE.md`: Exit Codes 表に行 6 を追記
- `tests/test_exceptions.py`: exit_code == 6 検証 + 既存 exit code (1-5) との衝突なし検証
- `tests/test_cli.py`: `SecurityVerificationError` 発生時 CLI が exit 6 で終了することの検証

## 受け入れ条件 (Refs #454)

- [x] `SecurityVerificationError` が `exceptions.py` で定義され、exit code 6 を持つ
- [x] CLI から例外発生時に exit 6 で終了する動作のテストが通る
- [x] `docs/cli-spec.md` と `CLAUDE.md` の Exit Codes 表が更新されている
- [x] 既存の exit code 1-5 との衝突なし (test_security_verification_error_exit_code_is_unique で検証)
- [x] `ruff check .` / `ruff format --check .` / `pytest` 全通過 (689 passed, 37 deselected)

## スコープ外 (後続 issue)

- `--verify` CLI オプション実装 (Refs #454 "後続" — 別 issue)
- guard 呼び出しラッパー / subprocess 実装
- pyproject の `[guard]` optional-deps (Refs [#457](https://github.com/Idios/kobutachan-allaganeye/issues/457))

## テスト計画

- [x] `python -m pytest tests/test_exceptions.py tests/test_cli.py` 通過
- [x] `python -m pytest` 全体通過 (689 passed)
- [x] `python -m ruff check .` / `python -m ruff format --check .` 通過

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)