### PR TITLE
fix(pyproject): pip install -e . が output/ を誤検出するバグ修正 (Refs #469)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "kobutachan-allaganeye"
 version = "0.2.0"
 description = "FF14 Frontline video auto-highlight extraction tool"
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "typer>=0.9",
@@ -17,6 +17,9 @@ dependencies = [
 
 [project.scripts]
 allaganeye = "allaganeye.cli:app"
+
+[tool.setuptools.packages.find]
+include = ["allaganeye*"]
 
 [tool.setuptools.package-data]
 "allaganeye.audio.refs" = ["*.npz"]


### PR DESCRIPTION
## Summary

`pip install -e .` を `output/` ディレクトリ存在下で実行すると setuptools の flat-layout 自動検出が `output/` を 2 つ目の top-level パッケージと誤認してビルド失敗する問題を修正。

- `[tool.setuptools.packages.find] include = ["allaganeye*"]` を明示し auto-discovery を `allaganeye` 配下に限定
- `license = "MIT"` SPDX 文字列形式に変更 (setuptools 77+ の deprecation 対応)

## 受け入れ条件 (#469)

- [x] `pyproject.toml` に `[tool.setuptools.packages.find] include = ["allaganeye*"]` 追加 → [pyproject.toml:21-22](pyproject.toml#L21-L22)
- [x] `license = "MIT"` 形式に変更 (setuptools 77 deprecation 対応) → [pyproject.toml:9](pyproject.toml#L9)
- [x] `output/` が存在しても `pip install -e .` が成功することを確認 → 下記ログ
- [x] CI (pyright/pytest) がパスすることを確認 → 下記ログ + CI `lint-and-test` ジョブ pass

## 動作確認

### `output/` 存在下での pip install

```
$ mkdir -p output && touch output/.keep && ls output/
.keep

$ python -m pip install -e .
...
  Building editable for kobutachan-allaganeye (pyproject.toml): finished with status 'done'
  Created wheel for kobutachan-allaganeye: filename=kobutachan_allaganeye-0.2.0-0.editable-py3-none-any.whl
Successfully built kobutachan-allaganeye
Successfully installed kobutachan-allaganeye-0.2.0
```

修正前は `error: Multiple top-level packages discovered in a flat-layout: ['output', 'allaganeye'].` で失敗していた事象が解消。

### CI ローカル検証

```
$ python -m ruff check .
All checks passed!

$ python -m ruff format --check .
57 files already formatted

$ python -m pyright
0 errors, 0 warnings, 0 informations

$ python -m pytest
===================== 686 passed, 37 deselected in 22.86s =====================
```

## Test plan

- [x] `output/` 存在下での `pip install -e .` 成功確認
- [x] `ruff check .` / `ruff format --check .` パス
- [x] `pyright` 0 errors
- [x] `pytest` 686 passed (slow 除外)
- [x] CI `lint-and-test` ジョブが GitHub Actions で pass

## 関連

- Refs #469
- 発覚契機: #468 Phase 0 で allaganeye CLI を sidecar として呼ぶため install が必要になった
- 関連: #431 Quick Start venv トラブルシュート

🤖 Generated with [Claude Code](https://claude.com/claude-code)