### PR TITLE
feat(ci): リリース配布 workflow + Portable ZIP ビルドスクリプト (Refs #461)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version_override:
+        description: 'Version string used for dry-run build. Defaults to pyproject.toml version.'
+        required: false
+        type: string
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Resolve and verify version
+        id: parse
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYPROJECT_VERSION=$(python -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')
+          echo "pyproject.toml version: $PYPROJECT_VERSION"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+            echo "tag version: $TAG_VERSION"
+            if [[ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]]; then
+              echo "::error::Tag v$TAG_VERSION does not match pyproject.toml version $PYPROJECT_VERSION"
+              exit 1
+            fi
+            VERSION="$TAG_VERSION"
+          else
+            OVERRIDE='${{ inputs.version_override }}'
+            VERSION="${OVERRIDE:-$PYPROJECT_VERSION}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Using version: $VERSION"
+
+  build-windows:
+    needs: version-check
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build Portable ZIP
+        shell: pwsh
+        run: ./scripts/build-portable-zip.ps1 -Version '${{ needs.version-check.outputs.version }}'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: allaganeye-portable-windows
+          path: dist/allaganeye-v*-windows.zip
+          if-no-files-found: error
+
+  release:
+    needs: [version-check, build-windows]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: allaganeye-portable-windows
+          path: dist
+
+      - name: Extract release notes from CHANGELOG
+        shell: bash
+        run: python scripts/extract_release_notes.py '${{ needs.version-check.outputs.version }}' release-notes.md
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/allaganeye-v*-windows.zip
+          body_path: release-notes.md
+          generate_release_notes: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+      - 'scripts/build-portable-zip.ps1'
+      - 'scripts/extract_release_notes.py'
+      - 'pyproject.toml'
   workflow_dispatch:
     inputs:
       version_override:

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -70,6 +70,8 @@ claude/<scope>-* → PR → /review-pr (受け入れ条件チェック) → /tes
 - コマンド: `git tag -a v0.x.0 -m "Release v0.x.0: <レイヤー名>"`
 - `git push origin v0.x.0` すると [`.github/workflows/release.yml`](../.github/workflows/release.yml) が発火し、Windows Portable ZIP (`allaganeye-v<version>-windows.zip`) のビルドと GitHub Release への成果物自動添付を実行する (#461)
   - ビルドは [`scripts/build-portable-zip.ps1`](../scripts/build-portable-zip.ps1) で Python 3.11 embeddable + FFmpeg LGPL essentials を同梱する
+    - ダウンロードする外部バイナリ (Python embed / get-pip.py / FFmpeg) はスクリプト内に **SHA256 ダイジェストをハードコードして検証** する。ダイジェスト不一致時はビルドを fail。FFmpeg は特定バージョンタグを URL にピン留め (現在 `8.1`) して再現性を確保する
+    - 外部バイナリを更新する場合はスクリプト先頭の `$FFmpegVersion` / `$*Sha256` 定数を更新する
   - Release 本文は [`scripts/extract_release_notes.py`](../scripts/extract_release_notes.py) が CHANGELOG.md から該当バージョンのセクションを抽出する
   - タグ名と `pyproject.toml` の `version` が一致しない場合、workflow は fail する
 - 手動で dry-run ビルドを確認したい場合は、Actions タブから `Release` workflow を `workflow_dispatch` で起動する (Release は作成されず ZIP artifact のみ)

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -68,7 +68,12 @@ claude/<scope>-* → PR → /review-pr (受け入れ条件チェック) → /tes
 - `main` の HEAD にタグを打つ
 - タグ形式: `v<major>.<minor>.<patch>`
 - コマンド: `git tag -a v0.x.0 -m "Release v0.x.0: <レイヤー名>"`
-- GitHub Release は `/release` スキルで作成
+- `git push origin v0.x.0` すると [`.github/workflows/release.yml`](../.github/workflows/release.yml) が発火し、Windows Portable ZIP (`allaganeye-v<version>-windows.zip`) のビルドと GitHub Release への成果物自動添付を実行する (#461)
+  - ビルドは [`scripts/build-portable-zip.ps1`](../scripts/build-portable-zip.ps1) で Python 3.11 embeddable + FFmpeg LGPL essentials を同梱する
+  - Release 本文は [`scripts/extract_release_notes.py`](../scripts/extract_release_notes.py) が CHANGELOG.md から該当バージョンのセクションを抽出する
+  - タグ名と `pyproject.toml` の `version` が一致しない場合、workflow は fail する
+- 手動で dry-run ビルドを確認したい場合は、Actions タブから `Release` workflow を `workflow_dispatch` で起動する (Release は作成されず ZIP artifact のみ)
+- `/release` スキルは develop → main PR 作成・CHANGELOG 更新の支援に使う (Release 作成自体は上記 workflow が担う)
 
 ## レイヤー間の移行手順
 

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -1,0 +1,136 @@
+<#
+.SYNOPSIS
+Build the allaganeye Portable ZIP for Windows.
+
+.DESCRIPTION
+Downloads Python 3.11 embeddable and FFmpeg LGPL essentials, installs
+allaganeye and its runtime dependencies into the payload, adds a .bat
+launcher, and compresses everything into dist/allaganeye-v<version>-windows.zip.
+
+The script is idempotent: build/portable and dist are cleaned at the start.
+
+.PARAMETER Version
+Semantic version string (e.g. "0.2.0") used in the output ZIP filename.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Version
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$ProgressPreference = 'SilentlyContinue'
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$BuildDir = Join-Path $RepoRoot 'build\portable'
+$DistDir = Join-Path $RepoRoot 'dist'
+$PayloadName = "allaganeye-v$Version"
+$PayloadDir = Join-Path $BuildDir $PayloadName
+$ZipPath = Join-Path $DistDir "$PayloadName-windows.zip"
+
+$PythonVersion = '3.11.9'
+$PythonEmbedUrl = "https://www.python.org/ftp/python/$PythonVersion/python-$PythonVersion-embed-amd64.zip"
+$GetPipUrl = 'https://bootstrap.pypa.io/get-pip.py'
+$FFmpegUrl = 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip'
+
+function Invoke-Download {
+  param(
+    [Parameter(Mandatory = $true)][string]$Uri,
+    [Parameter(Mandatory = $true)][string]$OutPath
+  )
+  Write-Host "Downloading $Uri"
+  Invoke-WebRequest -Uri $Uri -OutFile $OutPath -UseBasicParsing
+}
+
+foreach ($dir in @($BuildDir, $DistDir)) {
+  if (Test-Path $dir) { Remove-Item -Recurse -Force $dir }
+  New-Item -ItemType Directory -Force -Path $dir | Out-Null
+}
+New-Item -ItemType Directory -Force -Path $PayloadDir | Out-Null
+
+# 1. Python embeddable
+$PythonZip = Join-Path $BuildDir 'python-embed.zip'
+Invoke-Download -Uri $PythonEmbedUrl -OutPath $PythonZip
+$PythonDir = Join-Path $PayloadDir 'python'
+Expand-Archive -Path $PythonZip -DestinationPath $PythonDir -Force
+
+$PthFile = Join-Path $PythonDir 'python311._pth'
+Set-Content -Path $PthFile -Encoding ASCII -Value @(
+  'python311.zip',
+  '.',
+  '..\lib',
+  'import site'
+)
+
+# 2. Install pip into the embedded interpreter
+$GetPipPath = Join-Path $BuildDir 'get-pip.py'
+Invoke-Download -Uri $GetPipUrl -OutPath $GetPipPath
+$PythonExe = Join-Path $PythonDir 'python.exe'
+& $PythonExe $GetPipPath --no-warn-script-location --no-cache-dir
+
+# 3. Install allaganeye + deps into payload\lib
+$LibDir = Join-Path $PayloadDir 'lib'
+New-Item -ItemType Directory -Force -Path $LibDir | Out-Null
+& $PythonExe -m pip install `
+    --target $LibDir `
+    --no-compile `
+    --no-warn-script-location `
+    --no-cache-dir `
+    $RepoRoot
+
+# 4. FFmpeg LGPL essentials
+$FFmpegZip = Join-Path $BuildDir 'ffmpeg.zip'
+Invoke-Download -Uri $FFmpegUrl -OutPath $FFmpegZip
+$FFmpegExtract = Join-Path $BuildDir 'ffmpeg-extracted'
+Expand-Archive -Path $FFmpegZip -DestinationPath $FFmpegExtract -Force
+$FFmpegBin = Get-ChildItem -Path $FFmpegExtract -Directory |
+  Select-Object -First 1 |
+  ForEach-Object { Join-Path $_.FullName 'bin' }
+if (-not $FFmpegBin -or -not (Test-Path $FFmpegBin)) {
+  throw "FFmpeg bin directory not found under $FFmpegExtract"
+}
+$FFmpegDest = Join-Path $PayloadDir 'ffmpeg'
+New-Item -ItemType Directory -Force -Path $FFmpegDest | Out-Null
+Copy-Item -Path (Join-Path $FFmpegBin 'ffmpeg.exe') -Destination $FFmpegDest
+Copy-Item -Path (Join-Path $FFmpegBin 'ffprobe.exe') -Destination $FFmpegDest
+
+# 5. Launcher
+$Launcher = @'
+@echo off
+setlocal
+set PAYLOAD=%~dp0
+set ALLAGANEYE_FFMPEG=%PAYLOAD%ffmpeg\ffmpeg.exe
+set PATH=%PAYLOAD%ffmpeg;%PATH%
+"%PAYLOAD%python\python.exe" -m allaganeye %*
+endlocal
+'@
+Set-Content -Path (Join-Path $PayloadDir 'allaganeye.bat') -Value $Launcher -Encoding ASCII
+
+# 6. README
+$Readme = @"
+# allaganeye v$Version (Portable ZIP for Windows)
+
+Python 3.11 and FFmpeg LGPL binaries are bundled alongside allaganeye.
+
+## Usage
+
+1. Extract this ZIP anywhere.
+2. Open a Command Prompt in the extracted folder.
+3. Run:
+
+    allaganeye.bat split <path-to-video>
+
+See https://github.com/Idios/kobutachan-allaganeye for full documentation.
+
+## Licenses
+
+- allaganeye: MIT (see the repository LICENSE file)
+- Python: PSF License (python\LICENSE.txt)
+- FFmpeg: LGPL (ffmpeg redistributable essentials build from gyan.dev)
+"@
+Set-Content -Path (Join-Path $PayloadDir 'README.txt') -Value $Readme -Encoding UTF8
+
+# 7. Compress
+Compress-Archive -Path $PayloadDir -DestinationPath $ZipPath -CompressionLevel Optimal
+Write-Host "Built $ZipPath"

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -7,6 +7,9 @@ Downloads Python 3.11 embeddable and FFmpeg LGPL essentials, installs
 allaganeye and its runtime dependencies into the payload, adds a .bat
 launcher, and compresses everything into dist/allaganeye-v<version>-windows.zip.
 
+Downloaded artefacts (Python embed, get-pip.py, FFmpeg zip) are pinned by URL
+and verified against hard-coded SHA256 digests. A mismatch aborts the build.
+
 The script is idempotent: build/portable and dist are cleaned at the start.
 
 .PARAMETER Version
@@ -31,16 +34,30 @@ $ZipPath = Join-Path $DistDir "$PayloadName-windows.zip"
 
 $PythonVersion = '3.11.9'
 $PythonEmbedUrl = "https://www.python.org/ftp/python/$PythonVersion/python-$PythonVersion-embed-amd64.zip"
+$PythonEmbedSha256 = '009D6BF7E3B2DDCA3D784FA09F90FE54336D5B60F0E0F305C37F400BF83CFD3B'
+
 $GetPipUrl = 'https://bootstrap.pypa.io/get-pip.py'
-$FFmpegUrl = 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip'
+$GetPipSha256 = 'FEBA1C697DF45BE1B539B40D93C102C9EE9DDE1D966303323B830B06F3FBCA3C'
+
+# FFmpeg version is pinned so the same allaganeye tag always ships the same FFmpeg.
+# To update: bump $FFmpegVersion, replace $FFmpegSha256 with the new asset's hash.
+$FFmpegVersion = '8.1'
+$FFmpegUrl = "https://github.com/GyanD/codexffmpeg/releases/download/$FFmpegVersion/ffmpeg-$FFmpegVersion-essentials_build.zip"
+$FFmpegSha256 = '8748283D821613D930B0E7BE685AAA9DF4CA6F0AD4D0C42FD02622B3623463C6'
 
 function Invoke-Download {
   param(
     [Parameter(Mandatory = $true)][string]$Uri,
-    [Parameter(Mandatory = $true)][string]$OutPath
+    [Parameter(Mandatory = $true)][string]$OutPath,
+    [Parameter(Mandatory = $true)][string]$ExpectedSha256
   )
   Write-Host "Downloading $Uri"
   Invoke-WebRequest -Uri $Uri -OutFile $OutPath -UseBasicParsing
+  $actual = (Get-FileHash -Algorithm SHA256 -Path $OutPath).Hash
+  if ($actual -ne $ExpectedSha256.ToUpperInvariant()) {
+    throw "SHA256 mismatch for ${Uri}: expected $ExpectedSha256, actual $actual"
+  }
+  Write-Host "  SHA256 verified: $actual"
 }
 
 foreach ($dir in @($BuildDir, $DistDir)) {
@@ -51,7 +68,7 @@ New-Item -ItemType Directory -Force -Path $PayloadDir | Out-Null
 
 # 1. Python embeddable
 $PythonZip = Join-Path $BuildDir 'python-embed.zip'
-Invoke-Download -Uri $PythonEmbedUrl -OutPath $PythonZip
+Invoke-Download -Uri $PythonEmbedUrl -OutPath $PythonZip -ExpectedSha256 $PythonEmbedSha256
 $PythonDir = Join-Path $PayloadDir 'python'
 Expand-Archive -Path $PythonZip -DestinationPath $PythonDir -Force
 
@@ -65,7 +82,7 @@ Set-Content -Path $PthFile -Encoding ASCII -Value @(
 
 # 2. Install pip into the embedded interpreter
 $GetPipPath = Join-Path $BuildDir 'get-pip.py'
-Invoke-Download -Uri $GetPipUrl -OutPath $GetPipPath
+Invoke-Download -Uri $GetPipUrl -OutPath $GetPipPath -ExpectedSha256 $GetPipSha256
 $PythonExe = Join-Path $PythonDir 'python.exe'
 & $PythonExe $GetPipPath --no-warn-script-location --no-cache-dir
 
@@ -79,9 +96,9 @@ New-Item -ItemType Directory -Force -Path $LibDir | Out-Null
     --no-cache-dir `
     $RepoRoot
 
-# 4. FFmpeg LGPL essentials
+# 4. FFmpeg LGPL essentials (version-pinned)
 $FFmpegZip = Join-Path $BuildDir 'ffmpeg.zip'
-Invoke-Download -Uri $FFmpegUrl -OutPath $FFmpegZip
+Invoke-Download -Uri $FFmpegUrl -OutPath $FFmpegZip -ExpectedSha256 $FFmpegSha256
 $FFmpegExtract = Join-Path $BuildDir 'ffmpeg-extracted'
 Expand-Archive -Path $FFmpegZip -DestinationPath $FFmpegExtract -Force
 $FFmpegBin = Get-ChildItem -Path $FFmpegExtract -Directory |
@@ -127,7 +144,7 @@ See https://github.com/Idios/kobutachan-allaganeye for full documentation.
 
 - allaganeye: MIT (see the repository LICENSE file)
 - Python: PSF License (python\LICENSE.txt)
-- FFmpeg: LGPL (ffmpeg redistributable essentials build from gyan.dev)
+- FFmpeg: LGPL (ffmpeg $FFmpegVersion essentials build from GyanD/codexffmpeg)
 "@
 Set-Content -Path (Join-Path $PayloadDir 'README.txt') -Value $Readme -Encoding UTF8
 

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Extract a single version's section from CHANGELOG.md for GitHub Release notes."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def extract(version: str, source: Path) -> str:
+    text = source.read_text(encoding="utf-8")
+    pattern = rf"## \[{re.escape(version)}\].*?(?=\n## \[|\Z)"
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise SystemExit(f"No CHANGELOG section for version {version}")
+    return match.group(0).strip()
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) != 3:
+        print(
+            "Usage: extract_release_notes.py <version> <output_path>",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    version = argv[1]
+    output = Path(argv[2])
+    source = Path("CHANGELOG.md")
+    notes = extract(version, source)
+    output.write_text(notes + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Summary

#452 で確定した「Portable ZIP (素の Python 同梱)」形式を、タグプッシュ時に自動ビルドして GitHub Release に添付するワークフローを定義しました。レビューを受けて以下を逐次反映:

- **commit 1ce4048**: `pull_request` トリガー追加 — `gh workflow run` が default branch 制約で 404 になる問題を回避し、PR 作成/更新時に Windows runner で自動 dry-run が走る
- **commit 874cc9f**: 外部バイナリ DL に SHA256 検証追加 + FFmpeg を `GyanD/codexffmpeg` 8.1 固定 URL にピン — supply chain 強化と再現性確保
- **commit 2530d39**: `.bat` ランチャーをダブルクリック/ドラッグ＆ドロップ対応に改善 — 非エンジニア向け方針 (#462 レビューで確定) への対応

## 追加ファイル

- [.github/workflows/release.yml](.github/workflows/release.yml) — `push: tags: ['v*.*.*']` / `pull_request: paths` / `workflow_dispatch` の 3 トリガーで 3 job を実行
- [scripts/build-portable-zip.ps1](scripts/build-portable-zip.ps1) — Windows Portable ZIP ビルドスクリプト
  - Python 3.11.9 embeddable (SHA256 verified)
  - FFmpeg 8.1 LGPL essentials (GyanD/codexffmpeg, SHA256 verified)
  - Launcher (ダブルクリック/D&D 対応、拡張子判定で自動 split)
- [scripts/extract_release_notes.py](scripts/extract_release_notes.py) — CHANGELOG.md から該当バージョンのセクションを抽出
- [docs/release-strategy.md](docs/release-strategy.md) — タグ運用セクションに本 workflow + SHA256 検証の注記

## 受け入れ条件 (#461)

- [x] `.github/workflows/release.yml` が存在し、タグプッシュで走る → [release.yml:4-6](.github/workflows/release.yml#L4-L6) の `on.push.tags`
- [x] テスト用の dry-run (ブランチで workflow_dispatch) でビルドが成功する → **`pull_request` トリガーで build-windows ジョブが PR CI 上で実走し pass。各 commit の Actions ページで確認可能**
- [x] 成果物の命名規則 (`allaganeye-v<version>-<os>.<ext>`) が一貫している → `allaganeye-v<version>-windows.zip`
- [x] バージョン整合性チェックが `pyproject.toml` version != tag で fail する → version-check job の bash 条件分岐
- [x] `docs/release-strategy.md` に本ワークフローへの参照が追記されている
- [x] `ruff check .` / `ruff format --check .` / `pytest` 全通過 → CI `lint-and-test` pass

## 主な設計判断

- **Python バージョン**: 3.11.9 (CI と揃える、pyproject.toml `requires-python>=3.11`) + SHA256 ピン
- **FFmpeg 配布元**: GyanD/codexffmpeg release の固定 URL (LGPL essentials build) + SHA256 + バージョン 8.1 ピン (再現性確保)
- **.bat ランチャー**: ASCII のみ (任意の Windows コードページで安全)。日本語ヘルプは docs/quickstart.md に集約。拡張子判定で動画ファイル D&D 時は split 自動実行
- **Release 本文**: `scripts/extract_release_notes.py` が CHANGELOG.md のバージョンセクションを抽出 (該当セクションが無ければ fail)
- **dry-run 実行手段**: `gh workflow run` は default branch にワークフローが必要な仕様のため、PR 時に自動発火する `pull_request` トリガー (`paths` で release.yml / scripts / pyproject.toml 変更時のみ) を追加。`release` job は `github.event_name == 'push'` ガードで PR 時は引き続き skip

## 動作確認

### PR CI (commit 1ce4048 時点)

| Job | 結果 | 所要 |
|---|---|---|
| version-check | pass | 6s |
| build-windows | **pass** | 1m34s |
| release | skipping (期待通り、push かつ tag でのみ走る) | — |
| lint-and-test | pass | 1m26s |

### ローカル手動検証 (commit 874cc9f, sweet-noyce-6ba11c)

- `./scripts/build-portable-zip.ps1 -Version 0.2.0` で:
  - Python / get-pip / FFmpeg それぞれ SHA256 verified
  - `dist/allaganeye-v0.2.0-windows.zip` (184 MB) 生成成功

### extract_release_notes.py

```
$ python scripts/extract_release_notes.py 0.1.1 /tmp/rn.md   # 成功
$ python scripts/extract_release_notes.py 9.9.9 /tmp/rn2.md  # 存在しないバージョンで exit 1
```

### ローカル CI

```
$ python -m ruff check .
All checks passed!

$ python -m ruff format --check .
58 files already formatted

$ python -m pytest
===================== 686 passed, 37 deselected in 16.13s =====================
```

## Test plan

- [x] `extract_release_notes.py` で CHANGELOG 0.1.1 セクション抽出成功 / 存在しないバージョンで exit 1
- [x] `release.yml` YAML syntax 有効
- [x] `ruff check` / `ruff format` / `pytest` 全 green
- [x] PR CI の `build-windows` ジョブで Windows runner の dry-run 完走 (SHA256 検証込み)
- [x] `release` ジョブが PR 時に skip されることを確認
- [x] .bat ランチャー改修後の build-windows 成功 (commit 2530d39 の CI 結果を参照)

## 将来 (post-merge / リリース時)

- `v0.2.0` タグを push すると release ジョブが走り、GitHub Release が自動作成され `allaganeye-v0.2.0-windows.zip` が添付される
- タグ名 (`v0.2.0`) と `pyproject.toml` の `version` (`0.2.0`) が一致しない場合、version-check ジョブが fail する
- CI annotations で Node.js 20 deprecation 警告が出ている (actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4)。 2026-06-02 から Node.js 24 が default、2026-09-16 に Node.js 20 が removed。別 issue で actions 更新を追う

## 関連

- Refs #461
- 依存: #452 (Portable ZIP 確定, closed), #451 (Windows 専用確定, closed), #469 (pyproject.toml setuptools 修正, merged PR #489)
- 連動: PR #495 (#462 Windows コードサイニング + SmartScreen docs)
- 後続: #462 (現 PR #495 で docs 対応中)

🤖 Generated with [Claude Code](https://claude.com/claude-code)