### PR TITLE
chore(ci): markdownlint-cli2 を CI に導入 (Refs #474) [admiring-gates-fcda42]

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,20 @@
+name: Markdownlint
+
+on:
+  pull_request:
+    branches: [main, "develop-*"]
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.yaml"
+      - ".github/workflows/markdownlint.yml"
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: "**/*.md"

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ htmlcov/
 .env
 ROLE
 
+# Node.js (markdownlint-cli2 など、`npx -y` のキャッシュ想定)
+node_modules/
+package-lock.json
+
 # Project specific
 *.mp4
 *.mkv

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,61 @@
+# markdownlint-cli2 configuration (#474).
+#
+# 段階導入方針: 既存ドキュメントで違反のあるルールは全て disable し、CI を
+# green な状態で開始する。新規コミット時に disable 対象外のルール (~40 種) が
+# 違反を検出すればエラーになる。段階的にルールを有効化する方針は
+# follow-up issue で管理する。
+#
+# 各 disable の理由:
+
+config:
+  # MD013 (line-length, 既存 294 件): 日本語ドキュメントは自動折り返し非対応の
+  # エディタが多く、80 文字制限は実情に合わない。
+  MD013: false
+
+  # MD040 (fenced-code-language, 既存 38 件): ``` 直後の言語指定を推奨する
+  # ルール。既存 38 件を段階的に修正するまで disable。
+  MD040: false
+
+  # MD032 (blanks-around-lists, 既存 37 件): リスト前後の空行を要求。
+  MD032: false
+
+  # MD031 (blanks-around-fences, 既存 18 件): ``` フェンス前後の空行を要求。
+  MD031: false
+
+  # MD022 (blanks-around-headings, 既存 17 件): 見出し前後の空行を要求。
+  MD022: false
+
+  # MD029 (ol-prefix, 既存 7 件): 番号付きリストの番号スタイル統一。
+  # 1./2./3. と 1./1./1. の混在を許容する。
+  MD029: false
+
+  # MD024 (no-duplicate-heading, 既存 7 件): CHANGELOG の複数バージョン節で
+  # 重複見出し (`### Changed` 等) が構造上必要。
+  MD024: false
+
+  # MD041 (first-line-h1, 既存 5 件): 先頭が H1 でないドキュメント
+  # (PR テンプレート、skill 定義等) が正当なケースとして存在する。
+  MD041: false
+
+  # MD036 (no-emphasis-as-heading, 既存 5 件): 強調を見出し代わりに使う記法を
+  # ドキュメントの一部で意図的に採用している。
+  MD036: false
+
+  # MD028 (no-blanks-blockquote, 既存 1 件): blockquote 内の空行を許容。
+  MD028: false
+
+  # MD038 (no-space-in-code, 既存 1 件): コードスパン内の空白を許容。
+  MD038: false
+
+# 対象ファイル: リポジトリ配下の全 .md を対象にし、依存物 / キャッシュ / 生成物を
+# 除外する。markdownlint-cli2 は引数未指定時に globs を参照する。
+globs:
+  - "**/*.md"
+
+ignores:
+  - "node_modules/**"
+  - ".venv/**"
+  - ".git/**"
+  - ".pytest_cache/**"
+  - ".ruff_cache/**"
+  - "**/kobutachan_allaganeye.egg-info/**"

--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -9,12 +9,18 @@
 
 - **ruff**: lint + format
 - **pyright**: 型チェック
+- **markdownlint-cli2**: Markdown ドキュメントの lint (CI)
 
 ```bash
 ruff check .
 ruff format --check .
 pyright
+
+# Markdown (Node.js 必須、ローカル実行は任意)
+npx -y markdownlint-cli2@0.18.1
 ```
+
+設定は [`.markdownlint-cli2.yaml`](../.markdownlint-cli2.yaml)。既存違反のあるルールを disable し、新規コミット時の違反を CI で捕捉する構成。段階的に disable を外す計画は `#474` 系の follow-up issue で管理する。
 
 ## スタイル
 


### PR DESCRIPTION
## Summary

Markdown ドキュメントの品質を CI で担保するため **markdownlint-cli2** を導入 (Refs [#474](https://github.com/Idios/kobutachan-allaganeye/issues/474))。

#474 対応方針の「既存 md ファイルの違反を確認・修正 (**大量の場合は disable ルールで段階導入**)」に従い、現状 430 件の違反があるルールを全て disable した設定で start。新規コミット時に disable 対象外の ~40 ルールが違反を検出すれば CI が失敗する構成。

## 違反現状の内訳 (既存 33 md ファイル)

```
294  MD013 (line-length)            ← JA テキスト主体、80 文字制限は非現実的
 38  MD040 (fenced-code-language)   ← ``` 直後の言語指定
 37  MD032 (blanks-around-lists)
 18  MD031 (blanks-around-fences)
 17  MD022 (blanks-around-headings)
  7  MD029 (ol-prefix)
  7  MD024 (no-duplicate-heading)   ← CHANGELOG で構造的に必要
  5  MD041 (first-line-h1)          ← PR テンプレート等
  5  MD036 (no-emphasis-as-heading)
  1  MD038 (no-space-in-code)
  1  MD028 (no-blanks-blockquote)
```

## 変更内容

| ファイル | 変更 |
|---|---|
| `.markdownlint-cli2.yaml` (新規) | 違反 11 ルール全てを disable、理由を各ルールのコメントに明示 |
| `.github/workflows/markdownlint.yml` (新規) | `DavidAnson/markdownlint-cli2-action@v20`、PR の md / config 変更時のみ起動 |
| `.gitignore` | `node_modules/` / `package-lock.json` 追加 (ローカル `npx` のキャッシュ用) |
| `docs/coding-conventions.md` | markdownlint-cli2 の記述を追加 (ruff / pyright と並列) |

## 設計判断

### ツール: markdownlint-cli2 (vs markdownlint-cli)

- markdownlint-cli2 は後発で高速、YAML 設定対応、公式 GitHub Action あり
- 既存 npm スクリプトが存在しないため、`npx -y` でオンデマンド実行

### CI: 新規 workflow (vs ci.yml に job 追加)

- Python 依存処理と独立しているため分離した方が並列化が効く
- `paths:` filter で md / config 変更時にのみ起動し、無駄な実行を減らす

### 段階導入: 全違反ルールを disable (vs 部分修正)

- 430 件の違反を 1 PR で修正するのはレビュー困難
- disable の理由を config のコメントに明示し、follow-up で段階有効化

## Test plan

- [x] ローカルで `npx -y markdownlint-cli2@0.18.1` を実行 → `Linting: 33 file(s)` / `Summary: 0 error(s)`
- [x] CI workflow は `paths` filter 設定済み (md / config 変更時のみ起動)
- [x] PR のチェック — `markdownlint` workflow が pass (初回実行で 0 errors 確認)

## 受け入れ条件

- [x] markdownlint ルール選定 (**markdownlint-cli2@0.18.1**)
- [x] 設定ファイル追加 (`.markdownlint-cli2.yaml`)
- [x] 既存 md ファイルの違反を確認 (disable ルールで段階導入)
- [x] CI workflow 追加 (`.github/workflows/markdownlint.yml`)
- pre-commit hook 追加: **optional** 扱いで本 PR では見送り (follow-up issue の余地あり)

## 関連

- Refs [#474](https://github.com/Idios/kobutachan-allaganeye/issues/474) (本 PR 対象)
- plan: `plans/l2-execution-plan.md` Group D

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
