### PR TITLE
docs(guard): allaganeye-guard をプログラム結合から運用連携に転換

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ FF14 PvPコンテンツ「フロントライン」の長時間録画動画（OBS
 | レイヤー | 処理 | 技術 | 状態 |
 |---|---|---|---|
 | L1: 試合分割 | 暗転検知で試合単位に分割 | FFmpeg（検知+分割） | **リリース済み** (v0.1.0-preview 2026-04-17, v0.1.1 2026-04-20) |
-| L2: 配布・統合 | GUI + ゼロ環境構築配布 + guard 統合 | Tauri 2.x + React 19 + TS + allaganeye-guard | **開発中** |
+| L2: 配布・統合 | GUI + ゼロ環境構築配布 | Tauri 2.x + React 19 + TS | **開発中** |
 | L3: メタデータ化 | キルログ・音声・チャットをタイムスタンプ化 | Tesseract / Whisper | 未着手 |
 | L4: 価値評価 | 抽出データをMLが判定 | ローカル ML（scikit-learn 等） | 未着手 |
 | L5: 自動編集 | 判定に基づき動画切り出し・投稿提案 | MoviePy / FFmpeg | 未着手 |
@@ -160,16 +160,14 @@ export ALLAGANEYE_SAMPLE_VIDEO_DIR=/path/to/videos
 - サブディレクトリ（`20260116/` 等）: 手動で試合分割済みのMP4（`YYYYMMDD_N.mp4`）
 - 未設定の場合、`sample_video_dir` fixture を使うテスト（`slow` マーカー）はスキップされる
 
-## セキュリティ検査（allaganeye-guard 連携）
+## セキュリティ検査（allaganeye-guard 運用連携）
 
-外部ユーザーから受領した動画ファイルを処理する前に、独立ツール `allaganeye-guard` でセキュリティ検査を行う。詳細は `docs/guard-integration.md` を参照。
+外部ユーザーから受領した動画ファイルを処理する前に、独立ツール `allaganeye-guard` でセキュリティ検査を行う。**プログラムレベルでの結合は行わず**、エージェント (= Claude + 人間メンテナ Idios) が手動で `allaganeye-guard verify` を実行する運用ルールとする (2026-04-21 方針確定、#454 参照)。詳細は `docs/guard-integration.md` を参照。
 
-- **リポジトリ**: [Idios/kobutachan-allaganeye-guard](https://github.com/Idios/kobutachan-allaganeye-guard)
-- `allaganeye-guard verify <file>` で検査、PASS なら `allaganeye split` で処理
-- 将来的に `--verify` オプションで自動呼び出しを実装予定
-- guard がインストールされていなくても allaganeye 本体は正常動作する
-- **外部動画データの検査**: Idios 以外のユーザーが issue・PR に添付した動画は、`allaganeye-guard verify` が PASS するまで処理しない（`docs/guard-integration.md` §8 参照）
-- **開発・リリース同期**: allaganeye のレイヤーリリース時に guard との互換性チェックが必要になる（`docs/guard-integration.md` §11 参照）
+- **リポジトリ**: [Idios/kobutachan-allaganeye-guard](https://github.com/Idios/kobutachan-allaganeye-guard) (独立パッケージ)
+- **運用**: `allaganeye-guard verify <file>` → PASS (exit 0 / 1) 後に `allaganeye split` で処理
+- **外部動画データの検査**: Idios 以外のユーザーが issue・PR に添付した動画は、`allaganeye-guard verify` が PASS するまで処理しない (`docs/guard-integration.md` §5 参照)
+- allaganeye 側に guard を import する実装・optional-deps・統合 exit code は持たない (独立性維持)
 
 ## リリース戦略
 
@@ -218,7 +216,7 @@ L2 からは**単一ワークツリー + skill ベースディスパッチ**を�
 - プレフィックス: `[bug]`, `[doc]`, `[refactor]`, `[task]`, `[question]`, `[risk]`
 - Assignee: 常に `Idios`
 - 作成者明示: 本文末尾に `作成: <session-id>`
-- ラベル: prefix ラベル + スコープラベル (`l2a-gui` / `l2b-installer` / `l2c-guard` / `l2-workflow` / `l2-decision` / `l1-residual` 等) + 優先度（`P1-high` / `P2-medium` / `P3-low`）
+- ラベル: prefix ラベル + スコープラベル (`l2a-gui` / `l2b-installer` / `l2-workflow` / `l2-decision` / `l1-residual` 等) + 優先度（`P1-high` / `P2-medium` / `P3-low`）
 - `Closes`/`Fixes` キーワードは使わない（クローズは手動）
 
 ## PR 作成ルール

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -14,7 +14,7 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
 │  出力: 試合ごとの MP4 + metadata.json              │
 ├─────────────────────────────────────────────────┤
 │  L2: 配布・統合（開発中）                            │
-│  GUI サポート + ゼロ環境構築配布 + guard 統合        │
+│  GUI サポート + ゼロ環境構築配布                     │
 ├─────────────────────────────────────────────────┤
 │  L3: メタデータ化（将来）                           │
 │  入力: L1 出力の試合動画                           │
@@ -164,14 +164,13 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
 | 2 | Linux | 未検証 | パッケージマネージャで PATH に入る（CI は lint/型チェックのみ） |
 | 3 | macOS | 未検証 | Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`) |
 
-## セキュリティ検査（allaganeye-guard）
+## セキュリティ検査（allaganeye-guard 運用連携）
 
-外部ユーザーから受領した動画ファイルを処理する前に、独立ツール `kobutachan-allaganeye-guard` でセキュリティ検査を行う。
+外部ユーザーから受領した動画ファイルを処理する前に、独立ツール `kobutachan-allaganeye-guard` でセキュリティ検査を行う。**プログラムレベルでの結合は行わず**、エージェント (Claude + 人間メンテナ Idios) が手動で `allaganeye-guard verify` を実行する運用ルールとする (2026-04-21 方針確定、#454 参照)。
 
-- **リポジトリ**: `Idios/kobutachan-allaganeye-guard`（独立パッケージ）
-- **依存方向**: allaganeye → guard（一方向。guard は allaganeye に依存しない）
-- **連携方式**: subprocess 呼び出し（`allaganeye-guard verify --json <file>`）
-- **オプション依存**: `pip install allaganeye[guard]` で一緒にインストール可能。なくても動作する
+- **リポジトリ**: `Idios/kobutachan-allaganeye-guard` (独立パッケージ)
+- **依存方向**: 運用上のみ一方向 (guard verify 先行 → allaganeye split 後続)。パッケージ依存関係としては**完全独立** (import / optional-deps / 統合 exit code を持たない)
+- **運用**: `allaganeye-guard verify <file>` → PASS (exit 0 / 1) 後に `allaganeye split` で処理
 
 詳細は `docs/guard-integration.md` を参照。
 

--- a/docs/guard-integration.md
+++ b/docs/guard-integration.md
@@ -4,16 +4,22 @@
 
 [kobutachan-allaganeye-guard](https://github.com/Idios/kobutachan-allaganeye-guard) は、allaganeye が処理する動画ファイルのセキュリティ検査を行う独立ツール。外部ユーザーから受領したバグ再現データに攻撃コードやマルウェアが含まれていないことを、allaganeye のパイプラインに渡す前に検証する。
 
-### なぜ独立ツールか
+### 運用原則 (2026-04-21 確定)
 
-- **セキュリティ境界の分離**: 検査対象（allaganeye）と検査ツールを同一コードベースに置かない
-- **依存方向の明確化**: allaganeye → guard の一方向依存。guard は allaganeye に依存しない
+allaganeye と allaganeye-guard は**プログラムレベルでの結合を行わない**。両ツールは独立した CLI として存在し、エージェント (= Claude Code セッションで動くこのアシスタント + 人間メンテナ Idios の両方) が外部から受け取った動画データを扱う際に、allaganeye で処理する前に `allaganeye-guard verify` を**手動で実行する**運用に一本化する。
+
+### なぜ結合しないか
+
+- **セキュリティ境界の分離**: 検査対象 (allaganeye) と検査ツールを同一コードベース・同一プロセスに置かない。結合すると allaganeye 側の脆弱性が検査フェーズ前に露出しうる
+- **依存方向の明確化**: allaganeye と guard は**運用上の一方向依存** (guard verify が先、allaganeye split が後)。パッケージ依存関係としては**完全独立**
 - **独立したリリースサイクル**: CVE 対応等のセキュリティ更新を allaganeye のリリースと独立して行える
+- **allaganeye 側の軽量化**: guard を optional-deps にすらしないことで、allaganeye の依存グラフとインストール手順を最小に保つ
 
 ```
-allaganeye-guard（セキュリティ検査）
-       ↑ subprocess 呼び出し
-allaganeye（動画処理）
+allaganeye-guard (セキュリティ検査 CLI)
+      │  ← 運用ルールによる手動チェーン (プログラム結合なし)
+      ▼
+allaganeye (動画処理 CLI)
 ```
 
 ---
@@ -26,7 +32,7 @@ allaganeye（動画処理）
 |---|---|---|
 | v0.4.0 | 2026-04-12 | #262: バッチ検査、エラーハンドリング改善 |
 
-> このテーブルはディレクターが guard リリース issue（`[info] allaganeye-guard`）を検出した際に更新する。更新後、リリース issue をクローズする。
+> このテーブルはメンテナ (Idios) が guard リリース issue (`[info] allaganeye-guard`) を検出した際に更新する。更新後、リリース issue をクローズする。
 
 ---
 
@@ -34,13 +40,13 @@ allaganeye（動画処理）
 
 | ID | 脅威 | 検査フェーズ |
 |---|---|---|
-| T1 | 不正コンテナ（FFmpeg 脆弱性を突く細工） | Phase 1 + 2 |
+| T1 | 不正コンテナ (FFmpeg 脆弱性を突く細工) | Phase 1 + 2 |
 | T2 | MKV 添付ファイルにマルウェア混入 | Phase 2 |
 | T3 | 字幕トラックによるレンダラ脆弱性攻撃 | Phase 2 + 3 |
-| T4 | ポリグロットファイル（拡張子偽装） | Phase 1 |
+| T4 | ポリグロットファイル (拡張子偽装) | Phase 1 |
 | T5 | メタデータによるパストラバーサル | Phase 1 + 2 |
 | T6 | メタデータによるコマンドインジェクション | Phase 2 |
-| T7 | リソース枯渇（圧縮爆弾的構造） | Phase 1 + 2 |
+| T7 | リソース枯渇 (圧縮爆弾的構造) | Phase 1 + 2 |
 | T8 | 未知のコーデックによる予測不能な動作 | Phase 2 |
 
 ---
@@ -51,7 +57,7 @@ allaganeye（動画処理）
 入力ファイル
     │
     ▼
-  Phase 1: ファイルレベル検査（FFmpeg 不使用）
+  Phase 1: ファイルレベル検査 (FFmpeg 不使用)
   - マジックバイト検証
   - 拡張子と実体の一致
   - ファイルサイズ上限
@@ -59,7 +65,7 @@ allaganeye（動画処理）
   - ポリグロット検出
     │ PASS
     ▼
-  Phase 2: コンテナレベル検査（MediaConch / MKVToolNix / ffprobe）
+  Phase 2: コンテナレベル検査 (MediaConch / MKVToolNix / ffprobe)
   - コンテナ仕様準拠
   - 添付ファイル検出
   - ストリーム種別・コーデック許可リスト
@@ -67,7 +73,7 @@ allaganeye（動画処理）
   - メタデータ文字列の安全性
     │ PASS
     ▼
-  Phase 3: パターン検査（YARA / ClamAV）
+  Phase 3: パターン検査 (YARA / ClamAV)
   - 既知エクスプロイトパターン
   - マルウェアシグネチャ
     │ PASS
@@ -79,231 +85,100 @@ allaganeye（動画処理）
 
 ---
 
-## 4. allaganeye からの利用方法
+## 4. 使用方法
 
-### 4.1 手動実行（推奨）
-
-外部から受領したファイルを処理する前に手動で検査する。
+外部から受領したファイルを処理する前に、エージェント (Claude + 人間メンテナ Idios の両方) が手動で検査する。
 
 ```bash
 # 検査
 allaganeye-guard verify received_file.mkv
 
-# PASS なら処理
+# PASS (exit 0、または exit 1 = warnings あり) なら処理
 allaganeye split received_file.mkv -o output/
 ```
 
 ワンライナー:
 
 ```bash
-# UNIX
+# UNIX / Git Bash
 allaganeye-guard verify received_file.mkv && allaganeye split received_file.mkv
 
 # PowerShell
 allaganeye-guard verify received_file.mkv; if ($LASTEXITCODE -eq 0) { allaganeye split received_file.mkv }
 ```
 
-### 4.2 自動呼び出し（将来実装）
+### guard の Exit Code と対応
 
-allaganeye の `split` コマンドに `--verify` オプションを追加し、処理前に guard を自動呼び出しする。
+エージェントは以下の exit code を基に判断する。
 
-```bash
-# 自動検査付き
-allaganeye split --verify received_file.mkv
+| コード | 意味 | 対応 |
+|---|---|---|
+| 0 | PASS (警告なし) | `allaganeye split` で処理続行 |
+| 1 | PASS with warnings | 警告を確認した上で処理続行 |
+| 2 | FAIL (セキュリティ検査不合格) | 処理を中止。提供者に確認または報告 |
+| 3 | ERROR (ツール実行エラー、依存ツール不足) | guard 側のインストール・依存関係を確認 |
+| 4 | 入力エラー (ファイル不存在、引数不正) | 引数を見直す |
 
-# strict モード
-allaganeye split --verify --verify-strict received_file.mkv
-
-# 検査スキップ（自己責任）
-allaganeye split --skip-verify received_file.mkv
-```
-
-自動呼び出し時、allaganeye は guard を subprocess として実行し `--json` 出力を解析する。
-
-#### guard 未インストール時の振る舞い
-
-| 設定 | 振る舞い |
-|---|---|
-| `--verify` 明示指定 | guard が見つからなければエラー終了 |
-| デフォルト（auto） | 見つかれば実行、なければスキップして警告表示 |
-| `--skip-verify` | 検査をスキップ |
+allaganeye 側には guard の exit code を反映する統合 exit code は設けない (本ドキュメント §1 「運用原則」参照)。
 
 ---
 
-## 5. guard の Exit Code と allaganeye の対応
-
-### guard の Exit Code
-
-| コード | 意味 |
-|---|---|
-| 0 | PASS（警告なし） |
-| 1 | PASS with warnings |
-| 2 | FAIL（セキュリティ検査不合格） |
-| 3 | ERROR（ツール実行エラー、依存ツール不足） |
-| 4 | 入力エラー（ファイル不存在、引数不正） |
-
-### allaganeye 側の対応
-
-| guard exit code | allaganeye の動作 |
-|---|---|
-| 0 | 処理を続行 |
-| 1 | 警告を表示して処理を続行 |
-| 2 | 処理を中断。FAIL 理由を表示 |
-| 3, 4 | 処理を中断。エラー内容を表示 |
-
-allaganeye 側で検査不合格を表す exit code は **6**（Security verification failed）を新設する。
-
----
-
-## 6. JSON インターフェース
-
-allaganeye が guard を subprocess で呼び出す際は `--json` フラグを使用する。
-
-### 出力スキーマ
-
-```json
-{
-  "version": "0.1.0",
-  "file": "recording.mkv",
-  "file_size_bytes": 48531234567,
-  "result": "pass",
-  "warnings": 0,
-  "phases": [
-    {
-      "name": "file_level",
-      "result": "pass",
-      "checks": [
-        {
-          "id": "1.1",
-          "name": "magic_bytes",
-          "result": "pass",
-          "detail": "Matroska (EBML)"
-        }
-      ]
-    }
-  ],
-  "timestamp": "2026-04-05T12:00:00+09:00",
-  "duration_ms": 1234
-}
-```
-
-### result フィールドの判定
-
-| 値 | 条件 |
-|---|---|
-| `pass` | 全 Phase が pass（WARN があっても pass） |
-| `fail` | いずれかの Phase で FAIL |
-| `error` | ツール実行エラー |
-
-### 後方互換性
-
-- `version` フィールドで互換性を判定する
-- フィールドの追加は許容（minor バージョン）
-- フィールドの削除・型変更は禁止（major バージョン変更が必要）
-
----
-
-## 7. パッケージ依存管理
-
-### allaganeye 側の pyproject.toml
-
-```toml
-[project.optional-dependencies]
-guard = ["kobutachan-allaganeye-guard"]
-```
-
-- 基本インストールに guard を含めない（オプション依存）
-- `pip install allaganeye[guard]` で guard も一緒にインストール可能
-- guard がなくても allaganeye 本体は正常動作する
-
----
-
-## 8. 外部動画データの検査ルール
+## 5. 外部動画データの検査ルール
 
 GitHub の issue・PR に添付またはリンクされた動画ファイルについて、以下のルールに従う。
 
 | データの出所 | guard 検査 |
 |---|---|
-| Idios が作成した issue/PR の添付・リンク | 不要（自己録画データ） |
+| Idios が作成した issue/PR の添付・リンク | 不要 (自己録画データ) |
 | Idios 以外が作成した issue/PR の添付・リンク | **必須** |
-| 外部ユーザーから直接受領したファイル（§9） | **必須** |
-| `ALLAGANEYE_SAMPLE_VIDEO_DIR` の既存データ | 不要（検証済み） |
+| 外部ユーザーから直接受領したファイル (§6) | **必須** |
+| `ALLAGANEYE_SAMPLE_VIDEO_DIR` の既存データ | 不要 (検証済み) |
 
 ### 検査手順
 
 1. ファイルをダウンロードし、隔離ディレクトリに保存する
-2. guard を最新版に更新する（`git pull && pip install -e .`）。YARA ルールセットは随時更新されるため、古いバージョンでの検査は不十分な可能性がある
+2. guard を最新版に更新する (`git pull && pip install -e .`)。YARA ルールセットは随時更新されるため、古いバージョンでの検査は不十分な可能性がある
 3. `allaganeye-guard verify <file>` を実行する
 4. **PASS するまで allaganeye で処理しない**
-5. guard 未インストールの場合は先にインストールする（§7 参照）
+5. guard 未インストールの場合は先にインストールする ([kobutachan-allaganeye-guard](https://github.com/Idios/kobutachan-allaganeye-guard) リポジトリ参照)
 6. FAIL の場合は処理せず、issue・PR にコメントして提供者に確認を求める
-7. 検査結果（PASS / FAIL）を issue・PR にコメントとして記録する
+7. 検査結果 (PASS / FAIL) を issue・PR にコメントとして記録する
 
 ---
 
-## 9. バグ報告時の運用フロー
+## 6. バグ報告時の運用フロー
 
 外部ユーザーからバグ再現データを受領する際の手順。
 
-### 情報収集（段階的）
+### 情報収集 (段階的)
 
 | Stage | 内容 | 動画データ |
 |---|---|---|
 | 1 | `--verbose` 出力 + `debug-brightness` CSV | 不要 |
-| 2 | 問題箇所周辺を切り出した最小再現動画 | 必要（同意必須） |
-| 3 | フル動画（最終手段） | 必要（同意必須） |
+| 2 | 問題箇所周辺を切り出した最小再現動画 | 必要 (同意必須) |
+| 3 | フル動画 (最終手段) | 必要 (同意必須) |
 
-### 受領時の必須手順
+### 受領時の必須手順 (メンテナ側)
 
-1. Issue Template の同意チェックボックスが全てチェック済みであることを確認
+1. Issue Template (#458 で整備予定) の同意チェックボックスが全てチェック済みであることを確認
 2. ファイルをダウンロードし、隔離ディレクトリに保存
-3. **`allaganeye-guard verify` を実行**（PASS するまで allaganeye で処理しない）
+3. **エージェント (Claude + Idios) が `allaganeye-guard verify` を実行**。PASS するまで allaganeye で処理しない
 4. 調査完了後、ローカルデータを削除し Issue にコメントで報告
 
 ### プライバシー同意
 
-動画ファイルには個人情報（音声、チャットログ、プレイヤー名等）が含まれうる。再現性を保つためデータは改変しない方針のため、提供者から以下の同意を取得する:
+動画ファイルには個人情報 (音声、チャットログ、プレイヤー名等) が含まれうる。再現性を保つためデータは改変しない方針のため、提供者から以下の同意を取得する:
 
 - 個人情報が含まれる可能性の理解
-- 開発者がバグ調査目的で閲覧することへの同意
+- メンテナがバグ調査目的で閲覧することへの同意
 - バグ解決後にデータが削除されることの理解
 
-同意は GitHub Issue Template のチェックボックスで取得する（`.github/ISSUE_TEMPLATE/bug_report.yml`）。
+同意は GitHub Issue Template のチェックボックスで取得する (`.github/ISSUE_TEMPLATE/bug_report.yml`、#458 で整備予定)。なお**セキュリティ検査の実行はメンテナ側の責務**であり、Issue Template ではユーザーに guard 実行を求めない。
 
 ---
 
-## 10. allaganeye 側の実装タスク
+## 参考: 過去の program-integration 計画について
 
-guard 連携のために allaganeye 側で必要な変更。**リリース目標: L2 (v0.2.0)** に統合して実装。
+2026-04-21 以前、本ドキュメントには allaganeye 側に `--verify` CLI オプション、`allaganeye/guard.py` subprocess ラッパー、exit code 6 (SecurityVerificationError)、`pyproject.toml` の `[guard]` optional-deps、`tests/test_guard_integration.py` 統合テスト等を追加する program-integration 計画が含まれていた (旧 §4.2 / §5 / §6 / §7 / §10 / §11)。
 
-| # | 変更内容 | 対象ファイル | 優先度 |
-|---|---|---|---|
-| 1 | exit code 6（Security verification failed）追加 | `exceptions.py`, `docs/cli-spec.md` | P1 |
-| 2 | `--verify` / `--skip-verify` オプション | `cli.py`, `commands/split_matches.py` | P2 |
-| 3 | guard subprocess 呼び出し関数 | 新規 `guard.py` | P2 |
-| 4 | `.github/ISSUE_TEMPLATE/bug_report.yml` | `.github/` | P2 |
-| 5 | バグ報告ガイド | `docs/bug-report-guide.md` | P2 |
-| 6 | 統合テスト | `tests/test_guard_integration.py` | P3 |
-| 7 | `pyproject.toml` の optional-dependencies に guard を追加 | `pyproject.toml` | P1 |
-
----
-
-## 11. 保守と定期見直し
-
-guard はセキュリティツールのため、以下の定期見直しが必要（詳細は guard リポジトリの `docs/maintenance-policy.md`）。
-
-| 対象 | 頻度 | 担当 |
-|---|---|---|
-| YARA ルールセット | 月次 + FFmpeg CVE 公開時 | guard リードエンジニア |
-| コーデック許可リスト | allaganeye レイヤーリリース時 | guard ディレクター |
-| バックエンドツールバージョン | 四半期ごと | guard リードエンジニア |
-| 脅威モデル | 半年ごと | guard ディレクター |
-
-### allaganeye リリース時の連携チェック
-
-allaganeye の各レイヤーリリース時に以下を確認する:
-
-1. guard の最新バージョンとの互換性（JSON スキーマ）
-2. allaganeye が新たに対応したコーデックが guard の許可リストに含まれているか
-3. exit code 体系の衝突がないか
-4. `allaganeye split --verify` の統合テストが通るか
+本方針転換によりこれらの構想は全て破棄し、本ドキュメントからも削除した。関連 issue (#454 / #455 / #456 / #457 / #460) と PR #488 はクローズ済み。復活が必要になった場合は本 §1 「運用原則」を先に見直すこと。

--- a/docs/issue-policy.md
+++ b/docs/issue-policy.md
@@ -39,10 +39,11 @@
 |--------|-----------|
 | `l2a-gui` | L2 GUI 関連 (#105 系) |
 | `l2b-installer` | L2 インストーラ関連 (#106 系) |
-| `l2c-guard` | L2 guard 統合 (`docs/guard-integration.md` §10) |
-| `l2-workflow` | 開発プロセス改善 |
+| `l2-workflow` | 開発プロセス改善 + allaganeye-guard 運用連携 doc 整備 |
 | `l2-decision` | 方針判断が必要な issue |
 | `l1-residual` | L1 残課題 (#412-#440 系) |
+
+> `l2c-guard` ラベルは 2026-04-21 廃止 (guard との program integration 構想を破棄、#454 参照)。関連 doc 整備は `l2-workflow` で追跡。
 
 L3 以降のレイヤーは着手時に適切なスコープラベルを新設する。
 

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -4,7 +4,7 @@ L1 で運用した「マルチセッション・ロール方式」 (director / l
 
 ## 背景
 
-L1 のロール方式は単一スコープ (試合分割) では機能したが、L2 の 3 スコープ並行開発 (GUI / インストーラ / guard 統合) では以下の問題が顕在化する:
+L1 のロール方式は単一スコープ (試合分割) では機能したが、L2 の複数スコープ並行開発 (GUI / インストーラ + 周辺プロセス改善) では以下の問題が顕在化する:
 
 - 4 セッション × 3 スコープ = 12 ワークツリーとなり、ブランチ・コンフリクト管理が困難
 - ロール切り替え (`/assume-role`) の摩擦コストがセッション間往復で増える
@@ -34,17 +34,16 @@ E:/projects/kobutachan-tools/kobutachan-allaganeye/  ← 唯一の worktree (mai
 
 新規 skill の追加は**実際に反復利用されることが判明した時点**で行う (L2 実装開始後、同じプレイブックを 2-3 回使った段階等)。事前に空の skill ファイルは作らない。
 
-### 3 スコープ並行開発のブランチ戦略
+### 複数スコープ並行開発のブランチ戦略
 
-L2 は `develop-0.2.0` を統合先とする。3 スコープは**単一ブランチの統合**で運用する:
+L2 は `develop-0.2.0` を統合先とする。複数スコープは**単一ブランチの統合**で運用する:
 
 ```
 main (リリースタグのみ)
  └── develop-0.2.0 (L2 統合先)
       ├── claude/l2-gui-*            ← GUI 関連作業ブランチ (#105 子)
       ├── claude/l2-installer-*      ← インストーラ作業 (#106 子)
-      ├── claude/l2-guard-*          ← guard 統合 (#N1-N7)
-      ├── claude/l2-workflow-*       ← L2-0 プロセス系
+      ├── claude/l2-workflow-*       ← L2-0 プロセス系 + guard 運用連携 doc
       └── claude/l1-residual-*       ← L1 残課題消化 (#412-#440)
 ```
 
@@ -97,7 +96,7 @@ PR #343 のような「複数 Issue が不完全修正のままクローズさ�
 旧ロール前提の `/check-work` は廃止。新規タスクは以下の手順で発見する:
 
 1. `gh issue list --state open --assignee Idios --sort updated` で最近更新された issue を確認
-2. スコープラベル (`l2a-gui`, `l2b-installer`, `l2c-guard`, `l2-workflow`) でフィルタし、優先度 (`P1-high`) 順に並べる
+2. スコープラベル (`l2a-gui`, `l2b-installer`, `l2-workflow`) でフィルタし、優先度 (`P1-high`) 順に並べる
 3. 着手対象が選ばれたら `/plan` を呼んで実装前の計画を固める
 
 ユーザーが「次に何する?」と聞いた場合、Claude は上記を実施し `AskUserQuestion` で候補提示する。
@@ -130,10 +129,11 @@ PR #343 のような「複数 Issue が不完全修正のままクローズさ�
 
 - `l2a-gui` — GUI 関連 (#105 系)
 - `l2b-installer` — インストーラ関連 (#106 系)
-- `l2c-guard` — guard 統合 (guard-integration.md §10)
-- `l2-workflow` — 開発プロセス改善
+- `l2-workflow` — 開発プロセス改善 + allaganeye-guard 運用連携 doc 整備 (#458 / #459)
 - `l2-decision` — 方針決定 issue
 - `l1-residual` — L1 残課題 (#412-#440 系)
+
+> `l2c-guard` ラベルは 2026-04-21 廃止 (guard との program integration 構想を破棄したため)。関連 doc 整備は `l2-workflow` で追跡。
 
 ### 優先度ラベル (既存維持)
 
@@ -186,7 +186,7 @@ PR #343 のような「複数 Issue が不完全修正のままクローズさ�
 | lead-engineer (設計・レビュー) | Plan モード (設計) + `/review-pr` (レビュー) |
 | engineer (実装) | Claude の通常ツール (Edit/Write/Bash) + TodoWrite |
 | tester (テスト) | 通常セッション内で手動テスト実行 + PR コメント記録 |
-| `role:director` / `role:lead-engineer` / `role:engineer` / `role:tester` ラベル | スコープラベル (`l2-workflow`, `l2a-gui`, `l2b-installer`, `l2c-guard` 等) で代替 |
+| `role:director` / `role:lead-engineer` / `role:engineer` / `role:tester` ラベル | スコープラベル (`l2-workflow`, `l2a-gui`, `l2b-installer` 等) で代替 |
 
 ## タスクフロー (旧ロールハンドオフの代替)
 

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -14,11 +14,11 @@ SemVer に従い、各レイヤーを minor バージョンで区切る。
 | L4: 価値評価 | 0.4.0 | `v0.4.0` | 2026-05-10 |
 | L5: 自動編集 | 0.5.0 | `v0.5.0` | 2026-05-17 |
 
-L2 は 3 スコープを 1 リリースに統合する:
+L2 は以下のスコープを 1 リリースに統合する:
 - GUI サポート (#105)
 - ゼロ環境構築配布 (#106)
-- allaganeye-guard 統合 (`--verify`、exit code 6、`guard.py` ラッパー他 — `docs/guard-integration.md` §10)
 - 開発プロセス刷新 (L2-0: ハイブリッド skill 方式への移行、レビュープロセス改善)
+- allaganeye-guard の運用連携ドキュメント整備 (#458 / #459 — プログラム結合は行わない、`docs/guard-integration.md` 参照)
 
 ### 拡張レイヤー（L6）
 
@@ -41,8 +41,7 @@ main (リリースタグ時のみ更新、L1: v0.1.0-preview / v0.1.1 タグ済�
  └── develop-0.2.0 (L2 開発の統合先)
       ├── claude/l2-gui-*            ← GUI 関連作業 (#105 系)
       ├── claude/l2-installer-*      ← インストーラ作業 (#106 系)
-      ├── claude/l2-guard-*          ← guard 統合 (N1-N7)
-      ├── claude/l2-workflow-*       ← L2-0 プロセス系
+      ├── claude/l2-workflow-*       ← L2-0 プロセス系 + guard 運用連携 doc
       └── claude/l1-residual-*       ← L1 残課題消化 (#412-#440)
 ```
 


### PR DESCRIPTION
## 概要

2026-04-21 方針転換: allaganeye と allaganeye-guard は**プログラムレベルでの結合を行わない**運用原則に確定した。両ツールは独立 CLI として存在し、エージェント (= Claude Code セッションで動くこのアシスタント + 人間メンテナ Idios の両方) が外部動画データを扱う際に、手動で `allaganeye-guard verify` を実行する運用ルールに一本化する。

関連クローズ:
- PR [apps#488](https://github.com/Idios/kobutachan-allaganeye/pull/488) (exit code 6 追加) — クローズ済み
- [#454](https://github.com/Idios/kobutachan-allaganeye/issues/454) exit code 6 (SecurityVerificationError) — クローズ済み
- [#455](https://github.com/Idios/kobutachan-allaganeye/issues/455) `allaganeye/guard.py` subprocess ラッパー — クローズ済み
- [#456](https://github.com/Idios/kobutachan-allaganeye/issues/456) `--verify` / `--skip-verify` CLI オプション — クローズ済み
- [#457](https://github.com/Idios/kobutachan-allaganeye/issues/457) pyproject `[guard]` optional-deps — クローズ済み
- [#460](https://github.com/Idios/kobutachan-allaganeye/issues/460) `tests/test_guard_integration.py` — クローズ済み

運用系 issue (再スコープ):
- [#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) ISSUE_TEMPLATE — ユーザー側 guard verify checkbox を削除、privacy/機密情報 checkbox のみ残す方針に更新、ラベル `l2c-guard` → `l2-workflow`
- [#459](https://github.com/Idios/kobutachan-allaganeye/issues/459) bug-report-guide — §3 (user-side guard 手順) を削除、メンテナ側 guard 実行を §4 に明示する方針に更新、ラベル `l2c-guard` → `l2-workflow`

GitHub ラベル: `l2c-guard` 削除済み (全 issue から自動除去済み、label 本体も削除)。

## 変更ファイル (6 件)

| ファイル | 変更概要 |
|---|---|
| `docs/guard-integration.md` | §4.2 自動呼び出し / §5 allaganeye 側 exit code / §6 JSON インターフェース / §7 optional-deps / §10 実装タスク一覧 / §11 互換性チェックを**完全削除**。§1 概要に**運用原則**を追記。§4 を「使用方法 (手動のみ)」として単一統合方式に再構成。巻末に過去 program-integration 計画の歴史的注記を追加 (231→149 行相当) |
| `CLAUDE.md` | L2 レイヤー表行 14 から「guard 統合」を除外。§セキュリティ検査 を運用連携ベースに書き換え (`--verify` 将来実装 / 互換性チェックの記述を削除)。スコープラベル列挙から `l2c-guard` を削除 |
| `docs/design-overview.md` | L2 レイヤー表の guard 統合記述を削除。§セキュリティ検査 から subprocess 呼び出し方式 / optional-deps 記述を削除、運用連携ベースに書き換え |
| `docs/release-strategy.md` | L2 スコープリストの「`--verify`、exit code 6、`guard.py` ラッパー他」を「guard 運用連携 doc 整備 (#458 / #459)」に置換。ブランチ戦略から `claude/l2-guard-*` を削除し `l2-workflow` に guard doc を吸収 |
| `docs/l2-workflow.md` | 3 スコープ並行開発 → 複数スコープ。ブランチ戦略 / タスク発見 / スコープラベル定義 / 移行対応表から `l2c-guard` 参照を削除。ラベル廃止の歴史的注記を追加 |
| `docs/issue-policy.md` | スコープラベル表から `l2c-guard` 行を削除、廃止注記を追加 |

## 検証

- [x] `python -m ruff check .` — All checks passed!
- [x] `python -m ruff format --check .` — 57 files already formatted
- [x] `python -m pytest` — 686 passed, 37 deselected (slow)
- [x] 全 `l2c-guard` 参照が歴史的注記 (2 箇所: l2-workflow.md, issue-policy.md) 以外から除去されていること
- [x] 全 `--verify` 参照が歴史的注記 (guard-integration.md 巻末) 以外から除去されていること
- [x] 全 exit code 6 参照が歴史的注記以外から除去されていること

## スコープ外

- `allaganeye/exceptions.py` / `allaganeye/cli.py` / `tests/` は無変更 (develop-0.2.0 ベースで元々 exit 6 / SecurityVerificationError は未導入のため)
- #458 / #459 の実装本体 (新規 `.github/ISSUE_TEMPLATE/bug_report.yml` / `docs/bug-report-guide.md`) は別 PR で対応

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)