### PR TITLE
chore(ci): markdownlint MD024 を siblings_only: true で有効化 (Refs #474 Phase 3) [admiring-gates-fcda42]

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -29,9 +29,12 @@ config:
   # 1./2./3. と 1./1./1. の混在を許容する。
   MD029: false
 
-  # MD024 (no-duplicate-heading, 既存 7 件): CHANGELOG の複数バージョン節で
-  # 重複見出し (`### Changed` 等) が構造上必要。
-  MD024: false
+  # MD024 (no-duplicate-heading, #474 Phase 3 で有効化): CHANGELOG の複数
+  # バージョン節で重複見出し (`### Changed` 等) が構造上必要なため、
+  # `siblings_only: true` で同階層 (同じ親見出し直下) の重複のみを禁止する。
+  # 異なる `## [x.y.z]` セクション間の `### Changed` 重複は許容される。
+  MD024:
+    siblings_only: true
 
   # MD041 (first-line-h1, 既存 5 件): 先頭が H1 でないドキュメント
   # (PR テンプレート、skill 定義等) が正当なケースとして存在する。


### PR DESCRIPTION
## Summary

`#474` 段階有効化計画の **フェーズ 3** に対応 (Refs [#474](https://github.com/Idios/kobutachan-allaganeye/issues/474))。

MD024 (`no-duplicate-heading`) を完全 disable から `siblings_only: true` での有効化に切替。CHANGELOG.md の複数バージョン節で同名見出し (`### Changed` / `### Fixed` 等) が異なる `## [x.y.z]` 親の下にある構造を許容しつつ、同階層内 (同じ親見出し直下) の真の重複は検出する。

## 変更内容

| ファイル | 変更 |
|---|---|
| `.markdownlint-cli2.yaml` | MD024 の config 値を `false` → `{siblings_only: true}`。コメントもフェーズ 3 有効化を反映 |

## 設定比較

```yaml
# Before
MD024: false

# After
MD024:
  siblings_only: true
```

## Test plan

- [x] `npx -y markdownlint-cli2@0.18.1` 実行 → `Linting: 33 file(s)` / `Summary: 0 error(s)`
- [x] CHANGELOG.md が既存構造のまま violation 無し (期待動作、siblings_only により許容)

## 受け入れ条件 (#474 Phase 3)

- [x] `siblings_only: true` 設定に変更
- [x] CHANGELOG.md の既存構造を壊さない
- [x] CI (markdownlint workflow) が pass する

## 関連

- Refs [#474](https://github.com/Idios/kobutachan-allaganeye/issues/474) Phase 3

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
