### PR TITLE
fix(preuse-hook): block 時 state 記録を停止 + bypass 運用文書化 (Refs #513)

### DIFF
--- a/.claude/hooks/preuse.py
+++ b/.claude/hooks/preuse.py
@@ -309,16 +309,18 @@ def main() -> int:
     # Pattern 判定 (candidate の command を recent に含めずに判定)
     key, message = _classify(command, recent)
 
-    # Bulk カウント目的で今回の command を state に記録.
-    # 常時 gate と bulk gate のどちらでも、state は更新する (後続判定の
-    # ために今回のコマンドも履歴に入れる).
-    _append_op(state_path, command.strip(), now)
-
     if key is not None:
+        # block された時点では state に記録しない (#513).
+        # 実行されないコマンドを bulk counter に入れると、prefix 付け忘れ
+        # による再試行で counter が累積的に膨張し、閾値を永続的に超えて
+        # 再ブロックが続く不具合になる。bypass 経由で実行された場合のみ
+        # bypass ルート側で記録されるので、実測の実行回数と state が一致する。
         print(
             f"[preuse:{key}] {message}\n"
-            "承認済みの場合は `ALLAGANEYE_PREUSE_BYPASS=1 <command>` で "
-            "再実行してください (1 回分のみ bypass)。\n"
+            "このコマンドは未実行で state にも記録されていません。\n"
+            "ユーザー承認済みの場合は必ず `ALLAGANEYE_PREUSE_BYPASS=1 <command>` "
+            "prefix を付けて再実行してください (1 回分のみ bypass)。\n"
+            "prefix なしで同じコマンドを再送しても同じ理由でブロックされます。\n"
             f"Detected command: {command.strip()[:400]}",
             file=sys.stderr,
         )
@@ -326,6 +328,8 @@ def main() -> int:
         # hook convention).  Claude will pause and escalate to the user.
         return 2
 
+    # Block 通過時のみ state に記録 (bulk カウント用).
+    _append_op(state_path, command.strip(), now)
     return 0
 
 

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -173,6 +173,29 @@ PR #343 のような「複数 Issue が不完全修正のままクローズさ�
 
 **真のハードゲート候補 (未実装)**: `PreToolUse` で `gh` bulk 操作の exit 2 ブロック、GitHub Action でマージブロック。L2 実装中に必要性が顕在化したら別 issue で対応。
 
+#### PreToolUse hook の bypass 運用 (#485 / #513)
+
+`preuse.py` が exit 2 でブロックした `gh` コマンドは、ユーザー承認後に `ALLAGANEYE_PREUSE_BYPASS=1 <command>` prefix を付けて再実行することで 1 回分だけ通過できる (`_BYPASS_PREFIX` 正規表現)。
+
+運用手順:
+
+1. Claude が `gh` コマンドを発行 → hook が bulk 閾値 (3 件 / 60s) または always gate (PR マージ等) でブロック (exit 2)
+2. Claude は `AskUserQuestion` でサンプル 1 件を提示し、**「全件 OK / 個別調整 / やめる」** の 3 択を問う (Iron Law 2)
+3. ユーザーが承認したら、該当コマンドに `ALLAGANEYE_PREUSE_BYPASS=1 ` prefix を付けて再実行する
+
+   ```bash
+   ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 123
+   ```
+
+4. prefix は strip されて `gh issue close 123` が実行される。`[preuse:bypass]` 監査ログが stderr に出力され、実行コマンド本体のみが state (`.claude/state/recent_ops.json`) に記録され、以降の bulk 判定に正しく参入する
+
+重要ポイント:
+
+- prefix は **1 コマンドごとに都度付与** する。bulk 承認を得た場合でも各コマンドに個別に付ける (1 回分のみ bypass の仕様)
+- **ブロックされたコマンドは state に記録されない** (#513)。prefix を付け忘れて素の再送をしても、counter が累積膨張することはなく同じ理由で再ブロックされるだけ
+- `ALLAGANEYE_PREUSE_BYPASS=0` 等は認識されない (prefix 正規表現は `=1` 固定)
+- `.claude/settings.local.json` で `"pretooluse_gate": false` を設定すると gate 全体を無効化できる (緊急避難用、通常は true = デフォルト)
+
 ## 移行前後の対応表
 
 旧 → 新の変換:

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -181,7 +181,7 @@ PR #343 のような「複数 Issue が不完全修正のままクローズさ�
 
 1. Claude が `gh` コマンドを発行 → hook が bulk 閾値 (3 件 / 60s) または always gate (PR マージ等) でブロック (exit 2)
 2. Claude は `AskUserQuestion` でサンプル 1 件を提示し、**「全件 OK / 個別調整 / やめる」** の 3 択を問う (Iron Law 2)
-3. ユーザーが承認したら、該当コマンドに `ALLAGANEYE_PREUSE_BYPASS=1 ` prefix を付けて再実行する
+3. ユーザーが承認したら、該当コマンドに `ALLAGANEYE_PREUSE_BYPASS=1` prefix (末尾スペース込み) を付けて再実行する
 
    ```bash
    ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 123

--- a/tests/test_preuse_hook.py
+++ b/tests/test_preuse_hook.py
@@ -167,9 +167,12 @@ def test_bypass_counts_toward_subsequent_bulk(_isolated_paths, monkeypatch):
     """Bypassed close still adds to the 60s window for non-bypassed retries."""
     _invoke(_bash_event("gh issue close 1"), monkeypatch)
     _invoke(_bash_event("gh issue close 2"), monkeypatch)
-    _invoke(_bash_event("gh issue close 3"), monkeypatch)  # blocked & recorded
+    _invoke(
+        _bash_event("gh issue close 3"), monkeypatch
+    )  # blocked (NOT recorded, #513)
     _invoke(_bash_event("ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 3"), monkeypatch)
-    # Next un-prefixed close is still blocked -- counter includes the bypass.
+    # Next un-prefixed close is still blocked -- bypass entry (3 in window)
+    # plus current (4) exceed threshold=3.
     rc, _ = _invoke(_bash_event("gh issue close 4"), monkeypatch)
     assert rc == 2
 
@@ -351,6 +354,70 @@ def test_missing_tool_input(_isolated_paths, monkeypatch):
     event = {"tool_name": "Bash"}
     rc, _ = _invoke(event, monkeypatch)
     assert rc == 0
+
+
+# ---------------------------------------------------------------
+# State hygiene: blocked commands must NOT inflate bulk counters (#513)
+# ---------------------------------------------------------------
+
+
+def test_blocked_bulk_command_not_recorded(_isolated_paths, monkeypatch):
+    """Blocked bulk command must not be recorded to state (#513 A).
+
+    Previously every blocked invocation was appended to state, so the
+    bulk counter included ghost entries for commands that never ran.
+    """
+    _invoke(_bash_event("gh issue close 1"), monkeypatch)
+    _invoke(_bash_event("gh issue close 2"), monkeypatch)
+    rc, _ = _invoke(_bash_event("gh issue close 3"), monkeypatch)
+    assert rc == 2
+    data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
+    # Only the two allowed closes are recorded; the blocked 3rd is dropped.
+    assert len(data) == 2
+    assert all("close 3" not in entry.get("cmd", "") for entry in data)
+
+
+def test_blocked_always_gated_command_not_recorded(_isolated_paths, monkeypatch):
+    """Blocked always-mode pr_merge must not create any state entry (#513)."""
+    rc, _ = _invoke(_bash_event("gh pr merge 42 --squash"), monkeypatch)
+    assert rc == 2
+    if _isolated_paths["state"].exists():
+        data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
+        assert data == []
+
+
+def test_forgotten_bypass_retry_does_not_inflate_counter(_isolated_paths, monkeypatch):
+    """Un-prefixed retries of a blocked command must not grow state (#513).
+
+    Regression guard for the scenario: Claude forgets the bypass prefix
+    and retries the same command multiple times.  Previously every attempt
+    was appended to state, so bulk counters would grow indefinitely even
+    though no command actually ran.  With the fix, state is unchanged
+    after any number of un-prefixed retries, and the subsequent
+    user-approved bypass adds exactly one entry.
+    """
+    _invoke(_bash_event("gh issue close 1"), monkeypatch)
+    _invoke(_bash_event("gh issue close 2"), monkeypatch)
+    for _ in range(5):
+        rc, _ = _invoke(_bash_event("gh issue close 3"), monkeypatch)
+        assert rc == 2
+    data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
+    assert len(data) == 2
+    rc, _ = _invoke(
+        _bash_event("ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 3"), monkeypatch
+    )
+    assert rc == 0
+    data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
+    assert len(data) == 3
+
+
+def test_block_message_mentions_state_not_recorded(_isolated_paths, monkeypatch):
+    """Block stderr explains both bypass prefix and state hygiene (#513 B)."""
+    _invoke(_bash_event("gh issue create --title a"), monkeypatch)
+    _invoke(_bash_event("gh issue create --title b"), monkeypatch)
+    _, err = _invoke(_bash_event("gh issue create --title c"), monkeypatch)
+    assert "ALLAGANEYE_PREUSE_BYPASS=1" in err
+    assert "記録" in err
 
 
 # ---------------------------------------------------------------


### PR DESCRIPTION
## 概要

`.claude/hooks/preuse.py` の PreToolUse gate で、block 判定後にも `_append_op` が呼ばれていたため state に ghost 記録が残り、ユーザー承認後に `ALLAGANEYE_PREUSE_BYPASS=1` prefix を付け忘れて再試行すると bulk counter が累積膨張し、閾値を下回っても永続的に再ブロックされる不具合 (Refs #513) を修正する。併せて stderr ブロックメッセージと `docs/l2-workflow.md` で bypass 運用フローを強化する。

## 変更点

- **A: state hygiene 修正** (`.claude/hooks/preuse.py`): `_append_op` を block 判定 (return 2) の後へ移動。block された未実行コマンドは state に記録されなくなり、prefix 付け忘れ retry で counter が膨張しなくなる。bypass ルート (`_BYPASS_PREFIX.match` ヒット時) の `_append_op` は変更なし (実行される bypass 付きコマンドは引き続き bulk counter に載せる)
- **B-1: stderr メッセージ強化** (`.claude/hooks/preuse.py`): ブロックメッセージを「コマンドが未実行で state に記録されていない」「`ALLAGANEYE_PREUSE_BYPASS=1 <command>` prefix を必ず付けて再実行」「prefix なしの再送は同じ理由でブロックされる」と明示的に誘導
- **B-2: ドキュメント整備** (`docs/l2-workflow.md`): §「強制メカニズム」に「PreToolUse hook の bypass 運用 (#485 / #513)」サブセクションを新設し、block → `AskUserQuestion` → 承認後 prefix 付きで再実行の 4 ステップ運用フローと重要ポイント (prefix は 1 コマンドごと、block 時は state 記録されない、`=0` は不可、settings で全体 off 可) を記載
- **テスト追加** (`tests/test_preuse_hook.py`): state hygiene 回帰テスト 4 件を新設 (bulk / always の block 時に state 非記録、prefix 忘れ retry 5 連発で counter 不変、block メッセージに「記録」文言を含む)。既存 `test_bypass_counts_toward_subsequent_bulk` のコメントを本修正後の挙動 (`# blocked (NOT recorded, #513)`) に更新

## 受け入れ基準 / 確認項目 (Iron Law 1: 逐条検証)

- [x] `.claude/hooks/preuse.py` で block 時は `_append_op` が呼ばれないことを単体テストで確認 — 対応 diff: `.claude/hooks/preuse.py:311-329` / 対応 test: `tests/test_preuse_hook.py::test_blocked_bulk_command_not_recorded`, `::test_blocked_always_gated_command_not_recorded`
- [x] bypass ルート (`ALLAGANEYE_PREUSE_BYPASS=1` prefix) では従来どおり `_append_op` が呼ばれることを単体テストで確認 — 対応 diff: `.claude/hooks/preuse.py:295-305` (変更なし) / 対応 test: `tests/test_preuse_hook.py::test_bypass_records_stripped_command_to_state` (既存) および `::test_forgotten_bypass_retry_does_not_inflate_counter` 後半で bypass 1 回分が記録されることを assert
- [x] stderr ブロックメッセージで bypass prefix の必須性が強調されていることを目視確認 — 対応 diff: `.claude/hooks/preuse.py:318-325` / 対応 test: `tests/test_preuse_hook.py::test_bypass_block_message_mentions_bypass_option` (既存), `::test_block_message_mentions_state_not_recorded` (新規: 「記録」文言も検証)
- [x] CLAUDE.md または `docs/l2-workflow.md` に bypass prefix の使い方が記載されていることを確認 — 対応 diff: `docs/l2-workflow.md:175-198` に「PreToolUse hook の bypass 運用 (#485 / #513)」サブセクション新設
- [x] 既存テスト (`tests/test_preuse_hook.py` 既存 29 件) が通る — `python -m pytest tests/test_preuse_hook.py` で 33/33 pass (既存 29 + 新規 4)
- [x] bulk モード gate の「block → 承認済み bypass → 連続実行」回帰シナリオを新規テストで追加 — 対応 test: `tests/test_preuse_hook.py::test_forgotten_bypass_retry_does_not_inflate_counter` (block → 5 連発 retry (rc=2 / state 不変) → bypass 承認 (rc=0 / state +1))

## PR チェックリスト (Iron Law 遵守確認)

### Iron Law 1: 受け入れ条件検証

- [x] 元 issue の `## 受け入れ条件` を上記で逐条検証した
- [x] UI/出力変更の場合、実サンプル (CLI 出力・スクリーンショット) を本文に添付した — 該当なし (hook stderr は内部動作、テストで文字列アサート済み)

### Iron Law 3: スコープ遵守 (scope-guard)

- [x] 変更ファイルがすべて元 issue のスコープ内であることを確認した (`git diff --stat` で確認) — 変更 3 ファイル: `.claude/hooks/preuse.py` (A/B-1), `docs/l2-workflow.md` (B-2), `tests/test_preuse_hook.py` (受け入れ条件テスト)
- [x] スコープ外変更がある場合、その理由と対応する子 issue 番号を「## 備考」に記載した — 該当なし

### Iron Law 4: クローズキーワード禁止

- [x] 本文・コミットメッセージに `Closes` / `Fixes` / `Resolves` キーワードが含まれていない (issue クローズは手動)

### 品質ゲート

- [x] 全テスト通過 (`pytest`) — `python -m pytest` で 699 pass / 37 deselected (slow marker)
- [x] Lint 通過 (`ruff check .` + `ruff format --check .`) — 変更 2 ファイルで All checks passed / format 適用済み
- [x] 型チェック通過 (`pyright`) — `python -m pyright .claude/hooks/preuse.py tests/test_preuse_hook.py` で 0 errors
- [x] 関連ドキュメント更新 — `docs/l2-workflow.md` に bypass 運用サブセクを追記 (受け入れ条件の一つ)
- [x] **新規 CLI オプション追加時**: `docs/output-spec.md` のマトリクス更新 (#405) — 該当なし (hook 内部の修正、CLI オプション追加なし)
- [x] CLAUDE.md / `docs/l2-workflow.md` の更新要否確認 — `docs/l2-workflow.md` に bypass 運用を追記。CLAUDE.md は hook 関連記述なし (本件でも追加不要と判断)
- [x] 出力書式を変更した場合、`docs/cli-spec.md` の該当出力例も更新 — 該当なし (CLI 出力書式は変更していない)

## 関連

- Refs #513
- Refs #485 / PR #491 (bypass prefix 機構の前段)
- Refs #401 (PreToolUse hook 実装の起点)
- Base branch: `develop-0.2.0`
- Session: `nervous-aryabhata-7eaca1`

## 備考

- `mode=always` gate (`pr_merge`) は bulk counter を参照しないので A の修正で挙動変化はなし。ただし「block 時に state 記録しない」方針の一貫性から pr_merge も同じパスを通る (`test_blocked_always_gated_command_not_recorded` でカバー)
- 既存 `test_bypass_counts_toward_subsequent_bulk` はシナリオ結果 (rc=2) が維持されるためテストコード自体の変更は最小 (コメントのみ) だが、内部 state の構成は変わっている (ghost なし + bypass 1 件のみで threshold 到達)
