### PR TITLE
fix(detector): scorebar V2 で emblem 位置を動的検出し 4K Game DVR 対応 (Refs #522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- scorebar V2 で emblem 位置を 1080p 固定座標から動的検出に変更し、4K Game DVR 録画で試合境界が認識できない問題を改善 (#522)
+- scorebar V2 (`_has_scorebar_v2`) を two-path OR semantics に変更 (Primary=absolute `_EMBLEM_POSITIONS` + Rescue=dynamic span + `_EMBLEM_RELATIVE_POSITIONS`)。1080p OBS validated set (20260116/118/119/219) は Primary で完全無回帰、4K Game DVR の HUD scale 差異は Rescue path で救済 (#522)
 
 ## [0.1.1] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- scorebar V2 で emblem 位置を 1080p 固定座標から動的検出に変更し、4K Game DVR 録画で試合境界が認識できない問題を改善 (#522)
+
 ## [0.1.1] - 2026-04-20
 
 L1 (試合分割) の正式リリース版。2026-04-17 に `v0.1.0-preview` として公開後、品質向上を経て `v0.1.1` として正式リリース。verbose 出力の網羅的改善、GPU/CPU 検知精度の一致、進捗バー UX 修正、メタデータ拡充、運用ルール強化。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 7. 各暗転候補の ±5s を 0.25s 間隔で再プローブし、正確な持続時間を計測
 
 **スコアバーフィルタリング**（`src_resolution` 提供時、CLIのデフォルトパス）
-8. `filter_blackouts_with_scorebar()` で各暗転領域の前後フレームのスコアバー有無を判定し、暗転を分類（`match_boundary` / `in_match` / `non_fl`）。V2 検出 (`_has_scorebar_v2`) は 1920x1080 リサイズ後に `_find_scorebar_horizontal_range` で scorebar 外輪郭を動的検出し、emblem 位置を相対比 (`_EMBLEM_RELATIVE_POSITIONS`) で計算してから GC 紋章 3 点 AND 判定する (#307, #522)。1080p OBS と 4K Game DVR の HUD スケール差異に対応。span 検出失敗時は V1 (`_has_scorebar`, channel-std + edge) へフォールバック
+8. `filter_blackouts_with_scorebar()` で各暗転領域の前後フレームのスコアバー有無を判定し、暗転を分類（`match_boundary` / `in_match` / `non_fl`）。V2 検出 (`_has_scorebar_v2`) は 1920x1080 リサイズ後に **two-path OR semantics** で GC 紋章 3 点 AND 判定 (#307, #522): **Primary=absolute `_EMBLEM_POSITIONS`** (pre-#522 validated)、**Rescue=dynamic span (`_find_scorebar_horizontal_range`) + `_EMBLEM_RELATIVE_POSITIONS` 相対比**。Primary pass で short-circuit、両 path fail で False。`raw_rgb` None / opencv 未インストール時のみ None → V1 (`_has_scorebar`, channel-std + edge) フォールバック。1080p OBS validated set の挙動を完全保持しつつ 4K Game DVR の HUD スケール差異は Rescue で救済
 9. `non_fl`（非FL暗転）と短い `in_match`（試合内暗転）を除外。隣接する `match_boundary` ペア間の短いギャップをマージ
 
 **音声昇格**（`--no-audio` 未指定時、#288）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 7. 各暗転候補の ±5s を 0.25s 間隔で再プローブし、正確な持続時間を計測
 
 **スコアバーフィルタリング**（`src_resolution` 提供時、CLIのデフォルトパス）
-8. `filter_blackouts_with_scorebar()` で各暗転領域の前後フレームのスコアバー有無を判定し、暗転を分類（`match_boundary` / `in_match` / `non_fl`）
+8. `filter_blackouts_with_scorebar()` で各暗転領域の前後フレームのスコアバー有無を判定し、暗転を分類（`match_boundary` / `in_match` / `non_fl`）。V2 検出 (`_has_scorebar_v2`) は 1920x1080 リサイズ後に `_find_scorebar_horizontal_range` で scorebar 外輪郭を動的検出し、emblem 位置を相対比 (`_EMBLEM_RELATIVE_POSITIONS`) で計算してから GC 紋章 3 点 AND 判定する (#307, #522)。1080p OBS と 4K Game DVR の HUD スケール差異に対応。span 検出失敗時は V1 (`_has_scorebar`, channel-std + edge) へフォールバック
 9. `non_fl`（非FL暗転）と短い `in_match`（試合内暗転）を除外。隣接する `match_boundary` ペア間の短いギャップをマージ
 
 **音声昇格**（`--no-audio` 未指定時、#288）

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -576,6 +576,23 @@ _EMBLEM_POSITIONS: list[tuple[str, int, int, int, int]] = [
     ("right", 1263, 2, 1318, 40),
 ]
 
+# Legacy absolute coordinates above are kept for reference and for tests
+# that exercise fixed-layout frame builders.  Production code uses
+# ``_EMBLEM_RELATIVE_POSITIONS`` with ``_find_scorebar_horizontal_range``
+# to follow HUD scale variations (1080p OBS vs 4K Game DVR) -- see #522.
+#
+# Ratios measured against dynamically-detected scorebar span on 13
+# in-match frames across 3 OBS 1080p recordings (20260116/20260118/
+# 20260119) on 2026-04-22.  half-width ratios equal current absolute
+# half-widths (32.5 / 17 / 27.5 px) divided by median detected span
+# (717 px).  See .scorebar_measure_emblem.py for the measurement script.
+_EMBLEM_RELATIVE_POSITIONS: list[tuple[str, float, float, int, int]] = [
+    # (name, x_rel_center, half_width_rel, y1, y2)
+    ("left", 0.0455, 0.0453, 2, 40),
+    ("center", 0.3427, 0.0237, 22, 42),
+    ("right", 0.9638, 0.0384, 2, 40),
+]
+
 _EMBLEM_SAT_THRESHOLD = 70.0
 """Minimum mean HSV saturation (of bright pixels) at each emblem position.
 
@@ -599,6 +616,58 @@ Validated: 5 recordings, 156+ non-match frames, zero 3-position FP.
 
 # Method selector: "v2" (GC-emblem 3-point AND) or "v1" (channel-std).
 _SCOREBAR_METHOD: str = "v2"
+
+
+# ---------------------------------------------------------------------------
+# Scorebar horizontal range detection (V2 dynamic positioning, #522)
+# ---------------------------------------------------------------------------
+# The scorebar's horizontal extent varies between recording setups:
+# 1080p OBS captures draw it nearly full-width, while 4K Game DVR draws
+# it narrower and more centered (HUD-scale / render-range / window-mode
+# differences -- not a resolution-scaling artifact).  V2 emblem detection
+# locates the scorebar dynamically and computes emblem positions as
+# ratios of that range, replacing hardcoded absolute coordinates.
+
+_SCOREBAR_SCAN_Y_START = 0
+_SCOREBAR_SCAN_Y_END = 45
+"""Vertical slice (pixel rows) to analyze for scorebar horizontal extent.
+
+Covers y=0..45 in the 1920x1080 probe frame to include the colored band
+without stepping into emblem glyphs below.  Both 1080p OBS and 4K Game
+DVR captures place the FL scorebar within this row range.
+"""
+
+_SCOREBAR_SCAN_SAT_THRESHOLD = 80.0
+"""Minimum per-pixel HSV saturation to qualify as a scorebar pixel.
+
+FL scorebar red/blue/yellow bands show saturation typically >= 150.
+Lobby backgrounds show median saturation 66-79.  80 sits in the gap.
+"""
+
+_SCOREBAR_SCAN_VAL_THRESHOLD = 60.0
+"""Minimum per-pixel HSV value (brightness) to exclude dark frames."""
+
+_SCOREBAR_SCAN_COL_RATIO = 0.30
+"""Fraction of rows in scan ROI that must be saturated for a column.
+
+Robust against anti-aliased band edges and thin sub-pixel details.
+"""
+
+_SCOREBAR_SCAN_MIN_WIDTH_PX = 500
+"""Minimum detected span (pixels) to accept as scorebar.
+
+1080p OBS scorebar spans ~712-1090 px.  4K Game DVR in-match span is
+~613-620 px.  The floor of 500 safely clears both while rejecting 4K
+Game DVR lobby UI artifacts (observed: ~409 px width at screen-top
+minimap/content-name widget).  Confirmed during #522 validation.
+"""
+
+_SCOREBAR_SCAN_MAX_GAP_PX = 80
+"""Maximum gap (pixels) to bridge when merging saturated runs.
+
+Center of scorebar contains a timer / score-number gap of desaturated
+columns; 80px covers it without merging across separate UI elements.
+"""
 
 
 def _probe_frame_rgb_hires(video_path: Path, timestamp: float) -> bytes | None:
@@ -646,27 +715,109 @@ def _probe_frame_rgb_hires(video_path: Path, timestamp: float) -> bytes | None:
     return result.stdout[:rgb_size]
 
 
+def _find_scorebar_horizontal_range(raw_rgb: bytes) -> tuple[int, int] | None:
+    """Detect horizontal extent [x_left, x_right] of the FL scorebar.
+
+    Scans rows y=``_SCOREBAR_SCAN_Y_START``..``_SCOREBAR_SCAN_Y_END`` of a
+    1920x1080 RGB frame, counts columns where at least
+    ``_SCOREBAR_SCAN_COL_RATIO`` of rows have HSV saturation
+    > ``_SCOREBAR_SCAN_SAT_THRESHOLD`` AND value
+    > ``_SCOREBAR_SCAN_VAL_THRESHOLD``.  The longest contiguous run of
+    saturated columns (bridging gaps up to ``_SCOREBAR_SCAN_MAX_GAP_PX``)
+    becomes the scorebar span.
+
+    Returns ``(x_left, x_right)`` with both endpoints inclusive when the
+    detected span is at least ``_SCOREBAR_SCAN_MIN_WIDTH_PX`` wide.
+    Returns ``None`` when:
+
+    - cv2 is not installed (matches V2 "None -> V1 fallback" contract),
+    - no saturated run is found (lobby / loading / all-dark frame), or
+    - the longest run is narrower than the minimum width.
+    """
+    try:
+        import cv2
+    except ImportError:
+        return None
+
+    width = _SCOREBAR_V2_PROBE_WIDTH
+    height = _SCOREBAR_V2_PROBE_HEIGHT
+    frame = np.frombuffer(raw_rgb, dtype=np.uint8).reshape(height, width, 3)
+
+    top = frame[_SCOREBAR_SCAN_Y_START:_SCOREBAR_SCAN_Y_END, :, :]
+    bgr = cv2.cvtColor(top, cv2.COLOR_RGB2BGR)
+    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    sat = hsv[:, :, 1].astype(np.float32)
+    val = hsv[:, :, 2].astype(np.float32)
+
+    pixel_mask = (sat > _SCOREBAR_SCAN_SAT_THRESHOLD) & (
+        val > _SCOREBAR_SCAN_VAL_THRESHOLD
+    )
+    col_fraction = pixel_mask.mean(axis=0)
+    col_saturated = col_fraction >= _SCOREBAR_SCAN_COL_RATIO
+
+    raw_runs: list[tuple[int, int]] = []
+    i = 0
+    while i < width:
+        if col_saturated[i]:
+            j = i
+            while j < width and col_saturated[j]:
+                j += 1
+            raw_runs.append((i, j - 1))
+            i = j
+        else:
+            i += 1
+
+    if not raw_runs:
+        return None
+
+    merged: list[tuple[int, int]] = [raw_runs[0]]
+    for start, end in raw_runs[1:]:
+        prev_start, prev_end = merged[-1]
+        if start - prev_end - 1 <= _SCOREBAR_SCAN_MAX_GAP_PX:
+            merged[-1] = (prev_start, end)
+        else:
+            merged.append((start, end))
+
+    longest = max(merged, key=lambda r: r[1] - r[0])
+    span_width = longest[1] - longest[0] + 1
+    if span_width < _SCOREBAR_SCAN_MIN_WIDTH_PX:
+        return None
+
+    return longest
+
+
 def _has_scorebar_v2(raw_rgb: bytes | None) -> bool | None:
     """Determine if FL scorebar is present using GC-emblem 3-point AND.
 
-    Checks 3 fixed positions in the scorebar where GC emblems appear
-    (left/center/right).  At each position, computes HSV saturation and
-    Sobel edge density.  Returns True only if ALL 3 positions exceed
-    both thresholds (AND condition).
+    Dynamically locates the scorebar horizontal range
+    (``_find_scorebar_horizontal_range``) to follow HUD scale variations
+    across recording setups (1080p OBS full-width, 4K Game DVR
+    narrow-centered, etc.), then checks 3 emblem positions at relative
+    offsets within that range (``_EMBLEM_RELATIVE_POSITIONS``).  At each
+    position computes HSV saturation and Sobel edge density.  Returns
+    ``True`` only if ALL 3 positions exceed both thresholds (AND).
 
     This exploits the structural invariant that FL scorebar always has
-    3 GC emblems at fixed positions, while lobby backgrounds never have
-    high-saturation + high-edge-density content at all 3 positions
-    simultaneously.
+    3 GC emblems at the same horizontal ratios within the bar, while
+    lobby backgrounds never have high-saturation + high-edge-density
+    content at all 3 positions simultaneously.
 
     Requires 1920x1080 input (see ``_probe_frame_rgb_hires``).
 
-    Returns True if scorebar detected, False if not, or None if probe
-    failed (raw_rgb is None).
+    Returns ``True`` if scorebar detected, ``False`` if emblems fail the
+    AND check, or ``None`` if:
+
+    - probe failed (``raw_rgb`` is None),
+    - opencv is not installed, or
+    - the scorebar horizontal range cannot be located (#522).
+
+    The ``None`` contract lets ``_probe_scorebar_context`` fall back to
+    V1 (channel-std) detection.
 
     Validated on 5 recordings (0408/0209/0116/0118/0119):
     - 156+ non-match frames: zero FP
     - In-match TPR: 98.7% (FN only on UI-hidden transition frames)
+    - 4K Game DVR regression fix: #522 (2026-04-22)
     """
     if raw_rgb is None:
         return None
@@ -680,11 +831,25 @@ def _has_scorebar_v2(raw_rgb: bytes | None) -> bool | None:
         )
         return None
 
+    # Dynamically locate the scorebar horizontal range to accommodate
+    # different HUD layouts (1080p OBS full-width vs 4K Game DVR
+    # narrow-centered).  #522.
+    span = _find_scorebar_horizontal_range(raw_rgb)
+    if span is None:
+        logger.debug("scorebar_v2: no horizontal range detected -> None (V1 fallback)")
+        return None
+    x_left, x_right = span
+    bar_width = x_right - x_left
+
     width = _SCOREBAR_V2_PROBE_WIDTH
     height = _SCOREBAR_V2_PROBE_HEIGHT
     frame = np.frombuffer(raw_rgb, dtype=np.uint8).reshape(height, width, 3)
 
-    for name, x1, y1, x2, y2 in _EMBLEM_POSITIONS:
+    for name, cx_rel, hw_rel, y1, y2 in _EMBLEM_RELATIVE_POSITIONS:
+        cx = x_left + cx_rel * bar_width
+        half = hw_rel * bar_width
+        x1 = int(cx - half)
+        x2 = int(cx + half)
         region = frame[y1:y2, x1:x2, :]
         bgr = cv2.cvtColor(region, cv2.COLOR_RGB2BGR)
         hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
@@ -706,16 +871,20 @@ def _has_scorebar_v2(raw_rgb: bytes | None) -> bool | None:
 
         if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
             logger.debug(
-                "scorebar_v2: %s sat=%.1f edge=%.1f -> fail (th: sat>%.0f edge>%.0f)",
+                "scorebar_v2: %s x=%d..%d sat=%.1f edge=%.1f -> fail",
                 name,
+                x1,
+                x2,
                 mean_sat,
                 edge_density,
-                _EMBLEM_SAT_THRESHOLD,
-                _EMBLEM_EDGE_THRESHOLD,
             )
             return False
 
-    logger.debug("scorebar_v2: all 3 positions passed -> True")
+    logger.debug(
+        "scorebar_v2: span=%d..%d all 3 positions passed -> True",
+        x_left,
+        x_right,
+    )
     return True
 
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -786,38 +786,92 @@ def _find_scorebar_horizontal_range(raw_rgb: bytes) -> tuple[int, int] | None:
     return longest
 
 
+def _emblem_and_check(
+    frame: "np.ndarray",
+    positions: list[tuple[str, int, int, int, int]],
+    path_label: str,
+    cv2_module,
+) -> bool:
+    """Evaluate 3-point emblem AND on the given positions.
+
+    Returns True if ALL 3 emblems pass sat/edge thresholds, otherwise
+    False.  Each position is ``(name, x1, y1, x2, y2)``.
+    """
+    for name, x1, y1, x2, y2 in positions:
+        region = frame[y1:y2, x1:x2, :]
+        bgr = cv2_module.cvtColor(region, cv2_module.COLOR_RGB2BGR)
+        hsv = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2HSV)
+        gray = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2GRAY)
+
+        # Saturation of bright pixels (exclude very dark pixels)
+        val = hsv[:, :, 2].astype(np.float32)
+        sat = hsv[:, :, 1].astype(np.float32)
+        bright_mask = val > 30
+        if bright_mask.sum() > 5:
+            mean_sat = float(sat[bright_mask].mean())
+        else:
+            mean_sat = 0.0
+
+        # Edge density (Sobel magnitude)
+        sobel_x = cv2_module.Sobel(gray, cv2_module.CV_64F, 1, 0, ksize=3)
+        sobel_y = cv2_module.Sobel(gray, cv2_module.CV_64F, 0, 1, ksize=3)
+        edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
+
+        if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
+            logger.debug(
+                "scorebar_v2 (%s): %s x=%d..%d sat=%.1f edge=%.1f -> fail",
+                path_label,
+                name,
+                x1,
+                x2,
+                mean_sat,
+                edge_density,
+            )
+            return False
+    logger.debug("scorebar_v2 (%s): all 3 positions passed -> True", path_label)
+    return True
+
+
 def _has_scorebar_v2(raw_rgb: bytes | None) -> bool | None:
     """Determine if FL scorebar is present using GC-emblem 3-point AND.
 
-    Dynamically locates the scorebar horizontal range
-    (``_find_scorebar_horizontal_range``) to follow HUD scale variations
-    across recording setups (1080p OBS full-width, 4K Game DVR
-    narrow-centered, etc.), then checks 3 emblem positions at relative
-    offsets within that range (``_EMBLEM_RELATIVE_POSITIONS``).  At each
-    position computes HSV saturation and Sobel edge density.  Returns
-    ``True`` only if ALL 3 positions exceed both thresholds (AND).
+    Two-path evaluation with OR semantics:
 
-    This exploits the structural invariant that FL scorebar always has
-    3 GC emblems at the same horizontal ratios within the bar, while
-    lobby backgrounds never have high-saturation + high-edge-density
-    content at all 3 positions simultaneously.
+    1. **Primary**: absolute coordinates (``_EMBLEM_POSITIONS``).
+       This preserves the pre-#522 behavior validated on 5 recordings
+       (0408/0209/0116/0118/0119) with 156+ non-match frames and zero
+       FP.  Returns True immediately on AND pass (short-circuit).
+    2. **Secondary**: dynamic scorebar horizontal range detection
+       (``_find_scorebar_horizontal_range``) with emblem positions
+       computed from ``_EMBLEM_RELATIVE_POSITIONS``.  This handles
+       HUD-scale variations such as 4K Game DVR's narrow-centered
+       scorebar (#522).  Evaluated only if Primary returned False.
+       Returns True on AND pass.
+
+    OR semantics ensures 1080p OBS validated set stays FP-free (Primary
+    is authoritative), while 4K Game DVR recordings (where Primary fails
+    due to scorebar layout offset) gain a rescue path via Secondary.
+
+    At each position computes HSV saturation and Sobel edge density.
+    Returns True only if all 3 positions in the same path exceed both
+    thresholds (``_EMBLEM_SAT_THRESHOLD``, ``_EMBLEM_EDGE_THRESHOLD``).
 
     Requires 1920x1080 input (see ``_probe_frame_rgb_hires``).
 
-    Returns ``True`` if scorebar detected, ``False`` if emblems fail the
-    AND check, or ``None`` if:
+    Returns ``True`` if scorebar detected by either path, ``False`` if
+    both paths fail, or ``None`` if:
 
-    - probe failed (``raw_rgb`` is None),
-    - opencv is not installed, or
-    - the scorebar horizontal range cannot be located (#522).
+    - probe failed (``raw_rgb`` is None), or
+    - opencv is not installed.
 
     The ``None`` contract lets ``_probe_scorebar_context`` fall back to
     V1 (channel-std) detection.
 
     Validated on 5 recordings (0408/0209/0116/0118/0119):
-    - 156+ non-match frames: zero FP
+    - 156+ non-match frames: zero FP (Primary)
     - In-match TPR: 98.7% (FN only on UI-hidden transition frames)
-    - 4K Game DVR regression fix: #522 (2026-04-22)
+    - 4K Game DVR regression fix: #522 (2026-04-22) -- Secondary
+    - 20260219 long-recording regression fix: #522 two-path (2026-04-23)
     """
     if raw_rgb is None:
         return None
@@ -831,61 +885,35 @@ def _has_scorebar_v2(raw_rgb: bytes | None) -> bool | None:
         )
         return None
 
-    # Dynamically locate the scorebar horizontal range to accommodate
-    # different HUD layouts (1080p OBS full-width vs 4K Game DVR
-    # narrow-centered).  #522.
-    span = _find_scorebar_horizontal_range(raw_rgb)
-    if span is None:
-        logger.debug("scorebar_v2: no horizontal range detected -> None (V1 fallback)")
-        return None
-    x_left, x_right = span
-    bar_width = x_right - x_left
-
     width = _SCOREBAR_V2_PROBE_WIDTH
     height = _SCOREBAR_V2_PROBE_HEIGHT
     frame = np.frombuffer(raw_rgb, dtype=np.uint8).reshape(height, width, 3)
 
-    for name, cx_rel, hw_rel, y1, y2 in _EMBLEM_RELATIVE_POSITIONS:
-        cx = x_left + cx_rel * bar_width
-        half = hw_rel * bar_width
-        x1 = int(cx - half)
-        x2 = int(cx + half)
-        region = frame[y1:y2, x1:x2, :]
-        bgr = cv2.cvtColor(region, cv2.COLOR_RGB2BGR)
-        hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
-        gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+    # Path 1: absolute coordinates (pre-#522 validated path).
+    if _emblem_and_check(frame, list(_EMBLEM_POSITIONS), "absolute", cv2):
+        return True
 
-        # Saturation of bright pixels (exclude very dark pixels)
-        val = hsv[:, :, 2].astype(np.float32)
-        sat = hsv[:, :, 1].astype(np.float32)
-        bright_mask = val > 30
-        if bright_mask.sum() > 5:
-            mean_sat = float(sat[bright_mask].mean())
-        else:
-            mean_sat = 0.0
-
-        # Edge density (Sobel magnitude)
-        sobel_x = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
-        sobel_y = cv2.Sobel(gray, cv2.CV_64F, 0, 1, ksize=3)
-        edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
-
-        if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
-            logger.debug(
-                "scorebar_v2: %s x=%d..%d sat=%.1f edge=%.1f -> fail",
+    # Path 2: dynamic span rescue for HUD-scaled recordings (4K Game DVR).
+    span = _find_scorebar_horizontal_range(raw_rgb)
+    if span is not None:
+        x_left, x_right = span
+        bar_width = x_right - x_left
+        positions: list[tuple[str, int, int, int, int]] = [
+            (
                 name,
-                x1,
-                x2,
-                mean_sat,
-                edge_density,
+                int(x_left + cx_rel * bar_width - hw_rel * bar_width),
+                y1,
+                int(x_left + cx_rel * bar_width + hw_rel * bar_width),
+                y2,
             )
-            return False
+            for name, cx_rel, hw_rel, y1, y2 in _EMBLEM_RELATIVE_POSITIONS
+        ]
+        if _emblem_and_check(
+            frame, positions, f"dynamic span={x_left}..{x_right}", cv2
+        ):
+            return True
 
-    logger.debug(
-        "scorebar_v2: span=%d..%d all 3 positions passed -> True",
-        x_left,
-        x_right,
-    )
-    return True
+    return False
 
 
 def _has_scorebar(raw_rgb: bytes | None, height: int) -> bool | None:

--- a/docs/scorebar-detection-design.md
+++ b/docs/scorebar-detection-design.md
@@ -117,8 +117,10 @@ OR 結合により、1080p OBS validated set は Primary で完結 (FP 耐性保
 
 ### 検証サマリー
 
-- 1080p OBS (20260118 baseline): 改修前と match_count / boundary 時刻完全一致 (5 matches、時刻同一)
-- 4K Game DVR: emblem 位置は scorebar に正しく追従 (可視化検証済み)。ただし Pass 2 region 幅が狭く classify post probes (region_end + 1/2/3s) が暗転 fade-in 中に hit して V1 fallback で False になるケースあり
+- 1080p OBS 4 録画 (20260116/20260118/20260119/20260219) で改修前と match_count / boundary 時刻・types 完全一致 (境界差 <0.5s)。初版 dynamic primary で発覚した 20260219 Match 6/16 結合退行 (33-41min 超長 match) は two-path 化で解消
+- 4K Game DVR file 1: Path 1 absolute fail → Path 2 dynamic rescue (span=652..1272) で in-match True 復帰、lobby は両 path fail で False (FP なし)
+- emblem 位置の追従は 1080p / 4K 両方で可視化確認済み
+- ただし 4K Game DVR の試合境界完全回復は Pass 2 region 幅が狭く classify post probes が暗転 fade-in 中に hit する別問題で未達 (#524 で follow-up)
 
 ### 残課題 (follow-up)
 

--- a/docs/scorebar-detection-design.md
+++ b/docs/scorebar-detection-design.md
@@ -78,3 +78,43 @@ ROI brightness ∈ (20, 140)          ... 暗転・白飛びを排除
 2. **時間的静止判定の再導入 (C1)**: A1+A2 でカバーできないエッジケース（ローディング画面が A1+A2 を通過する場合）が発見された場合、`_is_static_from_frames()` を defense-in-depth として再導入する。実装は git history から復元可能
 3. **セグメントレベル分類 (B1)**: 暗転分類から直接セグメント判定への移行
 4. **副次 ROI (C3)**: ミニマップ ROI の 320x180 での有効性を調査
+
+## V2: GC-emblem 3-point AND と動的 scorebar 外輪郭検出 (#307, #522)
+
+### 背景
+
+V1 (`_has_scorebar`) は 320x180 低解像度 ROI での色特徴量判定を行うが、ロビー背景や GC 配色の順序変動で偽陽性が発生しうる。PR #313 で V2 (`_has_scorebar_v2`) を導入し、1920x1080 高解像度フレームの 3 GC emblem 位置で HSV saturation と Sobel edge density の AND を取ることで構造的に FP を排除した。
+
+### 動的 emblem 位置 (#522)
+
+V2 導入時の `_EMBLEM_POSITIONS` は 1920x1080 絶対座標の hardcode で、1080p OBS 録画で validated された。しかし 4K Game DVR 録画 (Windows/Xbox) では FF14 HUD scale が異なり scorebar が画面中央寄りに描画されるため、絶対座標の left/right 位置が scorebar 外 (ゲーム背景) にヒットする FP 問題が発生した。
+
+解決策として、frame ごとに scorebar 外輪郭を動的検出し、emblem 位置を scorebar 幅の相対比で計算する仕組みを追加:
+
+1. `_find_scorebar_horizontal_range(raw_rgb)`: 画面上部 y=0..45 の HSV saturation mask で saturated 列の最長 run を scorebar span として返す。run 幅 < 500px は None (lobby UI 誤検出排除)
+2. `_EMBLEM_RELATIVE_POSITIONS`: 1080p OBS validated set 13 frames の実測 median 相対比
+   - left: `cx_rel=0.0455, half_width_rel=0.0453`
+   - center: `cx_rel=0.3427, half_width_rel=0.0237`
+   - right: `cx_rel=0.9638, half_width_rel=0.0384`
+3. `_has_scorebar_v2`: span 検出 → 相対位置で emblem 絶対座標を計算 → 既存 3-point AND
+4. span 検出失敗時は `None` を返し、V1 (`_has_scorebar`) fallback に委譲 (既存契約維持)
+
+### 閾値定数 (V2 動的検出)
+
+| 定数 | 値 | 役割 |
+|---|---|---|
+| `_SCOREBAR_SCAN_Y_START` / `_Y_END` | 0 / 45 | 画面上部 scan ROI |
+| `_SCOREBAR_SCAN_SAT_THRESHOLD` | 80.0 | saturated pixel 閾値 (lobby 背景 66-79 を超え、scorebar バンド >= 150 の中間) |
+| `_SCOREBAR_SCAN_VAL_THRESHOLD` | 60.0 | 暗フレーム排除 |
+| `_SCOREBAR_SCAN_COL_RATIO` | 0.30 | 行の 30% 以上が saturated であれば該当列を qualifying |
+| `_SCOREBAR_SCAN_MIN_WIDTH_PX` | 500 | scorebar と認める最小幅 (1080p 712+, 4K DVR 613+, lobby 409 FP 排除) |
+| `_SCOREBAR_SCAN_MAX_GAP_PX` | 80 | scorebar 中央 timer/score 部のギャップを bridge |
+
+### 検証サマリー
+
+- 1080p OBS (20260118 baseline): 改修前と match_count / boundary 時刻完全一致 (5 matches、時刻同一)
+- 4K Game DVR: emblem 位置は scorebar に正しく追従 (可視化検証済み)。ただし Pass 2 region 幅が狭く classify post probes (region_end + 1/2/3s) が暗転 fade-in 中に hit して V1 fallback で False になるケースあり
+
+### 残課題 (follow-up)
+
+- 4K Game DVR の長めの UI fade-in (~2-3s) に対応するため、classify_blackout の post probe offset を動的に調整する (別 issue)

--- a/docs/scorebar-detection-design.md
+++ b/docs/scorebar-detection-design.md
@@ -89,15 +89,20 @@ V1 (`_has_scorebar`) は 320x180 低解像度 ROI での色特徴量判定を行
 
 V2 導入時の `_EMBLEM_POSITIONS` は 1920x1080 絶対座標の hardcode で、1080p OBS 録画で validated された。しかし 4K Game DVR 録画 (Windows/Xbox) では FF14 HUD scale が異なり scorebar が画面中央寄りに描画されるため、絶対座標の left/right 位置が scorebar 外 (ゲーム背景) にヒットする FP 問題が発生した。
 
-解決策として、frame ごとに scorebar 外輪郭を動的検出し、emblem 位置を scorebar 幅の相対比で計算する仕組みを追加:
+解決策として **two-path OR semantics** を採用。Primary は pre-#522 validated の absolute `_EMBLEM_POSITIONS`、Rescue は scorebar span 動的検出 + `_EMBLEM_RELATIVE_POSITIONS` 相対比で HUD scale 差異を吸収する。
 
 1. `_find_scorebar_horizontal_range(raw_rgb)`: 画面上部 y=0..45 の HSV saturation mask で saturated 列の最長 run を scorebar span として返す。run 幅 < 500px は None (lobby UI 誤検出排除)
 2. `_EMBLEM_RELATIVE_POSITIONS`: 1080p OBS validated set 13 frames の実測 median 相対比
    - left: `cx_rel=0.0455, half_width_rel=0.0453`
    - center: `cx_rel=0.3427, half_width_rel=0.0237`
    - right: `cx_rel=0.9638, half_width_rel=0.0384`
-3. `_has_scorebar_v2`: span 検出 → 相対位置で emblem 絶対座標を計算 → 既存 3-point AND
-4. span 検出失敗時は `None` を返し、V1 (`_has_scorebar`) fallback に委譲 (既存契約維持)
+3. `_has_scorebar_v2` (two-path OR):
+   - **Primary**: `_EMBLEM_POSITIONS` (absolute) で 3-point AND check → pass なら True (short-circuit)
+   - **Rescue**: Primary fail 時のみ span 検出 → 相対位置で emblem 絶対座標計算 → 3-point AND check → pass なら True
+   - 両 path fail で False、`raw_rgb is None` / opencv 未インストール時のみ None → V1 (`_has_scorebar`) fallback
+4. `_emblem_and_check` helper で両 path の AND 評価を共通化
+
+OR 結合により、1080p OBS validated set は Primary で完結 (FP 耐性保持)、4K Game DVR の HUD-scaled scorebar は Rescue で救済。初版 (dynamic primary) で発覚した 20260219 (5h+ 長時間録画) の Match 6/16 結合退行 (33-41min 超長 match) は two-path 化で解消。
 
 ### 閾値定数 (V2 動的検出)
 

--- a/tests/test_scorebar_v2.py
+++ b/tests/test_scorebar_v2.py
@@ -284,15 +284,16 @@ class TestHasScorebarV2:
         """Probe failure (None) -> None passthrough."""
         assert _has_scorebar_v2(None) is None
 
-    def test_empty_frame_returns_none(self):
-        """All-zero frame -> no scorebar outline -> None (V1 fallback, #522).
+    def test_empty_frame_returns_false(self):
+        """All-zero frame -> absolute fallback -> 0 sat, 0 edge -> False.
 
-        Contract change in #522: previously returned False when the first
-        emblem failed the AND check.  With dynamic scorebar range
-        detection, an empty frame fails the span-detection step and
-        returns None so V1 can evaluate.
+        #522 hybrid: when dynamic scorebar span detection fails, V2 falls
+        back to absolute ``_EMBLEM_POSITIONS`` instead of returning None.
+        For an empty frame this fallback still fails on the first emblem
+        (sat=0, edge=0) -> False.  This preserves the pre-#522 empty-
+        frame contract.
         """
-        assert _has_scorebar_v2(_empty_hires_frame()) is None
+        assert _has_scorebar_v2(_empty_hires_frame()) is False
 
     @pytest.mark.parametrize("x_left,x_right", [(500, 1400), (700, 1300)])
     def test_detects_scorebar_at_dynamic_layout(self, x_left, x_right):
@@ -305,14 +306,17 @@ class TestHasScorebarV2:
         frame = _make_hires_frame_with_emblems_at_layout(x_left, x_right)
         assert _has_scorebar_v2(frame) is True
 
-    def test_frame_without_scorebar_strip_returns_none(self):
-        """Frame with emblems but no scorebar outline -> None.
+    def test_frame_without_scorebar_strip_returns_true_via_absolute(self):
+        """Frame with emblems but no scorebar outline -> absolute fallback -> True.
 
-        Exercises the ``_find_scorebar_horizontal_range -> None`` path
-        when the surrounding scorebar strip is absent.
+        Exercises the hybrid fallback path (#522): when
+        ``_find_scorebar_horizontal_range`` returns None (no saturated
+        outline), V2 evaluates ``_EMBLEM_POSITIONS`` absolutely.  The
+        emblems are placed at the same absolute coordinates, so the
+        3-point AND still passes.
         """
         frame = _make_hires_frame_with_emblems(include_scorebar_strip=False)
-        assert _has_scorebar_v2(frame) is None
+        assert _has_scorebar_v2(frame) is True
 
     def test_all_three_emblems_present_returns_true(self):
         """All 3 emblems with high sat + high edge -> True."""

--- a/tests/test_scorebar_v2.py
+++ b/tests/test_scorebar_v2.py
@@ -20,8 +20,11 @@ from allaganeye.video.detector import (
     _EMBLEM_EDGE_THRESHOLD,
     _EMBLEM_POSITIONS,
     _EMBLEM_SAT_THRESHOLD,
+    _SCOREBAR_SCAN_MAX_GAP_PX,
+    _SCOREBAR_SCAN_MIN_WIDTH_PX,
     _SCOREBAR_V2_PROBE_HEIGHT,
     _SCOREBAR_V2_PROBE_WIDTH,
+    _find_scorebar_horizontal_range,
     _has_scorebar_v2,
     _probe_frame_rgb_hires,
 )
@@ -43,6 +46,7 @@ def _make_hires_frame_with_emblems(
     emblem_color: tuple[int, int, int] = (200, 30, 30),
     use_emblems: tuple[bool, bool, bool] = (True, True, True),
     bg_color: tuple[int, int, int] = (40, 40, 40),
+    include_scorebar_strip: bool = True,
 ) -> bytes:
     """Build a 1920x1080 RGB frame with optional per-emblem high-feature regions.
 
@@ -53,6 +57,13 @@ def _make_hires_frame_with_emblems(
     pattern which sums to zero with a 3x3 Sobel kernel).
     Bytes layout matches what ``_probe_frame_rgb_hires`` would produce:
     row-major RGB24.
+
+    By default also paints a saturated scorebar strip (single-color, low
+    edge) from the leftmost emblem's x1 to the rightmost emblem's x2 so
+    that ``_find_scorebar_horizontal_range`` detects a span covering all
+    3 emblem positions.  Pass ``include_scorebar_strip=False`` to build
+    a frame that exercises the span-detection fallback (no scorebar
+    outline -> ``_has_scorebar_v2`` returns ``None``).
     """
     width = _SCOREBAR_V2_PROBE_WIDTH
     height = _SCOREBAR_V2_PROBE_HEIGHT
@@ -60,6 +71,16 @@ def _make_hires_frame_with_emblems(
     frame[:, :, 0] = bg_color[0]
     frame[:, :, 1] = bg_color[1]
     frame[:, :, 2] = bg_color[2]
+
+    if include_scorebar_strip:
+        # Saturated blue strip spanning the emblems' horizontal extent.
+        # Single-color (no stripe) -> high sat but low edge density, so
+        # non-emblem positions within the strip fail the per-emblem AND.
+        strip_x1 = _EMBLEM_POSITIONS[0][1]
+        strip_x2 = _EMBLEM_POSITIONS[2][3]
+        frame[0:45, strip_x1 : strip_x2 + 1, 0] = 50
+        frame[0:45, strip_x1 : strip_x2 + 1, 1] = 50
+        frame[0:45, strip_x1 : strip_x2 + 1, 2] = 200
 
     for (_, x1, y1, x2, y2), enable in zip(_EMBLEM_POSITIONS, use_emblems, strict=True):
         if not enable:
@@ -81,6 +102,178 @@ def _make_hires_frame_with_emblems(
     return frame.tobytes()
 
 
+def _make_hires_frame_with_emblems_at_layout(
+    x_left: int,
+    x_right: int,
+    emblem_color: tuple[int, int, int] = (200, 30, 30),
+    use_emblems: tuple[bool, bool, bool] = (True, True, True),
+    bg_color: tuple[int, int, int] = (40, 40, 40),
+) -> bytes:
+    """Build a frame simulating a scorebar at [x_left, x_right] with dynamic emblems.
+
+    Paints a saturated strip over ``y=0..45`` spanning ``x_left..x_right``
+    and overlays striped emblems at positions computed from
+    ``_EMBLEM_RELATIVE_POSITIONS`` and the given horizontal range, so the
+    3-point AND detection logic is exercised at layouts other than the
+    default 1080p OBS one (e.g. the narrower 4K Game DVR scorebar).
+    """
+    from allaganeye.video.detector import _EMBLEM_RELATIVE_POSITIONS
+
+    width = _SCOREBAR_V2_PROBE_WIDTH
+    height = _SCOREBAR_V2_PROBE_HEIGHT
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    frame[:, :, 0] = bg_color[0]
+    frame[:, :, 1] = bg_color[1]
+    frame[:, :, 2] = bg_color[2]
+
+    # Saturated single-color strip (high sat, low edge).
+    frame[0:45, x_left : x_right + 1, 0] = 50
+    frame[0:45, x_left : x_right + 1, 1] = 50
+    frame[0:45, x_left : x_right + 1, 2] = 200
+
+    bar_width = x_right - x_left
+    for (_, cx_rel, hw_rel, y1, y2), enable in zip(
+        _EMBLEM_RELATIVE_POSITIONS, use_emblems, strict=True
+    ):
+        if not enable:
+            continue
+        cx = x_left + cx_rel * bar_width
+        half = hw_rel * bar_width
+        ex1 = int(cx - half)
+        ex2 = int(cx + half)
+        region = frame[y1:y2, ex1:ex2, :]
+        for col in range(region.shape[1]):
+            block = (col // 2) % 2
+            if block == 0:
+                region[:, col, 0] = emblem_color[0]
+                region[:, col, 1] = emblem_color[1]
+                region[:, col, 2] = emblem_color[2]
+            else:
+                region[:, col, :] = 0
+
+    return frame.tobytes()
+
+
+def _make_hires_frame_with_strips(
+    x_ranges: list[tuple[int, int]],
+    y_start: int = 0,
+    y_end: int = 45,
+    saturated_color: tuple[int, int, int] = (200, 30, 30),
+    bg_color: tuple[int, int, int] = (40, 40, 40),
+) -> bytes:
+    """Build a 1920x1080 RGB frame with saturated horizontal strips.
+
+    Each ``(x_start, x_end)`` range is filled inclusive on both ends with
+    ``saturated_color`` at rows ``y_start``..``y_end``.  Used to simulate
+    scorebar outlines in ``_find_scorebar_horizontal_range`` tests.
+    """
+    width = _SCOREBAR_V2_PROBE_WIDTH
+    height = _SCOREBAR_V2_PROBE_HEIGHT
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    frame[:, :, 0] = bg_color[0]
+    frame[:, :, 1] = bg_color[1]
+    frame[:, :, 2] = bg_color[2]
+    for x_start, x_end in x_ranges:
+        frame[y_start:y_end, x_start : x_end + 1, 0] = saturated_color[0]
+        frame[y_start:y_end, x_start : x_end + 1, 1] = saturated_color[1]
+        frame[y_start:y_end, x_start : x_end + 1, 2] = saturated_color[2]
+    return frame.tobytes()
+
+
+def _make_hires_frame_with_strip(
+    x_start: int,
+    x_end: int,
+    y_start: int = 0,
+    y_end: int = 45,
+    saturated_color: tuple[int, int, int] = (200, 30, 30),
+    bg_color: tuple[int, int, int] = (40, 40, 40),
+) -> bytes:
+    """Convenience wrapper for a single saturated strip."""
+    return _make_hires_frame_with_strips(
+        [(x_start, x_end)], y_start, y_end, saturated_color, bg_color
+    )
+
+
+# ---------------------------------------------------------------------------
+# _find_scorebar_horizontal_range
+# ---------------------------------------------------------------------------
+
+
+class TestFindScorebarHorizontalRange:
+    """Dynamic scorebar horizontal range detection (#522)."""
+
+    def test_full_width_band_returns_full_range(self):
+        """Wide saturated band (1080p OBS-like) -> range matches."""
+        frame = _make_hires_frame_with_strip(500, 1400)
+        result = _find_scorebar_horizontal_range(frame)
+        assert result == (500, 1400)
+
+    def test_narrower_centered_band_returns_narrower_range(self):
+        """4K DVR-like narrow band -> narrow range detected."""
+        frame = _make_hires_frame_with_strip(700, 1300)
+        result = _find_scorebar_horizontal_range(frame)
+        assert result == (700, 1300)
+
+    def test_no_saturated_region_returns_none(self):
+        """Empty / low-saturation frame (lobby-like) -> None."""
+        assert _find_scorebar_horizontal_range(_empty_hires_frame()) is None
+
+    def test_too_narrow_region_returns_none(self):
+        """Saturated band narrower than MIN_WIDTH_PX -> None."""
+        # Width 301 < 400 (_SCOREBAR_SCAN_MIN_WIDTH_PX)
+        frame = _make_hires_frame_with_strip(500, 800)
+        assert _SCOREBAR_SCAN_MIN_WIDTH_PX > 301
+        assert _find_scorebar_horizontal_range(frame) is None
+
+    def test_two_disjoint_regions_returns_longest(self):
+        """Two far-apart regions -> only the larger one returned."""
+        # (100, 700) width 601 + (1200, 1400) width 201
+        # gap = 1200 - 700 - 1 = 499 > MAX_GAP_PX (80) -> not bridged.
+        frame = _make_hires_frame_with_strips([(100, 700), (1200, 1400)])
+        result = _find_scorebar_horizontal_range(frame)
+        assert result == (100, 700)
+
+    def test_small_gap_is_bridged(self):
+        """Gap within MAX_GAP_PX -> runs merged into one span."""
+        # (500, 900) + (950, 1400), gap = 49 <= 80 -> bridged.
+        frame = _make_hires_frame_with_strips([(500, 900), (950, 1400)])
+        assert _SCOREBAR_SCAN_MAX_GAP_PX >= 49
+        result = _find_scorebar_horizontal_range(frame)
+        assert result == (500, 1400)
+
+    def test_large_gap_not_bridged(self):
+        """Gap > MAX_GAP_PX -> runs not merged; longest returned."""
+        # (500, 1000) width 501 + (1200, 1500) width 301
+        # gap = 1200 - 1000 - 1 = 199 > 80 -> not merged.
+        # Longest = (500, 1000) width 501 >= MIN_WIDTH_PX.
+        frame = _make_hires_frame_with_strips([(500, 1000), (1200, 1500)])
+        assert _SCOREBAR_SCAN_MAX_GAP_PX < 199
+        result = _find_scorebar_horizontal_range(frame)
+        assert result == (500, 1000)
+
+    def test_opencv_unavailable_returns_none(self):
+        """ImportError on cv2 -> None (lets caller fall back to V1)."""
+        import builtins
+        import sys
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "cv2":
+                raise ImportError("simulated missing cv2")
+            return real_import(name, *args, **kwargs)
+
+        saved = sys.modules.pop("cv2", None)
+        try:
+            with patch("builtins.__import__", side_effect=fake_import):
+                frame = _make_hires_frame_with_strip(500, 1400)
+                result = _find_scorebar_horizontal_range(frame)
+            assert result is None
+        finally:
+            if saved is not None:
+                sys.modules["cv2"] = saved
+
+
 # ---------------------------------------------------------------------------
 # _has_scorebar_v2
 # ---------------------------------------------------------------------------
@@ -91,9 +284,35 @@ class TestHasScorebarV2:
         """Probe failure (None) -> None passthrough."""
         assert _has_scorebar_v2(None) is None
 
-    def test_empty_frame_returns_false(self):
-        """All-zero frame -> 0 sat, 0 edge -> False (first emblem fails)."""
-        assert _has_scorebar_v2(_empty_hires_frame()) is False
+    def test_empty_frame_returns_none(self):
+        """All-zero frame -> no scorebar outline -> None (V1 fallback, #522).
+
+        Contract change in #522: previously returned False when the first
+        emblem failed the AND check.  With dynamic scorebar range
+        detection, an empty frame fails the span-detection step and
+        returns None so V1 can evaluate.
+        """
+        assert _has_scorebar_v2(_empty_hires_frame()) is None
+
+    @pytest.mark.parametrize("x_left,x_right", [(500, 1400), (700, 1300)])
+    def test_detects_scorebar_at_dynamic_layout(self, x_left, x_right):
+        """Scorebar at non-default horizontal layouts is detected correctly.
+
+        Covers the 1080p-full-width and 4K-DVR-narrow layouts using
+        ``_EMBLEM_RELATIVE_POSITIONS`` to place emblems inside the given
+        span (#522).
+        """
+        frame = _make_hires_frame_with_emblems_at_layout(x_left, x_right)
+        assert _has_scorebar_v2(frame) is True
+
+    def test_frame_without_scorebar_strip_returns_none(self):
+        """Frame with emblems but no scorebar outline -> None.
+
+        Exercises the ``_find_scorebar_horizontal_range -> None`` path
+        when the surrounding scorebar strip is absent.
+        """
+        frame = _make_hires_frame_with_emblems(include_scorebar_strip=False)
+        assert _has_scorebar_v2(frame) is None
 
     def test_all_three_emblems_present_returns_true(self):
         """All 3 emblems with high sat + high edge -> True."""


### PR DESCRIPTION
## Summary

- `_has_scorebar_v2` を **two-path OR semantics** に変更 (Refs #522): **Primary=absolute `_EMBLEM_POSITIONS`** (pre-#522 validated, 156+ FP-free)、**Rescue=dynamic span (`_find_scorebar_horizontal_range`) + `_EMBLEM_RELATIVE_POSITIONS`** 相対比
- Primary pass で short-circuit、両 path fail で False。`raw_rgb` None / opencv 未インストール時のみ None → V1 fallback
- 1080p OBS validated set は Primary で挙動完全保持、4K Game DVR の HUD-scaled scorebar は Rescue path で救済
- 20260116 / 20260118 / 20260119 / 20260219 の 4 録画で改修前/後 metadata 完全一致 (match_count / 境界時刻 <0.5s / type) を実動画で確認

## 主要な変更

- `allaganeye/video/detector.py`:
  - 新関数 `_find_scorebar_horizontal_range(raw_rgb)`: 画面上部 y=0..45 の HSV saturation mask で scorebar 外輪郭を動的検出
  - 新定数 `_SCOREBAR_SCAN_*` (SAT / VAL / COL_RATIO / MIN_WIDTH=500 / MAX_GAP)
  - 新定数 `_EMBLEM_RELATIVE_POSITIONS`: 1080p OBS validated set (13 frames × 3 recordings) の実測 median 相対比
  - 新 helper `_emblem_and_check`: 3-point AND 評価を両 path で共通化
  - `_has_scorebar_v2`: **two-path OR semantics** に変更
    - Path 1 (Primary): `_EMBLEM_POSITIONS` (absolute) で 3-point AND → pass なら True short-circuit
    - Path 2 (Rescue): Primary fail 時のみ dynamic span + `_EMBLEM_RELATIVE_POSITIONS` 相対比で 3-point AND → pass なら True
    - 両 path fail で False、`raw_rgb is None` / opencv 未インストール時のみ None
  - 旧 `_EMBLEM_POSITIONS` は Path 1 で活用 (削除せず)
- `tests/test_scorebar_v2.py`:
  - 新クラス `TestFindScorebarHorizontalRange` (8 tests)
  - `TestHasScorebarV2` 拡張: parametrized `test_detects_scorebar_at_dynamic_layout[500-1400, 700-1300]`
  - 空フレーム契約を **pre-#522 に戻し** (`test_empty_frame_returns_false`): 空 → Path 1 で全 emblem 0 → False
  - `test_frame_without_scorebar_strip_returns_true_via_absolute`: emblem 描画のみ (scorebar strip 無し) → Path 1 absolute が authoritative → True
  - helper `_make_hires_frame_with_emblems` に `include_scorebar_strip` 引数追加、新 helper `_make_hires_frame_with_emblems_at_layout` / `_make_hires_frame_with_strips` 追加
- `docs/scorebar-detection-design.md`: V2 + two-path セクション追記
- `CLAUDE.md`: 検知アルゴリズム章の scorebar フィルタリング説明を two-path 記述に更新
- `CHANGELOG.md`: `[Unreleased]` Fixed に two-path 説明を追加

## 検証

### 1080p OBS 無回帰 (merge 条件)

4 録画で `allaganeye split --gpu --no-cache` を改修前 HEAD~1 (develop-0.2.0) と two-path (HEAD) で比較:

| 録画 | Duration | 改修前 match_count | two-path match_count | 境界時刻差 |
|---|---|---|---|---|
| 20260116 | 2h01m | 7 | **7** | 全境界 <0.5s + types 一致 |
| 20260118 | 2h17m | 5 | **5** | 全境界 <0.5s + types 一致 |
| 20260119 | 2h34m | 9 | **9** | 全境界 <0.5s + types 一致 |
| **20260219** | **5h05m** | **17** | **17** | 全境界 <0.5s + types 一致 |

初版 (dynamic span primary) では 20260219 で Match 6 (4881-7710s, 33.3min) / Match 16 (15857-18328s, 41.2min) の 2 match が境界結合で超長化する退行があったが、two-path 化 (commit `5cb2d1c`) で解消。詳細は [#issuecomment-4300987146](https://github.com/Idios/kobutachan-allaganeye/pull/525#issuecomment-4300987146)。

### 4K Game DVR rescue path 動作確認

`_has_scorebar_v2` を 4K DVR file 1 に直接呼び出し:

| 条件 | 結果 |
|---|---|
| t=500 (in-match) | Path 1 absolute fail (sat=59.6 edge=27.6) → Path 2 dynamic rescue (span=652..1272, all 3 passed) → **True** ✓ |
| t=30 (lobby) | Path 1 absolute fail + Path 2 dynamic fail → **False** ✓ (FP なし) |

視覚検証 (`.scorebar_visualize_dyn.py`): 1080p / 4K 両方で emblem 枠が実 emblem にぴったり一致。

### 自動テスト

- `pytest tests/test_scorebar_v2.py -v` → 32 passed (新 `TestFindScorebarHorizontalRange` 8 + `TestHasScorebarV2` 拡張)
- `pytest tests/ -q` → 残 tests 全 pass
- `ruff check` / `ruff format --check` → All pass
- `pyright allaganeye/video/detector.py tests/test_scorebar_v2.py` → 0 errors

### 測定手順 (再現用)

`_EMBLEM_RELATIVE_POSITIONS` の比率は `.scorebar_measure_emblem.py` (worktree-local、gitignore 対象) で以下の手順で算出:

1. 1080p OBS validated set `{20260116, 20260118, 20260119}` の試合中フレーム (t=300/500/700/900/1200s) で `_find_scorebar_horizontal_range` を実行
2. 各 frame で検出 span に対する既存 `_EMBLEM_POSITIONS` 中心 x の相対比を計算
3. 13 samples の median を採用:
   - `left: cx_rel=0.0455, half_width_rel=0.0453`
   - `center: cx_rel=0.3427, half_width_rel=0.0237`
   - `right: cx_rel=0.9638, half_width_rel=0.0384`

## 残課題 (別 issue)

- 4K Game DVR 5 ファイル (`E:/videos/M1wa_zeromus/`) での試合境界の完全回復は #524 (P2-medium) で follow-up。Pass 2 region が暗転中心部のみを取り、classify_blackout の post probes (`region_end + 1/2/3s`) が 4K の長め UI fade-in (~2-3s) と重なり scorebar 検出不可になる問題。退行リスクが大きいため本 PR のスコープ外
- `tests/baselines/*.json` の V2 基準 regenerate (現在は V1 時代の値でも match_count 5 が一致するため実用上問題なし)

## Test plan

- [x] `pytest tests/test_scorebar_v2.py -v` で 32 tests pass (two-path 対応後)
- [x] `pytest tests/ -q` で残 tests 全 pass
- [x] `ruff check` / `ruff format --check` / `pyright` 全 pass
- [x] 1080p OBS 4 録画 (20260116/118/119/219) で改修前/後 metadata 完全一致を実測確認 (境界時刻 <0.5s + types)
- [x] 4K Game DVR file 1 で Path 2 rescue 動作確認 (in-match True / lobby False)
- [x] 4K Game DVR emblem 位置が scorebar に追従することを可視化確認

Refs #522
Follow-up: #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)
