### PR TITLE
test(gui): detection_params 型違反 + Rust load_metadata テスト (Refs #520 #521)

### DIFF
--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -149,6 +149,7 @@ GUI による初回 `[適用]` 時のみ作成。
 |---|---|
 | metadata.json を削除 | GUI load でファイル未存在エラー。GUI は "No metadata. Run detect first." を表示 |
 | 不正な JSON (parse error) | GUI load で zod が fail → error 表示。CLI `split --from-metadata` は `InputFileError` で exit code 2 |
+| root が JSON object でない (array / 文字列等) | Rust `load_metadata` / Python `read_metadata` ともに "must be a JSON object" エラーで拒否 (挙動統一、#521) |
 | 必須フィールド欠落 (source / matches 等) | zod validation で拒否、GUI はエラー表示。CLI は `InputFileError` |
 | 意味不正 (negative time, end < start 等) | zod `.refine()` が検知 (GUI)、CLI は `float()` キャスト失敗で `InputFileError` |
 | source ファイル移動・削除 | CLI は `InputFileError` (`source video not found`) / GUI は `[書き出し]` 時に同様エラー |

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -5,14 +5,24 @@ use serde_json::Value;
 
 #[tauri::command]
 async fn load_metadata(path: String) -> Result<Value, String> {
-    let meta_path = PathBuf::from(&path);
+    load_metadata_sync(&PathBuf::from(&path))
+}
+
+fn load_metadata_sync(meta_path: &Path) -> Result<Value, String> {
     if !meta_path.exists() {
         return Err(format!("metadata file not found: {}", meta_path.display()));
     }
-    let content = fs::read_to_string(&meta_path)
+    let content = fs::read_to_string(meta_path)
         .map_err(|e| format!("read failed ({}): {}", meta_path.display(), e))?;
-    serde_json::from_str::<Value>(&content)
-        .map_err(|e| format!("invalid JSON in {}: {}", meta_path.display(), e))
+    let value: Value = serde_json::from_str(&content)
+        .map_err(|e| format!("invalid JSON in {}: {}", meta_path.display(), e))?;
+    if !value.is_object() {
+        return Err(format!(
+            "metadata file {} root must be a JSON object",
+            meta_path.display()
+        ));
+    }
+    Ok(value)
 }
 
 #[tauri::command]
@@ -273,5 +283,42 @@ mod tests {
         assert!(backup.exists());
         let parent = meta.parent().unwrap();
         assert!(parent.join("metadata.original.json").exists());
+    }
+
+    #[test]
+    fn load_metadata_returns_error_when_file_missing() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let err = load_metadata_sync(&meta).unwrap_err();
+        assert!(err.contains("metadata file not found"));
+    }
+
+    #[test]
+    fn load_metadata_returns_error_on_invalid_json() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        fs::write(&meta, r#"{"source": "a.mkv", invalid"#).unwrap();
+        let err = load_metadata_sync(&meta).unwrap_err();
+        assert!(err.contains("invalid JSON"));
+    }
+
+    #[test]
+    fn load_metadata_returns_ok_on_valid_json() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let payload = json!({"source": "a.mkv", "matches": []});
+        fs::write(&meta, serde_json::to_string_pretty(&payload).unwrap()).unwrap();
+        let value = load_metadata_sync(&meta).unwrap();
+        assert_eq!(value, payload);
+    }
+
+    #[test]
+    fn load_metadata_rejects_non_object_root() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        // Valid JSON but root is an array — Python side's read_metadata also rejects this.
+        fs::write(&meta, r#"["not", "an", "object"]"#).unwrap();
+        let err = load_metadata_sync(&meta).unwrap_err();
+        assert!(err.contains("must be a JSON object"));
     }
 }

--- a/gui/src/types/metadata.schema.test.ts
+++ b/gui/src/types/metadata.schema.test.ts
@@ -140,4 +140,65 @@ describe('MetadataSchema', () => {
     const doc = { ...validMetadata(), schema_version: 1 };
     expect(MetadataSchema.safeParse(doc).success).toBe(false);
   });
+
+  // #520 — detection_params type violations.
+
+  it('rejects when detection_params number fields are non-number', () => {
+    const doc = validMetadata();
+    const numberFields: Array<keyof typeof doc.detection_params> = [
+      'sample_interval',
+      'blackout_threshold',
+      'min_match_duration',
+      'min_blackout_duration',
+    ];
+    for (const field of numberFields) {
+      const patched = {
+        ...doc,
+        detection_params: { ...doc.detection_params, [field]: '2' },
+      };
+      expect(MetadataSchema.safeParse(patched).success).toBe(false);
+    }
+  });
+
+  it('rejects when detection_params.no_audio is non-boolean', () => {
+    const doc = validMetadata();
+    for (const v of [0, 1, 'false', null]) {
+      const patched = {
+        ...doc,
+        detection_params: { ...doc.detection_params, no_audio: v },
+      };
+      expect(MetadataSchema.safeParse(patched).success).toBe(false);
+    }
+  });
+
+  it('rejects when detection_params.use_gpu is outside number | boolean | null', () => {
+    const doc = validMetadata();
+    for (const v of ['cuda', [], {}]) {
+      const patched = {
+        ...doc,
+        detection_params: { ...doc.detection_params, use_gpu: v },
+      };
+      expect(MetadataSchema.safeParse(patched).success).toBe(false);
+    }
+  });
+
+  it('rejects when detection_params.workers is outside number | null', () => {
+    const doc = validMetadata();
+    for (const v of [true, false, '4']) {
+      const patched = {
+        ...doc,
+        detection_params: { ...doc.detection_params, workers: v },
+      };
+      expect(MetadataSchema.safeParse(patched).success).toBe(false);
+    }
+  });
+
+  it('rejects when detection_params is missing or null', () => {
+    const doc = validMetadata() as Partial<ReturnType<typeof validMetadata>>;
+    delete doc.detection_params;
+    expect(MetadataSchema.safeParse(doc).success).toBe(false);
+
+    const nulled = { ...validMetadata(), detection_params: null };
+    expect(MetadataSchema.safeParse(nulled).success).toBe(false);
+  });
 });


### PR DESCRIPTION
## 概要

PR [#512](https://github.com/Idios/kobutachan-allaganeye/pull/512) のレビューコメントで特定されたテストギャップ 2 件を統合実装。

## 受け入れ条件

### [#520](https://github.com/Idios/kobutachan-allaganeye/issues/520) zod 型違反テスト

- [x] `sample_interval` / `blackout_threshold` / `min_match_duration` / `min_blackout_duration` が非 number を reject
- [x] `no_audio` が非 boolean を reject
- [x] `use_gpu` が `number` / `boolean` / `null` 以外 (string "cuda" 等) を reject
- [x] `workers` が `number` / `null` 以外 (boolean / string) を reject
- [x] `detection_params` 自体が欠落 or null を reject
- [x] `cd gui && npm test` 全通過 (210 passed)
- [x] 既存 9 ケースに影響なし

### [#521](https://github.com/Idios/kobutachan-allaganeye/issues/521) Rust load_metadata テスト

- [x] `load_metadata` を async Tauri command + `fn load_metadata_sync(&Path) -> Result<Value, String>` に分離 (`apply_changes` と同じパターン)
- [x] テスト 4 本追加:
    - `load_metadata_returns_error_when_file_missing`
    - `load_metadata_returns_error_on_invalid_json`
    - `load_metadata_returns_ok_on_valid_json`
    - `load_metadata_rejects_non_object_root`
- [x] `cargo test --lib`: 14 passed (既存 10 + 新規 4)
- [x] 既存 `apply_changes_*` / `atomic_write_*` / `restore_*` / `check_backup_*` テストに影響なし
- [x] Python `read_metadata` との挙動差 (non-object root) を解消: `value.is_object()` チェック追加
- [x] `docs/metadata-spec.md` § ユーザー手動編集シナリオに統一挙動を明記

## 設計判断

#521 の「任意」項目 `load_metadata_rejects_non_object_root` は採用。Python 側 `read_metadata` (allaganeye/detection/metadata_writer.py) と挙動を揃えて CLI ↔ GUI 契約の一貫性を確保 (ユーザー確認済み)。

## テスト結果

| 種類 | コマンド | 結果 |
|---|---|---|
| vitest | `npm --prefix=gui test -- --run` | 25 files / 210 passed |
| cargo | `cd gui/src-tauri && cargo test --lib` | 14 passed / 0 failed |
| eslint | `npm --prefix=gui run lint` | ok |
| tsc | `npm --prefix=gui run typecheck` | ok |

## 手動確認 (PR レビュー時)

- [x] CI pass (python/gui-frontend/gui-rust/markdownlint 全 pass)
- [x] zod 型違反 5 群の reject 動作が意図通り (vitest 210 passed、metadata.schema.test.ts の 5 新規 describe 全 pass で検証)
- [x] Rust 4 テストがエラーメッセージ期待文字列を含むことを確認 (cargo test --lib 14 passed; 各テストの assert `err.contains(...)` が match)

## 関連

- 派生元 PR: [#512](https://github.com/Idios/kobutachan-allaganeye/pull/512) (Phase 1 data layer)
- 対応 issue: [#520](https://github.com/Idios/kobutachan-allaganeye/issues/520) / [#521](https://github.com/Idios/kobutachan-allaganeye/issues/521)
- 仕様書: `docs/metadata-spec.md`

[elated-wozniak-50d3bb]

