### PR TITLE
feat(installer,ci): Python 3.11.9 + BtbN LGPLv3 FFmpeg 8.1 統一 (Refs #510 #508)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,21 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.11.9"
 
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - name: Install ffmpeg (BtbN LGPLv3 n8.1 static, pinned)
+        shell: bash
+        run: |
+          set -euo pipefail
+          FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-22-13-15/ffmpeg-n8.1-10-g7f5c90f77e-linux64-lgpl-8.1.tar.xz"
+          FFMPEG_SHA256="863a5eb145a06529f3ce3c1ee4908abb24ac60d63b47659af9d696abbca9257e"
+          curl -fsSL -o /tmp/ffmpeg.tar.xz "$FFMPEG_URL"
+          echo "$FFMPEG_SHA256  /tmp/ffmpeg.tar.xz" | sha256sum -c -
+          mkdir -p /tmp/ffmpeg
+          tar -xJf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg --strip-components=1
+          echo "/tmp/ffmpeg/bin" >> "$GITHUB_PATH"
+          /tmp/ffmpeg/bin/ffmpeg -version
+          /tmp/ffmpeg/bin/ffprobe -version
 
       - name: Install dependencies
         run: pip install -e ".[dev]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.11.9'
 
       - name: Resolve and verify version
         id: parse
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.11.9'
 
       - name: Build Portable ZIP
         shell: pwsh
@@ -82,7 +82,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.11.9'
 
       - uses: actions/download-artifact@v4
         with:

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -9,8 +9,8 @@
 開発セットアップには以下 3 つのソフトウェアが必要です。
 
 - **Git**: ソースコードの取得・更新に使います
-- **Python 3.11 以上**: 実行環境です（Portable ZIP 同梱の Python とは別に必要です）
-- **ffmpeg / ffprobe 4.1 以上**: 動画の解析・分割エンジンです
+- **Python 3.11 (3.11.9 推奨)**: 実行環境です（Portable ZIP 同梱の Python とは別に必要です）。CI と Portable ZIP は 3.11.9 で固定しているため、ローカルも同じ patch に揃えると挙動差を避けられます
+- **ffmpeg / ffprobe 8.1 LGPLv3 推奨**: 動画の解析・分割エンジンです。最低 4.1 で動作しますが、CI / Portable ZIP は BtbN の LGPLv3 8.1 static に固定しているので同系列を推奨します
 
 ### Git
 
@@ -67,10 +67,10 @@ python --version
 # https://www.python.org/downloads/ → 「Add python.exe to PATH」にチェックを入れてインストール
 
 # winget
-winget install Python.Python.3.13
+winget install Python.Python.3.11
 
 # Microsoft Store
-# Microsoft Store で「Python 3.13」を検索してインストール
+# Microsoft Store で「Python 3.11」を検索してインストール
 ```
 
 **macOS**:
@@ -80,7 +80,7 @@ winget install Python.Python.3.13
 # https://www.python.org/downloads/
 
 # Homebrew
-brew install python@3.13
+brew install python@3.11
 ```
 
 **Linux (Ubuntu/Debian)**:
@@ -92,7 +92,7 @@ sudo apt update && sudo apt install python3 python3-pip python3-venv
 #### インストール確認
 
 ```bash
-python --version   # "Python 3.11.x" 以上が表示されること
+python --version   # "Python 3.11.9" (推奨) または "Python 3.11.x" 以上が表示されること
 pip --version      # pip が利用可能であること
 ```
 
@@ -105,7 +105,7 @@ ffmpeg -version
 ffprobe -version
 ```
 
-**最低バージョン: 4.1**（`-avoid_negative_ts make_zero` 等の機能を使用）
+**推奨: ffmpeg 8.1 LGPLv3** (CI / Portable ZIP と同じ系列)。**最低バージョン: 4.1**（`-avoid_negative_ts make_zero` 等の機能を使用）が、CI / Portable ZIP 同梱版との挙動差を避けるため 8.1 LGPLv3 を推奨します。
 
 #### インストール方法
 
@@ -139,8 +139,8 @@ sudo apt update && sudo apt install ffmpeg
 #### インストール確認
 
 ```bash
-ffmpeg -version   # "ffmpeg version 4.x" 以上が表示されること
-ffprobe -version  # "ffprobe version 4.x" 以上が表示されること
+ffmpeg -version   # "ffmpeg version 8.1" (推奨) または "ffmpeg version 4.x" 以上が表示されること
+ffprobe -version  # 同上
 ```
 
 **PATH が通らない場合**: Allagan Eye は winget のインストール先を自動検索するため、多くの場合 PATH の手動設定は不要です。自動検索で見つからない場合は `ALLAGANEYE_FFMPEG` 環境変数に ffmpeg/ffprobe の入ったディレクトリを指定してください:
@@ -301,3 +301,35 @@ allaganeye debug-brightness <video_path> --start 100 --end 200 --interval 0.5
 - [動画処理設計](video-processing.md)
 - [リリース戦略](release-strategy.md)
 - [コーディング規約](coding-conventions.md)
+
+## 9. Python / FFmpeg バージョン更新チェックリスト
+
+CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージョンを揃えるため、bump 時は以下を**同時に**更新する (#510 で 2026-04-23 に統一)。
+
+### Python (現在 3.11.9 に固定)
+
+| 場所 | キー |
+|---|---|
+| `.github/workflows/ci.yml` | `python-version: "3.11.9"` |
+| `.github/workflows/release.yml` (3 ジョブ) | `python-version: '3.11.9'` |
+| `scripts/build-portable-zip.ps1` | `$PythonVersion = '3.11.9'` + `$PythonEmbedSha256` |
+| `docs/developer-setup.md` §1 | 「Python 3.11 (3.11.9 推奨)」の記載 |
+
+### FFmpeg (現在 BtbN LGPLv3 n8.1 / `autobuild-2026-04-22-13-15` に固定)
+
+更新手順:
+
+1. [BtbN/FFmpeg-Builds/releases](https://github.com/BtbN/FFmpeg-Builds/releases) で新しい `autobuild-YYYY-MM-DD-HH-MM` タグを選ぶ
+2. 必要な 2 資産 (win64-lgpl-8.1.zip / linux64-lgpl-8.1.tar.xz) の SHA256 を取得:
+   ```bash
+   gh api repos/BtbN/FFmpeg-Builds/releases/tags/<タグ名> \
+     --jq '.assets[] | select(.name | test("n8[.]1.*(win64-lgpl-8[.]1[.]zip|linux64-lgpl-8[.]1[.]tar[.]xz)$")) | {name, digest}'
+   ```
+3. 以下 2 箇所を**同一タグ・同一 autobuild 系列で**更新:
+
+| 場所 | キー |
+|---|---|
+| `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` |
+| `.github/workflows/ci.yml` (`Install ffmpeg` ステップ) | `FFMPEG_URL` / `FFMPEG_SHA256` (linux64-lgpl 版) |
+
+4. ローカルで Portable ZIP ビルドが緑になることを確認 (`pwsh ./scripts/build-portable-zip.ps1 -Version <version>`) し、PR で CI の `build-windows` と `python` ジョブ両方が通ることを確認する

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -327,10 +327,11 @@ CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージ�
      --jq '.assets[] | select(.name | test("n8[.]1.*(win64-lgpl-8[.]1[.]zip|linux64-lgpl-8[.]1[.]tar[.]xz)$")) | {name, digest}'
    ```
 
-1. 以下 2 箇所を**同一タグ・同一 autobuild 系列で**更新 (下表参照)
+1. 以下を**同一タグ・同一 autobuild 系列で**更新 (下表参照)。major version 系列変更 (例: 8.x → 9.x) 時は docs の major version 記述も揃える
 1. ローカルで Portable ZIP ビルドが緑になることを確認 (`pwsh ./scripts/build-portable-zip.ps1 -Version <version>`) し、PR で CI の `build-windows` と `python` ジョブ両方が通ることを確認する
 
 | 場所 | キー |
 |---|---|
 | `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` |
 | `.github/workflows/ci.yml` (`Install ffmpeg` ステップ) | `FFMPEG_URL` / `FFMPEG_SHA256` (linux64-lgpl 版) |
+| `docs/developer-setup.md` §1 | 「ffmpeg / ffprobe 8.1 LGPLv3 推奨」「推奨: ffmpeg 8.1 LGPLv3」の major version 記述 (系列変更時のみ) |

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -320,16 +320,17 @@ CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージ�
 更新手順:
 
 1. [BtbN/FFmpeg-Builds/releases](https://github.com/BtbN/FFmpeg-Builds/releases) で新しい `autobuild-YYYY-MM-DD-HH-MM` タグを選ぶ
-2. 必要な 2 資産 (win64-lgpl-8.1.zip / linux64-lgpl-8.1.tar.xz) の SHA256 を取得:
+1. 必要な 2 資産 (win64-lgpl-8.1.zip / linux64-lgpl-8.1.tar.xz) の SHA256 を取得:
+
    ```bash
    gh api repos/BtbN/FFmpeg-Builds/releases/tags/<タグ名> \
      --jq '.assets[] | select(.name | test("n8[.]1.*(win64-lgpl-8[.]1[.]zip|linux64-lgpl-8[.]1[.]tar[.]xz)$")) | {name, digest}'
    ```
-3. 以下 2 箇所を**同一タグ・同一 autobuild 系列で**更新:
+
+1. 以下 2 箇所を**同一タグ・同一 autobuild 系列で**更新 (下表参照)
+1. ローカルで Portable ZIP ビルドが緑になることを確認 (`pwsh ./scripts/build-portable-zip.ps1 -Version <version>`) し、PR で CI の `build-windows` と `python` ジョブ両方が通ることを確認する
 
 | 場所 | キー |
 |---|---|
 | `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` |
 | `.github/workflows/ci.yml` (`Install ffmpeg` ステップ) | `FFMPEG_URL` / `FFMPEG_SHA256` (linux64-lgpl 版) |
-
-4. ローカルで Portable ZIP ビルドが緑になることを確認 (`pwsh ./scripts/build-portable-zip.ps1 -Version <version>`) し、PR で CI の `build-windows` と `python` ジョブ両方が通ることを確認する

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -3,7 +3,7 @@
 Build the allaganeye Portable ZIP for Windows.
 
 .DESCRIPTION
-Downloads Python 3.11 embeddable and FFmpeg LGPL essentials, installs
+Downloads Python 3.11 embeddable and FFmpeg LGPLv3 static (BtbN), installs
 allaganeye and its runtime dependencies into the payload, adds a .bat
 launcher, and compresses everything into dist/allaganeye-v<version>-windows.zip.
 
@@ -39,11 +39,16 @@ $PythonEmbedSha256 = '009D6BF7E3B2DDCA3D784FA09F90FE54336D5B60F0E0F305C37F400BF8
 $GetPipUrl = 'https://bootstrap.pypa.io/get-pip.py'
 $GetPipSha256 = 'FEBA1C697DF45BE1B539B40D93C102C9EE9DDE1D966303323B830B06F3FBCA3C'
 
-# FFmpeg version is pinned so the same allaganeye tag always ships the same FFmpeg.
-# To update: bump $FFmpegVersion, replace $FFmpegSha256 with the new asset's hash.
+# FFmpeg is pinned to a specific BtbN autobuild so the same allaganeye tag ships
+# the same binary and the LGPLv3 license applies uniformly across CI and Portable ZIP.
+# To update: bump $FFmpegBuildTag / $FFmpegAsset / $FFmpegSha256 together.
+# CI workflows (`.github/workflows/ci.yml`) must be updated with the matching
+# linux64-lgpl asset at the same build tag; see docs/developer-setup.md § 9.
 $FFmpegVersion = '8.1'
-$FFmpegUrl = "https://github.com/GyanD/codexffmpeg/releases/download/$FFmpegVersion/ffmpeg-$FFmpegVersion-essentials_build.zip"
-$FFmpegSha256 = '8748283D821613D930B0E7BE685AAA9DF4CA6F0AD4D0C42FD02622B3623463C6'
+$FFmpegBuildTag = 'autobuild-2026-04-22-13-15'
+$FFmpegAsset = 'ffmpeg-n8.1-10-g7f5c90f77e-win64-lgpl-8.1'
+$FFmpegUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$FFmpegBuildTag/$FFmpegAsset.zip"
+$FFmpegSha256 = '230B29CD76AA194F76FB48BBF5D81CBAB8EFD7CD4FD1D7DE6500A040A8587A1C'
 
 function Invoke-Download {
   param(
@@ -96,7 +101,7 @@ New-Item -ItemType Directory -Force -Path $LibDir | Out-Null
     --no-cache-dir `
     $RepoRoot
 
-# 4. FFmpeg LGPL essentials (version-pinned)
+# 4. FFmpeg LGPLv3 static, BtbN/FFmpeg-Builds (version-pinned)
 $FFmpegZip = Join-Path $BuildDir 'ffmpeg.zip'
 Invoke-Download -Uri $FFmpegUrl -OutPath $FFmpegZip -ExpectedSha256 $FFmpegSha256
 $FFmpegExtract = Join-Path $BuildDir 'ffmpeg-extracted'
@@ -193,7 +198,7 @@ See https://github.com/Idios/kobutachan-allaganeye for full documentation.
 
 - allaganeye: MIT (see the repository LICENSE file)
 - Python: PSF License (python\LICENSE.txt)
-- FFmpeg: LGPL (ffmpeg $FFmpegVersion essentials build from GyanD/codexffmpeg)
+- FFmpeg: LGPLv3 (ffmpeg n$FFmpegVersion win64-lgpl static build from BtbN/FFmpeg-Builds, tag $FFmpegBuildTag)
 "@
 Set-Content -Path (Join-Path $PayloadDir 'README.txt') -Value $Readme -Encoding UTF8
 


### PR DESCRIPTION
## Summary

- CI / Portable ZIP / 開発環境で Python と FFmpeg のバージョンを統一。`"3.11"` latest patch の揺らぎと GyanD essentials build (GPL 疑い) 起因の #508 リスクをまとめて解消。
- Python 3.11.9 を 3 環境すべてに pin。FFmpeg は BtbN LGPLv3 n8.1 static build (`autobuild-2026-04-22-13-15`) に URL + SHA256 固定で切替。
- `docs/developer-setup.md` に §9 として bump 時の更新箇所チェックリスト (Python 4 箇所、FFmpeg 2 箇所) を追加して運用で単一管理を代替。

## Refs

- #510 (主タスク、Lead 1 #527 block 解除点)
- #508 (本 PR で BtbN LGPLv3 への切替によりバイナリ由来の GPL 疑いリスクは解消。Portable ZIP 経由 8.5GB MKV 実戦 E2E では timeout 再現せず)

## Changes

| ファイル | 変更内容 |
|---|---|
| `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` を BtbN LGPLv3 に差し替え、README / コメント文言を更新 |
| `.github/workflows/ci.yml` | Python `"3.11"` → `"3.11.9"` に pin、Install ffmpeg を apt → BtbN linux64-lgpl tar.xz pinned download に切替 |
| `.github/workflows/release.yml` | Python `'3.11'` → `'3.11.9'` に pin (3 ジョブ) |
| `docs/developer-setup.md` | Python 推奨 3.13→3.11.9、FFmpeg 推奨 4.1+ → 8.1 LGPLv3、§9 bump 時チェックリスト追加 (markdownlint MD029/MD031 準拠) |

## #510 受け入れ条件の逐条対応

| 受け入れ条件 | 対応 |
|---|---|
| CI と release の `python-version` が build-portable-zip.ps1 と同じ Python 版 (3.11.9) に pin | ✅ `.github/workflows/ci.yml`, `.github/workflows/release.yml` 3 箇所、`scripts/build-portable-zip.ps1:35` すべて 3.11.9 |
| ci.yml の Install ffmpeg ステップが Portable ZIP 同梱版と同じ FFmpeg バージョン系列 (8.1) で URL + SHA256 pinned | ✅ `.github/workflows/ci.yml` の `Install ffmpeg (BtbN LGPLv3 n8.1 static, pinned)` ステップ (linux64-lgpl、同じ autobuild tag) |
| developer-setup.md の Python / FFmpeg 推奨が CI / Portable ZIP と揃い、更新運用ルールが docs に記載 | ✅ §1 推奨更新、§9 bump 時チェックリスト追加 |
| バージョン単一管理の仕組み / bump 時チェックリスト化 | ✅ チェックリスト化で担保 (§9) |
| 統一後の pytest が緑になることを CI で実証 | ✅ 本 PR の CI `python` ジョブで pytest 720 passed (BtbN linux64-lgpl 使用) |

## 実機検証

### ビルド成果物の検証

- `powershell.exe ./scripts/build-portable-zip.ps1 -Version 0.2.0-test` を worktree で実行 → ビルド成功、SHA256 verified (`230B29CD...7A1C`)
- 生成物内 `ffmpeg.exe -version`: `ffmpeg version n8.1-10-g7f5c90f77e-20260422` / configuration `--enable-version3` + libx264/libx265/libfdk-aac 等 disable で pure LGPLv3 構成を確認
- CI `build-windows` artifact 展開後の `ffmpeg.exe` も同一版 (SHA256 `4c2891e5...5458`) = Portable ZIP が確かに BtbN bin を梱包
- `README.txt` Licenses セクション: `FFmpeg: LGPLv3 (ffmpeg n8.1 win64-lgpl static build from BtbN/FFmpeg-Builds, tag autobuild-2026-04-22-13-15)` に更新済み
- ローカル: `ruff check .` / `ruff format --check .` (64 files) / `pytest` (720 passed, 37 deselected) すべて緑

### BtbN FFmpeg の 3 経路 E2E (同一 8.5GB Frontline MKV, `20260116/2026-01-17 00-43-10.mkv`, 19:11)

| 経路 | コマンド | detected_at | 検出結果 | match_001.mp4 SHA256 |
|---|---|---|---|---|
| (A) venv + ALLAGANEYE_FFMPEG=BtbN (CPU) | `python -m allaganeye split --no-audio` | 00:18:52Z | 1 match 00:04-16:22 (16m18s, fl_match) | `b34a854c...fd4c` |
| (B) venv + ALLAGANEYE_FFMPEG=BtbN (GPU, RTX 5090) | `python -m allaganeye split --gpu --no-audio` | 00:32:56Z | 1 match 00:04-16:22 (16m18s, fl_match) | `b34a854c...fd4c` |
| (C) Portable ZIP `allaganeye.bat` (CPU) | `allaganeye.bat <mkv> -o ... --no-audio` | 00:36:46Z | 1 match 00:04-16:22 (16m18s, fl_match) | `b34a854c...fd4c` |

**3 経路すべてで bit-exact 一致** (match_001.mp4 = 8,470,901,472 bytes、SHA256 `b34a854c1bcbc5a97b45f2d6f1da42eb5372ed47ba2125993dc5909df8b9fd4c` 完全同一)。差分は metadata.json の timestamp / use_gpu フラグ / output_file パスのみ。

**副次効果**: #508 の Portable ZIP 特有 "CPU chunk decode timeout 多発" は 8.5GB × 1 経路で再現せず (BtbN への切替で改善した可能性大、ただし元 issue の 30-80GB マラソン MKV では未検証 → G6)

### Smoke 検証

- 9 秒 AV1 MKV で (A)(B)(C) すべて実行 → Pass 1 プローブ正常完了、境界 0 で exit 2 (期待通り)

## Test plan (本 PR 内)

- [x] CI `python` ジョブが BtbN linux64-lgpl を download + SHA256 verify + pytest 720 passed で通る
- [x] CI `release.yml` `build-windows` ジョブが `scripts/build-portable-zip.ps1` でビルド成功し `allaganeye-v*-windows.zip` artifact を出す
- [x] CI `markdownlint` が `docs/developer-setup.md` §9 の新規 markdown で緑になる (commit 5c97408)
- [x] CI `validate-checklist` が緑
- [x] ローカル: 8.5GB Frontline MKV で (A)(B)(C) 3 経路実戦 E2E すべて成功、bit-exact 一致
- [x] CI artifact の Portable ZIP 展開 → `allaganeye.bat` ドラッグ&ドロップ相当 (引数渡し) の end-to-end が動作

## テストギャップ分析

### 本 PR がカバーした範囲

| 項目 | 手段 | 結果 |
|---|---|---|
| Python 3.11.9 pin が 3 環境一致 | 差分 grep + 手動レビュー | ✅ |
| BtbN linux64-lgpl の download + SHA256 verify | CI python ジョブの Install ffmpeg ステップ | ✅ |
| BtbN win64-lgpl の Portable ZIP 同梱 | release.yml build-windows ジョブ + artifact 検証 | ✅ |
| pure LGPLv3 構成の確認 | `ffmpeg -configuration` で libx264/libx265/libfdk-aac 等 disable を目視確認 | ✅ |
| **G1: `--gpu` モードの BtbN static 上での動作** | RTX 5090 + CUDA 13.2 で 8.5GB MKV 実戦 E2E | ✅ **CPU と bit-exact 一致** |
| **G2: Portable ZIP 展開 → `allaganeye.bat` 起動の end-to-end** | CI artifact 展開後、引数渡しで 8.5GB MKV 実戦 E2E | ✅ **venv CPU/GPU と bit-exact 一致** |
| **G4: linux64-lgpl / win64-lgpl の features 一致** | BtbN `variants/defaults-lgpl.sh` を両 OS で共有 (`FF_CONFIGURE="--enable-version3 --disable-debug"`)、OS 固有は `{linux,windows}-install-static.sh` のみ | ✅ 設定ファイルレベルで担保 |

### 残っているギャップ (follow-up 候補)

| # | ギャップ | リスク | 対応案 |
|---|---|---|---|
| G3 | BtbN autobuild アセット名の将来変更検知 | `ffmpeg-n8.1-N-g<sha>-win64-lgpl-8.1.zip` 命名が将来変わると build-portable-zip.ps1 の `Get-ChildItem -First 1` で silently 壊れる可能性 | #528 (Pester) で「展開後 `bin/` が存在しない場合 throw する」テストで早期検知予定 |
| G5 | `Invoke-Download` の SHA256 throw 経路の unit test | 将来リファクタ時に検証ロジックが壊れても PR 段階で気付かない | #528 の Pester シナリオで SHA256 一致 / 不一致の両方をカバー予定 |
| G6 | #508 元 issue 条件 (30-80GB マラソン MKV) での再現性確認 | 本 PR の実戦 E2E は 8.5GB 1 試合分のみ。複数試合・大容量条件で CPU chunk decode timeout が消えたかは別途検証必要 | マージ後 Idios がマラソン MKV で実機検証、問題があれば別 issue で記録 |

### 優先度付き follow-up

- P1: G6 → マージ後に Idios が手動検証。問題があれば #508 を re-open or 新規 issue
- P2: G3, G5 → #528 (Pester、既存 P3 issue) でカバー

## スコープ外 (後続 PR)

- `#509 (FFmpeg LICENSE/COPYING 同梱)` — BtbN 配布に含まれる `LICENSE.txt` の同梱と README 文言追記は別 PR
- `#528 (Pester 単体テスト)` — `Invoke-Download` の SHA256 検証 / 展開ロジック / README 生成の Pester 化は別 PR (G3, G5 をカバー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)