### PR TITLE
feat(gui): metadata.json 排他管理 (mtime 検知 + conflict modal) (Refs #514)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,12 +99,12 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | `audio/refs/` | 同梱参照特徴量（`fanfare.npz`） |
 | `commands/detect.py` | detect コマンド。検知のみ実行し metadata.json を出力 (#463) |
 | `detection/` | 検知パイプラインの共有ヘルパ (#463)。`format.py` (フォーマッタ) / `metadata_writer.py` (atomic read/write) |
-| `gui/` | L2a Tauri GUI (React 19 + TS + Vite + Zustand + zod)。`#483` で bootstrap、`#463` で data 層、`#464` で画面骨格 + CSS Modules、`#516` で `[元に戻す]` 機能。詳細は [docs/gui-development.md](docs/gui-development.md) / [docs/design/README.md](docs/design/README.md) / [docs/ui-architecture.md](docs/ui-architecture.md) |
+| `gui/` | L2a Tauri GUI (React 19 + TS + Vite + Zustand + zod)。`#483` で bootstrap、`#463` で data 層、`#464` で画面骨格 + CSS Modules、`#516` で `[元に戻す]` 機能、`#514` で排他管理 (mtime 検知 + ConflictModal)。詳細は [docs/gui-development.md](docs/gui-development.md) / [docs/design/README.md](docs/design/README.md) / [docs/ui-architecture.md](docs/ui-architecture.md) |
 | `gui/src/screens/` | 5 画面 (drop / detecting / complete / preview / export) + phase reducer。#464 で追加 |
-| `gui/src/components/` | 共通 UI コンポーネント (AllaganCorner / AllaganSigil / WindowChrome / BrightnessTimeline / RestoreButton 等)。#464 で追加 |
+| `gui/src/components/` | 共通 UI コンポーネント (AllaganCorner / AllaganSigil / WindowChrome / BrightnessTimeline / RestoreButton / ConflictModal 等)。#464 で追加 |
 | `gui/src/state/` | Zustand store (`appStateStore` = screen + selection / `metadataStore` = load/apply/restore/loadSample) |
 | `gui/src/styles/tokens.css` | `aetherTheme` の CSS 変数定義 (#464 で追加) |
-| `gui/src-tauri/` | Tauri 2 Rust バックエンド (`load_metadata` / `apply_changes` / `restore_from_original` / `check_backup_exists` command、axum/tower-http による動画配信は #465 で実装予定) |
+| `gui/src-tauri/` | Tauri 2 Rust バックエンド (`load_metadata` / `apply_changes` / `restore_from_original` / `check_backup_exists` / `get_metadata_mtime` command、axum/tower-http による動画配信は #465 で実装予定) |
 
 ### 検知アルゴリズム（detector.py）
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -195,9 +195,9 @@ GUI が `load_metadata` した瞬間のファイル mtime を `metadataStore.loa
 - **検知単位**: epoch ms (u64)。Windows / Linux / macOS いずれも `fs::Metadata::modified()` が返す `SystemTime` を ms に丸めて比較
 - **挙動**: 不一致時は Rust が `conflict: external modification detected ...` を返し、GUI は `conflictError` state に格納して `ConflictModal` を表示
 - **ユーザー選択肢**:
-    - **上書き** → `metadataStore.applyOverwrite()` で `expectedMtimeMs=null` 再送 (check bypass)
-    - **リロード** → `metadataStore.reloadAfterConflict()` で metadata.json を再読み込み (GUI 編集は破棄)
-    - **キャンセル** → `metadataStore.dismissConflict()` でモーダルのみ閉じる (編集は保持、ディスクに触らない)
+  - **上書き** → `metadataStore.applyOverwrite()` で `expectedMtimeMs=null` 再送 (check bypass)
+  - **リロード** → `metadataStore.reloadAfterConflict()` で metadata.json を再読み込み (GUI 編集は破棄)
+  - **キャンセル** → `metadataStore.dismissConflict()` でモーダルのみ閉じる (編集は保持、ディスクに触らない)
 - **新規書き込み** (target が未存在): mtime check 対象外。`expectedMtimeMs` が指定されても skip し通常書き込み
 - **Rust command**: `get_metadata_mtime(path) -> Option<u64>` を追加。`apply_changes` の戻り値は書き込み後の mtime (`u64`) に変更され、GUI 側 `loadedMtimeMs` を自動更新
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -188,13 +188,26 @@ GUI による初回 `[適用]` 時のみ作成。
 5. 本 doc の版数の表を更新
 6. テスト: `tests/test_migrations.py` に migration 関数単体 + end-to-end 読み込みテスト
 
+## 排他管理 (mtime 検知、#514)
+
+GUI が `load_metadata` した瞬間のファイル mtime を `metadataStore.loadedMtimeMs` に保存し、`apply_changes` 呼び出し時に Rust 側へ `expectedMtimeMs` として渡す。Rust 側は `fs::metadata(path).modified()` から現在の mtime を取得し、渡された値と一致しなければ `conflict: ...` で拒否する。
+
+- **検知単位**: epoch ms (u64)。Windows / Linux / macOS いずれも `fs::Metadata::modified()` が返す `SystemTime` を ms に丸めて比較
+- **挙動**: 不一致時は Rust が `conflict: external modification detected ...` を返し、GUI は `conflictError` state に格納して `ConflictModal` を表示
+- **ユーザー選択肢**:
+    - **上書き** → `metadataStore.applyOverwrite()` で `expectedMtimeMs=null` 再送 (check bypass)
+    - **リロード** → `metadataStore.reloadAfterConflict()` で metadata.json を再読み込み (GUI 編集は破棄)
+    - **キャンセル** → `metadataStore.dismissConflict()` でモーダルのみ閉じる (編集は保持、ディスクに触らない)
+- **新規書き込み** (target が未存在): mtime check 対象外。`expectedMtimeMs` が指定されても skip し通常書き込み
+- **Rust command**: `get_metadata_mtime(path) -> Option<u64>` を追加。`apply_changes` の戻り値は書き込み後の mtime (`u64`) に変更され、GUI 側 `loadedMtimeMs` を自動更新
+
 ## 将来の拡張 (Phase 1 スコープ外)
 
 以下は派生 issue で追跡する (本 Phase 1 では実装せず、設計余地だけ確保):
 
 | 拡張 | 追跡 issue | 内容 |
 |---|---|---|
-| 排他管理 (mtime 検知 / 同時編集警告) | (新規起票予定) | GUI load 時の mtime 記録、save 時の外部変更検知 UX |
+| ~~排他管理 (mtime 検知 / 同時編集警告)~~ | [#514](https://github.com/Idios/kobutachan-allaganeye/issues/514) (実装済み、上記 §排他管理 参照) | GUI load 時の mtime 記録、save 時の外部変更検知 UX |
 | ~~schema_version フィールド~~ | [#515](https://github.com/Idios/kobutachan-allaganeye/issues/515) (実装済み、上記 §schema_version 参照) | 明示的な版数管理 + migration 基盤 |
 | ~~`[元に戻す]` 機能~~ | [#516](https://github.com/Idios/kobutachan-allaganeye/issues/516) (Phase 2 で実装済み) | `metadata.original.json` → `metadata.json` 復元ボタン (Rust `restore_from_original` + `metadataStore.restore`) |
 | draft auto save | (新規起票予定) | GUI 一時編集を `metadata.draft.json` に定期保存 (リロード耐性) |

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
@@ -25,9 +26,36 @@ fn load_metadata_sync(meta_path: &Path) -> Result<Value, String> {
     Ok(value)
 }
 
+/// #514 — return the mtime (ms since epoch) of an existing metadata file,
+/// or `None` when the file is missing. Used by the GUI to detect external
+/// modifications between load and apply.
 #[tauri::command]
-async fn apply_changes(path: String, metadata: Value) -> Result<(), String> {
-    apply_changes_sync(&PathBuf::from(&path), &metadata)
+async fn get_metadata_mtime(path: String) -> Result<Option<u64>, String> {
+    Ok(file_mtime_ms(&PathBuf::from(&path)))
+}
+
+fn file_mtime_ms(path: &Path) -> Option<u64> {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t: SystemTime| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+}
+
+#[tauri::command]
+async fn apply_changes(
+    path: String,
+    metadata: Value,
+    expected_mtime_ms: Option<u64>,
+) -> Result<u64, String> {
+    let meta_path = PathBuf::from(&path);
+    apply_changes_sync(&meta_path, &metadata, expected_mtime_ms)?;
+    file_mtime_ms(&meta_path).ok_or_else(|| {
+        format!(
+            "apply succeeded but could not read post-write mtime: {}",
+            meta_path.display()
+        )
+    })
 }
 
 /// #516 — atomically restore metadata.json from the first-Apply backup.
@@ -70,7 +98,30 @@ async fn check_backup_exists(path: String) -> Result<bool, String> {
     Ok(parent.join("metadata.original.json").exists())
 }
 
-fn apply_changes_sync(meta_path: &Path, payload: &Value) -> Result<(), String> {
+fn apply_changes_sync(
+    meta_path: &Path,
+    payload: &Value,
+    expected_mtime_ms: Option<u64>,
+) -> Result<(), String> {
+    // #514 — refuse to overwrite a file that has been modified externally
+    // since the caller last loaded it. Target not existing is not a conflict
+    // (treat as a fresh write).
+    if let Some(expected) = expected_mtime_ms {
+        if meta_path.exists() {
+            let actual = file_mtime_ms(meta_path).ok_or_else(|| {
+                format!("cannot read mtime of {}", meta_path.display())
+            })?;
+            if actual != expected {
+                return Err(format!(
+                    "conflict: external modification detected ({} expected mtime {}, got {})",
+                    meta_path.display(),
+                    expected,
+                    actual
+                ));
+            }
+        }
+    }
+
     let parent = meta_path
         .parent()
         .ok_or_else(|| format!("metadata path has no parent: {}", meta_path.display()))?;
@@ -128,6 +179,7 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .invoke_handler(tauri::generate_handler![
             load_metadata,
+            get_metadata_mtime,
             apply_changes,
             restore_from_original,
             check_backup_exists,
@@ -176,7 +228,7 @@ mod tests {
         fs::write(&meta, serde_json::to_string_pretty(&original).unwrap()).unwrap();
 
         let edited = json!({"source": "a.mkv", "matches": [{"m": 1, "edited": true}]});
-        apply_changes_sync(&meta, &edited).unwrap();
+        apply_changes_sync(&meta, &edited, None).unwrap();
 
         assert!(backup.exists());
         let backup_value: Value =
@@ -194,9 +246,9 @@ mod tests {
         let original = json!({"version": "v1"});
         fs::write(&meta, serde_json::to_string_pretty(&original).unwrap()).unwrap();
 
-        apply_changes_sync(&meta, &json!({"version": "v2"})).unwrap();
-        apply_changes_sync(&meta, &json!({"version": "v3"})).unwrap();
-        apply_changes_sync(&meta, &json!({"version": "v4"})).unwrap();
+        apply_changes_sync(&meta, &json!({"version": "v2"}), None).unwrap();
+        apply_changes_sync(&meta, &json!({"version": "v3"}), None).unwrap();
+        apply_changes_sync(&meta, &json!({"version": "v4"}), None).unwrap();
 
         // backup stays the very first snapshot
         let backup_value: Value =
@@ -212,7 +264,7 @@ mod tests {
         let meta = tmp.path().join("metadata.json");
         let backup = tmp.path().join("metadata.original.json");
         // No pre-existing metadata.json
-        apply_changes_sync(&meta, &json!({"first": true})).unwrap();
+        apply_changes_sync(&meta, &json!({"first": true}), None).unwrap();
         assert!(meta.exists());
         // No backup created because there was nothing to back up
         assert!(!backup.exists());
@@ -320,5 +372,77 @@ mod tests {
         fs::write(&meta, r#"["not", "an", "object"]"#).unwrap();
         let err = load_metadata_sync(&meta).unwrap_err();
         assert!(err.contains("must be a JSON object"));
+    }
+
+    // #514 — mtime-based exclusive control for apply_changes.
+
+    #[test]
+    fn apply_changes_succeeds_when_expected_mtime_matches() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        fs::write(&meta, r#"{"v":1}"#).unwrap();
+        let current = file_mtime_ms(&meta).expect("mtime exists for newly written file");
+
+        apply_changes_sync(&meta, &json!({"v": 2}), Some(current)).unwrap();
+
+        let after: Value =
+            serde_json::from_str(&fs::read_to_string(&meta).unwrap()).unwrap();
+        assert_eq!(after, json!({"v": 2}));
+    }
+
+    #[test]
+    fn apply_changes_returns_conflict_when_expected_mtime_mismatches() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        fs::write(&meta, r#"{"v":1}"#).unwrap();
+        // An obviously stale mtime — `1 ms after epoch` is decades before any
+        // real-world file write, so the comparison is deterministic.
+        let stale: u64 = 1;
+
+        let err = apply_changes_sync(&meta, &json!({"v": 2}), Some(stale)).unwrap_err();
+        assert!(err.starts_with("conflict:"), "unexpected error: {err}");
+
+        // Conflict must not overwrite the file.
+        let current: Value =
+            serde_json::from_str(&fs::read_to_string(&meta).unwrap()).unwrap();
+        assert_eq!(current, json!({"v": 1}));
+    }
+
+    #[test]
+    fn apply_changes_skips_check_when_expected_mtime_is_none() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        fs::write(&meta, r#"{"v":1}"#).unwrap();
+
+        // None → check is bypassed even though the file already exists.
+        apply_changes_sync(&meta, &json!({"v": 2}), None).unwrap();
+        let after: Value =
+            serde_json::from_str(&fs::read_to_string(&meta).unwrap()).unwrap();
+        assert_eq!(after, json!({"v": 2}));
+    }
+
+    #[test]
+    fn apply_changes_skips_check_when_target_missing() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        // First write: no existing file to conflict against, so expected_mtime
+        // must not block the write.
+        apply_changes_sync(&meta, &json!({"first": true}), Some(12345)).unwrap();
+        assert!(meta.exists());
+    }
+
+    #[test]
+    fn file_mtime_ms_returns_none_for_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("missing.json");
+        assert!(file_mtime_ms(&meta).is_none());
+    }
+
+    #[test]
+    fn file_mtime_ms_returns_some_for_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        fs::write(&meta, r#"{}"#).unwrap();
+        assert!(file_mtime_ms(&meta).is_some());
     }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -445,4 +445,72 @@ mod tests {
         fs::write(&meta, r#"{}"#).unwrap();
         assert!(file_mtime_ms(&meta).is_some());
     }
+
+    /// Integration test: simulate an external process writing the file after
+    /// GUI load. The fresh mtime must differ from the cached one, and
+    /// `apply_changes_sync` must refuse the stale handle with a conflict error
+    /// while leaving the external write intact. Review指摘 3 (#514 再見直し).
+    #[test]
+    fn apply_changes_detects_conflict_after_real_external_write() {
+        use std::thread::sleep;
+        use std::time::Duration;
+
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        fs::write(&meta, r#"{"v":1}"#).unwrap();
+        let initial_mtime = file_mtime_ms(&meta).expect("initial mtime");
+
+        // Simulate an external writer (another process) replacing the file.
+        // 20ms sleep comfortably exceeds NTFS (100ns) / ext4 (ns) / APFS (ns)
+        // mtime resolutions so the second write produces a strictly newer
+        // timestamp. macOS HFS+ (1s granularity) is out of CI scope.
+        sleep(Duration::from_millis(20));
+        fs::write(&meta, r#"{"external":true}"#).unwrap();
+        let after_external = file_mtime_ms(&meta).expect("post-external mtime");
+        assert!(
+            after_external > initial_mtime,
+            "external write must advance mtime ({after_external} > {initial_mtime})",
+        );
+
+        // apply_changes_sync with the stale initial mtime must refuse the write.
+        let err = apply_changes_sync(&meta, &json!({"v": 2}), Some(initial_mtime))
+            .unwrap_err();
+        assert!(err.starts_with("conflict:"), "unexpected error: {err}");
+
+        // File still reflects the external write (not overwritten).
+        let current: Value =
+            serde_json::from_str(&fs::read_to_string(&meta).unwrap()).unwrap();
+        assert_eq!(current, json!({"external": true}));
+    }
+
+    /// Integration test: consecutive applies must rotate the mtime correctly.
+    /// After apply 1, the caller holds a fresh mtime; apply 2 with that fresh
+    /// mtime succeeds, and a subsequent apply with the original stale mtime
+    /// must fail. This detects the regression where a GUI self-write would
+    /// immediately conflict on its own next apply. Review指摘 3 (#514 再見直し).
+    #[test]
+    fn consecutive_applies_rotate_mtime_correctly() {
+        use std::thread::sleep;
+        use std::time::Duration;
+
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        fs::write(&meta, r#"{"v":1}"#).unwrap();
+        let m1 = file_mtime_ms(&meta).unwrap();
+
+        sleep(Duration::from_millis(20));
+        apply_changes_sync(&meta, &json!({"v": 2}), Some(m1)).unwrap();
+        let m2 = file_mtime_ms(&meta).unwrap();
+        assert!(m2 > m1, "mtime must advance after apply ({m2} > {m1})");
+
+        sleep(Duration::from_millis(20));
+        apply_changes_sync(&meta, &json!({"v": 3}), Some(m2)).unwrap();
+        let m3 = file_mtime_ms(&meta).unwrap();
+        assert!(m3 > m2, "mtime must advance again ({m3} > {m2})");
+
+        // The original m1 is now stale — attempting to apply with it must fail
+        // (regression guard: prevents accepting pre-first-apply handles).
+        let err = apply_changes_sync(&meta, &json!({"v": 4}), Some(m1)).unwrap_err();
+        assert!(err.starts_with("conflict:"), "unexpected error: {err}");
+    }
 }

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,3 +1,4 @@
+import { ConflictModal } from './components/ConflictModal';
 import { SideRail } from './components/SideRail';
 import { StateSwitcher } from './components/StateSwitcher';
 import { CompleteScreen } from './screens/CompleteScreen';
@@ -42,6 +43,8 @@ export default function App() {
           {screen === 'export' && <ExportScreen />}
         </main>
       </div>
+      {/* #514 — global modal for metadata.json external-modification conflicts. */}
+      <ConflictModal />
     </div>
   );
 }

--- a/gui/src/components/ConflictModal.module.css
+++ b/gui/src/components/ConflictModal.module.css
@@ -1,0 +1,76 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(var(--ae-bg-rgb), 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9000;
+}
+
+.panel {
+  min-width: 420px;
+  max-width: 640px;
+  background: var(--ae-panel);
+  border: var(--ae-panel-border);
+  border-radius: 4px;
+  padding: 24px 28px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+}
+
+.title {
+  font-family: var(--ae-font-ui);
+  font-size: 14px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--ae-gold-bright);
+  margin: 0 0 16px 0;
+}
+
+.message {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  color: var(--ae-danger);
+  word-break: break-all;
+  margin: 0 0 12px 0;
+  line-height: 1.5;
+}
+
+.hint {
+  font-family: var(--ae-font-body);
+  font-size: 12px;
+  color: var(--ae-text-dim);
+  margin: 0 0 20px 0;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.button {
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.33);
+  color: var(--ae-gold);
+  font-family: var(--ae-font-ui);
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.button:hover:not(:disabled) {
+  background: rgba(var(--ae-gold-rgb), 0.1);
+  color: var(--ae-gold-bright);
+}
+
+.button:disabled {
+  border-color: rgba(var(--ae-gold-rgb), 0.13);
+  color: var(--ae-gold-dim);
+  cursor: not-allowed;
+  opacity: 0.7;
+}

--- a/gui/src/components/ConflictModal.test.tsx
+++ b/gui/src/components/ConflictModal.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+
+import { useMetadataStore } from '../state/metadataStore';
+import type { Metadata } from '../types/metadata';
+import { ConflictModal } from './ConflictModal';
+
+function seedMetadata(): Metadata {
+  return {
+    source: 'C:/videos/src.mkv',
+    source_duration: 100,
+    source_duration_display: '1:40',
+    detected_at: '2026-04-22T00:00:00Z',
+    detection_params: {
+      sample_interval: 2,
+      blackout_threshold: 15,
+      min_match_duration: 300,
+      min_blackout_duration: 3,
+      no_audio: false,
+      use_gpu: null,
+      workers: null,
+    },
+    matches: [
+      {
+        index: 1,
+        start_time: 0,
+        end_time: 50,
+        start_display: '00:00',
+        end_display: '00:50',
+        duration: 50,
+        duration_display: '50s',
+        type: 'fl_match',
+        output_file: 'match_001.mp4',
+      },
+    ],
+    gaps: [],
+  };
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  useMetadataStore.getState().clear();
+});
+
+describe('ConflictModal', () => {
+  it('renders nothing when conflictError is null', () => {
+    const { container } = render(<ConflictModal />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders dialog + 3 action buttons when conflictError is set', () => {
+    useMetadataStore.setState({
+      conflictError: 'conflict: external modification detected',
+    });
+    render(<ConflictModal />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/conflict: external/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '上書き' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'リロード' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'キャンセル' })).toBeInTheDocument();
+  });
+
+  it('cancel dismisses the modal without side effects', async () => {
+    useMetadataStore.setState({
+      conflictError: 'conflict: x',
+      dirty: true,
+    });
+    render(<ConflictModal />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+    const state = useMetadataStore.getState();
+    expect(state.conflictError).toBeNull();
+    expect(state.dirty).toBe(true);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('overwrite invokes apply_changes with expectedMtimeMs=null', async () => {
+    useMetadataStore.setState({
+      conflictError: 'conflict: x',
+      metadata: seedMetadata(),
+      filePath: '/tmp/metadata.json',
+      loadedMtimeMs: 1700,
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'apply_changes') return Promise.resolve(2500);
+      if (cmd === 'check_backup_exists') return Promise.resolve(false);
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    render(<ConflictModal />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '上書き' }));
+    await waitFor(() => {
+      expect(useMetadataStore.getState().conflictError).toBeNull();
+    });
+    const applyCall = invokeMock.mock.calls.find((c) => c[0] === 'apply_changes');
+    expect(applyCall).toBeDefined();
+    const args = applyCall![1] as { expectedMtimeMs: number | null };
+    expect(args.expectedMtimeMs).toBeNull();
+  });
+
+  it('reload re-invokes load_metadata + get_metadata_mtime', async () => {
+    useMetadataStore.setState({
+      conflictError: 'conflict: x',
+      metadata: seedMetadata(),
+      filePath: '/tmp/metadata.json',
+      loadedMtimeMs: 1700,
+      dirty: true,
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'load_metadata') return Promise.resolve(seedMetadata());
+      if (cmd === 'get_metadata_mtime') return Promise.resolve(1900);
+      if (cmd === 'check_backup_exists') return Promise.resolve(false);
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    render(<ConflictModal />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'リロード' }));
+    await waitFor(() => {
+      expect(useMetadataStore.getState().loadedMtimeMs).toBe(1900);
+    });
+    expect(useMetadataStore.getState().conflictError).toBeNull();
+    expect(useMetadataStore.getState().dirty).toBe(false);
+  });
+});

--- a/gui/src/components/ConflictModal.tsx
+++ b/gui/src/components/ConflictModal.tsx
@@ -1,0 +1,72 @@
+import { useMetadataStore } from '../state/metadataStore';
+import styles from './ConflictModal.module.css';
+
+/**
+ * #514: modal surfaced when `apply_changes` returns a conflict error because
+ * metadata.json was modified externally between load and apply.
+ *
+ * Three exits:
+ * - 上書き: re-run apply with the mtime check bypassed (external edits lost).
+ * - リロード: discard in-memory edits and re-load metadata.json from disk.
+ * - キャンセル: close the modal without touching disk (edits stay in store).
+ *
+ * Global modal — rendered once in App.tsx regardless of the current screen.
+ */
+export function ConflictModal() {
+  const conflictError = useMetadataStore((s) => s.conflictError);
+  const applying = useMetadataStore((s) => s.applying);
+  const applyOverwrite = useMetadataStore((s) => s.applyOverwrite);
+  const reloadAfterConflict = useMetadataStore((s) => s.reloadAfterConflict);
+  const dismissConflict = useMetadataStore((s) => s.dismissConflict);
+
+  if (!conflictError) return null;
+
+  return (
+    <div
+      className={styles.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ae-conflict-title"
+    >
+      <div className={styles.panel}>
+        <h2 id="ae-conflict-title" className={styles.title}>
+          metadata.json が外部で変更されました
+        </h2>
+        <p className={styles.message}>{conflictError}</p>
+        <p className={styles.hint}>
+          「上書き」で外部変更を破棄し GUI の編集を適用、「リロード」で最新の metadata.json を読み直し (編集は破棄)、「キャンセル」で何もせずこのモーダルを閉じます。
+        </p>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.button}
+            onClick={() => {
+              void applyOverwrite();
+            }}
+            disabled={applying}
+          >
+            上書き
+          </button>
+          <button
+            type="button"
+            className={styles.button}
+            onClick={() => {
+              void reloadAfterConflict();
+            }}
+            disabled={applying}
+          >
+            リロード
+          </button>
+          <button
+            type="button"
+            className={styles.button}
+            onClick={() => dismissConflict()}
+            disabled={applying}
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -519,4 +519,88 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
     expect(state.conflictError).toBeNull();
     expect(state.loadError).toContain('io error');
   });
+
+  // Review 指摘 3: end-to-end recovery — conflict → reload → re-apply succeeds.
+  // Current `reloadAfterConflict re-loads...` test stops at the reload; this one
+  // proves the next apply completes with the rotated mtime (regression guard).
+  it('conflict → reload → apply completes the full recovery flow', async () => {
+    // Step 1: initial load + apply triggers conflict.
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      apply_changes_error: new Error(
+        'conflict: external modification detected (expected 1700, got 1800)',
+      ),
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'pending-edit' });
+    await useMetadataStore.getState().apply();
+    expect(useMetadataStore.getState().conflictError).toContain('conflict');
+
+    // Step 2: reload → fresh mtime, conflictError cleared.
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1900,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().reloadAfterConflict();
+    expect(useMetadataStore.getState().loadedMtimeMs).toBe(1900);
+    expect(useMetadataStore.getState().conflictError).toBeNull();
+
+    // Step 3: re-edit and re-apply with the fresh mtime → success.
+    useMetadataStore.getState().updateMatch(1, { name: 'retry' });
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1900,
+      apply_changes: 2100,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().apply();
+
+    const applyCalls = invokeMock.mock.calls.filter((c) => c[0] === 'apply_changes');
+    const lastApply = applyCalls[applyCalls.length - 1];
+    const args = lastApply[1] as { expectedMtimeMs: number | null };
+    expect(args.expectedMtimeMs).toBe(1900);
+    expect(useMetadataStore.getState().conflictError).toBeNull();
+    expect(useMetadataStore.getState().loadedMtimeMs).toBe(2100);
+    expect(useMetadataStore.getState().dirty).toBe(false);
+  });
+
+  // Review 指摘 4: second apply must use the rotated mtime from the first apply
+  // (not the original load mtime). Current `passes the recorded mtime...` test
+  // only checks post-apply `loadedMtimeMs`; this one proves the next apply call
+  // sends the rotated value as expectedMtimeMs — guards against the "self-write
+  // then conflict on own next apply" regression.
+  it('second apply uses the rotated mtime from the first apply, not the original', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      apply_changes: 2500,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+
+    // First apply: expectedMtimeMs=1700 → post-write mtime rotates to 2500.
+    useMetadataStore.getState().updateMatch(1, { name: 'first' });
+    await useMetadataStore.getState().apply();
+    expect(useMetadataStore.getState().loadedMtimeMs).toBe(2500);
+
+    // Second apply: swap apply_changes to return 3300, then assert the
+    // expectedMtimeMs sent is the rotated 2500 (not the original 1700).
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'apply_changes') return Promise.resolve(3300);
+      if (cmd === 'check_backup_exists') return Promise.resolve(false);
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    useMetadataStore.getState().updateMatch(1, { name: 'second' });
+    await useMetadataStore.getState().apply();
+
+    const applyCalls = invokeMock.mock.calls.filter((c) => c[0] === 'apply_changes');
+    const args = applyCalls[applyCalls.length - 1][1] as {
+      expectedMtimeMs: number | null;
+    };
+    expect(args.expectedMtimeMs).toBe(2500);
+    expect(useMetadataStore.getState().loadedMtimeMs).toBe(3300);
+  });
 });

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -60,7 +60,9 @@ function validMetadata(): Metadata {
 interface MockConfig {
   load_metadata?: unknown;
   load_metadata_error?: Error;
-  apply_changes?: unknown;
+  get_metadata_mtime?: number | null;
+  get_metadata_mtime_error?: Error;
+  apply_changes?: number;
   apply_changes_error?: Error;
   restore_from_original?: unknown;
   restore_from_original_error?: Error;
@@ -74,9 +76,15 @@ function configureInvoke(cfg: MockConfig) {
       case 'load_metadata':
         if (cfg.load_metadata_error) return Promise.reject(cfg.load_metadata_error);
         return Promise.resolve(cfg.load_metadata);
+      case 'get_metadata_mtime':
+        if (cfg.get_metadata_mtime_error)
+          return Promise.reject(cfg.get_metadata_mtime_error);
+        return Promise.resolve(cfg.get_metadata_mtime ?? null);
       case 'apply_changes':
         if (cfg.apply_changes_error) return Promise.reject(cfg.apply_changes_error);
-        return Promise.resolve(cfg.apply_changes);
+        // Rust side returns post-write mtime as u64. Default to a sentinel
+        // so apply() can still update loadedMtimeMs when tests don't care.
+        return Promise.resolve(cfg.apply_changes ?? 2000);
       case 'restore_from_original':
         if (cfg.restore_from_original_error)
           return Promise.reject(cfg.restore_from_original_error);
@@ -230,7 +238,7 @@ describe('useMetadataStore.apply', () => {
 });
 
 describe('useMetadataStore.clear', () => {
-  it('resets the store to its initial empty state including #516 fields', () => {
+  it('resets the store to its initial empty state including #514/#516 fields', () => {
     useMetadataStore.setState({
       metadata: validMetadata(),
       filePath: '/tmp/x/metadata.json',
@@ -241,6 +249,8 @@ describe('useMetadataStore.clear', () => {
       hasBackup: true,
       restoring: true,
       restoreError: 'prev restore error',
+      loadedMtimeMs: 12345,
+      conflictError: 'prev conflict',
     });
 
     useMetadataStore.getState().clear();
@@ -255,6 +265,8 @@ describe('useMetadataStore.clear', () => {
     expect(s.hasBackup).toBe(false);
     expect(s.restoring).toBe(false);
     expect(s.restoreError).toBeNull();
+    expect(s.loadedMtimeMs).toBeNull();
+    expect(s.conflictError).toBeNull();
   });
 });
 
@@ -357,5 +369,154 @@ describe('useMetadataStore.loadSample', () => {
     expect(state.filePath).toBeNull();
     expect(state.dirty).toBe(false);
     expect(state.hasBackup).toBe(false);
+    expect(state.loadedMtimeMs).toBeNull();
+    expect(state.conflictError).toBeNull();
+  });
+});
+
+// #514 — mtime-based exclusive control for metadata.json edits.
+
+describe('useMetadataStore (#514 mtime + conflict)', () => {
+  it('records loadedMtimeMs from get_metadata_mtime after a successful load', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    const state = useMetadataStore.getState();
+    expect(state.loadedMtimeMs).toBe(1700);
+    expect(state.conflictError).toBeNull();
+    // get_metadata_mtime is called alongside load_metadata.
+    expect(invokeMock).toHaveBeenCalledWith('get_metadata_mtime', { path: 'p' });
+  });
+
+  it('passes the recorded mtime as expectedMtimeMs when apply is called', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      apply_changes: 2500,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().apply();
+
+    const applyCall = invokeMock.mock.calls.find((c) => c[0] === 'apply_changes');
+    expect(applyCall).toBeDefined();
+    const args = applyCall![1] as { expectedMtimeMs: number | null };
+    expect(args.expectedMtimeMs).toBe(1700);
+
+    // Post-apply mtime rotates forward so the next apply uses the fresh value.
+    expect(useMetadataStore.getState().loadedMtimeMs).toBe(2500);
+    expect(useMetadataStore.getState().conflictError).toBeNull();
+  });
+
+  it('surfaces conflict errors in conflictError, not applyError', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      apply_changes_error: new Error(
+        'conflict: external modification detected (expected mtime 1700, got 1800)',
+      ),
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().apply();
+
+    const state = useMetadataStore.getState();
+    expect(state.applying).toBe(false);
+    expect(state.applyError).toBeNull();
+    expect(state.conflictError).toContain('conflict:');
+    // Store retains dirty edits so the user can choose to overwrite.
+    expect(state.dirty).toBe(true);
+  });
+
+  it('routes non-conflict errors to applyError and leaves conflictError null', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      apply_changes_error: new Error('write failed: disk full'),
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().apply();
+
+    const state = useMetadataStore.getState();
+    expect(state.applyError).toContain('disk full');
+    expect(state.conflictError).toBeNull();
+  });
+
+  it('applyOverwrite re-runs apply with expectedMtimeMs=null', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      apply_changes: 2500,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().applyOverwrite();
+
+    const applyCalls = invokeMock.mock.calls.filter((c) => c[0] === 'apply_changes');
+    const lastApply = applyCalls[applyCalls.length - 1];
+    const args = lastApply[1] as { expectedMtimeMs: number | null };
+    expect(args.expectedMtimeMs).toBeNull();
+    expect(useMetadataStore.getState().loadedMtimeMs).toBe(2500);
+  });
+
+  it('reloadAfterConflict re-loads metadata.json from disk', async () => {
+    // First load with mtime 1700, then `conflictError` is set.
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      apply_changes_error: new Error('conflict: stale'),
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'dirty' });
+    await useMetadataStore.getState().apply();
+    expect(useMetadataStore.getState().conflictError).toContain('conflict');
+
+    // Reload now returns a fresh validMetadata (no `name` edit) + new mtime.
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1900,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().reloadAfterConflict();
+
+    const state = useMetadataStore.getState();
+    expect(state.conflictError).toBeNull();
+    expect(state.loadedMtimeMs).toBe(1900);
+    expect(state.metadata?.matches[0].name).toBeUndefined();
+    expect(state.dirty).toBe(false);
+  });
+
+  it('reloadAfterConflict is a no-op when filePath is null (sample mode)', async () => {
+    useMetadataStore.setState({ conflictError: 'stale' });
+    await useMetadataStore.getState().reloadAfterConflict();
+    expect(useMetadataStore.getState().conflictError).toBeNull();
+  });
+
+  it('dismissConflict clears the modal state without reloading or reapplying', () => {
+    useMetadataStore.setState({ conflictError: 'conflict: x', dirty: true });
+    useMetadataStore.getState().dismissConflict();
+    const state = useMetadataStore.getState();
+    expect(state.conflictError).toBeNull();
+    expect(state.dirty).toBe(true); // edits are retained
+  });
+
+  it('load that fails clears loadedMtimeMs and conflictError', async () => {
+    // Seed with prior state
+    useMetadataStore.setState({ loadedMtimeMs: 999, conflictError: 'stale' });
+    configureInvoke({ load_metadata_error: new Error('io error') });
+    await useMetadataStore.getState().load('p');
+    const state = useMetadataStore.getState();
+    expect(state.loadedMtimeMs).toBeNull();
+    expect(state.conflictError).toBeNull();
+    expect(state.loadError).toContain('io error');
   });
 });

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -24,6 +24,20 @@ export interface MetadataState {
   /** #516: last restore error message, if any. */
   restoreError: string | null;
 
+  /**
+   * #514: mtime (ms since epoch) of metadata.json recorded at load time.
+   * Passed to `apply_changes` so Rust can refuse to overwrite a file that
+   * was modified externally between load and apply. `null` when no file is
+   * loaded (sample mode or after `clear()`).
+   */
+  loadedMtimeMs: number | null;
+  /**
+   * #514: last conflict error produced by apply. Non-null means the UI must
+   * surface the "overwrite / reload / cancel" modal. Resolved via
+   * `applyOverwrite` / `reloadAfterConflict` / `dismissConflict`.
+   */
+  conflictError: string | null;
+
   load: (path: string) => Promise<void>;
   updateMatch: (index: number, patch: MatchEditPatch) => void;
   apply: () => Promise<void>;
@@ -34,6 +48,13 @@ export interface MetadataState {
   restore: () => Promise<void>;
   /** #516: re-probe the filesystem to update hasBackup. Called after load / apply / restore. */
   refreshBackupStatus: () => Promise<void>;
+
+  /** #514: re-apply with the mtime check bypassed (overwrite external edits). */
+  applyOverwrite: () => Promise<void>;
+  /** #514: discard in-memory edits and re-load metadata.json from disk. */
+  reloadAfterConflict: () => Promise<void>;
+  /** #514: close the conflict modal without side effects (edits stay in store). */
+  dismissConflict: () => void;
 
   /** Phase 2 only: load the in-memory sample metadata (no filePath set). */
   loadSample: () => void;
@@ -67,7 +88,43 @@ function normalizeForPersistence(metadata: Metadata): Metadata {
   };
 }
 
-export const useMetadataStore = create<MetadataState>((set, get) => ({
+export const useMetadataStore = create<MetadataState>((set, get) => {
+  /**
+   * #514 shared implementation for `apply` / `applyOverwrite`. When
+   * `overwrite` is true the stored `loadedMtimeMs` is discarded so the Rust
+   * side skips the conflict check.
+   */
+  async function runApply(overwrite: boolean): Promise<void> {
+    const { metadata, filePath, loadedMtimeMs } = get();
+    if (!metadata || !filePath) return;
+    set({ applying: true, applyError: null, conflictError: null });
+    try {
+      const normalized = normalizeForPersistence(metadata);
+      const newMtime = await invoke<number>('apply_changes', {
+        path: filePath,
+        metadata: normalized,
+        expectedMtimeMs: overwrite ? null : loadedMtimeMs,
+      });
+      set({
+        metadata: normalized,
+        dirty: false,
+        applying: false,
+        applyError: null,
+        loadedMtimeMs: newMtime,
+        conflictError: null,
+      });
+      await get().refreshBackupStatus();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.startsWith('conflict:')) {
+        set({ applying: false, conflictError: msg });
+      } else {
+        set({ applying: false, applyError: msg });
+      }
+    }
+  }
+
+  return {
   metadata: null,
   filePath: null,
   dirty: false,
@@ -79,10 +136,17 @@ export const useMetadataStore = create<MetadataState>((set, get) => ({
   restoring: false,
   restoreError: null,
 
+  loadedMtimeMs: null,
+  conflictError: null,
+
   load: async (path) => {
     try {
       const raw = await invoke<unknown>('load_metadata', { path });
       const parsed = MetadataSchema.parse(raw);
+      // #514: record mtime alongside contents so subsequent apply can detect
+      // external modifications. A missing mtime (file vanished between the
+      // two calls) is recorded as null; apply will then skip the check.
+      const mtime = await invoke<number | null>('get_metadata_mtime', { path });
       set({
         metadata: parsed as unknown as Metadata,
         filePath: path,
@@ -90,6 +154,8 @@ export const useMetadataStore = create<MetadataState>((set, get) => ({
         loadError: null,
         applyError: null,
         restoreError: null,
+        loadedMtimeMs: mtime ?? null,
+        conflictError: null,
       });
       await get().refreshBackupStatus();
     } catch (e) {
@@ -99,6 +165,8 @@ export const useMetadataStore = create<MetadataState>((set, get) => ({
         dirty: false,
         loadError: e instanceof Error ? e.message : String(e),
         hasBackup: false,
+        loadedMtimeMs: null,
+        conflictError: null,
       });
     }
   },
@@ -116,28 +184,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => ({
   },
 
   apply: async () => {
-    const { metadata, filePath } = get();
-    if (!metadata || !filePath) return;
-    set({ applying: true, applyError: null });
-    try {
-      const normalized = normalizeForPersistence(metadata);
-      await invoke('apply_changes', {
-        path: filePath,
-        metadata: normalized,
-      });
-      set({
-        metadata: normalized,
-        dirty: false,
-        applying: false,
-        applyError: null,
-      });
-      await get().refreshBackupStatus();
-    } catch (e) {
-      set({
-        applying: false,
-        applyError: e instanceof Error ? e.message : String(e),
-      });
-    }
+    await runApply(false);
   },
 
   reset: () => {
@@ -155,6 +202,8 @@ export const useMetadataStore = create<MetadataState>((set, get) => ({
       hasBackup: false,
       restoring: false,
       restoreError: null,
+      loadedMtimeMs: null,
+      conflictError: null,
     });
   },
 
@@ -192,6 +241,23 @@ export const useMetadataStore = create<MetadataState>((set, get) => ({
     }
   },
 
+  applyOverwrite: async () => {
+    await runApply(true);
+  },
+
+  reloadAfterConflict: async () => {
+    const { filePath } = get();
+    if (!filePath) {
+      set({ conflictError: null });
+      return;
+    }
+    await get().load(filePath);
+  },
+
+  dismissConflict: () => {
+    set({ conflictError: null });
+  },
+
   loadSample: () => {
     set({
       metadata: sampleMetadata,
@@ -203,6 +269,9 @@ export const useMetadataStore = create<MetadataState>((set, get) => ({
       hasBackup: false,
       restoring: false,
       restoreError: null,
+      loadedMtimeMs: null,
+      conflictError: null,
     });
   },
-}));
+  };
+});


### PR DESCRIPTION
## 概要

[#514](https://github.com/Idios/kobutachan-allaganeye/issues/514) — GUI と CLI が同一 `metadata.json` を更新する際の排他管理を実装。GUI load 時にファイル mtime を記録し、`apply_changes` で不一致を検出したらユーザーに「上書き / リロード / キャンセル」の 3 択を提示する。

## 受け入れ条件

- [x] Rust 側: `apply_changes` に `expected_mtime_ms: Option<u64>` 引数追加。不一致時に `conflict: external modification detected ...` を返す
- [x] Rust 側: `get_metadata_mtime(path) -> Option<u64>` command 新設
- [x] Rust 側: `apply_changes` 戻り値を post-write mtime (`u64`) に (GUI で `loadedMtimeMs` の自動更新に使用)
- [x] GUI 側: `metadataStore.load` で mtime を保存、`apply` で `expectedMtimeMs` を渡す
- [x] GUI 側: `metadataStore` に `loadedMtimeMs` / `conflictError` / `applyOverwrite` / `reloadAfterConflict` / `dismissConflict` を追加
- [x] UI 側: conflict 時の modal (`ConflictModal` component、App.tsx に global 配置、3 択)
- [x] Rust 単体テスト 6 本追加
    - `apply_changes_succeeds_when_expected_mtime_matches`
    - `apply_changes_returns_conflict_when_expected_mtime_mismatches`
    - `apply_changes_skips_check_when_expected_mtime_is_none`
    - `apply_changes_skips_check_when_target_missing`
    - `file_mtime_ms_returns_none_for_missing_file`
    - `file_mtime_ms_returns_some_for_existing_file`
- [x] vitest 追加
    - `metadataStore` conflict 9 ケース (load 後 mtime 記録 / apply で expected 渡し / conflict → conflictError / その他は applyError / overwrite で null 渡し / reload で再 load / dismiss で clear / load 失敗で clear / sample/clear で null)
    - `ConflictModal` 5 ケース (null 非表示 / 3 ボタン描画 / cancel / overwrite / reload)

## 設計判断

- **`expected_mtime_ms` の型**: issue 原文は `Option<String>` だが、比較の型安全性と ms 精度を考慮して `Option<u64>` (epoch ms) で採用 (ユーザー確認済み)
- **新規書き込み時 (target 未存在)**: `expected_mtime_ms` が指定されても check を skip。新規ファイル作成は conflict にならない (Python `apply_changes` の初回書き込み挙動と整合)
- **Rust `load_metadata` は変更せず**: mtime 取得は別 command `get_metadata_mtime` として追加し、既存 API への影響を最小化 (呼び出し順は `load_metadata` → `get_metadata_mtime`、race は次回 apply で conflict として検出される)

## テスト結果

| 種類 | コマンド | 結果 |
|---|---|---|
| cargo | `cd gui/src-tauri && cargo test --lib` | 16 passed (既存 10 + 新規 6) |
| vitest | `npm --prefix=gui test -- --run` | 26 files / 219 passed |
| eslint | `npm --prefix=gui run lint` | ok |
| tsc | `npm --prefix=gui run typecheck` | ok |

## 手動確認 (PR レビュー時)

- [x] CI pass (python/gui-frontend/gui-rust/markdownlint 全 pass)
- [x] ConflictModal 発火 + 3 択動作 (vitest で段階的に実証: ConflictModal.test.tsx 5 ケース + metadataStore.test.ts mtime+conflict 9 ケース、計 14 テストで null / dialog / cancel / overwrite / reload / conflictError vs applyError 分岐を網羅)。Tauri dev での実機検証は Phase 3 (#465) マージ後に実ファイル load → 外部編集フローが成立した時点で Idios が実施
- [x] 「上書き」で applyOverwrite → expectedMtimeMs=null で apply (vitest `applyOverwrite re-runs apply with expectedMtimeMs=null`)
- [x] 「リロード」で reloadAfterConflict → load 再実行 (vitest `reloadAfterConflict re-loads metadata.json from disk`)
- [x] 「キャンセル」で dismissConflict → conflictError=null + edit 保持 (vitest `dismissConflict clears the modal state without reloading or reapplying`)

## 関連

- 派生元 issue: [#463](https://github.com/Idios/kobutachan-allaganeye/issues/463) (Phase 1 data layer)
- 仕様書: `docs/metadata-spec.md` § 排他管理 (mtime 検知、#514)
- 前提 PR: [#512](https://github.com/Idios/kobutachan-allaganeye/pull/512) Phase 1 data layer (`load_metadata` / `apply_changes` / `metadataStore`)

[elated-wozniak-50d3bb]

