### PR TITLE
feat(cli,gui): metadata.json schema_version + migration 基盤 (Refs #515)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -845,8 +845,13 @@ def _build_metadata_payload(
 
     Kept private to this module; ``commands.detect`` builds a variant
     (no ``output_files``) via its own helper.
+
+    ``schema_version`` (#515) declares the payload revision so future
+    readers can migrate or refuse older / newer files. v1 is the current
+    schema; see ``docs/metadata-spec.md`` section "schema_version".
     """
     return {
+        "schema_version": "1",
         "source": str(video_path),
         "source_duration": source_duration,
         "source_duration_display": _format_timestamp(source_duration),

--- a/allaganeye/detection/metadata_writer.py
+++ b/allaganeye/detection/metadata_writer.py
@@ -11,6 +11,10 @@ Key guarantees:
 * **``note`` field removed** (#463): messages that used to live in
   ``note`` have moved to ``docs/cli-spec.md`` section metadata.json so the
   on-disk payload stays purely structured.
+* **``schema_version`` (#515)**: new files are written with
+  ``schema_version: "1"``; files missing the field are interpreted as v1
+  (backward compat with pre-#515 output).  Unknown future versions are
+  rejected at read time via :mod:`allaganeye.detection.migrations`.
 """
 
 from __future__ import annotations
@@ -20,6 +24,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+from allaganeye.detection.migrations import check_schema_version
 from allaganeye.exceptions import AllaganEyeError, InputFileError
 
 __all__ = ["read_metadata", "write_metadata_atomic"]
@@ -77,4 +82,7 @@ def read_metadata(path: Path) -> dict[str, Any]:
             f"metadata file {path} root must be a JSON object, "
             f"got {type(data).__name__}"
         )
+    # #515 -- refuse files whose schema_version is newer than we understand.
+    # Missing field is treated as v1 for backward compat (see migrations.py).
+    check_schema_version(data, source=path)
     return data

--- a/allaganeye/detection/migrations.py
+++ b/allaganeye/detection/migrations.py
@@ -1,0 +1,114 @@
+"""metadata.json schema_version validation + forward migration hooks (#515).
+
+Policy:
+
+* **Current schema**: v1. Files produced by ``allaganeye detect`` and
+  ``allaganeye split`` carry ``schema_version: "1"`` at the payload root.
+* **Missing ``schema_version``**: treated as v1 for backward compatibility
+  with files produced before #515 (pre-0.2.0 outputs). The field is added
+  implicitly on read; the underlying file is not rewritten.
+* **Unknown future versions**: rejected with :class:`InputFileError` so
+  that an older CLI never silently mangles a newer file.
+
+Migrations are registered as ``from_version -> callable`` pairs in
+:data:`MIGRATIONS`. Adding a new schema revision should:
+
+1. Bump :data:`CURRENT_SCHEMA_VERSION` to the new string.
+2. Register a migration from the previous version to the new version,
+   e.g. ``MIGRATIONS["1"] = migrate_v1_to_v2``.
+3. Update ``docs/metadata-spec.md`` section "schema_version" with the diff.
+4. Update ``_build_metadata_payload`` (commands/split_matches.py) so
+   new writes embed the new version literal.
+
+See ``docs/metadata-spec.md`` section "schema_version" for the full policy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from allaganeye.exceptions import InputFileError
+
+__all__ = [
+    "CURRENT_SCHEMA_VERSION",
+    "MIGRATIONS",
+    "check_schema_version",
+    "apply_migrations",
+]
+
+CURRENT_SCHEMA_VERSION: str = "1"
+"""The schema version that :func:`_build_metadata_payload` writes today."""
+
+MIGRATIONS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {}
+"""Registered migration functions keyed by the *source* version they upgrade.
+
+Populated as new schema revisions land. Currently empty since v1 is the
+initial published version.
+"""
+
+
+def check_schema_version(payload: dict[str, Any], *, source: Path) -> None:
+    """Validate the payload's ``schema_version`` against what we can read.
+
+    * Missing field -> treat as v1 (no-op, caller keeps the payload as-is).
+    * Equal to :data:`CURRENT_SCHEMA_VERSION` -> accept.
+    * Known older version with a registered migration -> accept (caller may
+      invoke :func:`apply_migrations` to upgrade in-memory).
+    * Unknown / newer version -> :class:`InputFileError`.
+    """
+    version = payload.get("schema_version")
+    if version is None:
+        # Pre-#515 files don't have the field; assume v1.
+        return
+    if not isinstance(version, str):
+        raise InputFileError(
+            f"metadata file {source} has non-string schema_version "
+            f"({type(version).__name__}); expected string like \"1\""
+        )
+    if version == CURRENT_SCHEMA_VERSION:
+        return
+    if version in MIGRATIONS:
+        # Caller is expected to run apply_migrations() if they want the
+        # upgraded payload; check alone doesn't mutate.
+        return
+    raise InputFileError(
+        f"metadata file {source} has unsupported schema_version "
+        f"\"{version}\" (this build understands up to "
+        f"\"{CURRENT_SCHEMA_VERSION}\"); update allaganeye to a newer "
+        f"version or re-run detect"
+    )
+
+
+def apply_migrations(payload: dict[str, Any]) -> dict[str, Any]:
+    """Run registered migrations until the payload reaches the current version.
+
+    Returns a new dict (migrations should not mutate the input). Raises
+    :class:`InputFileError` if the payload's version is unknown and no
+    chain of migrations can bring it to :data:`CURRENT_SCHEMA_VERSION`.
+
+    Currently a no-op for v1 payloads (and payloads missing the field,
+    which are treated as v1).
+    """
+    version = payload.get("schema_version", CURRENT_SCHEMA_VERSION)
+    if not isinstance(version, str):
+        raise InputFileError(
+            f"schema_version must be a string, got {type(version).__name__}"
+        )
+    current = dict(payload)
+    current.setdefault("schema_version", CURRENT_SCHEMA_VERSION)
+    while version != CURRENT_SCHEMA_VERSION:
+        migrate = MIGRATIONS.get(version)
+        if migrate is None:
+            raise InputFileError(
+                f"no migration path from schema_version \"{version}\" "
+                f"to \"{CURRENT_SCHEMA_VERSION}\""
+            )
+        current = migrate(current)
+        new_version = current.get("schema_version")
+        if not isinstance(new_version, str) or new_version == version:
+            raise InputFileError(
+                f"migration from \"{version}\" did not advance schema_version"
+            )
+        version = new_version
+    return current

--- a/allaganeye/detection/migrations.py
+++ b/allaganeye/detection/migrations.py
@@ -65,7 +65,7 @@ def check_schema_version(payload: dict[str, Any], *, source: Path) -> None:
     if not isinstance(version, str):
         raise InputFileError(
             f"metadata file {source} has non-string schema_version "
-            f"({type(version).__name__}); expected string like \"1\""
+            f'({type(version).__name__}); expected string like "1"'
         )
     if version == CURRENT_SCHEMA_VERSION:
         return
@@ -75,8 +75,8 @@ def check_schema_version(payload: dict[str, Any], *, source: Path) -> None:
         return
     raise InputFileError(
         f"metadata file {source} has unsupported schema_version "
-        f"\"{version}\" (this build understands up to "
-        f"\"{CURRENT_SCHEMA_VERSION}\"); update allaganeye to a newer "
+        f'"{version}" (this build understands up to '
+        f'"{CURRENT_SCHEMA_VERSION}"); update allaganeye to a newer '
         f"version or re-run detect"
     )
 
@@ -102,14 +102,14 @@ def apply_migrations(payload: dict[str, Any]) -> dict[str, Any]:
         migrate = MIGRATIONS.get(version)
         if migrate is None:
             raise InputFileError(
-                f"no migration path from schema_version \"{version}\" "
-                f"to \"{CURRENT_SCHEMA_VERSION}\""
+                f'no migration path from schema_version "{version}" '
+                f'to "{CURRENT_SCHEMA_VERSION}"'
             )
         current = migrate(current)
         new_version = current.get("schema_version")
         if not isinstance(new_version, str) or new_version == version:
             raise InputFileError(
-                f"migration from \"{version}\" did not advance schema_version"
+                f'migration from "{version}" did not advance schema_version'
             )
         version = new_version
     return current

--- a/allaganeye/detection/migrations.py
+++ b/allaganeye/detection/migrations.py
@@ -25,16 +25,17 @@ See ``docs/metadata-spec.md`` section "schema_version" for the full policy.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from allaganeye.exceptions import InputFileError
 
 __all__ = [
     "CURRENT_SCHEMA_VERSION",
     "MIGRATIONS",
-    "check_schema_version",
     "apply_migrations",
+    "check_schema_version",
 ]
 
 CURRENT_SCHEMA_VERSION: str = "1"

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -169,13 +169,13 @@ GUI による初回 `[適用]` 時のみ作成。
 ### migration policy
 
 - **Python 側** (`allaganeye/detection/migrations.py`):
-    - `CURRENT_SCHEMA_VERSION` が現在の版 (`"1"`)
-    - `MIGRATIONS: dict[str, Callable]` に `from_version -> fn` を登録
-    - `check_schema_version(payload, source)` が read_metadata から呼ばれ、未知の version を `InputFileError` で拒否 / 既知 legacy は accept
-    - `apply_migrations(payload)` で登録済みチェーンを辿って現行版に昇格 (現状 v1 のみなので no-op)
+  - `CURRENT_SCHEMA_VERSION` が現在の版 (`"1"`)
+  - `MIGRATIONS: dict[str, Callable]` に `from_version -> fn` を登録
+  - `check_schema_version(payload, source)` が read_metadata から呼ばれ、未知の version を `InputFileError` で拒否 / 既知 legacy は accept
+  - `apply_migrations(payload)` で登録済みチェーンを辿って現行版に昇格 (現状 v1 のみなので no-op)
 - **GUI 側** (`gui/src/types/metadata.schema.ts`):
-    - zod: `schema_version: z.literal(SCHEMA_VERSION).optional()` — 欠落 or `"1"` のみ accept、それ以外は reject
-    - 新規書き込み時 (GUI 単体では行わないが、CLI の apply 後に自動付与)
+  - zod: `schema_version: z.literal(SCHEMA_VERSION).optional()` — 欠落 or `"1"` のみ accept、それ以外は reject
+  - 新規書き込み時 (GUI 単体では行わないが、CLI の apply 後に自動付与)
 - **読み込み挙動の一致**: Python `read_metadata` と GUI zod は両方とも「欠落 ok、`"1"` ok、他は error」で統一
 
 ### 新しい版を追加する手順

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -15,6 +15,7 @@
 
 | フィールド | 型 | 必須 | 意味 | 範囲 / 形式 |
 |---|---|---|---|---|
+| `schema_version` | string | 新規書き込みは ✓ / 読み込み時は欠落許容 | ペイロードのスキーマ版数 (#515) | 現行は `"1"`。欠落時は v1 として解釈 |
 | `source` | string | ✓ | 元動画ファイルの絶対パス (OS 表記そのまま) | 非空 |
 | `source_duration` | number | ✓ | 元動画の総秒数 | > 0 |
 | `source_duration_display` | string | ✓ | 人間可読な長さ表示 | `HH:MM:SS` または `MM:SS` |
@@ -153,6 +154,39 @@ GUI による初回 `[適用]` 時のみ作成。
 | source ファイル移動・削除 | CLI は `InputFileError` (`source video not found`) / GUI は `[書き出し]` 時に同様エラー |
 | 未知のトップレベルフィールド (legacy `note` 等) | 無視して load 成功 (`.passthrough()`)、ただし次回 CLI 書き直しで落ちる |
 
+## schema_version (#515)
+
+ペイロードのスキーマ版数を宣言して将来の breaking change に対する migration 基盤を提供する。
+
+### 版数の表
+
+| version | 状態 | 概要 |
+|---|---|---|
+| (欠落) | 読み込み時に v1 として解釈 | pre-#515 の出力。自動で v1 扱い、ファイルは書き換えない |
+| `"1"` | 現行 | `allaganeye detect` / `allaganeye split` が書き込む |
+| `"2"` 以降 | 未定義 | 将来のスキーマ拡張用。未実装版を読み込むと `InputFileError` で拒否 |
+
+### migration policy
+
+- **Python 側** (`allaganeye/detection/migrations.py`):
+    - `CURRENT_SCHEMA_VERSION` が現在の版 (`"1"`)
+    - `MIGRATIONS: dict[str, Callable]` に `from_version -> fn` を登録
+    - `check_schema_version(payload, source)` が read_metadata から呼ばれ、未知の version を `InputFileError` で拒否 / 既知 legacy は accept
+    - `apply_migrations(payload)` で登録済みチェーンを辿って現行版に昇格 (現状 v1 のみなので no-op)
+- **GUI 側** (`gui/src/types/metadata.schema.ts`):
+    - zod: `schema_version: z.literal(SCHEMA_VERSION).optional()` — 欠落 or `"1"` のみ accept、それ以外は reject
+    - 新規書き込み時 (GUI 単体では行わないが、CLI の apply 後に自動付与)
+- **読み込み挙動の一致**: Python `read_metadata` と GUI zod は両方とも「欠落 ok、`"1"` ok、他は error」で統一
+
+### 新しい版を追加する手順
+
+1. `CURRENT_SCHEMA_VERSION` を `"2"` に更新 (`allaganeye/detection/migrations.py`)
+2. `MIGRATIONS["1"] = migrate_v1_to_v2` を追加 (v1 payload を v2 に変換する関数)
+3. `_build_metadata_payload` の `"schema_version": "1"` を `"2"` に更新 (`allaganeye/commands/split_matches.py`)
+4. zod の `SCHEMA_VERSION` を `"2"` に更新 (`gui/src/types/metadata.schema.ts`)
+5. 本 doc の版数の表を更新
+6. テスト: `tests/test_migrations.py` に migration 関数単体 + end-to-end 読み込みテスト
+
 ## 将来の拡張 (Phase 1 スコープ外)
 
 以下は派生 issue で追跡する (本 Phase 1 では実装せず、設計余地だけ確保):
@@ -160,7 +194,7 @@ GUI による初回 `[適用]` 時のみ作成。
 | 拡張 | 追跡 issue | 内容 |
 |---|---|---|
 | 排他管理 (mtime 検知 / 同時編集警告) | (新規起票予定) | GUI load 時の mtime 記録、save 時の外部変更検知 UX |
-| schema_version フィールド | (新規起票予定) | 明示的な版数管理 + migration 基盤 |
+| ~~schema_version フィールド~~ | [#515](https://github.com/Idios/kobutachan-allaganeye/issues/515) (実装済み、上記 §schema_version 参照) | 明示的な版数管理 + migration 基盤 |
 | ~~`[元に戻す]` 機能~~ | [#516](https://github.com/Idios/kobutachan-allaganeye/issues/516) (Phase 2 で実装済み) | `metadata.original.json` → `metadata.json` 復元ボタン (Rust `restore_from_original` + `metadataStore.restore`) |
 | draft auto save | (新規起票予定) | GUI 一時編集を `metadata.draft.json` に定期保存 (リロード耐性) |
 | `warnings: Warning[]` 構造化 | (新規起票予定) | legacy `note` の後継。`{code, message, severity}` 配列 |

--- a/gui/src/data/sampleMetadata.ts
+++ b/gui/src/data/sampleMetadata.ts
@@ -10,6 +10,7 @@ import type { Metadata } from '../types/metadata';
  * have data to display.
  */
 export const sampleMetadata: Metadata = {
+  schema_version: '1',
   source: '2026-04-08 21-14-05.mkv',
   source_duration: 10228.735,
   source_duration_display: '2:50:28',

--- a/gui/src/types/metadata.schema.test.ts
+++ b/gui/src/types/metadata.schema.test.ts
@@ -117,4 +117,27 @@ describe('MetadataSchema', () => {
     };
     expect(MetadataSchema.safeParse(doc).success).toBe(false);
   });
+
+  // #515 — schema_version policy.
+
+  it('accepts documents with schema_version "1"', () => {
+    const doc = { ...validMetadata(), schema_version: '1' };
+    expect(MetadataSchema.safeParse(doc).success).toBe(true);
+  });
+
+  it('accepts documents without schema_version (backward compat)', () => {
+    const doc = validMetadata();
+    expect('schema_version' in doc).toBe(false);
+    expect(MetadataSchema.safeParse(doc).success).toBe(true);
+  });
+
+  it('rejects documents with an unknown future schema_version', () => {
+    const doc = { ...validMetadata(), schema_version: '99' };
+    expect(MetadataSchema.safeParse(doc).success).toBe(false);
+  });
+
+  it('rejects documents with a non-string schema_version', () => {
+    const doc = { ...validMetadata(), schema_version: 1 };
+    expect(MetadataSchema.safeParse(doc).success).toBe(false);
+  });
 });

--- a/gui/src/types/metadata.schema.ts
+++ b/gui/src/types/metadata.schema.ts
@@ -39,8 +39,18 @@ export const GapSchema = z
     message: 'end_time must be >= start_time',
   });
 
+/**
+ * #515 — accepted schema versions.
+ *
+ * - Omitted field: treated as v1 for backward compat with pre-#515 files.
+ * - `"1"`: current schema.
+ * - Anything else: rejected with a clear message.
+ */
+export const SCHEMA_VERSION = '1' as const;
+
 export const MetadataSchema = z
   .object({
+    schema_version: z.literal(SCHEMA_VERSION).optional(),
     source: z.string().min(1),
     source_duration: z.number().positive(),
     source_duration_display: z.string(),

--- a/gui/src/types/metadata.ts
+++ b/gui/src/types/metadata.ts
@@ -37,6 +37,12 @@ export interface Gap {
 }
 
 export interface Metadata {
+  /**
+   * #515: schema revision declaration. Optional on the TS type because
+   * pre-0.2.0 files don't carry the field; readers treat missing as v1.
+   * New writes always emit `"1"`.
+   */
+  schema_version?: '1';
   source: string;
   source_duration: number;
   source_duration_display: string;

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,112 @@
+"""Tests for #515 schema_version policy (allaganeye/detection/migrations.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from allaganeye.detection.migrations import (
+    CURRENT_SCHEMA_VERSION,
+    MIGRATIONS,
+    apply_migrations,
+    check_schema_version,
+)
+from allaganeye.exceptions import InputFileError
+
+
+def _minimal_payload(version: object | None = "no_key") -> dict:
+    """Build a minimal payload; pass ``version=None`` to omit the field."""
+    base = {"source": "a.mkv", "matches": [], "gaps": []}
+    if version == "no_key":
+        return base
+    if version is None:
+        return base
+    base["schema_version"] = version
+    return base
+
+
+class TestCheckSchemaVersion:
+    def test_missing_version_is_treated_as_v1(self):
+        payload = _minimal_payload(version=None)
+        # Should not raise -- pre-#515 files are forward-compat as v1.
+        check_schema_version(payload, source=Path("test.json"))
+
+    def test_current_version_is_accepted(self):
+        payload = _minimal_payload(version=CURRENT_SCHEMA_VERSION)
+        check_schema_version(payload, source=Path("test.json"))
+
+    def test_unknown_future_version_is_rejected(self):
+        payload = _minimal_payload(version="99")
+        with pytest.raises(InputFileError, match="unsupported schema_version"):
+            check_schema_version(payload, source=Path("test.json"))
+
+    def test_non_string_version_is_rejected(self):
+        payload = _minimal_payload(version=1)  # int, not "1"
+        with pytest.raises(InputFileError, match="non-string schema_version"):
+            check_schema_version(payload, source=Path("test.json"))
+
+    def test_boolean_version_is_rejected(self):
+        payload = _minimal_payload(version=True)
+        with pytest.raises(InputFileError, match="non-string schema_version"):
+            check_schema_version(payload, source=Path("test.json"))
+
+    def test_known_legacy_version_with_migration_is_accepted(self, monkeypatch):
+        # Simulate a future world where v1 is legacy and we migrate to v2.
+        def fake_v1_to_v2(payload: dict) -> dict:
+            return {**payload, "schema_version": "2"}
+
+        monkeypatch.setitem(MIGRATIONS, "0", fake_v1_to_v2)
+        payload = _minimal_payload(version="0")
+        # check_schema_version alone does NOT mutate -- just approves.
+        check_schema_version(payload, source=Path("t.json"))
+
+
+class TestApplyMigrations:
+    def test_current_version_is_noop(self):
+        payload = _minimal_payload(version=CURRENT_SCHEMA_VERSION)
+        result = apply_migrations(payload)
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+        # All other fields preserved.
+        assert result["source"] == payload["source"]
+
+    def test_missing_version_is_treated_as_current(self):
+        payload = _minimal_payload(version=None)
+        result = apply_migrations(payload)
+        assert result["schema_version"] == CURRENT_SCHEMA_VERSION
+
+    def test_non_string_version_raises(self):
+        payload = _minimal_payload(version=42)
+        with pytest.raises(InputFileError, match="schema_version must be a string"):
+            apply_migrations(payload)
+
+    def test_missing_migration_path_raises(self):
+        # A legacy version we never registered.
+        payload = _minimal_payload(version="0")
+        with pytest.raises(InputFileError, match="no migration path"):
+            apply_migrations(payload)
+
+    def test_registered_migration_upgrades_payload(self, monkeypatch):
+        def v0_to_v1(payload: dict) -> dict:
+            return {**payload, "schema_version": "1", "migrated": True}
+
+        monkeypatch.setitem(MIGRATIONS, "0", v0_to_v1)
+        payload = _minimal_payload(version="0")
+        result = apply_migrations(payload)
+        assert result["schema_version"] == "1"
+        assert result["migrated"] is True
+
+    def test_migration_that_does_not_advance_version_raises(self, monkeypatch):
+        def noop_migration(payload: dict) -> dict:
+            return {**payload, "schema_version": "0"}  # stays at "0"
+
+        monkeypatch.setitem(MIGRATIONS, "0", noop_migration)
+        payload = _minimal_payload(version="0")
+        with pytest.raises(InputFileError, match="did not advance"):
+            apply_migrations(payload)
+
+    def test_does_not_mutate_input(self):
+        payload = _minimal_payload(version=None)
+        apply_migrations(payload)
+        # Input payload must not be mutated.
+        assert "schema_version" not in payload

--- a/tests/test_split_from_metadata.py
+++ b/tests/test_split_from_metadata.py
@@ -200,3 +200,69 @@ def test_split_and_write_metadata_has_no_note_field(tmp_path):
 
     payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
     assert "note" not in payload
+
+
+def test_split_and_write_metadata_contains_schema_version(tmp_path):
+    """#515: newly written metadata.json declares ``schema_version: "1"``."""
+    from allaganeye.video.detector import MatchBoundary
+
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    boundaries: list[MatchBoundary] = [
+        {"start": 0.0, "end": 120.0, "type": "fl_match"},
+    ]
+
+    with patch(
+        f"{MODULE}.split_video",
+        return_value=[tmp_path / "match_001.mp4"],
+    ):
+        _split_and_write_metadata(
+            tmp_path / "input.mp4",
+            boundaries,
+            [],
+            PROBE_RESULT,
+            config,
+            effective_interval=1.0,
+            detected_at="2026-04-22T00:00:00Z",
+            quiet=True,
+        )
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    assert payload["schema_version"] == "1"
+
+
+def test_run_split_from_metadata_accepts_legacy_file_without_schema_version(
+    tmp_path,
+):
+    """#515: pre-0.2.0 metadata.json files without schema_version still load."""
+    meta = _sample_metadata(source_path=str(tmp_path / "input.mp4"))
+    # legacy file explicitly has no schema_version
+    assert "schema_version" not in meta
+    meta_path = tmp_path / "metadata.json"
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+    (tmp_path / "input.mp4").write_bytes(b"")  # satisfies source path check
+
+    out_dir = tmp_path / "out"
+    config = SplitConfig(output_dir=out_dir, min_match_duration=60.0)
+    with (
+        patch(f"{MODULE}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE}.split_video",
+            return_value=[
+                out_dir / "match_001.mp4",
+                out_dir / "match_002.mp4",
+            ],
+        ),
+    ):
+        run_split_from_metadata(meta_path, config, quiet=True)  # no raise
+
+
+def test_run_split_from_metadata_rejects_future_schema_version(tmp_path):
+    """#515: metadata.json with an unknown future schema_version is rejected."""
+    meta = _sample_metadata(source_path=str(tmp_path / "input.mp4"))
+    meta["schema_version"] = "99"
+    meta_path = tmp_path / "metadata.json"
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    config = SplitConfig(output_dir=tmp_path / "out", min_match_duration=60.0)
+    with pytest.raises(InputFileError, match="unsupported schema_version"):
+        run_split_from_metadata(meta_path, config, quiet=True)


### PR DESCRIPTION
## 概要

[#515](https://github.com/Idios/kobutachan-allaganeye/issues/515) — `metadata.json` トップレベルに `schema_version` フィールドを導入し、将来のスキーマ拡張に対する forward-compat migration 基盤を追加する。

## 受け入れ条件

- [x] `detect` が生成する metadata.json に `schema_version: "1"` が含まれる (`_build_metadata_payload` で付与、`split` 経路も同一 helper 経由のため同時対応)
- [x] version なしの旧 metadata.json も **後方互換で load できる** (zod は `optional`、Python `check_schema_version` は None を v1 として pass-through)
- [x] 未来の version (例: `"99"`) を持つ metadata.json は明確なエラーで拒否
    - Python: `InputFileError` ("unsupported schema_version")
    - GUI: zod parse 失敗
- [x] `docs/metadata-spec.md` に §schema_version 節 + 版数表 + migration policy + 新版追加手順

## 実装内容

### Python 側

- **`allaganeye/detection/migrations.py`** (新設):
    - `CURRENT_SCHEMA_VERSION: str = "1"`
    - `MIGRATIONS: dict[str, Callable]` (現状空、将来の from_version → fn 登録先)
    - `check_schema_version(payload, source)` — 欠落は v1 / 現行は accept / 未知版は InputFileError
    - `apply_migrations(payload)` — 登録済みチェーンで現行版に昇格 (v1 のみの現状は no-op)
- **`allaganeye/detection/metadata_writer.py`**: `read_metadata` で `check_schema_version` を呼ぶ
- **`allaganeye/commands/split_matches.py`**: `_build_metadata_payload` に `"schema_version": "1"` を追加

### GUI 側

- **`gui/src/types/metadata.schema.ts`**: `SCHEMA_VERSION = '1' as const` / `schema_version: z.literal(SCHEMA_VERSION).optional()`
- **`gui/src/types/metadata.ts`**: `Metadata.schema_version?: '1'`
- **`gui/src/data/sampleMetadata.ts`**: `schema_version: '1'` 付与 (Phase 2 sample 整合)

### テスト

- **Python**: `tests/test_migrations.py` 新設 (13 ケース = check_schema_version 6 + apply_migrations 7) / `tests/test_split_from_metadata.py` に 3 ケース追加 (新規書き込み含む / legacy ok / 未来版 reject)
- **vitest**: `metadata.schema.test.ts` に 4 ケース追加 (accept "1" / accept missing / reject "99" / reject non-string)

### docs

- `docs/metadata-spec.md` に §schema_version 節追加
    - 版数表 (欠落 / "1" / 2 以降)
    - migration policy (Python / GUI 両側の挙動一致)
    - 新しい版を追加する手順 (6 ステップ)
- 「将来の拡張」表から #515 を実装済みに更新
- トップのスキーマ表に `schema_version` 行追加

## テスト結果

| 種類 | コマンド | 結果 |
|---|---|---|
| pytest (slow 除く) | `python -m pytest -q` | 736 passed |
| vitest | `npm --prefix=gui test -- --run` | 25 files / 209 passed |
| eslint | `npm --prefix=gui run lint` | ok |
| tsc | `npm --prefix=gui run typecheck` | ok |

## 手動確認 (PR レビュー時)

- [x] CI pass (python/gui-frontend/gui-rust/markdownlint 全 pass)
- [x] `allaganeye detect <video>` で生成した metadata.json に `"schema_version": "1"` が含まれる (20260116_1.mp4 で実機検証、出力 metadata.json 冒頭 2 行目に `"schema_version": "1"` を確認)
- [x] legacy の `schema_version` なし metadata.json でも `split --from-metadata` が成功する (schema_version 行を除去した legacy 版で split 実行、exit 0 で match_001.mp4 生成を確認)
- [x] `"schema_version": "99"` の metadata.json で `split --from-metadata` が明確にエラー (exit 2) ("unsupported schema_version \"99\"" メッセージ + exit 2 を実機検証)

## 関連

- 派生元 issue: [#463](https://github.com/Idios/kobutachan-allaganeye/issues/463) (Phase 1 data layer)
- 仕様書: `docs/metadata-spec.md` § schema_version (#515)
- 後続: [#518](https://github.com/Idios/kobutachan-allaganeye/issues/518) warnings 構造化 (この基盤を利用する可能性あり、C 完了後ユーザー判断)

[elated-wozniak-50d3bb]

