### PR TITLE
feat(gui): 編集 draft 自動保存 (リロード耐性) (Refs #517)

### DIFF
--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -211,7 +211,7 @@ GUI の編集バッファを `metadata.draft.json` に自動保存し、WebView 
 - **復元フロー**: `metadataStore.load` 成功後に自動で `loadDraft` を呼び、存在すれば `pendingDraft` にセット。`DraftRestoreModal` (App.tsx に global 配置) が「復元 / 破棄」を提示
 - **metadata.json load 失敗時の挙動**: `metadata.json` が不正 / 不存在 / 破損で load が失敗した場合、`loadDraft` は呼ばれず (`metadata` が null のため早期 return)、復元 modal も表示されない。ユーザーは `metadata.json` を復旧してから再 load することで、残存する draft が復元候補として提示される。`metadata.draft.json` のみ単独で存在する状態での復元は対象外
 - **source 不一致チェック**: draft の `source` が現在 load した metadata の `source` と異なる場合、stale draft として自動削除 (modal は出さない)。比較は Windows 前提で separator (`\\` ↔ `/`) と大文字小文字を正規化した上で行う (`normalizeSourcePath`)
-- **source 以外のドリフト** (matches 数・detection_params・source_duration 等): 検知対象外。source が一致する限り draft は有効と見なす。metadata.json を CLI で再生成した場合の排他管理は別 issue (§将来の拡張「排他管理 (mtime 検知 / 同時編集警告)」参照) で対応予定
+- **source 以外のドリフト** (matches 数・detection_params・source_duration 等): 検知対象外。source が一致する限り draft は有効と見なす。metadata.json を CLI で再生成した場合の検知は §排他管理 (#514) で別途実装されている (mtime mismatch → `ConflictModal`)。本機能と排他管理は独立したレイヤ: mtime check が metadata 本体の同期を担当し、draft は GUI 編集バッファの保全を担当する。両者の相互作用は §排他管理と draft の相互作用 参照
 - **apply 成功後**: `metadataStore.apply` が成功すると `clearDraft` を呼び、`metadata.draft.json` をディスクから削除
 - **save 失敗の可視化**: `save_draft` 呼び出しが失敗 (disk full / permission denied / atomic rename 失敗等) すると `metadataStore.draftSaveError` に格納される。`scheduleDraftSave` は fire-and-forget だが state 経由で UI が検知可能 (toast / status bar 表示は Phase 3 以降で拡張予定)。次回 save 成功時に自動クリア
 - **Rust commands**: `save_draft(path, draft)` / `load_draft(path) -> Option<Value>` / `clear_draft(path)` — すべて atomic、clear は no-op-when-missing
@@ -225,6 +225,16 @@ GUI の編集バッファを `metadata.draft.json` に自動保存し、WebView 
 | 破棄 | `clearDraft()` を呼んで `metadata.draft.json` を削除し、`pendingDraft=null` |
 
 draft の zod parse に失敗した場合は error-only modal を出し「破棄」のみ提示する。
+
+### 排他管理 (#514) と draft (#517) の相互作用
+
+GUI が `load` / `apply` / `reloadAfterConflict` を実行するとき、排他管理 (mtime) と draft (in-memory buffer) が同時に state を更新する。両者の契約を以下に固定:
+
+- **`load` 順序**: `load_metadata` → `get_metadata_mtime` → set state → `refreshBackupStatus` → `loadDraft`。mtime 記録が完了してから draft 検査を行う
+- **Modal 優先順位**: `conflictError` が非 null の場合、`DraftRestoreModal` は描画されない。`ConflictModal` (3 択: 上書き / リロード / キャンセル) を先に解消してから draft restore を提示
+- **`apply` 成功時の順序**: `loadedMtimeMs` 更新 → `refreshBackupStatus` → `cancelDraftSave` → `clearDraft`。mtime を確実に更新した後に draft clear
+- **`applyOverwrite` と draft**: `applyOverwrite` は `apply` と共通 helper (`runApply`) 経由なので、上書き成功後も draft clear が発火する
+- **`reloadAfterConflict` 後の draft**: `reloadAfterConflict` は `load(filePath)` を呼ぶため、source 一致な draft があれば `DraftRestoreModal` が再提示される (ユーザー編集の救済として意図された挙動)
 
 ## 将来の拡張 (Phase 1 スコープ外)
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -201,6 +201,27 @@ GUI が `load_metadata` した瞬間のファイル mtime を `metadataStore.loa
 - **新規書き込み** (target が未存在): mtime check 対象外。`expectedMtimeMs` が指定されても skip し通常書き込み
 - **Rust command**: `get_metadata_mtime(path) -> Option<u64>` を追加。`apply_changes` の戻り値は書き込み後の mtime (`u64`) に変更され、GUI 側 `loadedMtimeMs` を自動更新
 
+## draft auto save (#517)
+
+GUI の編集バッファを `metadata.draft.json` に自動保存し、WebView のリロードやアプリクラッシュ時にも編集内容を復元できるようにする。
+
+- **保存先**: `metadata.json` と同ディレクトリの `metadata.draft.json`。atomic write (`.tmp` → rename)
+- **保存タイミング**: `metadataStore.updateMatch` 呼び出し後の debounce (デフォルト 500ms)。`setDraftSaveDelay(ms)` でテスト時短縮可能
+- **保存内容**: in-memory の Metadata そのまま (編集フィールド `name` / `type_override` / `edited` も含む)。zod の `MatchSchema.passthrough()` で load 時に pass-through
+- **復元フロー**: `metadataStore.load` 成功後に自動で `loadDraft` を呼び、存在すれば `pendingDraft` にセット。`DraftRestoreModal` (App.tsx に global 配置) が「復元 / 破棄」を提示
+- **source 不一致チェック**: draft の `source` が現在 load した metadata の `source` と異なる場合、stale draft として自動削除 (modal は出さない)
+- **apply 成功後**: `metadataStore.apply` が成功すると `clearDraft` を呼び、`metadata.draft.json` をディスクから削除
+- **Rust commands**: `save_draft(path, draft)` / `load_draft(path) -> Option<Value>` / `clear_draft(path)` — すべて atomic、clear は no-op-when-missing
+
+### ユーザー選択肢 (DraftRestoreModal)
+
+| ボタン | 動作 |
+|---|---|
+| 復元 | `pendingDraft` を `metadata` に適用し `dirty=true`。ディスクには触らない (ユーザーが [適用] で永続化) |
+| 破棄 | `clearDraft()` を呼んで `metadata.draft.json` を削除し、`pendingDraft=null` |
+
+draft の zod parse に失敗した場合は error-only modal を出し「破棄」のみ提示する。
+
 ## 将来の拡張 (Phase 1 スコープ外)
 
 以下は派生 issue で追跡する (本 Phase 1 では実装せず、設計余地だけ確保):
@@ -210,7 +231,7 @@ GUI が `load_metadata` した瞬間のファイル mtime を `metadataStore.loa
 | ~~排他管理 (mtime 検知 / 同時編集警告)~~ | [#514](https://github.com/Idios/kobutachan-allaganeye/issues/514) (実装済み、上記 §排他管理 参照) | GUI load 時の mtime 記録、save 時の外部変更検知 UX |
 | ~~schema_version フィールド~~ | [#515](https://github.com/Idios/kobutachan-allaganeye/issues/515) (実装済み、上記 §schema_version 参照) | 明示的な版数管理 + migration 基盤 |
 | ~~`[元に戻す]` 機能~~ | [#516](https://github.com/Idios/kobutachan-allaganeye/issues/516) (Phase 2 で実装済み) | `metadata.original.json` → `metadata.json` 復元ボタン (Rust `restore_from_original` + `metadataStore.restore`) |
-| draft auto save | (新規起票予定) | GUI 一時編集を `metadata.draft.json` に定期保存 (リロード耐性) |
+| ~~draft auto save~~ | [#517](https://github.com/Idios/kobutachan-allaganeye/issues/517) (実装済み、上記 §draft auto save 参照) | GUI 一時編集を `metadata.draft.json` に定期保存 (リロード耐性) |
 | `warnings: Warning[]` 構造化 | (新規起票予定) | legacy `note` の後継。`{code, message, severity}` 配列 |
 
 ## 関連 issue / doc

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -206,10 +206,11 @@ GUI が `load_metadata` した瞬間のファイル mtime を `metadataStore.loa
 GUI の編集バッファを `metadata.draft.json` に自動保存し、WebView のリロードやアプリクラッシュ時にも編集内容を復元できるようにする。
 
 - **保存先**: `metadata.json` と同ディレクトリの `metadata.draft.json`。atomic write (`.tmp` → rename)
-- **保存タイミング**: `metadataStore.updateMatch` 呼び出し後の debounce (デフォルト 500ms)。`setDraftSaveDelay(ms)` でテスト時短縮可能
+- **保存タイミング**: `metadataStore.updateMatch` 呼び出し後の debounce (デフォルト 500ms)。`setDraftSaveDelay(ms)` でテスト時短縮可能。**debounce 発火前に異常終了した場合、直近 500ms 以内の編集は失われる (データロス上限 = debounce 間隔)**
 - **保存内容**: in-memory の Metadata そのまま (編集フィールド `name` / `type_override` / `edited` も含む)。zod の `MatchSchema.passthrough()` で load 時に pass-through
 - **復元フロー**: `metadataStore.load` 成功後に自動で `loadDraft` を呼び、存在すれば `pendingDraft` にセット。`DraftRestoreModal` (App.tsx に global 配置) が「復元 / 破棄」を提示
-- **source 不一致チェック**: draft の `source` が現在 load した metadata の `source` と異なる場合、stale draft として自動削除 (modal は出さない)
+- **source 不一致チェック**: draft の `source` が現在 load した metadata の `source` と異なる場合、stale draft として自動削除 (modal は出さない)。比較は Windows 前提で separator (`\\` ↔ `/`) と大文字小文字を正規化した上で行う (`normalizeSourcePath`)
+- **source 以外のドリフト** (matches 数・detection_params・source_duration 等): 検知対象外。source が一致する限り draft は有効と見なす。metadata.json を CLI で再生成した場合の排他管理は別 issue (§将来の拡張「排他管理 (mtime 検知 / 同時編集警告)」参照) で対応予定
 - **apply 成功後**: `metadataStore.apply` が成功すると `clearDraft` を呼び、`metadata.draft.json` をディスクから削除
 - **Rust commands**: `save_draft(path, draft)` / `load_draft(path) -> Option<Value>` / `clear_draft(path)` — すべて atomic、clear は no-op-when-missing
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -209,10 +209,13 @@ GUI の編集バッファを `metadata.draft.json` に自動保存し、WebView 
 - **保存タイミング**: `metadataStore.updateMatch` 呼び出し後の debounce (デフォルト 500ms)。`setDraftSaveDelay(ms)` でテスト時短縮可能。**debounce 発火前に異常終了した場合、直近 500ms 以内の編集は失われる (データロス上限 = debounce 間隔)**
 - **保存内容**: in-memory の Metadata そのまま (編集フィールド `name` / `type_override` / `edited` も含む)。zod の `MatchSchema.passthrough()` で load 時に pass-through
 - **復元フロー**: `metadataStore.load` 成功後に自動で `loadDraft` を呼び、存在すれば `pendingDraft` にセット。`DraftRestoreModal` (App.tsx に global 配置) が「復元 / 破棄」を提示
+- **metadata.json load 失敗時の挙動**: `metadata.json` が不正 / 不存在 / 破損で load が失敗した場合、`loadDraft` は呼ばれず (`metadata` が null のため早期 return)、復元 modal も表示されない。ユーザーは `metadata.json` を復旧してから再 load することで、残存する draft が復元候補として提示される。`metadata.draft.json` のみ単独で存在する状態での復元は対象外
 - **source 不一致チェック**: draft の `source` が現在 load した metadata の `source` と異なる場合、stale draft として自動削除 (modal は出さない)。比較は Windows 前提で separator (`\\` ↔ `/`) と大文字小文字を正規化した上で行う (`normalizeSourcePath`)
 - **source 以外のドリフト** (matches 数・detection_params・source_duration 等): 検知対象外。source が一致する限り draft は有効と見なす。metadata.json を CLI で再生成した場合の排他管理は別 issue (§将来の拡張「排他管理 (mtime 検知 / 同時編集警告)」参照) で対応予定
 - **apply 成功後**: `metadataStore.apply` が成功すると `clearDraft` を呼び、`metadata.draft.json` をディスクから削除
+- **save 失敗の可視化**: `save_draft` 呼び出しが失敗 (disk full / permission denied / atomic rename 失敗等) すると `metadataStore.draftSaveError` に格納される。`scheduleDraftSave` は fire-and-forget だが state 経由で UI が検知可能 (toast / status bar 表示は Phase 3 以降で拡張予定)。次回 save 成功時に自動クリア
 - **Rust commands**: `save_draft(path, draft)` / `load_draft(path) -> Option<Value>` / `clear_draft(path)` — すべて atomic、clear は no-op-when-missing
+- **クラッシュ時のアトミック性**: `save_draft` は `write_metadata_atomic` ヘルパー (`.tmp` → atomic rename) を使用する。save 中のクラッシュでは `metadata.draft.json` は書き換え前の状態で残る (partial 書き込みは発生しない)。`metadata.draft.json.tmp` が残存することがあるが、次回 save で上書きされる / 次回 load で読み込み対象外のため cleanup は不要
 
 ### ユーザー選択肢 (DraftRestoreModal)
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -681,4 +681,29 @@ mod tests {
         // Draft must not touch the backup file.
         assert!(!backup.exists());
     }
+
+    /// Review 指摘 F3: save_draft must complete correctly even when a stale
+    /// `metadata.draft.json.tmp` is left over from a previous crash. This
+    /// pins the atomic-write contract for the draft file: the rename is not
+    /// blocked by pre-existing tmp artifacts and the final file reflects the
+    /// new payload regardless of prior state.
+    #[test]
+    fn save_draft_succeeds_when_stale_tmp_file_exists() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let draft_file = tmp.path().join("metadata.draft.json");
+        let tmp_file = tmp.path().join("metadata.draft.json.tmp");
+        // Simulate a crash that left a stale .tmp file behind.
+        fs::write(&tmp_file, r#"{"corrupt": true}"#).unwrap();
+        assert!(tmp_file.exists());
+
+        let draft = json!({"source": "a.mkv", "matches": []});
+        save_draft_sync(&meta, &draft).unwrap();
+
+        // Final file must have the new content regardless of prior .tmp state.
+        assert!(draft_file.exists());
+        let roundtrip: Value =
+            serde_json::from_str(&fs::read_to_string(&draft_file).unwrap()).unwrap();
+        assert_eq!(roundtrip, draft);
+    }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -58,6 +58,63 @@ async fn apply_changes(
     })
 }
 
+/// #517 — persist the in-memory edit buffer as `metadata.draft.json` next to
+/// the live `metadata.json`. Survives WebView reloads and app crashes.
+#[tauri::command]
+async fn save_draft(path: String, draft: Value) -> Result<(), String> {
+    save_draft_sync(&PathBuf::from(&path), &draft)
+}
+
+/// #517 — reload the draft buffer if one exists. Returns `None` when no
+/// draft is on disk (fresh session or post-apply state).
+#[tauri::command]
+async fn load_draft(path: String) -> Result<Option<Value>, String> {
+    load_draft_sync(&PathBuf::from(&path))
+}
+
+/// #517 — delete the draft file. Called after a successful `apply` so a
+/// restart doesn't re-prompt about stale edits.
+#[tauri::command]
+async fn clear_draft(path: String) -> Result<(), String> {
+    clear_draft_sync(&PathBuf::from(&path))
+}
+
+fn draft_path_for(meta_path: &Path) -> Result<PathBuf, String> {
+    let parent = meta_path
+        .parent()
+        .ok_or_else(|| format!("metadata path has no parent: {}", meta_path.display()))?;
+    Ok(parent.join("metadata.draft.json"))
+}
+
+fn save_draft_sync(meta_path: &Path, draft: &Value) -> Result<(), String> {
+    let draft_path = draft_path_for(meta_path)?;
+    write_metadata_atomic(&draft_path, draft)
+}
+
+fn load_draft_sync(meta_path: &Path) -> Result<Option<Value>, String> {
+    let draft_path = draft_path_for(meta_path)?;
+    if !draft_path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&draft_path)
+        .map_err(|e| format!("read draft failed ({}): {}", draft_path.display(), e))?;
+    let value: Value = serde_json::from_str(&content)
+        .map_err(|e| format!("invalid JSON in draft {}: {}", draft_path.display(), e))?;
+    Ok(Some(value))
+}
+
+fn clear_draft_sync(meta_path: &Path) -> Result<(), String> {
+    let draft_path = draft_path_for(meta_path)?;
+    if !draft_path.exists() {
+        // Nothing to clear — treat as success so callers don't have to
+        // special-case the post-apply no-draft state.
+        return Ok(());
+    }
+    fs::remove_file(&draft_path).map_err(|e| {
+        format!("remove draft failed ({}): {}", draft_path.display(), e)
+    })
+}
+
 /// #516 — atomically restore metadata.json from the first-Apply backup.
 #[tauri::command]
 async fn restore_from_original(path: String) -> Result<(), String> {
@@ -181,6 +238,9 @@ pub fn run() {
             load_metadata,
             get_metadata_mtime,
             apply_changes,
+            save_draft,
+            load_draft,
+            clear_draft,
             restore_from_original,
             check_backup_exists,
         ])
@@ -512,5 +572,113 @@ mod tests {
         // (regression guard: prevents accepting pre-first-apply handles).
         let err = apply_changes_sync(&meta, &json!({"v": 4}), Some(m1)).unwrap_err();
         assert!(err.starts_with("conflict:"), "unexpected error: {err}");
+    }
+
+    // #517 — draft auto-save tests.
+
+    #[test]
+    fn save_draft_creates_sibling_draft_file() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let draft_file = tmp.path().join("metadata.draft.json");
+        let draft = json!({"source": "a.mkv", "matches": []});
+
+        save_draft_sync(&meta, &draft).unwrap();
+
+        assert!(draft_file.exists());
+        let roundtrip: Value =
+            serde_json::from_str(&fs::read_to_string(&draft_file).unwrap()).unwrap();
+        assert_eq!(roundtrip, draft);
+    }
+
+    #[test]
+    fn save_draft_overwrites_existing_draft() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let draft_file = tmp.path().join("metadata.draft.json");
+        fs::write(&draft_file, r#"{"old": true}"#).unwrap();
+
+        let new_draft = json!({"new": true});
+        save_draft_sync(&meta, &new_draft).unwrap();
+
+        let roundtrip: Value =
+            serde_json::from_str(&fs::read_to_string(&draft_file).unwrap()).unwrap();
+        assert_eq!(roundtrip, new_draft);
+    }
+
+    #[test]
+    fn load_draft_returns_none_when_file_missing() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let result = load_draft_sync(&meta).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_draft_returns_parsed_value_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let draft_file = tmp.path().join("metadata.draft.json");
+        let draft = json!({"source": "a.mkv", "matches": [{"m": 1}]});
+        fs::write(&draft_file, serde_json::to_string_pretty(&draft).unwrap()).unwrap();
+
+        let result = load_draft_sync(&meta).unwrap();
+        assert_eq!(result, Some(draft));
+    }
+
+    #[test]
+    fn load_draft_returns_err_on_invalid_json() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let draft_file = tmp.path().join("metadata.draft.json");
+        fs::write(&draft_file, r#"{"broken": invalid"#).unwrap();
+
+        let err = load_draft_sync(&meta).unwrap_err();
+        assert!(err.contains("invalid JSON in draft"));
+    }
+
+    #[test]
+    fn clear_draft_removes_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let draft_file = tmp.path().join("metadata.draft.json");
+        fs::write(&draft_file, r#"{}"#).unwrap();
+        assert!(draft_file.exists());
+
+        clear_draft_sync(&meta).unwrap();
+        assert!(!draft_file.exists());
+    }
+
+    #[test]
+    fn clear_draft_is_noop_when_file_missing() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        // No draft on disk — should still succeed.
+        clear_draft_sync(&meta).unwrap();
+    }
+
+    #[test]
+    fn save_and_load_draft_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let draft = json!({"source": "a.mkv", "matches": [{"index": 1}]});
+
+        save_draft_sync(&meta, &draft).unwrap();
+        let loaded = load_draft_sync(&meta).unwrap();
+        assert_eq!(loaded, Some(draft));
+    }
+
+    #[test]
+    fn draft_lives_alongside_metadata_not_backup() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let backup = tmp.path().join("metadata.original.json");
+        let draft_file = tmp.path().join("metadata.draft.json");
+
+        save_draft_sync(&meta, &json!({"m": 1})).unwrap();
+
+        assert!(draft_file.exists());
+        // Draft must not touch the backup file.
+        assert!(!backup.exists());
     }
 }

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,4 +1,5 @@
 import { ConflictModal } from './components/ConflictModal';
+import { DraftRestoreModal } from './components/DraftRestoreModal';
 import { SideRail } from './components/SideRail';
 import { StateSwitcher } from './components/StateSwitcher';
 import { CompleteScreen } from './screens/CompleteScreen';
@@ -45,6 +46,8 @@ export default function App() {
       </div>
       {/* #514 — global modal for metadata.json external-modification conflicts. */}
       <ConflictModal />
+      {/* #517 — global modal for draft restore offers on mount/post-load. */}
+      <DraftRestoreModal />
     </div>
   );
 }

--- a/gui/src/components/DraftRestoreModal.module.css
+++ b/gui/src/components/DraftRestoreModal.module.css
@@ -1,0 +1,76 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(var(--ae-bg-rgb), 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9000;
+}
+
+.panel {
+  min-width: 420px;
+  max-width: 640px;
+  background: var(--ae-panel);
+  border: var(--ae-panel-border);
+  border-radius: 4px;
+  padding: 24px 28px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+}
+
+.title {
+  font-family: var(--ae-font-ui);
+  font-size: 14px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--ae-gold-bright);
+  margin: 0 0 16px 0;
+}
+
+.message {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  color: var(--ae-danger);
+  word-break: break-all;
+  margin: 0 0 12px 0;
+  line-height: 1.5;
+}
+
+.hint {
+  font-family: var(--ae-font-body);
+  font-size: 12px;
+  color: var(--ae-text-dim);
+  margin: 0 0 20px 0;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.button {
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.33);
+  color: var(--ae-gold);
+  font-family: var(--ae-font-ui);
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.button:hover:not(:disabled) {
+  background: rgba(var(--ae-gold-rgb), 0.1);
+  color: var(--ae-gold-bright);
+}
+
+.button:disabled {
+  border-color: rgba(var(--ae-gold-rgb), 0.13);
+  color: var(--ae-gold-dim);
+  cursor: not-allowed;
+  opacity: 0.7;
+}

--- a/gui/src/components/DraftRestoreModal.test.tsx
+++ b/gui/src/components/DraftRestoreModal.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+
+import { useMetadataStore } from '../state/metadataStore';
+import type { Metadata } from '../types/metadata';
+import { DraftRestoreModal } from './DraftRestoreModal';
+
+function seedMetadata(): Metadata {
+  return {
+    source: 'C:/videos/src.mkv',
+    source_duration: 100,
+    source_duration_display: '1:40',
+    detected_at: '2026-04-22T00:00:00Z',
+    detection_params: {
+      sample_interval: 2,
+      blackout_threshold: 15,
+      min_match_duration: 300,
+      min_blackout_duration: 3,
+      no_audio: false,
+      use_gpu: null,
+      workers: null,
+    },
+    matches: [
+      {
+        index: 1,
+        start_time: 0,
+        end_time: 50,
+        start_display: '00:00',
+        end_display: '00:50',
+        duration: 50,
+        duration_display: '50s',
+        type: 'fl_match',
+        output_file: 'match_001.mp4',
+      },
+    ],
+    gaps: [],
+  };
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  useMetadataStore.getState().clear();
+});
+
+describe('DraftRestoreModal', () => {
+  it('renders nothing when no pendingDraft and no draftLoadError', () => {
+    const { container } = render(<DraftRestoreModal />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders restore dialog with 2 buttons when pendingDraft is set', () => {
+    useMetadataStore.setState({ pendingDraft: seedMetadata() });
+    render(<DraftRestoreModal />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(/編集中の draft を復元しますか/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '復元' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '破棄' })).toBeInTheDocument();
+  });
+
+  it('restore applies the draft to the store as a dirty edit', async () => {
+    const draft = {
+      ...seedMetadata(),
+      matches: seedMetadata().matches.map((m) => ({ ...m, name: 'from-draft' })),
+    };
+    useMetadataStore.setState({
+      metadata: seedMetadata(),
+      pendingDraft: draft,
+      filePath: '/tmp/metadata.json',
+    });
+    render(<DraftRestoreModal />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '復元' }));
+    const state = useMetadataStore.getState();
+    expect(state.metadata?.matches[0].name).toBe('from-draft');
+    expect(state.dirty).toBe(true);
+    expect(state.pendingDraft).toBeNull();
+    // Restore is in-memory only — no disk I/O.
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('discard invokes clear_draft and removes the pending state', async () => {
+    useMetadataStore.setState({
+      pendingDraft: seedMetadata(),
+      filePath: '/tmp/metadata.json',
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'clear_draft') return Promise.resolve();
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    render(<DraftRestoreModal />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '破棄' }));
+    await waitFor(() => {
+      expect(useMetadataStore.getState().pendingDraft).toBeNull();
+    });
+    expect(invokeMock).toHaveBeenCalledWith('clear_draft', {
+      path: '/tmp/metadata.json',
+    });
+  });
+
+  it('shows error-only modal when draftLoadError is set', () => {
+    useMetadataStore.setState({
+      draftLoadError: 'parse error: invalid JSON',
+      filePath: '/tmp/metadata.json',
+    });
+    render(<DraftRestoreModal />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByText(/draft を読み取れませんでした/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/parse error/)).toBeInTheDocument();
+    // Only the discard button is offered in the error path.
+    expect(screen.getByRole('button', { name: '破棄' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '復元' })).toBeNull();
+  });
+});

--- a/gui/src/components/DraftRestoreModal.test.tsx
+++ b/gui/src/components/DraftRestoreModal.test.tsx
@@ -122,4 +122,17 @@ describe('DraftRestoreModal', () => {
     expect(screen.getByRole('button', { name: '破棄' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '復元' })).toBeNull();
   });
+
+  // Review 指摘 2-2 (#517 × #514): ConflictModal が前に出ている間は
+  // DraftRestoreModal を描画しない。両 Modal の同時表示で backdrop が
+  // 重なる UX 崩壊を防ぐ (ConflictModal の 3 択を先に解消させる)。
+  it('does not render while conflictError is set (ConflictModal takes priority)', () => {
+    useMetadataStore.setState({
+      pendingDraft: seedMetadata(),
+      conflictError: 'conflict: external modification detected',
+      filePath: '/tmp/metadata.json',
+    });
+    const { container } = render(<DraftRestoreModal />);
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/gui/src/components/DraftRestoreModal.tsx
+++ b/gui/src/components/DraftRestoreModal.tsx
@@ -1,0 +1,87 @@
+import { useMetadataStore } from '../state/metadataStore';
+import styles from './DraftRestoreModal.module.css';
+
+/**
+ * #517: modal offered on mount / after load when a `metadata.draft.json`
+ * exists for the current metadata file. User chooses whether to apply the
+ * draft to the in-memory buffer (then 適用 to persist) or discard it.
+ *
+ * Global modal — rendered once in App.tsx regardless of the current screen.
+ */
+export function DraftRestoreModal() {
+  const pendingDraft = useMetadataStore((s) => s.pendingDraft);
+  const draftLoadError = useMetadataStore((s) => s.draftLoadError);
+  const restoreDraft = useMetadataStore((s) => s.restoreDraft);
+  const discardDraft = useMetadataStore((s) => s.discardDraft);
+
+  if (!pendingDraft && !draftLoadError) return null;
+
+  if (draftLoadError) {
+    // Draft existed but could not be parsed — offer discard only.
+    return (
+      <div
+        className={styles.backdrop}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ae-draft-error-title"
+      >
+        <div className={styles.panel}>
+          <h2 id="ae-draft-error-title" className={styles.title}>
+            draft を読み取れませんでした
+          </h2>
+          <p className={styles.message}>{draftLoadError}</p>
+          <p className={styles.hint}>
+            metadata.draft.json が破損しているか schema が一致しません。破棄して続行します。
+          </p>
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.button}
+              onClick={() => {
+                void discardDraft();
+              }}
+            >
+              破棄
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={styles.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ae-draft-restore-title"
+    >
+      <div className={styles.panel}>
+        <h2 id="ae-draft-restore-title" className={styles.title}>
+          編集中の draft を復元しますか?
+        </h2>
+        <p className={styles.hint}>
+          前回の編集内容が metadata.draft.json に保存されています。「復元」で編集バッファに適用 (適用ボタンで metadata.json に反映)、「破棄」で draft を削除して現行の metadata.json を使用します。
+        </p>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.button}
+            onClick={() => restoreDraft()}
+          >
+            復元
+          </button>
+          <button
+            type="button"
+            className={styles.button}
+            onClick={() => {
+              void discardDraft();
+            }}
+          >
+            破棄
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gui/src/components/DraftRestoreModal.tsx
+++ b/gui/src/components/DraftRestoreModal.tsx
@@ -11,9 +11,13 @@ import styles from './DraftRestoreModal.module.css';
 export function DraftRestoreModal() {
   const pendingDraft = useMetadataStore((s) => s.pendingDraft);
   const draftLoadError = useMetadataStore((s) => s.draftLoadError);
+  const conflictError = useMetadataStore((s) => s.conflictError);
   const restoreDraft = useMetadataStore((s) => s.restoreDraft);
   const discardDraft = useMetadataStore((s) => s.discardDraft);
 
+  // #517 × #514: ConflictModal は metadata 本体の同期が優先。draft restore は
+  // conflict 解消後に提示する (Modal 同時表示による UX 崩壊を回避)。
+  if (conflictError) return null;
   if (!pendingDraft && !draftLoadError) return null;
 
   if (draftLoadError) {

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -801,4 +801,53 @@ describe('useMetadataStore (#517 draft)', () => {
     expect(state.draftLoadError).toBeNull();
     expect(state.draftSaving).toBe(false);
   });
+
+  // Review 指摘 A: path normalization. Platform is Windows-only (CLAUDE.md),
+  // so separator / case differences must not be read as different sources.
+  // Without normalization the draft is silently discarded even though it's
+  // the same file (regression on 受け入れ条件 #3).
+  it('loadDraft treats source paths differing only in separator as equal', async () => {
+    const meta = validMetadata();
+    // Draft captured with backslashes, live metadata with forward slashes.
+    const draft = { ...meta, source: meta.source.replace(/\//g, '\\') };
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: draft,
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    expect(useMetadataStore.getState().pendingDraft).not.toBeNull();
+  });
+
+  it('loadDraft treats source paths differing only in case as equal (Windows)', async () => {
+    const meta = validMetadata();
+    const draft = { ...meta, source: meta.source.toUpperCase() };
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: draft,
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    expect(useMetadataStore.getState().pendingDraft).not.toBeNull();
+  });
+
+  // Review 指摘 B: schema_version unknown → draft parse fails → draftLoadError.
+  // Proves 受け入れ条件 #3 is exercised through the schema_version axis.
+  // Guards against a silent regression when v2 migration is introduced.
+  it('loadDraft surfaces an error when the draft schema_version is unknown', async () => {
+    const meta = validMetadata();
+    const draft = { ...meta, schema_version: '99' };
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: draft,
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    const state = useMetadataStore.getState();
+    expect(state.pendingDraft).toBeNull();
+    expect(state.draftLoadError).toBeTruthy();
+  });
 });

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -891,3 +891,80 @@ describe('useMetadataStore (#517 draft)', () => {
     expect(useMetadataStore.getState().draftSaveError).toBeNull();
   });
 });
+
+// Review 指摘 4: #514 × #517 相互作用。各 Modal / action の順序契約と state
+// 共存の妥当性を unit レベルで pin し、将来 refactor で silent regression が
+// 発生しないよう保護する。
+describe('useMetadataStore (#514 × #517 interaction)', () => {
+  // 4-1: load は mtime 記録が終わってから loadDraft を呼ぶ。順序が入れ替わると
+  // draft 検査時に metadata が未確定 or mtime 未記録になる。
+  it('load invokes get_metadata_mtime before loadDraft', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+      load_draft: null,
+    });
+    await useMetadataStore.getState().load('p');
+    const calls = invokeMock.mock.calls.map((c) => c[0] as string);
+    const mtimeIdx = calls.indexOf('get_metadata_mtime');
+    const loadDraftIdx = calls.indexOf('load_draft');
+    expect(mtimeIdx).toBeGreaterThanOrEqual(0);
+    expect(loadDraftIdx).toBeGreaterThan(mtimeIdx);
+  });
+
+  // 4-2: applyOverwrite は apply と共通 helper (runApply) 経由なので、上書き
+  // 成功後も clear_draft が発火することを保証する。
+  it('applyOverwrite success triggers clearDraft via shared runApply', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+      apply_changes: 9999,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().applyOverwrite();
+    const clearCall = invokeMock.mock.calls.find((c) => c[0] === 'clear_draft');
+    expect(clearCall).toBeDefined();
+  });
+
+  // 4-3: reloadAfterConflict は load(filePath) を呼ぶため、source 一致な draft
+  // があれば pendingDraft が再設定される (ユーザー編集救済の意図挙動)。
+  it('reloadAfterConflict re-triggers loadDraft via load', async () => {
+    const meta = validMetadata();
+    const draft = {
+      ...meta,
+      matches: meta.matches.map((m) => ({ ...m, name: 'rescued' })),
+    };
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: draft,
+    });
+    await useMetadataStore.getState().load('p');
+    // conflict 発火を simulate
+    useMetadataStore.setState({ conflictError: 'conflict: external' });
+    await useMetadataStore.getState().reloadAfterConflict();
+    expect(useMetadataStore.getState().pendingDraft?.matches[0].name).toBe(
+      'rescued',
+    );
+    expect(useMetadataStore.getState().conflictError).toBeNull();
+  });
+
+  // 4-4: state 層では conflictError と pendingDraft が共存できる。排他制御は
+  // UI 層 (DraftRestoreModal が conflictError 非 null 時に return null) が担う。
+  // store に排他条件を入れると「conflict 解消後に draft modal が復活する」
+  // 挙動を壊してしまう。
+  it('conflictError and pendingDraft can coexist in state (resolved at render layer)', async () => {
+    const meta = validMetadata();
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: meta,
+    });
+    await useMetadataStore.getState().load('p');
+    expect(useMetadataStore.getState().pendingDraft).not.toBeNull();
+    useMetadataStore.setState({ conflictError: 'conflict: external' });
+    expect(useMetadataStore.getState().conflictError).toBeTruthy();
+    expect(useMetadataStore.getState().pendingDraft).not.toBeNull();
+  });
+});

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -794,12 +794,14 @@ describe('useMetadataStore (#517 draft)', () => {
       pendingDraft: validMetadata(),
       draftLoadError: 'prev',
       draftSaving: true,
+      draftSaveError: 'prev-save-err',
     });
     useMetadataStore.getState().clear();
     const state = useMetadataStore.getState();
     expect(state.pendingDraft).toBeNull();
     expect(state.draftLoadError).toBeNull();
     expect(state.draftSaving).toBe(false);
+    expect(state.draftSaveError).toBeNull();
   });
 
   // Review 指摘 A: path normalization. Platform is Windows-only (CLAUDE.md),
@@ -849,5 +851,43 @@ describe('useMetadataStore (#517 draft)', () => {
     const state = useMetadataStore.getState();
     expect(state.pendingDraft).toBeNull();
     expect(state.draftLoadError).toBeTruthy();
+  });
+
+  // Review 指摘 F1: saveDraft failures must surface via draftSaveError.
+  // scheduleDraftSave calls saveDraft fire-and-forget, so without this guard
+  // disk-full / permission-denied failures would be silent unhandled
+  // rejections. A save that never landed breaks the "restore after crash"
+  // contract — users need a way to detect it.
+  it('saveDraft surfaces invoke errors via draftSaveError state', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+      save_draft_error: new Error('disk full'),
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().saveDraft();
+    const state = useMetadataStore.getState();
+    expect(state.draftSaveError).toContain('disk full');
+    expect(state.draftSaving).toBe(false);
+  });
+
+  it('saveDraft clears previous draftSaveError on next success', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+      save_draft_error: new Error('transient'),
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().saveDraft();
+    expect(useMetadataStore.getState().draftSaveError).toBeTruthy();
+
+    // Next save succeeds → error cleared.
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().saveDraft();
+    expect(useMetadataStore.getState().draftSaveError).toBeNull();
   });
 });

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -68,6 +68,13 @@ interface MockConfig {
   restore_from_original_error?: Error;
   check_backup_exists?: boolean;
   check_backup_exists_error?: Error;
+  // #517
+  save_draft?: unknown;
+  save_draft_error?: Error;
+  load_draft?: unknown;
+  load_draft_error?: Error;
+  clear_draft?: unknown;
+  clear_draft_error?: Error;
 }
 
 function configureInvoke(cfg: MockConfig) {
@@ -93,6 +100,15 @@ function configureInvoke(cfg: MockConfig) {
         if (cfg.check_backup_exists_error)
           return Promise.reject(cfg.check_backup_exists_error);
         return Promise.resolve(cfg.check_backup_exists ?? false);
+      case 'save_draft':
+        if (cfg.save_draft_error) return Promise.reject(cfg.save_draft_error);
+        return Promise.resolve(cfg.save_draft);
+      case 'load_draft':
+        if (cfg.load_draft_error) return Promise.reject(cfg.load_draft_error);
+        return Promise.resolve(cfg.load_draft ?? null);
+      case 'clear_draft':
+        if (cfg.clear_draft_error) return Promise.reject(cfg.clear_draft_error);
+        return Promise.resolve(cfg.clear_draft);
       default:
         return Promise.reject(new Error(`unmocked invoke: ${cmd}`));
     }
@@ -371,6 +387,8 @@ describe('useMetadataStore.loadSample', () => {
     expect(state.hasBackup).toBe(false);
     expect(state.loadedMtimeMs).toBeNull();
     expect(state.conflictError).toBeNull();
+    expect(state.pendingDraft).toBeNull();
+    expect(state.draftLoadError).toBeNull();
   });
 });
 
@@ -602,5 +620,185 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
     };
     expect(args.expectedMtimeMs).toBe(2500);
     expect(useMetadataStore.getState().loadedMtimeMs).toBe(3300);
+  });
+});
+
+// #517 — draft auto-save.
+
+describe('useMetadataStore (#517 draft)', () => {
+  it('saveDraft invokes save_draft with the current metadata', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().saveDraft();
+
+    const saveCall = invokeMock.mock.calls.find((c) => c[0] === 'save_draft');
+    expect(saveCall).toBeDefined();
+    expect(saveCall![1]).toMatchObject({ path: 'p' });
+    // The draft payload carries the in-memory metadata (including name).
+    const draft = (saveCall![1] as { draft: Metadata }).draft;
+    expect(draft.matches[0].name).toBe('x');
+  });
+
+  it('saveDraft is a no-op when no filePath is set (sample mode)', async () => {
+    useMetadataStore.getState().loadSample();
+    await useMetadataStore.getState().saveDraft();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('loadDraft populates pendingDraft when backing source matches', async () => {
+    const meta = validMetadata();
+    const draft = { ...meta, matches: meta.matches.map((m) => ({ ...m, name: 'restored' })) };
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: draft,
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    const state = useMetadataStore.getState();
+    expect(state.pendingDraft).not.toBeNull();
+    expect(state.pendingDraft?.matches[0].name).toBe('restored');
+    expect(state.draftLoadError).toBeNull();
+  });
+
+  it('loadDraft discards drafts whose source does not match the loaded file', async () => {
+    const meta = validMetadata();
+    // Draft points at a different source video.
+    const draft = { ...meta, source: 'C:/videos/DIFFERENT.mkv' };
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: draft,
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    const state = useMetadataStore.getState();
+    expect(state.pendingDraft).toBeNull();
+    // Stale draft is cleaned up on disk.
+    const clearCall = invokeMock.mock.calls.find((c) => c[0] === 'clear_draft');
+    expect(clearCall).toBeDefined();
+  });
+
+  it('loadDraft sets draftLoadError on parse failure', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+      load_draft: { bogus: true }, // won't pass zod
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    const state = useMetadataStore.getState();
+    expect(state.pendingDraft).toBeNull();
+    expect(state.draftLoadError).toBeTruthy();
+  });
+
+  it('loadDraft is a no-op when no draft exists on disk', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+      load_draft: null,
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    const state = useMetadataStore.getState();
+    expect(state.pendingDraft).toBeNull();
+    expect(state.draftLoadError).toBeNull();
+  });
+
+  it('restoreDraft applies pendingDraft to metadata and marks dirty', async () => {
+    const meta = validMetadata();
+    const draft = {
+      ...meta,
+      matches: meta.matches.map((m) => ({ ...m, name: 'from-draft' })),
+    };
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: draft,
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    useMetadataStore.getState().restoreDraft();
+    const state = useMetadataStore.getState();
+    expect(state.metadata?.matches[0].name).toBe('from-draft');
+    expect(state.dirty).toBe(true);
+    expect(state.pendingDraft).toBeNull();
+  });
+
+  it('discardDraft removes the on-disk draft and clears pendingDraft', async () => {
+    const meta = validMetadata();
+    configureInvoke({
+      load_metadata: meta,
+      check_backup_exists: false,
+      load_draft: meta,
+    });
+    await useMetadataStore.getState().load('p');
+    await useMetadataStore.getState().loadDraft();
+    expect(useMetadataStore.getState().pendingDraft).not.toBeNull();
+
+    await useMetadataStore.getState().discardDraft();
+    expect(useMetadataStore.getState().pendingDraft).toBeNull();
+    const clearCall = invokeMock.mock.calls.find((c) => c[0] === 'clear_draft');
+    expect(clearCall).toBeDefined();
+  });
+
+  it('clearDraft is a no-op when filePath is null', async () => {
+    useMetadataStore.setState({ filePath: null, pendingDraft: null });
+    // No mock for clear_draft — should still succeed because we skip invoke.
+    await useMetadataStore.getState().clearDraft();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('apply success triggers clearDraft', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      check_backup_exists: false,
+      apply_changes: undefined,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().apply();
+    const clearCall = invokeMock.mock.calls.find((c) => c[0] === 'clear_draft');
+    expect(clearCall).toBeDefined();
+  });
+
+  it('updateMatch schedules a debounced saveDraft', async () => {
+    const { setDraftSaveDelay } = await import('./metadataStore');
+    setDraftSaveDelay(10); // speed up the debounce for the test
+    try {
+      configureInvoke({
+        load_metadata: validMetadata(),
+        check_backup_exists: false,
+      });
+      await useMetadataStore.getState().load('p');
+      useMetadataStore.getState().updateMatch(1, { name: 'x' });
+      // Not invoked yet — debounce in flight.
+      expect(
+        invokeMock.mock.calls.find((c) => c[0] === 'save_draft'),
+      ).toBeUndefined();
+      await new Promise((r) => setTimeout(r, 25));
+      expect(
+        invokeMock.mock.calls.find((c) => c[0] === 'save_draft'),
+      ).toBeDefined();
+    } finally {
+      setDraftSaveDelay(500);
+    }
+  });
+
+  it('clear() resets all draft state', () => {
+    useMetadataStore.setState({
+      pendingDraft: validMetadata(),
+      draftLoadError: 'prev',
+      draftSaving: true,
+    });
+    useMetadataStore.getState().clear();
+    const state = useMetadataStore.getState();
+    expect(state.pendingDraft).toBeNull();
+    expect(state.draftLoadError).toBeNull();
+    expect(state.draftSaving).toBe(false);
   });
 });

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -9,6 +9,19 @@ export type MatchEditPatch = Partial<
   Pick<Match, 'name' | 'type_override' | 'edited'>
 >;
 
+/**
+ * Normalize a filesystem path for source-equality comparison (#517, review).
+ *
+ * The current platform is Windows-only (see CLAUDE.md), so two paths that
+ * differ only in separator (`\` vs `/`) or letter case should be treated as
+ * pointing at the same file. Without normalization a draft whose source was
+ * captured with one convention is dropped as stale even though it's the same
+ * video — the draft the user was editing would be silently discarded.
+ */
+function normalizeSourcePath(p: string): string {
+  return p.replace(/\\/g, '/').toLowerCase();
+}
+
 export interface MetadataState {
   metadata: Metadata | null;
   filePath: string | null;
@@ -354,7 +367,12 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       const parsed = MetadataSchema.parse(raw) as unknown as Metadata;
       // #517: if the draft was produced against a different source video,
       // it's stale — drop it rather than offering restore on the wrong file.
-      if (parsed.source !== metadata.source) {
+      // Normalize separator + case (Windows only) so the same file captured
+      // with `C:\...` vs `C:/...` or `...MKV` vs `...mkv` round-trips as equal.
+      if (
+        normalizeSourcePath(parsed.source) !==
+        normalizeSourcePath(metadata.source)
+      ) {
         await invoke('clear_draft', { path: filePath });
         set({ pendingDraft: null, draftLoadError: null });
         return;

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -61,6 +61,14 @@ export interface MetadataState {
   draftLoadError: string | null;
   /** #517: true while an auto-save (debounced saveDraft) is in flight. */
   draftSaving: boolean;
+  /**
+   * #517: last draft save error (disk full / permission denied / atomic
+   * rename failure). Cleared on the next successful save. Surfacing this in
+   * state lets the UI notify the user — otherwise save failures are silent
+   * unhandled rejections and the "restore after crash" contract is weakened
+   * (a save that never landed cannot be restored).
+   */
+  draftSaveError: string | null;
 
   load: (path: string) => Promise<void>;
   updateMatch: (index: number, patch: MatchEditPatch) => void;
@@ -205,6 +213,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
   pendingDraft: null,
   draftLoadError: null,
   draftSaving: false,
+  draftSaveError: null,
 
   load: async (path) => {
     try {
@@ -225,6 +234,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         conflictError: null,
         pendingDraft: null,
         draftLoadError: null,
+        draftSaveError: null,
       });
       await get().refreshBackupStatus();
       // #517: automatically probe for a draft after a successful load. If one
@@ -242,6 +252,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         conflictError: null,
         pendingDraft: null,
         draftLoadError: null,
+        draftSaveError: null,
       });
     }
   },
@@ -290,6 +301,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       pendingDraft: null,
       draftLoadError: null,
       draftSaving: false,
+      draftSaveError: null,
     });
   },
 
@@ -347,9 +359,14 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
   saveDraft: async () => {
     const { filePath, metadata } = get();
     if (!filePath || !metadata) return;
-    set({ draftSaving: true });
+    // Clear any prior save error up-front so consumers see a fresh attempt.
+    set({ draftSaving: true, draftSaveError: null });
     try {
       await invoke('save_draft', { path: filePath, draft: metadata });
+    } catch (e) {
+      // Surface the failure via state — scheduleDraftSave's fire-and-forget
+      // call would otherwise swallow the rejection silently (see F1 review).
+      set({ draftSaveError: e instanceof Error ? e.message : String(e) });
     } finally {
       set({ draftSaving: false });
     }
@@ -433,6 +450,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       pendingDraft: null,
       draftLoadError: null,
       draftSaving: false,
+      draftSaveError: null,
     });
   },
   };

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -37,6 +37,17 @@ export interface MetadataState {
    * `applyOverwrite` / `reloadAfterConflict` / `dismissConflict`.
    */
   conflictError: string | null;
+  /**
+   * #517: a draft snapshot loaded from metadata.draft.json that differs from
+   * the live metadata on disk. Non-null means the UI should ask the user
+   * whether to restore or discard. Resolved via `restoreDraft()` /
+   * `discardDraft()`.
+   */
+  pendingDraft: Metadata | null;
+  /** #517: last draft load error (corrupt draft / parse failure). */
+  draftLoadError: string | null;
+  /** #517: true while an auto-save (debounced saveDraft) is in flight. */
+  draftSaving: boolean;
 
   load: (path: string) => Promise<void>;
   updateMatch: (index: number, patch: MatchEditPatch) => void;
@@ -56,11 +67,47 @@ export interface MetadataState {
   /** #514: close the conflict modal without side effects (edits stay in store). */
   dismissConflict: () => void;
 
+  /** #517: write the current in-memory metadata to metadata.draft.json. */
+  saveDraft: () => Promise<void>;
+  /** #517: probe the filesystem for a draft; populates `pendingDraft` if the
+   *  draft is valid and references the same source. Call after `load()`. */
+  loadDraft: () => Promise<void>;
+  /** #517: delete metadata.draft.json (post-apply cleanup). */
+  clearDraft: () => Promise<void>;
+  /** #517: apply `pendingDraft` to `metadata` and mark the store dirty so the
+   *  user can re-apply. Does NOT touch disk — user still needs to press 適用. */
+  restoreDraft: () => void;
+  /** #517: drop `pendingDraft` and delete the on-disk draft file. */
+  discardDraft: () => Promise<void>;
+
   /** Phase 2 only: load the in-memory sample metadata (no filePath set). */
   loadSample: () => void;
 }
 
 const PERSISTABLE_TYPES = new Set<TypeOverride>(['fl_match', 'unknown']);
+
+/** #517: draft auto-save debounce interval. Module-scoped so tests can
+ *  override by importing `setDraftSaveDelay`. */
+let draftSaveDelayMs = 500;
+export function setDraftSaveDelay(ms: number): void {
+  draftSaveDelayMs = ms;
+}
+let draftSaveTimer: ReturnType<typeof setTimeout> | null = null;
+function scheduleDraftSave(trigger: () => void): void {
+  if (draftSaveTimer !== null) {
+    clearTimeout(draftSaveTimer);
+  }
+  draftSaveTimer = setTimeout(() => {
+    draftSaveTimer = null;
+    trigger();
+  }, draftSaveDelayMs);
+}
+function cancelDraftSave(): void {
+  if (draftSaveTimer !== null) {
+    clearTimeout(draftSaveTimer);
+    draftSaveTimer = null;
+  }
+}
 
 function normalizeForPersistence(metadata: Metadata): Metadata {
   return {
@@ -114,6 +161,10 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         conflictError: null,
       });
       await get().refreshBackupStatus();
+      // #517: successful apply means the on-disk state caught up with our
+      // edits, so drop the draft.
+      cancelDraftSave();
+      await get().clearDraft();
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       if (msg.startsWith('conflict:')) {
@@ -138,6 +189,9 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
 
   loadedMtimeMs: null,
   conflictError: null,
+  pendingDraft: null,
+  draftLoadError: null,
+  draftSaving: false,
 
   load: async (path) => {
     try {
@@ -156,8 +210,14 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         restoreError: null,
         loadedMtimeMs: mtime ?? null,
         conflictError: null,
+        pendingDraft: null,
+        draftLoadError: null,
       });
       await get().refreshBackupStatus();
+      // #517: automatically probe for a draft after a successful load. If one
+      // exists and references the same source, the UI will surface a restore
+      // modal via `pendingDraft`.
+      await get().loadDraft();
     } catch (e) {
       set({
         metadata: null,
@@ -167,6 +227,8 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         hasBackup: false,
         loadedMtimeMs: null,
         conflictError: null,
+        pendingDraft: null,
+        draftLoadError: null,
       });
     }
   },
@@ -181,6 +243,13 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       metadata: { ...state.metadata, matches },
       dirty: true,
     });
+    // #517: auto-save the edit buffer. Only makes sense when a real file is
+    // loaded (sample mode has no backing path).
+    if (get().filePath) {
+      scheduleDraftSave(() => {
+        void get().saveDraft();
+      });
+    }
   },
 
   apply: async () => {
@@ -192,6 +261,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
   },
 
   clear: () => {
+    cancelDraftSave();
     set({
       metadata: null,
       filePath: null,
@@ -204,6 +274,9 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       restoreError: null,
       loadedMtimeMs: null,
       conflictError: null,
+      pendingDraft: null,
+      draftLoadError: null,
+      draftSaving: false,
     });
   },
 
@@ -258,7 +331,75 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
     set({ conflictError: null });
   },
 
+  saveDraft: async () => {
+    const { filePath, metadata } = get();
+    if (!filePath || !metadata) return;
+    set({ draftSaving: true });
+    try {
+      await invoke('save_draft', { path: filePath, draft: metadata });
+    } finally {
+      set({ draftSaving: false });
+    }
+  },
+
+  loadDraft: async () => {
+    const { filePath, metadata } = get();
+    if (!filePath || !metadata) return;
+    try {
+      const raw = await invoke<unknown>('load_draft', { path: filePath });
+      if (raw === null || raw === undefined) {
+        set({ pendingDraft: null, draftLoadError: null });
+        return;
+      }
+      const parsed = MetadataSchema.parse(raw) as unknown as Metadata;
+      // #517: if the draft was produced against a different source video,
+      // it's stale — drop it rather than offering restore on the wrong file.
+      if (parsed.source !== metadata.source) {
+        await invoke('clear_draft', { path: filePath });
+        set({ pendingDraft: null, draftLoadError: null });
+        return;
+      }
+      set({ pendingDraft: parsed, draftLoadError: null });
+    } catch (e) {
+      set({
+        pendingDraft: null,
+        draftLoadError: e instanceof Error ? e.message : String(e),
+      });
+    }
+  },
+
+  clearDraft: async () => {
+    const { filePath } = get();
+    if (!filePath) {
+      set({ pendingDraft: null });
+      return;
+    }
+    try {
+      await invoke('clear_draft', { path: filePath });
+    } finally {
+      set({ pendingDraft: null });
+    }
+  },
+
+  restoreDraft: () => {
+    const { pendingDraft } = get();
+    if (!pendingDraft) return;
+    // Apply the draft to the store as an in-memory edit. The user still has
+    // to press 適用 to persist, which mirrors the normal edit flow and gives
+    // them a chance to back out.
+    set({
+      metadata: pendingDraft,
+      dirty: true,
+      pendingDraft: null,
+    });
+  },
+
+  discardDraft: async () => {
+    await get().clearDraft();
+  },
+
   loadSample: () => {
+    cancelDraftSave();
     set({
       metadata: sampleMetadata,
       filePath: null,
@@ -271,6 +412,9 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       restoreError: null,
       loadedMtimeMs: null,
       conflictError: null,
+      pendingDraft: null,
+      draftLoadError: null,
+      draftSaving: false,
     });
   },
   };

--- a/gui/src/types/metadata.schema.ts
+++ b/gui/src/types/metadata.schema.ts
@@ -22,6 +22,10 @@ export const MatchSchema = z
     type: z.enum(['fl_match', 'unknown']),
     output_file: z.string(),
   })
+  // #517: passthrough match-level edit fields (`name` / `type_override` /
+  // `edited`) so metadata.draft.json round-trips them when reloaded.
+  // metadata.json proper still strips these via normalizeForPersistence.
+  .passthrough()
   .refine((m) => m.end_time >= m.start_time, {
     message: 'end_time must be >= start_time',
   });


### PR DESCRIPTION
## 概要

[#517](https://github.com/Idios/kobutachan-allaganeye/issues/517) — GUI の一時編集 state (`Match.name` / `type_override` / `edited`) を定期的に `metadata.draft.json` に自動保存し、WebView2 のリロードやアプリクラッシュで編集が失われないようにする。

## 受け入れ条件

- [x] Rust 側: `save_draft(path, draft)` / `load_draft(path) -> Option<Value>` / `clear_draft(path)` command (atomic write / no-op when missing)
- [x] GUI 側: `metadataStore` に `pendingDraft` / `draftLoadError` / `draftSaving` state + `saveDraft` / `loadDraft` / `clearDraft` / `restoreDraft` / `discardDraft` actions
- [x] `updateMatch` 後の debounce (500ms) で `saveDraft` 自動実行 (`setDraftSaveDelay` でテスト時短縮可)
- [x] `load` 成功後に `loadDraft` 自動呼び出し、存在すれば `pendingDraft` にセット (modal 表示)
- [x] `apply` 成功後に `clearDraft` で metadata.draft.json を削除
- [x] App マウント時に (load 経由で) draft 復元 modal が表示される (GUI で編集後、WebView を強制リロードしても draft から復元できる)
- [x] `[適用]` 後は draft ファイルが消える
- [x] draft が metadata.json と不整合 (source 不一致) なら自動的に破棄される
- [x] Rust / GUI 側に単体テスト

## 受け入れ条件の対応

### (issue 受け入れ条件 3 条)

- [x] **GUI で編集後、WebView を強制リロードしても draft から復元できる**: `metadataStore.load` → `loadDraft` 自動呼び出し → `pendingDraft` に復元候補 → `DraftRestoreModal` で「復元」を押すと `metadata` に適用 (vitest: `restoreDraft applies the draft to the store as a dirty edit`)
- [x] **`[適用]` 後は draft ファイルが消える**: `apply` 成功パスで `clearDraft` を呼び、Rust `clear_draft` が `metadata.draft.json` を削除 (vitest: `apply success triggers clearDraft`、cargo: `clear_draft_removes_existing_file`)
- [x] **draft が metadata.json と不整合な場合 (source 不一致等) は破棄されるか明確なエラー**: `loadDraft` が `source` 不一致を検知したら `clear_draft` を呼び `pendingDraft` を null に (vitest: `loadDraft discards drafts whose source does not match the loaded file`)。zod parse 失敗時は `draftLoadError` を立てて error-only modal (vitest: `loadDraft sets draftLoadError on parse failure`)

## 実装内容

### Rust (gui/src-tauri/src/lib.rs)

| 関数 | 役割 |
|---|---|
| `save_draft(path, draft)` | `metadata.json` の兄弟として `metadata.draft.json` を atomic write |
| `load_draft(path) -> Option<Value>` | 存在すれば Value / 無ければ None |
| `clear_draft(path)` | `metadata.draft.json` を削除 (存在しない時は no-op で成功) |

いずれも `write_metadata_atomic` ヘルパーを流用してアトミック性を保証。

### GUI (gui/src/state/metadataStore.ts)

- state: `pendingDraft: Metadata | null` / `draftLoadError: string | null` / `draftSaving: boolean`
- actions: `saveDraft` / `loadDraft` / `clearDraft` / `restoreDraft` / `discardDraft`
- `scheduleDraftSave` / `cancelDraftSave` モジュールレベル helper (debounce)
- `setDraftSaveDelay(ms)` エクスポート (vitest で 10ms に短縮)

### UI (gui/src/components/DraftRestoreModal.tsx)

- 正常時: 「復元 / 破棄」の 2 択
- draftLoadError (zod parse 失敗等) 時: 「破棄」のみ
- App.tsx に global 配置

### MatchSchema.passthrough()

metadata.draft.json は編集フィールド (`name` / `type_override` / `edited`) を含むため、`MatchSchema` に `.passthrough()` を追加して zod parse で落とさないようにした。metadata.json proper の `apply` 時は `normalizeForPersistence` で依然としてこれらを削るため、contract 違反にはならない。

## テスト結果

| 種類 | コマンド | 結果 |
|---|---|---|
| cargo | `cd gui/src-tauri && cargo test --lib` | 19 passed (既存 10 + 新規 9) |
| vitest | `npm --prefix=gui test -- --run` | 26 files / 222 passed |
| eslint | `npm --prefix=gui run lint` | ok |
| tsc | `npm --prefix=gui run typecheck` | ok |

### 新規テスト一覧

**cargo** (9 本):

- `save_draft_creates_sibling_draft_file` / `save_draft_overwrites_existing_draft`
- `load_draft_returns_none_when_file_missing` / `load_draft_returns_parsed_value_when_present` / `load_draft_returns_err_on_invalid_json`
- `clear_draft_removes_existing_file` / `clear_draft_is_noop_when_file_missing`
- `save_and_load_draft_roundtrip` / `draft_lives_alongside_metadata_not_backup`

**vitest metadataStore** (11 本):

- saveDraft 呼び出し / sample モードは no-op
- loadDraft で pendingDraft セット / source 不一致で廃棄 / parse 失敗で error / 無いときは null
- restoreDraft で metadata 適用 + dirty
- discardDraft で clear_draft invoke
- clearDraft (filePath null) no-op
- apply 成功で clearDraft 自動呼び出し
- updateMatch 後 debounce で saveDraft 自動実行
- clear() が draft state リセット

**vitest DraftRestoreModal** (5 本):

- null 非表示 / 復元 dialog 2 ボタン / restore で dirty 適用 (no invoke) / discard で clear_draft / draftLoadError は error-only modal

## 手動確認 (PR レビュー時)

- [x] CI pass (python/gui-frontend/gui-rust/markdownlint 全 pass)
- [x] DraftRestoreModal 発火 (vitest で段階的に実証: DraftRestoreModal.test.tsx 5 + metadataStore.test.ts draft 関連 11、計 16 テストで null / dialog / restore / discard / error 分岐を網羅)。Tauri dev での実機検証は Phase 3 マージ後 (実 detect 経由で filePath 設定後) に Idios が実施
- [x] 「復元」で pendingDraft を metadata に適用 + dirty (vitest `restoreDraft applies the draft to the store as a dirty edit`、適用で normalizeForPersistence 経由 apply も `apply success triggers clearDraft` テストで確認)
- [x] 「破棄」で clear_draft → pendingDraft=null + ファイル削除 (vitest `discardDraft removes the on-disk draft and clears pendingDraft` + Rust `clear_draft_removes_existing_file`)
- [x] source 不一致 draft の自動削除 (vitest `loadDraft discards drafts whose source does not match the loaded file`)
- [x] apply 成功後に clearDraft 自動呼び出し (vitest `apply success triggers clearDraft`)

## 関連

- 派生元 issue: [#463](https://github.com/Idios/kobutachan-allaganeye/issues/463) (Phase 1 data layer)
- 仕様書: `docs/metadata-spec.md` § draft auto save (#517)
- 前提: #463 Phase 1 data layer (`metadataStore` / `apply_changes`)

[elated-wozniak-50d3bb]

