### PR TITLE
fix(ffmpeg_path,docs,tests): BtbN LGPL 方針を code/test/docs サイドに浸透 (Refs #508)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,8 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 
 ### 外部依存
 
-- **ffmpeg / ffprobe**: 4.1 以上。PATH、`ALLAGANEYE_FFMPEG` 環境変数、または OS 別既知パスから自動検索（`allaganeye/ffmpeg_path.py`）
-  - Windows: winget (`Gyan.FFmpeg`) のインストール先を自動検索
+- **ffmpeg / ffprobe**: 4.1 以上。PATH、`ALLAGANEYE_FFMPEG` 環境変数、または OS 別既知パスから自動検索（`allaganeye/ffmpeg_path.py`）。配布版・開発環境ともに LGPLv3 版 (BtbN FFmpeg-Builds `win64-lgpl` static、libdav1d 入り) の使用を推奨 (#508)
+  - Windows: `ALLAGANEYE_FFMPEG` で BtbN LGPL ビルドを指定する運用を推奨。既存 winget (`Gyan.FFmpeg`, GPL) のインストール先も後方互換で自動検索される
   - macOS: Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`) を自動検索
 - **Python パッケージ**: numpy, typer, scipy, opencv-python-headless（scorebar V2 検出で使用 #307）
 - **対応プラットフォーム**: Windows のみ（実動画での動作確認済み）。Linux・macOS は未検証（CI では lint/型チェックのみ ubuntu で実行）

--- a/allaganeye/ffmpeg_path.py
+++ b/allaganeye/ffmpeg_path.py
@@ -105,7 +105,7 @@ def _search_macos_known_paths(name: str) -> str | None:
 
 def _error_message(name: str) -> str:
     lines = [
-        f"{name} not found. Install ffmpeg and ensure it is accessible.",
+        f"{name} not found. Install ffmpeg (LGPL build recommended) and ensure it is accessible.",
         "",
         "Options:",
         "  1. Add ffmpeg to PATH",
@@ -113,7 +113,13 @@ def _error_message(name: str) -> str:
     ]
     if sys.platform == "win32":
         lines.append(
-            "  3. Install via winget: winget install Gyan.FFmpeg (auto-discovered)"
+            "  3. Download BtbN LGPL build from "
+            "https://github.com/BtbN/FFmpeg-Builds/releases "
+            "(ffmpeg-nX.Y-...-win64-lgpl-X.Y.zip, recommended to match the Portable ZIP)"
+        )
+        lines.append(
+            "  4. Existing winget Gyan.FFmpeg (GPL) installs are still auto-discovered "
+            "as a fallback"
         )
     elif sys.platform == "darwin":
         lines.append("  3. Install via Homebrew: brew install ffmpeg (auto-discovered)")

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -6,7 +6,7 @@ CLI コマンド・引数・オプションの**構文**をまとめる。各オ
 
 | 要件 | 説明 |
 |---|---|
-| ffmpeg / ffprobe 4.1+ | 以下の順序で自動検索: (1) PATH (`shutil.which`) (2) `ALLAGANEYE_FFMPEG` 環境変数で指定したディレクトリ (3) OS 別既知パス（Windows: winget `Gyan.FFmpeg`、macOS: Homebrew） |
+| ffmpeg / ffprobe 4.1+ | 以下の順序で自動検索: (1) PATH (`shutil.which`) (2) `ALLAGANEYE_FFMPEG` 環境変数で指定したディレクトリ (3) OS 別既知パス（Windows: winget `Gyan.FFmpeg`、macOS: Homebrew）。配布版・dev 環境ともに LGPLv3 版 (BtbN FFmpeg-Builds `win64-lgpl` static) の使用を推奨 (#508)。winget `Gyan.FFmpeg` は GPL 版で、後方互換 fallback として自動検索される |
 
 ## グローバルオプション
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -160,7 +160,7 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
 
 | 優先度 | OS | 状態 | ffmpeg 自動検索 |
 |---|---|---|---|
-| 1 | Windows | 対応済み | winget (`Gyan.FFmpeg`) |
+| 1 | Windows | 対応済み | `ALLAGANEYE_FFMPEG` で BtbN LGPLv3 static (#508 推奨) または winget (`Gyan.FFmpeg`, GPL、後方互換 fallback) |
 | 2 | Linux | 未検証 | パッケージマネージャで PATH に入る（CI は lint/型チェックのみ） |
 | 3 | macOS | 未検証 | Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`) |
 

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -69,9 +69,9 @@ claude/<scope>-* → PR → /review-pr (受け入れ条件チェック) → /tes
 - タグ形式: `v<major>.<minor>.<patch>`
 - コマンド: `git tag -a v0.x.0 -m "Release v0.x.0: <レイヤー名>"`
 - `git push origin v0.x.0` すると [`.github/workflows/release.yml`](../.github/workflows/release.yml) が発火し、Windows Portable ZIP (`allaganeye-v<version>-windows.zip`) のビルドと GitHub Release への成果物自動添付を実行する (#461)
-  - ビルドは [`scripts/build-portable-zip.ps1`](../scripts/build-portable-zip.ps1) で Python 3.11 embeddable + FFmpeg LGPL essentials を同梱する
-    - ダウンロードする外部バイナリ (Python embed / get-pip.py / FFmpeg) はスクリプト内に **SHA256 ダイジェストをハードコードして検証** する。ダイジェスト不一致時はビルドを fail。FFmpeg は特定バージョンタグを URL にピン留め (現在 `8.1`) して再現性を確保する
-    - 外部バイナリを更新する場合はスクリプト先頭の `$FFmpegVersion` / `$*Sha256` 定数を更新する
+  - ビルドは [`scripts/build-portable-zip.ps1`](../scripts/build-portable-zip.ps1) で Python 3.11 embeddable + FFmpeg LGPLv3 static (BtbN FFmpeg-Builds win64-lgpl、libdav1d 入り) を同梱する
+    - ダウンロードする外部バイナリ (Python embed / get-pip.py / FFmpeg) はスクリプト内に **SHA256 ダイジェストをハードコードして検証** する。ダイジェスト不一致時はビルドを fail。FFmpeg は BtbN の `autobuild-YYYY-MM-DD-HH-MM` タグと特定アセット名を URL にピン留めして再現性を確保する (`latest` タグは日次更新の可動ポインタなので不可)
+    - 外部バイナリを更新する場合はスクリプト先頭の `$FFmpegBuildTag` / `$FFmpegAssetName` / `$*Sha256` 定数を更新する
   - Release 本文は [`scripts/extract_release_notes.py`](../scripts/extract_release_notes.py) が CHANGELOG.md から該当バージョンのセクションを抽出する
   - タグ名と `pyproject.toml` の `version` が一致しない場合、workflow は fail する
 - 手動で dry-run ビルドを確認したい場合は、Actions タブから `Release` workflow を `workflow_dispatch` で起動する (Release は作成されず ZIP artifact のみ)

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -120,7 +120,7 @@ def _ffmpeg_interval(request: pytest.FixtureRequest) -> None:
 
 ### Windows
 
-- ffmpeg のパス自動検索: winget (`Gyan.FFmpeg`) のインストール先を自動検索する。見つからない場合は `ALLAGANEYE_FFMPEG` 環境変数を設定する
+- ffmpeg のパス自動検索: `ALLAGANEYE_FFMPEG` 環境変数で BtbN LGPLv3 static (配布物と同一、libdav1d 入り) を指定する運用を推奨 (#508)。既存 winget (`Gyan.FFmpeg`, GPL) のインストール先も後方互換で自動検索される
 - GPU テスト: NVIDIA GPU + 最新ドライバが必要。GPU がない環境では自動的に CPU モードにフォールバックする
 
 ### Linux（未検証）

--- a/tests/test_ffmpeg_path.py
+++ b/tests/test_ffmpeg_path.py
@@ -1,6 +1,7 @@
 """Tests for ffmpeg/ffprobe path resolution."""
 
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -9,6 +10,7 @@ from allaganeye.exceptions import VideoProcessingError
 from allaganeye.ffmpeg_path import (
     _ENV_VAR,
     _check_dir,
+    _error_message,
     _find_binary,
     _search_macos_known_paths,
     _search_windows_known_paths,
@@ -86,6 +88,33 @@ class TestFindBinary:
         ):
             result = _find_binary("ffmpeg")
         assert result == "/usr/bin/ffmpeg"
+
+
+class TestErrorMessage:
+    """Tests for the install-instructions error message (#508)."""
+
+    def test_generic_recommends_lgpl(self):
+        msg = _error_message("ffmpeg")
+        assert "LGPL" in msg
+        assert _ENV_VAR in msg
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific guidance")
+    def test_windows_recommends_btbn_lgpl_and_keeps_winget_fallback(self):
+        """Windows message surfaces BtbN LGPL as primary and Gyan.FFmpeg as fallback.
+
+        Distribution ships BtbN LGPLv3 since #508. Devs should match licensing,
+        but existing winget `Gyan.FFmpeg` (GPL) installs are still auto-discovered
+        so the message documents that path as a backward-compat fallback.
+        """
+        msg = _error_message("ffmpeg")
+        assert "BtbN" in msg
+        assert "win64-lgpl" in msg
+        assert "Gyan.FFmpeg" in msg
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific guidance")
+    def test_macos_mentions_homebrew(self):
+        msg = _error_message("ffmpeg")
+        assert "brew install ffmpeg" in msg
 
 
 class TestCheckDir:

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -2945,9 +2945,10 @@ def test_probe_ffmpeg_version_returns_unknown_on_failure():
         ),
         # BtbN 'n' prefix (common on nightly CI builds)
         ("ffmpeg version n7.1 Copyright (c) 2000-2024", "7.1"),
-        # BtbN LGPL autobuild (shipped with Portable ZIP since #508)
+        # BtbN LGPL autobuild (shipped with Portable ZIP since #508 / #531;
+        # date matches $FFmpegBuildTag = autobuild-2026-04-22-13-15)
         (
-            "ffmpeg version n8.1-10-g7f5c90f77e-20260421 Copyright (c) 2000-2026",
+            "ffmpeg version n8.1-10-g7f5c90f77e-20260422 Copyright (c) 2000-2026",
             "8.1",
         ),
         # essentials_build variant

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -2945,6 +2945,11 @@ def test_probe_ffmpeg_version_returns_unknown_on_failure():
         ),
         # BtbN 'n' prefix (common on nightly CI builds)
         ("ffmpeg version n7.1 Copyright (c) 2000-2024", "7.1"),
+        # BtbN LGPL autobuild (shipped with Portable ZIP since #508)
+        (
+            "ffmpeg version n8.1-10-g7f5c90f77e-20260421 Copyright (c) 2000-2026",
+            "8.1",
+        ),
         # essentials_build variant
         ("ffmpeg version 6.0-essentials_build-www.gyan.dev", "6.0"),
         # Bare version (macOS Homebrew style)


### PR DESCRIPTION
## 概要

[#508](https://github.com/Idios/kobutachan-allaganeye/issues/508) (Portable ZIP で CPU chunk decode timeout 多発) の主対応は PR [#531](https://github.com/Idios/kobutachan-allaganeye/pull/531) (Python 3.11.9 + BtbN LGPLv3 FFmpeg 8.1 統一) で完了済み。本 PR は同方針を受けて、PR #531 の scope 外だった **code エラーメッセージ・周辺 docs・version parser テスト**を追従させる残務。

## 背景

本 PR は当初 `scripts/build-portable-zip.ps1` の BtbN 差し替えを主目的として作成したが、ほぼ同時に PR #531 が同じ差し替えを先に実施してマージされたため scope が重複した。`develop-0.2.0` (PR #531 マージ後) に rebase し、独自追加分のみに縮小した (既存 1/8 の変更はほぼ docs の文言整合と 2 ファイルのテスト追加)。

## 変更ファイル (8 files, +50 / -10)

### code + tests

- `allaganeye/ffmpeg_path.py` — 未導入時エラーメッセージ `_error_message` を「winget Gyan.FFmpeg 推奨」から「BtbN LGPL 手動配置を第一推奨 + winget Gyan.FFmpeg (GPL) は後方互換 fallback」に更新
- `tests/test_ffmpeg_path.py` (新規テストクラス `TestErrorMessage`) — エラーメッセージ文言ガード 3 テスト追加 (`LGPL` / `BtbN` / `win64-lgpl` / `Gyan.FFmpeg` fallback の必須含有)
- `tests/test_split_matches.py` — BtbN autobuild 版 version 文字列 (`n8.1-10-g7f5c90f77e-20260421`) を `_probe_ffmpeg_version` の trim テスト parametrize に追加

### docs (方針整合)

- `docs/release-strategy.md` — 「LGPL essentials」→「LGPLv3 static (BtbN)」用語統一、ピン対象定数名も `$FFmpegBuildTag` / `$FFmpegAssetName` に更新 (PR #531 で既に実施された実体に整合)
- `CLAUDE.md` §外部依存 — ffmpeg エントリに「配布版・開発環境ともに LGPLv3 版 (BtbN FFmpeg-Builds `win64-lgpl` static、libdav1d 入り) の使用を推奨 (#508)」を追記、Windows 行を `ALLAGANEYE_FFMPEG` + BtbN LGPL 推奨 / winget (`Gyan.FFmpeg`) 後方互換 fallback に更新
- `docs/cli-spec.md` §前提条件 — ffmpeg 行末尾に LGPL 推奨 / winget 後方互換の一文を追記
- `docs/design-overview.md` §クロスプラットフォーム対応 — Windows 行を `ALLAGANEYE_FFMPEG` で BtbN LGPLv3 static (#508 推奨) または winget (`Gyan.FFmpeg`, GPL、後方互換 fallback) に更新
- `docs/testing-guide.md` §Windows — ffmpeg パス自動検索を BtbN LGPL 第一推奨 / winget fallback に書き換え

## 検証

| 実施 | 結果 |
|---|---|
| pytest (fast, 723 tests + 1 macOS-only skipped) | PASS |
| ruff check / ruff format --check | clean |
| pyright | 0 errors, 0 warnings |
| CI markdownlint-cli2 (action v20、PR #531 と同じ rule set) | clean 想定 (pre-existing MD060 は本 PR 無関係、CI action version では非 enforce) |

## PR #531 との関係

| | PR #531 (マージ済) | PR #535 (本 PR、rebase 後) |
|---|---|---|
| `scripts/build-portable-zip.ps1` | BtbN LGPL 差し替え実施 | — (この PR では触らず、#531 版を使用) |
| `docs/developer-setup.md` | BtbN install 手順 + §9 bump checklist | — (同上) |
| CI workflows | BtbN LGPL linux64 を CI で download | — (触らず) |
| `allaganeye/ffmpeg_path.py` error msg | 未更新 | **本 PR で更新** |
| `tests/test_ffmpeg_path.py` | 未追加 | **本 PR で追加** |
| `tests/test_split_matches.py` BtbN parser | 未追加 | **本 PR で追加** |
| 外側 docs (`CLAUDE.md` / `cli-spec` / `design-overview` / `testing-guide` / `release-strategy`) | 未更新 | **本 PR で更新** |

## フォローアップ起票済み

- [#528](https://github.com/Idios/kobutachan-allaganeye/issues/528) `build-portable-zip.ps1` に Pester 単体テストを追加 (G6、scope-guard で分離)
- [#529](https://github.com/Idios/kobutachan-allaganeye/issues/529) → PR [#536](https://github.com/Idios/kobutachan-allaganeye/pull/536) で解決済 (scorebar baseline を scorebar-on semantics に移行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
