### PR TITLE
fix(tests): baseline を scorebar-on semantics に移行、20260118 の 4 件非FL を除外 (Refs #529)

### DIFF
--- a/tests/baselines/20260116.json
+++ b/tests/baselines/20260116.json
@@ -8,31 +8,38 @@
   "boundaries": [
     {
       "start": 49.125,
-      "end": 1052.375
+      "end": 1054.5,
+      "type": "fl_match"
     },
     {
       "start": 1256.0,
-      "end": 2176.625
+      "end": 2178.75,
+      "type": "fl_match"
     },
     {
-      "start": 2355.75,
-      "end": 3228.25
+      "start": 2355.0,
+      "end": 3230.5,
+      "type": "fl_match"
     },
     {
-      "start": 3516.25,
-      "end": 4235.875
+      "start": 3365.0,
+      "end": 4352.0,
+      "type": "fl_match"
     },
     {
-      "start": 4539.5,
-      "end": 5482.5
+      "start": 4538.0,
+      "end": 5484.5,
+      "type": "fl_match"
     },
     {
       "start": 5624.25,
-      "end": 6542.0
+      "end": 6542.0,
+      "type": "fl_match"
     },
     {
-      "start": 6737.25,
-      "end": 7303.488
+      "start": 6542.0,
+      "end": 7303.488,
+      "type": "unknown"
     }
   ],
   "elapsed": 633.9

--- a/tests/baselines/20260118.json
+++ b/tests/baselines/20260118.json
@@ -4,51 +4,37 @@
   "duration": 8234.73,
   "width": 1920,
   "height": 1080,
-  "match_count": 11,
+  "match_count": 6,
   "boundaries": [
     {
       "start": 177.25,
-      "end": 1218.75
+      "end": 1221.0,
+      "type": "fl_match"
     },
     {
-      "start": 1218.75,
-      "end": 1688.0
+      "start": 1686.0,
+      "end": 2610.75,
+      "type": "fl_match"
     },
     {
-      "start": 1688.0,
-      "end": 2608.5
-    },
-    {
-      "start": 2608.5,
-      "end": 2978.125
-    },
-    {
-      "start": 2978.125,
-      "end": 3926.0
+      "start": 2976.25,
+      "end": 3928.25,
+      "type": "fl_match"
     },
     {
       "start": 4200.25,
-      "end": 4572.5
-    },
-    {
-      "start": 4572.5,
-      "end": 5253.375
+      "end": 5255.5,
+      "type": "fl_match"
     },
     {
       "start": 5499.0,
-      "end": 6465.25
+      "end": 6467.5,
+      "type": "fl_match"
     },
     {
-      "start": 6465.25,
-      "end": 6802.75
-    },
-    {
-      "start": 6802.75,
-      "end": 7231.75
-    },
-    {
-      "start": 7231.75,
-      "end": 8114.625
+      "start": 7231.25,
+      "end": 8114.625,
+      "type": "fl_match"
     }
   ],
   "elapsed": 537.5

--- a/tests/baselines/20260119.json
+++ b/tests/baselines/20260119.json
@@ -4,47 +4,52 @@
   "duration": 9233.988,
   "width": 1920,
   "height": 1080,
-  "match_count": 10,
+  "match_count": 9,
   "boundaries": [
     {
       "start": 124.25,
-      "end": 865.625
+      "end": 867.5,
+      "type": "fl_match"
     },
     {
-      "start": 945.125,
-      "end": 1980.75
+      "start": 943.0,
+      "end": 1891.25,
+      "type": "fl_match"
     },
     {
       "start": 1985.0,
-      "end": 2927.0
+      "end": 2928.5,
+      "type": "fl_match"
     },
     {
-      "start": 3069.125,
-      "end": 3837.625
+      "start": 3068.0,
+      "end": 3839.25,
+      "type": "fl_match"
     },
     {
       "start": 3993.0,
-      "end": 4946.5
+      "end": 4948.75,
+      "type": "fl_match"
     },
     {
-      "start": 5099.5,
-      "end": 5848.25
-    },
-    {
-      "start": 6064.75,
-      "end": 6466.5
+      "start": 5098.25,
+      "end": 6035.0,
+      "type": "fl_match"
     },
     {
       "start": 6469.75,
-      "end": 7383.75
+      "end": 7385.25,
+      "type": "fl_match"
     },
     {
       "start": 7556.0,
-      "end": 8190.875
+      "end": 8193.0,
+      "type": "fl_match"
     },
     {
       "start": 8413.25,
-      "end": 9101.125
+      "end": 9101.125,
+      "type": "fl_match"
     }
   ],
   "elapsed": 681.4

--- a/tests/generate_baselines.py
+++ b/tests/generate_baselines.py
@@ -4,8 +4,16 @@ Usage:
     python tests/generate_baselines.py
 
 Requires ALLAGANEYE_SAMPLE_VIDEO_DIR to be set.
-Runs detection WITHOUT scorebar filtering (src_resolution=None)
-and saves results to tests/baselines/<name>.json.
+Runs detection WITH scorebar filtering (src_resolution from probe)
+and saves the filtered match set to tests/baselines/<name>.json (#529).
+
+The baseline records "the expected FL match set after scorebar V2 filtering"
+so that regression tests (test_scorebar_regression.py) verify ongoing
+detection output stays aligned with this canonical set.  An earlier version
+of this script ran detection without scorebar, producing a baseline that
+included non-FL content (e.g., Limsa duty-queue interludes for 20260118 that
+scorebar V2 correctly removes).  That drift caused baseline failures once
+scorebar V2 emblem detection (#522) landed; see #529 for the migration.
 """
 
 import json
@@ -54,7 +62,7 @@ def main() -> None:
             blackout_threshold=15.0,
             min_match_duration=300.0,
             min_blackout_duration=3.0,
-            # src_resolution omitted -> no scorebar filtering
+            src_resolution=(meta["width"], meta["height"]),  # scorebar filter (#529)
         )
         elapsed = time.monotonic() - start
 

--- a/tests/test_scorebar_regression.py
+++ b/tests/test_scorebar_regression.py
@@ -384,7 +384,26 @@ _BASELINES_DIR = Path(__file__).parent / "baselines"
 
 
 def _load_baseline(name: str) -> dict | None:
+    """Load the canonical (scorebar-on) baseline.
+
+    Since #529 the main baseline records FL matches AFTER scorebar V2
+    filtering.  Tests that need the pre-scorebar raw detection output
+    (e.g. TestNoResolutionCompat) should use ``_load_legacy_baseline``.
+    """
     path = _BASELINES_DIR / f"{name}.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_legacy_baseline(name: str) -> dict | None:
+    """Load the legacy raw-detection baseline (no scorebar, pre-#529).
+
+    Retained in ``tests/baselines/_legacy/`` to keep the backward-compat
+    check (``TestNoResolutionCompat``) meaningful after the main baseline
+    migrated to scorebar-on output in #529.
+    """
+    path = _BASELINES_DIR / "_legacy" / f"{name}.json"
     if not path.exists():
         return None
     return json.loads(path.read_text(encoding="utf-8"))
@@ -393,31 +412,37 @@ def _load_baseline(name: str) -> dict | None:
 @pytest.mark.slow_detect
 @pytest.mark.baseline_regen
 class TestNoResolutionCompat:
-    """When src_resolution is omitted, behavior must be identical to pre-#124."""
+    """When src_resolution is omitted, behavior must match raw (pre-scorebar) baseline.
+
+    Uses the ``_legacy/`` baselines that still capture the raw-detection
+    output (no scorebar filtering).  Keeps the #124 backward-compat check
+    valid after #529 migrated the main baseline to scorebar-on semantics.
+    """
 
     def test_same_count_as_baseline(
         self, target_recording: tuple[str, Path], detection_without_scorebar: dict
     ):
-        """Detection without src_resolution matches saved baseline count."""
+        """Detection without src_resolution matches saved legacy baseline count."""
         name, _ = target_recording
-        baseline = _load_baseline(name)
+        baseline = _load_legacy_baseline(name)
         if baseline is None:
-            pytest.skip(f"No baseline for {name}")
+            pytest.skip(f"No legacy baseline for {name}")
 
         detected = detection_without_scorebar["match_count"]
         baseline_count = baseline["match_count"]
         assert detected == baseline_count, (
-            f"{name}: without scorebar got {detected}, baseline was {baseline_count}"
+            f"{name}: without scorebar got {detected}, "
+            f"legacy baseline was {baseline_count}"
         )
 
     def test_boundaries_match_baseline(
         self, target_recording: tuple[str, Path], detection_without_scorebar: dict
     ):
-        """Each boundary timestamp matches baseline within 5s tolerance."""
+        """Each boundary timestamp matches legacy baseline within 5s tolerance."""
         name, _ = target_recording
-        baseline = _load_baseline(name)
+        baseline = _load_legacy_baseline(name)
         if baseline is None:
-            pytest.skip(f"No baseline for {name}")
+            pytest.skip(f"No legacy baseline for {name}")
 
         detected = detection_without_scorebar["boundaries"]
         baseline_b = baseline["boundaries"]
@@ -478,8 +503,12 @@ class TestBaselineComparison:
                     f"({bb['start']:.0f}-{bb['end']:.0f}s) not covered"
                 )
 
-        # Allow up to 3 uncovered: some baseline matches may be non-FL
-        # content that scorebar correctly removes
+        # Allow up to 3 uncovered to absorb small detection drift between
+        # baseline-generation time and now (#529 migrated the baseline to
+        # scorebar-on semantics, so in the healthy case all baseline matches
+        # should be covered; the tolerance guards against future regressions
+        # in scorebar V2 emblem detection or the upstream Pass 1/Pass 2
+        # pipeline).
         assert len(uncovered) <= 3, (
             f"{name}: {len(uncovered)} baseline matches lost:\n" + "\n".join(uncovered)
         )


### PR DESCRIPTION
## 概要

[#529](https://github.com/Idios/kobutachan-allaganeye/issues/529) (slow test `test_baseline_match_content_preserved[20260118]` で 4 matches lost、許容 3 超過) を修正。

**判定**: (c) 意図した削除 + (b) baseline 誤り。scorebar V2 emblem 検出 (#522) が正しく非FL を除外しており、検出コードの回帰ではない。baseline 側が pre-V2 時代の raw 検知 (非FL 含む全エントリ) のまま放置されていたため test が失敗していた。

## 調査サマリ

### 視覚的検証

20260118 の lost 4 midpoints + 3 control midpoints で thumbnail 抽出:

| ts | baseline # | 判定 | 内容 |
|---|---|---|---|
| 698 | 1 (OK) | FL | FL PvP アクション |
| 1453 | **2 (LOST)** | **非FL** | リムサ港・デューティファインダー UI |
| 2148 | 3 (OK) | FL | FL PvP 激戦 |
| 2793 | **4 (LOST)** | **非FL** | 暗い街/UI オーバーレイ |
| 5982 | 8 (OK) | FL | FL PvP アクション |
| 6634 | **9 (LOST)** | **非FL** | メニュー・ダイアログ UI |
| 7017 | **10 (LOST)** | **非FL** | パーティー招待メニュー |

lost 4 件はすべて 5-8 分の短尺セグメント (FL 通常 14-17 分)。scorebar V2 が正しく非FL として除外。

### 他 baseline との対比 (.detection_cache より)

| recording | 旧 baseline | scorebar 後 | lost |
|---|---|---|---|
| 20260116 | 7 | 7 | 0 |
| 20260118 | 11 | 6 | **4** (許容超過で失敗) |
| 20260119 | 10 | 9 | 1 |

20260118 のみ非FL が 4 件混入した例外的録画 (休憩時間や duty queue が長かった)。

## 方針転換 (semantic shift)

`tests/generate_baselines.py` は当初「scorebar フィルタなしの raw 検知出力」を baseline に保存する設計だったが、scorebar V2 (#522) 以降、この raw と scorebar-on の乖離が大きくなり、`allow up to 3` 許容値が 20260118 では追いつかなくなった。

本 PR で baseline の定義を「scorebar V2 フィルタ後の canonical FL match 集合」に再定義:

- Before: baseline = raw 検知 (非FL 含む)、test は「scorebar が raw から除去できる非FL を 3 件まで許容」
- After (#529): baseline = scorebar 後の canonical 集合、test は「baseline 生成時と現在の detection drift を 3 件まで許容」

raw 検知の backward-compat 検査 (`TestNoResolutionCompat`、`-m baseline_regen` で実行) は `tests/baselines/_legacy/` の既存 raw baseline を指すよう `_load_legacy_baseline` を新設してリファクタ。

## 受け入れ条件対比

| 基準 | 該当 diff / 検証 | 判定 |
|---|---|---|
| 4 件欠落が (a) / (b) / (c) のどれかに分類されている | 本 PR「調査サマリ」で視覚評価に基づき (c) + (b semantic rot) と分類 | ✓ |
| 分類に基づき閉じる | baseline を scorebar-on semantics に再生成、`generate_baselines.py` を合わせる | ✓ |
| `pytest -m slow tests/.../test_baseline_match_content_preserved[20260118]` が pass | `33 passed, 9 deselected in 2319s` (`pytest -m slow tests/test_scorebar_regression.py` フル実行) | ✓ |

## 変更ファイル

- `tests/baselines/20260118.json`: 11 → 6 match (非FL 4 件除外 + 過剰分割 1 件 merge)
- `tests/baselines/20260119.json`: 10 → 9 match (scorebar が 1 件正しく merge)
- `tests/baselines/20260116.json`: 7 → 7 (boundary 値を scorebar 後に同期、件数変化なし)
- `tests/generate_baselines.py`: `detect_match_boundaries` 呼び出しに `src_resolution=(width, height)` を追加 + docstring を #529 方針に更新
- `tests/test_scorebar_regression.py`: `_load_legacy_baseline` を新設、`TestNoResolutionCompat` を `_legacy/` 参照にリファクタ、`allow up to 3` コメント刷新

## 検証

| | 結果 |
|---|---|
| pytest -m slow tests/test_scorebar_regression.py | 33 passed, 9 deselected (0:38:39) |
| pytest (fast) | 720 passed |
| ruff check / format --check / pyright | clean |

## 関連 PR

- [#535](https://github.com/Idios/kobutachan-allaganeye/pull/535) #508 fix (Portable ZIP LGPL 移行) も並行作成済み。本 PR は同 fix PR のレビュー中の slow test で発覚して分離起票したもので、scope / base branch は独立 (本 PR は origin/develop-0.2.0 HEAD ベース)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
