### PR TITLE
feat(gui): Phase 3 preview 本物化 + ffmpeg 中断フロー (Refs #465 #523)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ htmlcov/
 .claude/settings.local.json
 .claude/worktrees/
 .claude/state/
+.claude/scheduled_tasks.lock
 .env
 ROLE
 

--- a/allaganeye/commands/detect.py
+++ b/allaganeye/commands/detect.py
@@ -172,6 +172,7 @@ def run_detect(
     payload = _build_metadata_payload(
         video_path=video_path,
         source_duration=metadata["duration"],
+        source_fps=metadata["fps"],
         detected_at=detected_at,
         effective_interval=effective_interval,
         config=config,

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -931,7 +931,7 @@ def _build_metadata_payload(
     schema; see ``docs/metadata-spec.md`` section "schema_version".
 
     ``source_fps`` (#465 review): the recording frame rate from ffprobe.
-    GUI uses this to compute frame-accurate ±1F seek (formerly assumed
+    GUI uses this to compute frame-accurate +-1F seek (formerly assumed
     60 fps). 120fps / 240fps recordings now step by 1/120 / 1/240 sec.
     """
     return {

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -892,6 +892,7 @@ def _split_and_write_metadata(
     result = _build_metadata_payload(
         video_path=video_path,
         source_duration=source_duration,
+        source_fps=metadata["fps"],
         detected_at=detected_at,
         effective_interval=effective_interval,
         config=config,
@@ -912,6 +913,7 @@ def _build_metadata_payload(
     *,
     video_path: Path,
     source_duration: float,
+    source_fps: float,
     detected_at: str,
     effective_interval: float,
     config: SplitConfig,
@@ -927,12 +929,17 @@ def _build_metadata_payload(
     ``schema_version`` (#515) declares the payload revision so future
     readers can migrate or refuse older / newer files. v1 is the current
     schema; see ``docs/metadata-spec.md`` section "schema_version".
+
+    ``source_fps`` (#465 review): the recording frame rate from ffprobe.
+    GUI uses this to compute frame-accurate ±1F seek (formerly assumed
+    60 fps). 120fps / 240fps recordings now step by 1/120 / 1/240 sec.
     """
     return {
         "schema_version": "1",
         "source": str(video_path),
         "source_duration": source_duration,
         "source_duration_display": _format_timestamp(source_duration),
+        "source_fps": source_fps,
         "detected_at": detected_at,
         "detection_params": {
             "sample_interval": effective_interval,

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -131,8 +131,10 @@ Electron / Tauri の両方で最小プロトタイプを構築し F1-F5 を計�
 ### Phase 3: preview 画面の本物化
 
 - `<video>` タグ + ffmpeg サムネキャッシュ (`~/.allaganeye/cache/<hash>/thumbs/*.webp`)
-- キーボードショートカット (←→ 1s / shift 10s / ⌥ 1F / space 再生)
+- キーボードショートカット (←→ 1s / shift 10s / ⌥ 1F / space 再生 / 画面クリックでも再生停止)
+- ショートカット hint を preview 画面下部にインライン表示 + stepper 各ボタンに tooltip
 - 編集の一時状態管理
+- **再生は axum 直接配信** (HTML5 `<video>` + range request → 127.0.0.1:random トークンゲート endpoint)。ffmpeg transcoding は preview では走らない。`PROCESS_TRACKER` は export 中のみ利用される。`× 閉じる` 時の in-flight ffmpeg 保護 (#523) は export 画面 (#545 Phase 4) で初めて発火する設計。サムネ生成の ffmpeg は pane mount 時に呼ばれ、プロセスは短命で追跡対象外
 
 ### Phase 4: export の本物化
 
@@ -167,9 +169,11 @@ Electron / Tauri の両方で最小プロトタイプを構築し F1-F5 を計�
 - **IN / OUT 2 画面** `<video>` タグ
 - 候補フレームストリップ (±3s, 12 frames @ 0.5s 間隔)
 - 微細タイムライン (±5s, 輝度 + 閾値)
-- ステッパー (−10s / −1s / −1F / +1F / +1s / +10s)
+- ステッパー (−10s / −1s / −1F / +1F / +1s / +10s) — 各ボタンに tooltip で対応キー表示
 - TC 数値入力 (HH:MM:SS.ff)
 - キーボード: ←→ 1s / shift ←→ 10s / ⌥ ←→ 1F / space 再生
+- クリック: video 領域クリックで active pane の再生/停止 (Space と等価)
+- 画面下部に視認可能な keyboard hint バー
 - 試合名 / type 編集可
 
 ### 5. export

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -132,7 +132,10 @@ Electron / Tauri の両方で最小プロトタイプを構築し F1-F5 を計�
 
 - `<video>` タグ + ffmpeg サムネキャッシュ (`~/.allaganeye/cache/<hash>/thumbs/*.webp`)
 - キーボードショートカット (←→ 1s / shift 10s / ⌥ 1F / space 再生 / 画面クリックでも再生停止)
+- 1F のフレーム step は `metadata.source_fps` を使用 (60 / 120 / 240 fps 録画それぞれで実 1 フレーム step)。欠落時は `DEFAULT_FPS=60` 代替
+- TC 表示 (`H:MM:SS.FF`) も同 fps で frame portion を表示・解釈
 - ショートカット hint を preview 画面下部にインライン表示 + stepper 各ボタンに tooltip
+- 再生中は TC 表示が `video.currentTime` に追従、停止時に最終位置にスナップ
 - 編集の一時状態管理
 - **再生は axum 直接配信** (HTML5 `<video>` + range request → 127.0.0.1:random トークンゲート endpoint)。ffmpeg transcoding は preview では走らない。`PROCESS_TRACKER` は export 中のみ利用される。`× 閉じる` 時の in-flight ffmpeg 保護 (#523) は export 画面 (#545 Phase 4) で初めて発火する設計。サムネ生成の ffmpeg は pane mount 時に呼ばれ、プロセスは短命で追跡対象外
 

--- a/docs/gui-development.md
+++ b/docs/gui-development.md
@@ -133,6 +133,25 @@ Stop-Process -Id <pid> -Force
 
 → MSVC Build Tools が未インストール。Visual Studio Build Tools 2022 の「C++ build tools」ワークロードをインストールして PATH を通す。
 
+### `cargo` 起動時に `error finalizing incremental compilation session directory ... アクセスが拒否されました (os error 5)` warning
+
+→ Cargo の incremental compilation cache (`gui/src-tauri/target/debug/incremental/...`) を別プロセスがロックしているため、Cargo が finalize に失敗している (Windows 限定の既知 warning)。コンパイルは成功するので機能影響なし。
+
+主な原因プロセス: Windows Defender real-time protection / Search Indexer / OneDrive。
+
+消したい場合は以下のいずれかで対処:
+
+1. **Windows Defender の除外設定** (推奨): `gui/src-tauri/target/` を除外フォルダに追加
+   - 設定 → 更新とセキュリティ → Windows セキュリティ → ウイルスと脅威の防止 → 除外の追加または削除 → フォルダー
+2. `CARGO_INCREMENTAL=0` 環境変数: warning は消えるが clean build が遅くなる
+3. ローカル `.cargo/config.toml` で `[build] incremental = false` (個人設定、commit しない)
+
+### `npm run tauri dev` 終了時に `[ERROR:ui\gfx\win\window_impl.cc] Failed to unregister class Chrome_WidgetWin_0. Error = 1412`
+
+→ WebView2 / Chromium の shutdown 時に window class registration を unregister しようとして既に消えているケース (Error 1412 = ERROR_CLASS_DOES_NOT_EXIST)。Chromium 系アプリに広く出る既知 benign warning で機能影響なし。
+
+`force_exit_app` (#523) では webview を明示 `destroy()` した後 50ms 待ってから `app.exit()` を呼ぶことで出現頻度を抑えているが、Chromium 内部の cleanup 順序により稀に出ることがある。完全に消す手段は WebView2 / Tauri 側の修正待ち。
+
 ## バージョンポリシー
 
 - **strict pin**: `package.json` および `Cargo.toml` の全依存を `=x.y.z` で厳格ピン。Phase 0 (#468) で検証した挙動を再現可能にするため

--- a/docs/gui-development.md
+++ b/docs/gui-development.md
@@ -150,7 +150,7 @@ Stop-Process -Id <pid> -Force
 
 → WebView2 / Chromium の shutdown 時に window class registration を unregister しようとして既に消えているケース (Error 1412 = ERROR_CLASS_DOES_NOT_EXIST)。Chromium 系アプリに広く出る既知 benign warning で機能影響なし。
 
-`force_exit_app` (#523) では webview を明示 `destroy()` した後 50ms 待ってから `app.exit()` を呼ぶことで出現頻度を抑えているが、Chromium 内部の cleanup 順序により稀に出ることがある。完全に消す手段は WebView2 / Tauri 側の修正待ち。
+`force_exit_app` (#523) では webview を明示 `destroy()` し、Tauri レベルの `WindowEvent::Destroyed` を oneshot で待ってから `app.exit()` を呼ぶ (500ms timeout fallback)。ただし `Destroyed` は Tauri 層の destroy 完了で fire し、その後 Chromium が独立して window class unregister を行うため race は依然残る。完全に消す手段は WebView2 / Tauri 側の修正待ち。
 
 ## バージョンポリシー
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -19,6 +19,7 @@
 | `source` | string | ✓ | 元動画ファイルの絶対パス (OS 表記そのまま) | 非空 |
 | `source_duration` | number | ✓ | 元動画の総秒数 | > 0 |
 | `source_duration_display` | string | ✓ | 人間可読な長さ表示 | `HH:MM:SS` または `MM:SS` |
+| `source_fps` | number | 新規書き込みは ✓ / 読み込み時は欠落許容 | 録画フレームレート (#465) | > 0。欠落時は GUI が `DEFAULT_FPS=60` で代替 |
 | `detected_at` | string | ✓ | 検知が実行された時刻 (UTC) | ISO 8601 (例: `2026-04-22T00:00:00Z`) |
 | `detection_params` | object | ✓ | 検知に使われたパラメータ (後述) | (object) |
 | `matches` | array | ✓ | 試合セグメント列 (0 件可) | |
@@ -120,7 +121,7 @@ GUI は以下のフィールドを in-memory で編集し、`[適用]` 時に `m
 
 以下は GUI では絶対に書き戻さない (CLI の観測記録として保全):
 
-- `source`, `source_duration`, `source_duration_display`
+- `source`, `source_duration`, `source_duration_display`, `source_fps`
 - `detected_at`, `detection_params`
 - `gaps` (CLI が計算、GUI は表示のみ)
 

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -22,11 +22,13 @@ name = "allaganeye-gui"
 version = "0.2.0"
 dependencies = [
  "axum",
+ "dirs",
  "futures",
  "hyper",
  "percent-encoding",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -37,6 +39,7 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -22,6 +22,9 @@ hyper = "=1.9.0"
 futures = "=0.3.32"
 urlencoding = "=2.1.3"
 percent-encoding = "=2.3.2"
+uuid = { version = "=1.23.1", features = ["v4"] }
+sha2 = "=0.10.9"
+dirs = "=6.0.0"
 
 [dev-dependencies]
 tempfile = "=3.27.0"

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -647,22 +647,62 @@ async fn kill_tracked_processes() -> Result<u32, String> {
 /// `prevent_close`, so the frontend must drive the actual exit through this
 /// command once it has finished cleanup.
 ///
-/// #465 review: WebView2 / Chromium の cleanup race を緩和するため、
-/// `app.exit` の前に webview window を明示 destroy し短い yield を入れる。
-/// 何もしないと shutdown 時に
+/// #465 review: WebView2 / Chromium の cleanup race を緩和するため、各
+/// webview window の `WindowEvent::Destroyed` を oneshot で待ってから
+/// `app.exit(0)` を呼ぶ。何もしないと shutdown 時に
 ///   `[ERROR:ui\gfx\win\window_impl.cc] Failed to unregister class
 ///    Chrome_WidgetWin_0. Error = 1412`
-/// が stderr に出る。Error 1412 = ERROR_CLASS_DOES_NOT_EXIST で、Chromium
-/// の window class registration が既に消えている race。`destroy()` で
-/// `on_window_event` の `prevent_close` を bypass し、50ms yield で
-/// cleanup を進ませてから exit する。完全には消せない (benign warning) が
-/// 出現頻度が下がる。
+/// が stderr に出る (Error 1412 = ERROR_CLASS_DOES_NOT_EXIST、Chromium の
+/// window class registration が既に消えている race)。`destroy()` で
+/// `on_window_event` の `prevent_close` を bypass し、Tauri レベルの
+/// `Destroyed` を確認してから exit する。
+///
+/// **限界**: Tauri レベルの `Destroyed` は WebView2 内部の window class
+/// unregister 完了より先に fire するため、これを待っても 1412 を完全に
+/// は防げない (Chromium 内部の race は依然残る)。ただし固定 sleep より
+/// 厳密で、destroy 後の最低保証になる。500ms timeout fallback で永久
+/// 待ちは回避する。
 #[tauri::command]
 async fn force_exit_app(app: tauri::AppHandle) {
-    for (_, window) in app.webview_windows() {
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::oneshot;
+
+    let windows: Vec<_> = app.webview_windows().into_values().collect();
+    if windows.is_empty() {
+        app.exit(0);
+        return;
+    }
+
+    let mut signals = Vec::with_capacity(windows.len());
+    for window in &windows {
+        let (tx, rx) = oneshot::channel::<()>();
+        // `on_window_event` callback may be re-invoked, so wrap the sender
+        // in `Option<Arc<Mutex>>` and `take()` it on first Destroyed.
+        let tx = Arc::new(Mutex::new(Some(tx)));
+        let tx_clone = Arc::clone(&tx);
+        window.on_window_event(move |event| {
+            if matches!(event, tauri::WindowEvent::Destroyed) {
+                if let Ok(mut guard) = tx_clone.lock() {
+                    if let Some(sender) = guard.take() {
+                        let _ = sender.send(());
+                    }
+                }
+            }
+        });
+        signals.push(rx);
+    }
+
+    for window in &windows {
         let _ = window.destroy();
     }
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // 500ms timeout で hang 回避。通常は数 ms 以内に Destroyed が fire する。
+    let _ = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        join_all(signals),
+    )
+    .await;
+
     app.exit(0);
 }
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use axum::{
     routing::get,
     Router,
 };
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 use futures::future::join_all;
 use serde::Serialize;
 use serde_json::Value;
@@ -646,8 +646,23 @@ async fn kill_tracked_processes() -> Result<u32, String> {
 /// terminate a running process. `on_window_event` always calls
 /// `prevent_close`, so the frontend must drive the actual exit through this
 /// command once it has finished cleanup.
+///
+/// #465 review: WebView2 / Chromium の cleanup race を緩和するため、
+/// `app.exit` の前に webview window を明示 destroy し短い yield を入れる。
+/// 何もしないと shutdown 時に
+///   `[ERROR:ui\gfx\win\window_impl.cc] Failed to unregister class
+///    Chrome_WidgetWin_0. Error = 1412`
+/// が stderr に出る。Error 1412 = ERROR_CLASS_DOES_NOT_EXIST で、Chromium
+/// の window class registration が既に消えている race。`destroy()` で
+/// `on_window_event` の `prevent_close` を bypass し、50ms yield で
+/// cleanup を進ませてから exit する。完全には消せない (benign warning) が
+/// 出現頻度が下がる。
 #[tauri::command]
 async fn force_exit_app(app: tauri::AppHandle) {
+    for (_, window) in app.webview_windows() {
+        let _ = window.destroy();
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     app.exit(0);
 }
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -238,6 +238,150 @@ async fn register_video(path: String) -> Result<RegisteredVideo, String> {
     })
 }
 
+/// #465 review (B): drop で確定した video ファイルを ffprobe で読み、
+/// duration / fps / width / height / codec / size を返す。Phase 2 で
+/// `dummyProbeVideo` (固定値) を返していた経路をこの実装で置換する。
+///
+/// 実装は ffprobe を subprocess 起動し JSON で出力されるストリーム情報を
+/// パースする。Python 側 (`allaganeye/video/probe.py`) と同じ ffprobe
+/// 経路を踏襲しており、結果は detection 用 ProbeResult と概ね一致する
+/// (audio_codec は Phase 3 GUI には不要なので返さない)。
+#[derive(Serialize, Clone, Debug)]
+struct VideoProbeInfo {
+    path: String,
+    #[serde(rename = "fileName")]
+    file_name: String,
+    #[serde(rename = "sizeBytes")]
+    size_bytes: u64,
+    #[serde(rename = "durationSeconds")]
+    duration_seconds: f64,
+    width: u32,
+    height: u32,
+    fps: f64,
+    codec: String,
+}
+
+#[tauri::command]
+async fn probe_video(path: String) -> Result<VideoProbeInfo, String> {
+    let file_path = PathBuf::from(&path);
+    let canonical = validate_video_path(&file_path)?;
+    probe_video_with(&canonical, "ffprobe").await
+}
+
+/// Pure helper testable in cargo unit tests by injecting an ffprobe-like
+/// command (e.g. a fixture-emitting shell script).
+async fn probe_video_with(
+    path: &Path,
+    ffprobe: &str,
+) -> Result<VideoProbeInfo, String> {
+    let size_bytes = fs::metadata(path)
+        .map_err(|e| format!("stat failed ({}): {}", path.display(), e))?
+        .len();
+
+    let output = tokio::process::Command::new(ffprobe)
+        .arg("-v")
+        .arg("quiet")
+        .arg("-print_format")
+        .arg("json")
+        .arg("-show_format")
+        .arg("-show_streams")
+        .arg(path)
+        .output()
+        .await
+        .map_err(|e| format!("ffprobe spawn failed: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "ffprobe failed (exit {:?}): {}",
+            output.status.code(),
+            stderr.trim()
+        ));
+    }
+
+    let json: Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("ffprobe json parse failed: {e}"))?;
+
+    let streams = json
+        .get("streams")
+        .and_then(|s| s.as_array())
+        .ok_or_else(|| "ffprobe output missing 'streams' array".to_string())?;
+    let video_stream = streams
+        .iter()
+        .find(|s| s.get("codec_type").and_then(|v| v.as_str()) == Some("video"))
+        .ok_or_else(|| "no video stream in ffprobe output".to_string())?;
+
+    let width = video_stream
+        .get("width")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| "video stream missing width".to_string())? as u32;
+    let height = video_stream
+        .get("height")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| "video stream missing height".to_string())? as u32;
+    let codec = video_stream
+        .get("codec_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    // Frame rate: prefer r_frame_rate (e.g. "60/1" or "60000/1001"), fall
+    // back to avg_frame_rate. Mirrors Python's probe.py logic.
+    let fps = parse_frame_rate_str(
+        video_stream.get("r_frame_rate").and_then(|v| v.as_str()),
+    )
+    .or_else(|| {
+        parse_frame_rate_str(
+            video_stream.get("avg_frame_rate").and_then(|v| v.as_str()),
+        )
+    })
+    .ok_or_else(|| "cannot determine frame rate".to_string())?;
+
+    let duration_seconds = json
+        .get("format")
+        .and_then(|f| f.get("duration"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<f64>().ok())
+        .ok_or_else(|| "format.duration missing or unparseable".to_string())?;
+    if duration_seconds <= 0.0 {
+        return Err("duration is non-positive".to_string());
+    }
+
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    Ok(VideoProbeInfo {
+        path: path.to_string_lossy().to_string(),
+        file_name,
+        size_bytes,
+        duration_seconds,
+        width,
+        height,
+        fps,
+        codec,
+    })
+}
+
+/// Parse a frame rate string like "60/1" or "60000/1001". Returns None when
+/// the string is missing, malformed, or evaluates to <= 0.
+fn parse_frame_rate_str(s: Option<&str>) -> Option<f64> {
+    let raw = s?;
+    let (num, den) = raw.split_once('/')?;
+    let num: f64 = num.parse().ok()?;
+    let den: f64 = den.parse().ok()?;
+    if den == 0.0 {
+        return None;
+    }
+    let fps = num / den;
+    if fps > 0.0 {
+        Some(fps)
+    } else {
+        None
+    }
+}
+
 /// Validate that `path` points to an existing regular file and return the
 /// canonicalized absolute path on success.
 fn validate_video_path(path: &Path) -> Result<PathBuf, String> {
@@ -731,6 +875,7 @@ pub fn run() {
             restore_from_original,
             check_backup_exists,
             register_video,
+            probe_video,
             generate_match_thumbnails,
             is_process_running,
             kill_tracked_processes,
@@ -1363,5 +1508,61 @@ mod tests {
         assert_eq!(thumb_token(3, 452.5), "match003_t452500");
         assert_eq!(thumb_token(0, 0.0), "match000_t0");
         assert_eq!(thumb_token(999, 1.001), "match999_t1001");
+    }
+
+    // #465 review (B): probe_video の frame rate parser
+
+    #[test]
+    fn parse_frame_rate_str_handles_simple_ratio() {
+        assert!((parse_frame_rate_str(Some("60/1")).unwrap() - 60.0).abs() < 1e-9);
+        assert!((parse_frame_rate_str(Some("30/1")).unwrap() - 30.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_frame_rate_str_handles_ntsc_ratio() {
+        // 60000/1001 ≒ 59.94
+        let fps = parse_frame_rate_str(Some("60000/1001")).unwrap();
+        assert!((fps - 59.94).abs() < 1e-2);
+    }
+
+    #[test]
+    fn parse_frame_rate_str_returns_none_for_zero_denominator() {
+        assert_eq!(parse_frame_rate_str(Some("60/0")), None);
+    }
+
+    #[test]
+    fn parse_frame_rate_str_returns_none_for_zero_numerator() {
+        // 0 fps は invalid (>0 でない)
+        assert_eq!(parse_frame_rate_str(Some("0/1")), None);
+    }
+
+    #[test]
+    fn parse_frame_rate_str_returns_none_for_malformed() {
+        assert_eq!(parse_frame_rate_str(Some("garbage")), None);
+        assert_eq!(parse_frame_rate_str(Some("60")), None); // no slash
+        assert_eq!(parse_frame_rate_str(Some("a/b")), None);
+        assert_eq!(parse_frame_rate_str(None), None);
+    }
+
+    /// #465 review (B): `probe_video_with` を inject 可能な ffprobe path で
+    /// 起動し、JSON 出力のパース → VideoProbeInfo マッピングを検証する。
+    /// 実 ffprobe の代わりに stdout に固定 JSON を出すスクリプト
+    /// (Windows なので cmd.exe + echo or python -c) を用意するのは複雑な
+    /// ので、ここでは ffprobe が無いケース (spawn 失敗 → エラー) のみを
+    /// 確認する。frame rate / JSON parse のロジックは parse_frame_rate_str
+    /// + serde_json の組み合わせとしてカバー済み。
+    #[tokio::test]
+    async fn probe_video_with_returns_error_when_ffprobe_missing() {
+        let tmp = TempDir::new().unwrap();
+        let video = tmp.path().join("dummy.mp4");
+        std::fs::write(&video, b"not a real video").unwrap();
+        let result = probe_video_with(&video, "this-binary-does-not-exist").await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("ffprobe spawn failed") || err.contains("ffprobe failed"),
+            "unexpected error: {}",
+            err
+        );
     }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,8 +1,66 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use axum::{
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use tauri::Emitter;
+use futures::future::join_all;
+use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tokio::sync::{Mutex, Semaphore};
+use tower_http::services::ServeFile;
+use uuid::Uuid;
+
+/// #465 -- per-token mapping from opaque UUID to absolute video file path.
+///
+/// Shared between the axum server's handler state and the Tauri commands so
+/// that `register_video` can insert and the handler can look up without
+/// copying the whole map each request.
+type TokenMap = Arc<Mutex<HashMap<Uuid, PathBuf>>>;
+
+/// #465 -- process-global video-server handle.
+///
+/// Holds the bound port (`None` until the first `register_video` call starts
+/// the server) and the shared token map. Wrapped in a `tokio::sync::Mutex`
+/// so multiple concurrent Tauri async commands can await it safely.
+struct VideoServer {
+    port: Option<u16>,
+    tokens: TokenMap,
+}
+
+impl VideoServer {
+    fn new() -> Self {
+        Self {
+            port: None,
+            tokens: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+static VIDEO_SERVER: OnceLock<Mutex<VideoServer>> = OnceLock::new();
+
+fn video_server() -> &'static Mutex<VideoServer> {
+    VIDEO_SERVER.get_or_init(|| Mutex::new(VideoServer::new()))
+}
+
+/// #465 -- payload returned to the GUI from `register_video`.
+///
+/// The frontend sets `url` as the `<video>` element's `src` and keeps `token`
+/// around in case it later needs to unregister the file (future feature).
+#[derive(Debug, Serialize)]
+pub struct RegisteredVideo {
+    pub url: String,
+    pub token: String,
+}
 
 #[tauri::command]
 async fn load_metadata(path: String) -> Result<Value, String> {
@@ -155,6 +213,125 @@ async fn check_backup_exists(path: String) -> Result<bool, String> {
     Ok(parent.join("metadata.original.json").exists())
 }
 
+/// #465 -- register a video file with the local HTTP server and return a
+/// playback URL for the GUI's `<video>` element.
+///
+/// Starts the axum server lazily on the first call (subsequent calls reuse
+/// the same bound port). The returned URL has the form
+/// `http://127.0.0.1:{port}/video/{token}` and is only reachable from the
+/// same machine; the server binds exclusively to 127.0.0.1.
+#[tauri::command]
+async fn register_video(path: String) -> Result<RegisteredVideo, String> {
+    let file_path = PathBuf::from(&path);
+    let canonical = validate_video_path(&file_path)?;
+
+    let port = ensure_server_started().await?;
+    let token = {
+        let guard = video_server().lock().await;
+        let mut tokens = guard.tokens.lock().await;
+        register_video_sync(&canonical, &mut tokens)
+    };
+
+    Ok(RegisteredVideo {
+        url: format!("http://127.0.0.1:{}/video/{}", port, token),
+        token: token.to_string(),
+    })
+}
+
+/// Validate that `path` points to an existing regular file and return the
+/// canonicalized absolute path on success.
+fn validate_video_path(path: &Path) -> Result<PathBuf, String> {
+    if !path.exists() {
+        return Err(format!("video file not found: {}", path.display()));
+    }
+    let meta = fs::metadata(path)
+        .map_err(|e| format!("stat failed ({}): {}", path.display(), e))?;
+    if !meta.is_file() {
+        return Err(format!(
+            "video path is not a regular file: {}",
+            path.display()
+        ));
+    }
+    fs::canonicalize(path)
+        .map_err(|e| format!("canonicalize failed ({}): {}", path.display(), e))
+}
+
+/// Pure helper: mint a new UUID, insert `(token, path)` into the token map,
+/// and return the token. Extracted so unit tests can exercise the
+/// registration logic without starting an axum server.
+fn register_video_sync(path: &Path, tokens: &mut HashMap<Uuid, PathBuf>) -> Uuid {
+    let token = Uuid::new_v4();
+    tokens.insert(token, path.to_path_buf());
+    token
+}
+
+/// Ensure the local video server is listening on 127.0.0.1 and return the
+/// bound port. Idempotent: re-uses the existing port on every call after the
+/// first.
+async fn ensure_server_started() -> Result<u16, String> {
+    let mut guard = video_server().lock().await;
+    if let Some(port) = guard.port {
+        return Ok(port);
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| format!("bind 127.0.0.1:0 failed: {}", e))?;
+    let addr = listener
+        .local_addr()
+        .map_err(|e| format!("local_addr failed: {}", e))?;
+
+    let tokens = guard.tokens.clone();
+    let app = build_router(tokens);
+
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            eprintln!("video server error: {}", e);
+        }
+    });
+
+    guard.port = Some(addr.port());
+    Ok(addr.port())
+}
+
+/// Build the axum `Router` that serves `GET /video/{token}` and dispatches
+/// to `ServeFile` (which handles HTTP Range requests natively) when the
+/// token resolves to a registered file.
+fn build_router(tokens: TokenMap) -> Router {
+    Router::new()
+        .route("/video/{token}", get(serve_video))
+        .with_state(tokens)
+}
+
+async fn serve_video(
+    State(tokens): State<TokenMap>,
+    AxumPath(token): AxumPath<String>,
+    request: axum::extract::Request,
+) -> axum::response::Response {
+    let parsed = match Uuid::parse_str(&token) {
+        Ok(t) => t,
+        Err(_) => return (StatusCode::NOT_FOUND, "unknown token").into_response(),
+    };
+
+    let path = {
+        let map = tokens.lock().await;
+        map.get(&parsed).cloned()
+    };
+
+    match path {
+        Some(p) => {
+            // ServeFile handles Range, Content-Type sniffing, and If-Range.
+            // Forward the original request so the Range header survives.
+            let mut svc = ServeFile::new(p);
+            match svc.try_call(request).await {
+                Ok(resp) => resp.into_response(),
+                Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "serve failed").into_response(),
+            }
+        }
+        None => (StatusCode::NOT_FOUND, "unknown token").into_response(),
+    }
+}
+
 fn apply_changes_sync(
     meta_path: &Path,
     payload: &Value,
@@ -178,6 +355,7 @@ fn apply_changes_sync(
             }
         }
     }
+
 
     let parent = meta_path
         .parent()
@@ -229,11 +407,265 @@ fn write_metadata_atomic(path: &Path, payload: &Value) -> Result<(), String> {
     Ok(())
 }
 
+/// #465 -- per-candidate thumbnail entry returned to the GUI.
+///
+/// `t_seconds` is the absolute timestamp (seconds from video start) where the
+/// thumbnail was extracted; `file_path` is an absolute path to the cached
+/// WebP file the frontend can read (via tauri_plugin_fs) or serve via the
+/// video HTTP server in a later iteration.
+#[derive(Debug, Serialize)]
+pub struct ThumbnailEntry {
+    pub t_seconds: f64,
+    pub file_path: String,
+}
+
+/// #465 -- stable per-video cache key derived from the absolute path and the
+/// file's last-modified time. Recreating the same video (even at the same
+/// path) yields a different hash because mtime changes, forcing a fresh
+/// thumbnail cache and preventing stale frames from being served.
+fn compute_video_cache_hash(video_path: &Path, mtime_ms: u64) -> String {
+    let mut hasher = Sha256::new();
+    let key = format!("{}:{}", video_path.display(), mtime_ms);
+    hasher.update(key.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest.iter() {
+        hex.push_str(&format!("{:02x}", byte));
+    }
+    hex
+}
+
+/// #465 -- resolve `<home>/.allaganeye/cache/<video_hash>/thumbs/`.
+///
+/// Returns the path without creating it; callers that intend to write thumbs
+/// are responsible for `create_dir_all`. On Windows the home directory comes
+/// from `USERPROFILE` via `dirs::home_dir`; on Unix it reads `HOME`.
+fn thumb_cache_dir(video_hash: &str) -> Result<PathBuf, String> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| "failed to resolve user home directory".to_string())?;
+    Ok(home
+        .join(".allaganeye")
+        .join("cache")
+        .join(video_hash)
+        .join("thumbs"))
+}
+
+/// #465 -- compute the evenly-spaced timestamps for a given boundary window.
+///
+/// Produces `count` samples covering
+/// `[boundary - window_seconds, boundary + window_seconds]`, clamped at 0.
+/// Pulled out for unit testing (no ffmpeg involvement).
+fn compute_candidate_timestamps(
+    boundary_t_seconds: f64,
+    window_seconds: f64,
+    count: u32,
+) -> Vec<f64> {
+    if count == 0 {
+        return Vec::new();
+    }
+    if count == 1 {
+        return vec![boundary_t_seconds.max(0.0)];
+    }
+    let start = boundary_t_seconds - window_seconds;
+    let end = boundary_t_seconds + window_seconds;
+    let step = (end - start) / f64::from(count - 1);
+    let mut out = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        let t = start + step * f64::from(i);
+        out.push(t.max(0.0));
+    }
+    out
+}
+
+/// #465 -- filesystem-safe token for a single cached thumbnail.
+///
+/// Format: `match{match_index:03}_t{timestamp_ms}` so the filename carries
+/// enough context to debug cache entries by eye (e.g. `match003_t452500`).
+fn thumb_token(match_index: u32, t_seconds: f64) -> String {
+    let t_ms = (t_seconds * 1000.0).round() as i64;
+    let t_ms = t_ms.max(0) as u64;
+    format!("match{:03}_t{}", match_index, t_ms)
+}
+
+/// #465 -- generate (or reuse cached) thumbnails for a match boundary window.
+///
+/// Spawns `ffmpeg` per missing frame with bounded concurrency. Returns one
+/// entry per requested timestamp in order; any ffmpeg failure aborts the
+/// whole call so the caller never sees a partially populated list.
+#[tauri::command]
+async fn generate_match_thumbnails(
+    video_path: String,
+    match_index: u32,
+    boundary_t_seconds: f64,
+    window_seconds: f64,
+    count: u32,
+) -> Result<Vec<ThumbnailEntry>, String> {
+    let video = PathBuf::from(&video_path);
+    if !video.exists() {
+        return Err(format!("video file not found: {}", video.display()));
+    }
+    let meta = fs::metadata(&video)
+        .map_err(|e| format!("stat failed ({}): {}", video.display(), e))?;
+    let mtime_ms = meta
+        .modified()
+        .map_err(|e| format!("mtime failed ({}): {}", video.display(), e))?
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .map_err(|e| format!("mtime before epoch ({}): {}", video.display(), e))?;
+    let canonical = fs::canonicalize(&video)
+        .map_err(|e| format!("canonicalize failed ({}): {}", video.display(), e))?;
+
+    let video_hash = compute_video_cache_hash(&canonical, mtime_ms);
+    let cache_dir = thumb_cache_dir(&video_hash)?;
+    fs::create_dir_all(&cache_dir)
+        .map_err(|e| format!("create cache dir {} failed: {}", cache_dir.display(), e))?;
+
+    let timestamps = compute_candidate_timestamps(boundary_t_seconds, window_seconds, count);
+    let semaphore = Arc::new(Semaphore::new(4));
+
+    let mut tasks = Vec::with_capacity(timestamps.len());
+    for t in timestamps.iter().copied() {
+        let token = thumb_token(match_index, t);
+        let out_path = cache_dir.join(format!("{}.webp", token));
+        let video_for_task = canonical.clone();
+        let sem = Arc::clone(&semaphore);
+        tasks.push(async move {
+            let _permit = sem
+                .acquire_owned()
+                .await
+                .map_err(|e| format!("semaphore closed: {}", e))?;
+            ensure_thumbnail_exists(&video_for_task, t, &out_path).await?;
+            Ok::<ThumbnailEntry, String>(ThumbnailEntry {
+                t_seconds: t,
+                file_path: out_path.to_string_lossy().to_string(),
+            })
+        });
+    }
+
+    let results = join_all(tasks).await;
+    let mut entries = Vec::with_capacity(results.len());
+    for r in results {
+        entries.push(r?);
+    }
+    Ok(entries)
+}
+
+/// #465 -- spawn ffmpeg to materialise a single thumbnail unless the cache
+/// file is already present and non-empty. On any non-zero exit, the stderr
+/// is folded into the returned error so the GUI can surface it.
+async fn ensure_thumbnail_exists(
+    video_path: &Path,
+    t_seconds: f64,
+    out_path: &Path,
+) -> Result<(), String> {
+    if let Ok(meta) = fs::metadata(out_path) {
+        if meta.is_file() && meta.len() > 0 {
+            return Ok(());
+        }
+    }
+    if let Some(parent) = out_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent).map_err(|e| {
+                format!("create dir {} failed: {}", parent.display(), e)
+            })?;
+        }
+    }
+
+    let t_arg = format!("{:.3}", t_seconds.max(0.0));
+    let output = tokio::process::Command::new("ffmpeg")
+        .arg("-y")
+        .arg("-ss")
+        .arg(&t_arg)
+        .arg("-i")
+        .arg(video_path)
+        .arg("-frames:v")
+        .arg("1")
+        .arg("-vf")
+        .arg("scale=160:90")
+        .arg("-q:v")
+        .arg("80")
+        .arg("-f")
+        .arg("webp")
+        .arg("-loglevel")
+        .arg("error")
+        .arg(out_path)
+        .output()
+        .await
+        .map_err(|e| format!("spawn ffmpeg failed at t={}: {}", t_arg, e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "ffmpeg failed at t={} (exit={:?}): {}",
+            t_arg,
+            output.status.code(),
+            stderr.trim()
+        ));
+    }
+    Ok(())
+}
+
+/// #523 -- tracker for long-running external processes (detecting /export
+/// ffmpeg invocations). Phase 3 preview itself does not spawn persistent
+/// children, but detecting (Phase 3) and export (Phase 4) will register
+/// their children here so the Close-Requested handler can kill them before
+/// exit.
+type ProcessMap = Arc<Mutex<HashMap<Uuid, tokio::process::Child>>>;
+
+static PROCESS_TRACKER: OnceLock<ProcessMap> = OnceLock::new();
+
+fn process_tracker() -> &'static ProcessMap {
+    PROCESS_TRACKER.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+}
+
+/// #523 -- report whether any child process is currently being tracked.
+/// Called by the frontend when it receives a `close-requested` event so it
+/// can decide whether to show the confirm modal or let the window close.
+#[tauri::command]
+async fn is_process_running() -> bool {
+    let tracker = process_tracker();
+    let guard = tracker.lock().await;
+    !guard.is_empty()
+}
+
+/// #523 -- kill every tracked child. Returns the number of processes that
+/// were alive at kill time. Best-effort -- already-dead children are silently
+/// skipped so partial kills don't block the exit flow.
+#[tauri::command]
+async fn kill_tracked_processes() -> Result<u32, String> {
+    let tracker = process_tracker();
+    let mut guard = tracker.lock().await;
+    let count = guard.len() as u32;
+    for (_, mut child) in guard.drain() {
+        let _ = child.kill().await;
+    }
+    Ok(count)
+}
+
+/// #523 -- explicit app exit, used after the user confirms they want to
+/// terminate a running process. `on_window_event` always calls
+/// `prevent_close`, so the frontend must drive the actual exit through this
+/// command once it has finished cleanup.
+#[tauri::command]
+async fn force_exit_app(app: tauri::AppHandle) {
+    app.exit(0);
+}
+
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())
+        .on_window_event(|window, event| {
+            // #523 -- intercept every CloseRequested. The frontend inspects
+            // tracked processes on receipt: if none are running it calls
+            // `force_exit_app` immediately; otherwise it surfaces the
+            // ConfirmExitModal and drives kill + exit on confirm.
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                let _ = window.emit("close-requested", ());
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             load_metadata,
             get_metadata_mtime,
@@ -243,6 +675,11 @@ pub fn run() {
             clear_draft,
             restore_from_original,
             check_backup_exists,
+            register_video,
+            generate_match_thumbnails,
+            is_process_running,
+            kill_tracked_processes,
+            force_exit_app,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -705,5 +1142,171 @@ mod tests {
         let roundtrip: Value =
             serde_json::from_str(&fs::read_to_string(&draft_file).unwrap()).unwrap();
         assert_eq!(roundtrip, draft);
+    }
+
+    /// #465 -- a non-existent path must be rejected before any token is
+    /// minted or the server is touched.
+    #[test]
+    fn register_video_rejects_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does_not_exist.mp4");
+        let err = validate_video_path(&missing).unwrap_err();
+        assert!(
+            err.contains("not found"),
+            "expected 'not found' in error, got: {}",
+            err
+        );
+    }
+
+    /// #465 -- directories are not valid video sources; we only allow
+    /// regular files. This prevents a caller from accidentally registering
+    /// a folder and serving its contents.
+    #[test]
+    fn register_video_rejects_directory() {
+        let tmp = TempDir::new().unwrap();
+        let err = validate_video_path(tmp.path()).unwrap_err();
+        assert!(
+            err.contains("not a regular file"),
+            "expected 'not a regular file' in error, got: {}",
+            err
+        );
+    }
+
+    /// #465 -- accepting a regular file returns a canonicalized absolute
+    /// path suitable for the token map.
+    #[test]
+    fn validate_video_path_accepts_regular_file() {
+        let tmp = TempDir::new().unwrap();
+        let video = tmp.path().join("clip.mp4");
+        fs::write(&video, b"fake mp4 bytes").unwrap();
+        let canonical = validate_video_path(&video).unwrap();
+        assert!(canonical.is_absolute());
+        assert!(canonical.exists());
+    }
+
+    /// #465 -- two consecutive registrations must yield distinct tokens and
+    /// leave both entries in the map.
+    #[test]
+    fn register_video_returns_distinct_tokens_for_two_registrations() {
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a.mp4");
+        let b = tmp.path().join("b.mp4");
+        fs::write(&a, b"aaa").unwrap();
+        fs::write(&b, b"bbb").unwrap();
+
+        let mut tokens: HashMap<Uuid, PathBuf> = HashMap::new();
+        let token_a = register_video_sync(&a, &mut tokens);
+        let token_b = register_video_sync(&b, &mut tokens);
+
+        assert_ne!(token_a, token_b, "tokens must be distinct");
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens.get(&token_a).unwrap(), &a);
+        assert_eq!(tokens.get(&token_b).unwrap(), &b);
+    }
+
+    /// #465 -- registering the same file twice also yields distinct tokens
+    /// (each registration is an independent handle; no deduplication).
+    #[test]
+    fn register_video_same_file_twice_yields_distinct_tokens() {
+        let tmp = TempDir::new().unwrap();
+        let video = tmp.path().join("clip.mp4");
+        fs::write(&video, b"same file").unwrap();
+
+        let mut tokens: HashMap<Uuid, PathBuf> = HashMap::new();
+        let t1 = register_video_sync(&video, &mut tokens);
+        let t2 = register_video_sync(&video, &mut tokens);
+
+        assert_ne!(t1, t2);
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens.get(&t1).unwrap(), &video);
+        assert_eq!(tokens.get(&t2).unwrap(), &video);
+    }
+
+    /// #465 -- same path + same mtime must produce the same hash across
+    /// invocations (cache hits rely on this).
+    #[test]
+    fn compute_video_cache_hash_is_deterministic() {
+        let path = Path::new("C:/videos/sample.mp4");
+        let h1 = compute_video_cache_hash(path, 1_700_000_000_000);
+        let h2 = compute_video_cache_hash(path, 1_700_000_000_000);
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64, "SHA256 hex is 64 chars");
+    }
+
+    /// #465 -- mtime deltas invalidate the cache so re-encoded videos at the
+    /// same path never serve stale thumbnails.
+    #[test]
+    fn compute_video_cache_hash_changes_with_mtime() {
+        let path = Path::new("C:/videos/sample.mp4");
+        let h1 = compute_video_cache_hash(path, 1_700_000_000_000);
+        let h2 = compute_video_cache_hash(path, 1_700_000_000_001);
+        assert_ne!(h1, h2);
+    }
+
+    /// #465 -- different paths never collide, even with identical mtimes.
+    #[test]
+    fn compute_video_cache_hash_changes_with_path() {
+        let mtime = 1_700_000_000_000u64;
+        let h1 = compute_video_cache_hash(Path::new("C:/videos/a.mp4"), mtime);
+        let h2 = compute_video_cache_hash(Path::new("C:/videos/b.mp4"), mtime);
+        assert_ne!(h1, h2);
+    }
+
+    /// #465 -- `thumb_cache_dir` must place the hash segment and the
+    /// literal `thumbs` leaf under `.allaganeye/cache/`. We check path
+    /// components to stay OS-separator-agnostic.
+    #[test]
+    fn thumb_cache_dir_includes_hash_and_thumbs_suffix() {
+        let hash = "deadbeef".repeat(8); // 64 chars like a real digest
+        let dir = thumb_cache_dir(&hash).unwrap();
+        let components: Vec<String> = dir
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().to_string())
+            .collect();
+        // Must end with ... / .allaganeye / cache / <hash> / thumbs
+        let n = components.len();
+        assert!(n >= 4, "path too short: {:?}", components);
+        assert_eq!(components[n - 1], "thumbs");
+        assert_eq!(components[n - 2], hash);
+        assert_eq!(components[n - 3], "cache");
+        assert_eq!(components[n - 4], ".allaganeye");
+    }
+
+    /// #465 -- timestamp grid is centred on the boundary, spans the full
+    /// window, and contains exactly `count` samples.
+    #[test]
+    fn compute_candidate_timestamps_centres_window() {
+        let ts = compute_candidate_timestamps(100.0, 2.0, 5);
+        assert_eq!(ts.len(), 5);
+        assert!((ts[0] - 98.0).abs() < 1e-9);
+        assert!((ts[2] - 100.0).abs() < 1e-9);
+        assert!((ts[4] - 102.0).abs() < 1e-9);
+    }
+
+    /// #465 -- the grid must never produce negative timestamps (ffmpeg
+    /// rejects `-ss <0`); clamp at 0.
+    #[test]
+    fn compute_candidate_timestamps_clamps_below_zero() {
+        let ts = compute_candidate_timestamps(1.0, 3.0, 5);
+        for t in &ts {
+            assert!(*t >= 0.0, "negative t: {}", t);
+        }
+        assert!((ts[0] - 0.0).abs() < 1e-9);
+    }
+
+    /// #465 -- single-sample requests return exactly the boundary.
+    #[test]
+    fn compute_candidate_timestamps_single_sample() {
+        let ts = compute_candidate_timestamps(42.5, 1.0, 1);
+        assert_eq!(ts, vec![42.5]);
+    }
+
+    /// #465 -- the token format carries the match index (3-digit pad) and
+    /// the ms timestamp so cached files are self-describing.
+    #[test]
+    fn thumb_token_formats_index_and_ms() {
+        assert_eq!(thumb_token(3, 452.5), "match003_t452500");
+        assert_eq!(thumb_token(0, 0.0), "match000_t0");
+        assert_eq!(thumb_token(999, 1.001), "match999_t1001");
     }
 }

--- a/gui/src/App.test.tsx
+++ b/gui/src/App.test.tsx
@@ -3,10 +3,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
+  convertFileSrc: (p: string) => `asset://localhost/${p}`,
 }));
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({
   open: vi.fn(),
+}));
+
+// #523: ConfirmExitModal calls listen() on mount; stub it so the App
+// test tree can render under jsdom.
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: () => Promise.resolve(() => undefined),
 }));
 
 import App from './App';

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,3 +1,4 @@
+import { ConfirmExitModal } from './components/ConfirmExitModal';
 import { ConflictModal } from './components/ConflictModal';
 import { DraftRestoreModal } from './components/DraftRestoreModal';
 import { SideRail } from './components/SideRail';
@@ -48,6 +49,8 @@ export default function App() {
       <ConflictModal />
       {/* #517 — global modal for draft restore offers on mount/post-load. */}
       <DraftRestoreModal />
+      {/* #523 -- global modal for ffmpeg-in-flight close confirmation. */}
+      <ConfirmExitModal />
     </div>
   );
 }

--- a/gui/src/__tests__/flow.integration.test.tsx
+++ b/gui/src/__tests__/flow.integration.test.tsx
@@ -12,17 +12,32 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { invokeMock, dialogOpenMock } = vi.hoisted(() => ({
+const { invokeMock, dialogOpenMock, listenMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   dialogOpenMock: vi.fn(),
+  listenMock: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: invokeMock,
+  // convertFileSrc is called by PreviewScreen to resolve cached thumbnails
+  // to URLs the browser can fetch. jsdom doesn't care about the scheme,
+  // so a simple passthrough is enough.
+  convertFileSrc: (p: string) => `asset://localhost/${p}`,
 }));
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({
   open: dialogOpenMock,
+}));
+
+// #523: ConfirmExitModal subscribes to the Tauri event bus on mount. The
+// real listen() reaches into Tauri's native shim which is absent under
+// vitest; stub it to a no-op that returns a no-op unsubscribe.
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => {
+    listenMock(...args);
+    return Promise.resolve(() => undefined);
+  },
 }));
 
 import App from '../App';
@@ -73,6 +88,21 @@ function configureHappyInvoke() {
         return Promise.resolve();
       case 'check_backup_exists':
         return Promise.resolve(true);
+      // #465
+      case 'register_video':
+        return Promise.resolve({
+          url: 'http://127.0.0.1:0/video/test-token',
+          token: 'test-token',
+        });
+      case 'generate_match_thumbnails':
+        return Promise.resolve([]);
+      // #523
+      case 'is_process_running':
+        return Promise.resolve(false);
+      case 'kill_tracked_processes':
+        return Promise.resolve(0);
+      case 'force_exit_app':
+        return Promise.resolve();
       default:
         return Promise.resolve();
     }

--- a/gui/src/__tests__/flow.integration.test.tsx
+++ b/gui/src/__tests__/flow.integration.test.tsx
@@ -94,6 +94,24 @@ function configureHappyInvoke() {
           url: 'http://127.0.0.1:0/video/test-token',
           token: 'test-token',
         });
+      case 'probe_video': {
+        // #465 review (B): drop が default で Tauri probe_video を呼ぶように
+        // なったので、テスト用 happy-path 値を返す。path は引数を echo back
+        // して selectedVideoPath assertion (dialog で resolve した値) と
+        // 一致させる。
+        const probePath =
+          (args as { path?: string } | undefined)?.path ?? 'C:/videos/x.mkv';
+        return Promise.resolve({
+          path: probePath,
+          fileName: probePath.split(/[/\\]/).pop() ?? probePath,
+          sizeBytes: 38 * 1024 * 1024 * 1024,
+          durationSeconds: 10228.735,
+          width: 1920,
+          height: 1080,
+          fps: 60,
+          codec: 'h264',
+        });
+      }
       case 'generate_match_thumbnails':
         return Promise.resolve([]);
       // #523
@@ -122,6 +140,9 @@ afterEach(() => {
 
 describe('flow A1: drop -> selected via [参照…]', () => {
   it('advances drop screen from idle through probing to selected', async () => {
+    // #465 review (B): drop が default で Tauri probe_video を呼ぶように
+    // なったので invoke happy mock が必須。
+    configureHappyInvoke();
     dialogOpenMock.mockResolvedValue('C:/videos/test.mkv');
     render(<App />);
     expect(screen.getByTestId('drop-screen')).toBeInTheDocument();
@@ -136,6 +157,7 @@ describe('flow A1: drop -> selected via [参照…]', () => {
 
 describe('flow A2: [OK] from selected -> detecting', () => {
   it('navigates to detecting and records the video path', async () => {
+    configureHappyInvoke();
     dialogOpenMock.mockResolvedValue('C:/videos/test.mkv');
     render(<App />);
 
@@ -186,6 +208,7 @@ describe('flow A4: complete <-> preview round-trip', () => {
 
 describe('flow F: drop [キャンセル] clears selection', () => {
   it('returns from selected to idle without setting selectedVideoPath', async () => {
+    configureHappyInvoke();
     dialogOpenMock.mockResolvedValue('C:/videos/test.mkv');
 
     render(<App />);

--- a/gui/src/components/ConfirmExitModal.module.css
+++ b/gui/src/components/ConfirmExitModal.module.css
@@ -1,0 +1,76 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(var(--ae-bg-rgb), 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9100;
+}
+
+.panel {
+  min-width: 420px;
+  max-width: 640px;
+  background: var(--ae-panel);
+  border: var(--ae-panel-border);
+  border-radius: 4px;
+  padding: 24px 28px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+}
+
+.title {
+  font-family: var(--ae-font-ui);
+  font-size: 14px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--ae-gold-bright);
+  margin: 0 0 16px 0;
+}
+
+.message {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  color: var(--ae-danger);
+  word-break: break-all;
+  margin: 0 0 12px 0;
+  line-height: 1.5;
+}
+
+.hint {
+  font-family: var(--ae-font-body);
+  font-size: 12px;
+  color: var(--ae-text-dim);
+  margin: 0 0 20px 0;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.button {
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.33);
+  color: var(--ae-gold);
+  font-family: var(--ae-font-ui);
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.button:hover:not(:disabled) {
+  background: rgba(var(--ae-gold-rgb), 0.1);
+  color: var(--ae-gold-bright);
+}
+
+.button:disabled {
+  border-color: rgba(var(--ae-gold-rgb), 0.13);
+  color: var(--ae-gold-dim);
+  cursor: not-allowed;
+  opacity: 0.7;
+}

--- a/gui/src/components/ConfirmExitModal.test.tsx
+++ b/gui/src/components/ConfirmExitModal.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeMock, listenMock, unlistenSpy } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  listenMock: vi.fn(),
+  unlistenSpy: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: listenMock,
+}));
+
+import { ConfirmExitModal } from './ConfirmExitModal';
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  listenMock.mockReset();
+  unlistenSpy.mockReset();
+  // Default: store the listener so tests can fire the close-requested event.
+  listenMock.mockImplementation(async () => unlistenSpy);
+});
+
+describe('ConfirmExitModal', () => {
+  it('renders nothing initially and subscribes to close-requested', async () => {
+    render(<ConfirmExitModal />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalledWith(
+        'close-requested',
+        expect.any(Function),
+      );
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('exits immediately when the event fires and no process is running', async () => {
+    let handler: () => void = () => undefined;
+    listenMock.mockImplementation(async (_: string, h: () => void) => {
+      handler = h;
+      return unlistenSpy;
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'is_process_running') return Promise.resolve(false);
+      if (cmd === 'force_exit_app') return Promise.resolve();
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    render(<ConfirmExitModal />);
+    await waitFor(() => expect(listenMock).toHaveBeenCalled());
+    handler();
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('force_exit_app');
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('shows the confirm dialog when a process is running', async () => {
+    let handler: () => void = () => undefined;
+    listenMock.mockImplementation(async (_: string, h: () => void) => {
+      handler = h;
+      return unlistenSpy;
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'is_process_running') return Promise.resolve(true);
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    render(<ConfirmExitModal />);
+    await waitFor(() => expect(listenMock).toHaveBeenCalled());
+    handler();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: '終了' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'キャンセル' })).toBeInTheDocument();
+  });
+
+  it('kill + exit on 終了', async () => {
+    let handler: () => void = () => undefined;
+    listenMock.mockImplementation(async (_: string, h: () => void) => {
+      handler = h;
+      return unlistenSpy;
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'is_process_running') return Promise.resolve(true);
+      if (cmd === 'kill_tracked_processes') return Promise.resolve(2);
+      if (cmd === 'force_exit_app') return Promise.resolve();
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    render(<ConfirmExitModal />);
+    await waitFor(() => expect(listenMock).toHaveBeenCalled());
+    handler();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    });
+    await userEvent.setup().click(
+      screen.getByRole('button', { name: '終了' }),
+    );
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('kill_tracked_processes');
+      expect(invokeMock).toHaveBeenCalledWith('force_exit_app');
+    });
+  });
+
+  it('キャンセル dismisses without invoking anything extra', async () => {
+    let handler: () => void = () => undefined;
+    listenMock.mockImplementation(async (_: string, h: () => void) => {
+      handler = h;
+      return unlistenSpy;
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'is_process_running') return Promise.resolve(true);
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    render(<ConfirmExitModal />);
+    await waitFor(() => expect(listenMock).toHaveBeenCalled());
+    handler();
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).toBeInTheDocument(),
+    );
+    await userEvent.setup().click(
+      screen.getByRole('button', { name: 'キャンセル' }),
+    );
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    // No kill / exit invocations after cancel.
+    const killCalled = invokeMock.mock.calls.some(
+      (c) => c[0] === 'kill_tracked_processes',
+    );
+    const exitCalled = invokeMock.mock.calls.some(
+      (c) => c[0] === 'force_exit_app',
+    );
+    expect(killCalled).toBe(false);
+    expect(exitCalled).toBe(false);
+  });
+});

--- a/gui/src/components/ConfirmExitModal.tsx
+++ b/gui/src/components/ConfirmExitModal.tsx
@@ -1,0 +1,117 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { useCallback, useEffect, useState } from 'react';
+
+import styles from './ConfirmExitModal.module.css';
+
+/**
+ * #523: bridge the Tauri-side `on_window_event(CloseRequested)` to a user
+ * confirmation flow when a tracked ffmpeg child is alive.
+ *
+ * Flow:
+ * 1. Rust prevents the window from closing and emits `close-requested`.
+ * 2. This component listens for it, asks Rust whether any process is
+ *    running, and either exits immediately (idle path) or surfaces the
+ *    modal (running path).
+ * 3. On "終了", the component kills tracked processes then calls
+ *    `force_exit_app`. On "キャンセル", it dismisses the modal and lets
+ *    the user keep working.
+ *
+ * Global modal -- rendered once in App.tsx.
+ */
+export function ConfirmExitModal() {
+  const [pending, setPending] = useState<boolean>(false);
+  const [busy, setBusy] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCloseRequested = useCallback(async () => {
+    try {
+      const running = await invoke<boolean>('is_process_running');
+      if (!running) {
+        await invoke('force_exit_app');
+        return;
+      }
+      setPending(true);
+    } catch (e) {
+      // Defensive: if the probe itself fails, show the modal so the user
+      // can still pick between kill + exit vs cancel rather than leaving
+      // them unable to close the window.
+      setError(e instanceof Error ? e.message : String(e));
+      setPending(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    (async () => {
+      unlisten = await listen('close-requested', () => {
+        void handleCloseRequested();
+      });
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, [handleCloseRequested]);
+
+  const handleKillAndExit = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await invoke('kill_tracked_processes');
+      await invoke('force_exit_app');
+    } catch (e) {
+      setBusy(false);
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setPending(false);
+    setError(null);
+  }, []);
+
+  if (!pending) return null;
+
+  return (
+    <div
+      className={styles.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ae-exit-title"
+    >
+      <div className={styles.panel}>
+        <h2 id="ae-exit-title" className={styles.title}>
+          実行中のプロセスがあります
+        </h2>
+        <p className={styles.hint}>
+          ffmpeg または関連プロセスが動作中です。「終了」でプロセスを中断してアプリを閉じます (中間ファイルは破棄)。「キャンセル」でモーダルを閉じて作業を続行します。
+        </p>
+        {error && (
+          <p className={styles.message} role="alert">
+            {error}
+          </p>
+        )}
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.button}
+            onClick={() => {
+              void handleKillAndExit();
+            }}
+            disabled={busy}
+          >
+            {busy ? '終了中…' : '終了'}
+          </button>
+          <button
+            type="button"
+            className={styles.button}
+            onClick={handleCancel}
+            disabled={busy}
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gui/src/components/FrameStrip.module.css
+++ b/gui/src/components/FrameStrip.module.css
@@ -26,6 +26,15 @@
   pointer-events: none;
 }
 
+.thumb {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
 .blackOverlay {
   position: absolute;
   inset: 0;

--- a/gui/src/components/FrameStrip.tsx
+++ b/gui/src/components/FrameStrip.tsx
@@ -1,6 +1,18 @@
 import { fmtPreciseTime } from '../utils/time';
 import styles from './FrameStrip.module.css';
 
+/**
+ * #465: a single cached thumbnail entry from
+ * `generate_match_thumbnails`. When supplied via `thumbs`, FrameStrip
+ * renders the WebP at that timestamp instead of the synthetic shimmer.
+ */
+export interface FrameStripThumb {
+  /** Absolute timestamp (seconds into the source video). */
+  t: number;
+  /** URL the browser can fetch to render the WebP (e.g. via convertFileSrc). */
+  url: string;
+}
+
 export interface FrameStripProps {
   /** The (assumed) boundary timestamp. */
   boundaryT: number;
@@ -10,6 +22,11 @@ export interface FrameStripProps {
   count?: number;
   /** Called when the user clicks a candidate frame. Receives the frame's timestamp. */
   onSelectFrame?: (t: number) => void;
+  /**
+   * #465: real thumbnails keyed by absolute timestamp. When omitted (Phase 2
+   * sample mode) the strip falls back to the synthetic shimmer preview.
+   */
+  thumbs?: readonly FrameStripThumb[];
 }
 
 interface FrameCell {
@@ -55,38 +72,71 @@ function synthesizeFrames(
  *
  * Mirror of FrameStrip in docs/design/bundle/project/variants/aether-preview.jsx.
  */
+function nearestThumbUrl(
+  thumbs: readonly FrameStripThumb[] | undefined,
+  t: number,
+): string | null {
+  if (!thumbs || thumbs.length === 0) return null;
+  let bestIdx = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < thumbs.length; i++) {
+    const d = Math.abs(thumbs[i].t - t);
+    if (d < bestDist) {
+      bestDist = d;
+      bestIdx = i;
+    }
+  }
+  return thumbs[bestIdx].url;
+}
+
 export function FrameStrip({
   boundaryT,
   windowSec,
   count = 12,
   onSelectFrame,
+  thumbs,
 }: FrameStripProps) {
   const frames = synthesizeFrames(boundaryT, windowSec, count);
   return (
     <div className={styles.strip} data-testid="frame-strip">
-      {frames.map((f, i) => (
-        <button
-          key={i}
-          type="button"
-          onClick={() => onSelectFrame?.(f.t)}
-          className={`${styles.cell}${f.isBoundary ? ` ${styles.cellBoundary}` : ''}`}
-          aria-label={`frame ${fmtPreciseTime(f.t)}`}
-          data-boundary={f.isBoundary ? 'true' : 'false'}
-        >
-          <div
-            className={styles.shimmer}
-            style={{
-              background: `radial-gradient(ellipse at ${40 + i * 3}% ${50 + (i % 3) * 10}%, rgba(232, 196, 122, ${f.brightness * 0.6}), transparent 60%)`,
-              backgroundColor: `rgba(var(--ae-gold-rgb), ${f.brightness * 0.4})`,
-            }}
-          />
-          {f.brightness < 0.15 && <div className={styles.blackOverlay} />}
-          {f.isBoundary && <div className={styles.boundaryBar} />}
-          <div className={styles.label}>
-            {fmtPreciseTime(f.t).split('.')[0].split(':').slice(-2).join(':')}
-          </div>
-        </button>
-      ))}
+      {frames.map((f, i) => {
+        const thumbUrl = nearestThumbUrl(thumbs, f.t);
+        return (
+          <button
+            key={i}
+            type="button"
+            onClick={() => onSelectFrame?.(f.t)}
+            className={`${styles.cell}${f.isBoundary ? ` ${styles.cellBoundary}` : ''}`}
+            aria-label={`frame ${fmtPreciseTime(f.t)}`}
+            data-boundary={f.isBoundary ? 'true' : 'false'}
+          >
+            {thumbUrl ? (
+              <img
+                className={styles.thumb}
+                src={thumbUrl}
+                alt=""
+                loading="lazy"
+                draggable={false}
+              />
+            ) : (
+              <div
+                className={styles.shimmer}
+                style={{
+                  background: `radial-gradient(ellipse at ${40 + i * 3}% ${50 + (i % 3) * 10}%, rgba(232, 196, 122, ${f.brightness * 0.6}), transparent 60%)`,
+                  backgroundColor: `rgba(var(--ae-gold-rgb), ${f.brightness * 0.4})`,
+                }}
+              />
+            )}
+            {!thumbUrl && f.brightness < 0.15 && (
+              <div className={styles.blackOverlay} />
+            )}
+            {f.isBoundary && <div className={styles.boundaryBar} />}
+            <div className={styles.label}>
+              {fmtPreciseTime(f.t).split('.')[0].split(':').slice(-2).join(':')}
+            </div>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/gui/src/components/MatchThumb.test.tsx
+++ b/gui/src/components/MatchThumb.test.tsx
@@ -1,7 +1,18 @@
-import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+  convertFileSrc: (p: string) => `asset://localhost/${p}`,
+}));
 
 import { MatchThumb } from './MatchThumb';
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
 
 describe('MatchThumb', () => {
   it('labels the thumbnail with the match index', () => {
@@ -9,7 +20,7 @@ describe('MatchThumb', () => {
     expect(getByLabelText('match 3 thumbnail')).toBeInTheDocument();
   });
 
-  it('produces a different hue per index (deterministic)', () => {
+  it('produces a different hue per index (deterministic) when no videoPath provided', () => {
     const { getByTestId, rerender } = render(<MatchThumb index={1} />);
     const hue1 = getByTestId('match-thumb').getAttribute('data-hue');
     rerender(<MatchThumb index={2} />);
@@ -25,5 +36,64 @@ describe('MatchThumb', () => {
     rerender(<MatchThumb index={1} width="100%" height="100%" />);
     expect(n.style.width).toBe('100%');
     expect(n.style.height).toBe('100%');
+  });
+
+  // #465 review (A): real frame thumbnail integration
+
+  it('renders the placeholder gradient (data-real=false) when videoPath is missing', () => {
+    const { getByTestId } = render(<MatchThumb index={5} />);
+    const el = getByTestId('match-thumb');
+    expect(el.getAttribute('data-real')).toBe('false');
+    expect(el.getAttribute('data-hue')).not.toBeNull();
+  });
+
+  it('renders a real frame (data-real=true) after generate_match_thumbnails resolves', async () => {
+    invokeMock.mockResolvedValueOnce([
+      { t_seconds: 12.5, file_path: 'C:/cache/match005_t12500.webp' },
+    ]);
+    const { getByTestId } = render(
+      <MatchThumb
+        index={5}
+        videoPath="C:/videos/x.mkv"
+        startTime={12.5}
+      />,
+    );
+    await waitFor(() => {
+      const el = getByTestId('match-thumb');
+      expect(el.getAttribute('data-real')).toBe('true');
+    });
+    const el = getByTestId('match-thumb');
+    expect(el.style.backgroundImage).toContain(
+      'asset://localhost/C:/cache/match005_t12500.webp',
+    );
+    // invoke は generate_match_thumbnails を 1 frame 分 (count=1, window=0)
+    // で呼ぶ
+    expect(invokeMock).toHaveBeenCalledWith(
+      'generate_match_thumbnails',
+      expect.objectContaining({
+        videoPath: 'C:/videos/x.mkv',
+        matchIndex: 5,
+        boundaryTSeconds: 12.5,
+        windowSeconds: 0,
+        count: 1,
+      }),
+    );
+  });
+
+  it('falls back to the gradient placeholder when generate_match_thumbnails rejects', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('ffmpeg not found'));
+    const { getByTestId } = render(
+      <MatchThumb
+        index={5}
+        videoPath="C:/videos/x.mkv"
+        startTime={12.5}
+      />,
+    );
+    // 初期値は false (placeholder) のまま、reject 後も placeholder のまま
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalled();
+    });
+    const el = getByTestId('match-thumb');
+    expect(el.getAttribute('data-real')).toBe('false');
   });
 });

--- a/gui/src/components/MatchThumb.tsx
+++ b/gui/src/components/MatchThumb.tsx
@@ -1,21 +1,108 @@
+import { convertFileSrc, invoke } from '@tauri-apps/api/core';
+import { useEffect, useState } from 'react';
+
 import styles from './MatchThumb.module.css';
+
+interface ThumbnailEntry {
+  t_seconds: number;
+  file_path: string;
+}
 
 export interface MatchThumbProps {
   index: number;
+  /**
+   * #465 review (A): video file path used to generate a real WebP thumbnail
+   * via the Rust `generate_match_thumbnails` Tauri command. When omitted
+   * (sample mode without a real video, or before the user picks a file),
+   * MatchThumb renders the deterministic gradient fallback so the layout
+   * stays identical.
+   */
+  videoPath?: string | null;
+  /**
+   * Boundary timestamp in seconds. When `videoPath` is provided this is the
+   * frame captured for the thumbnail (default: 0). Ignored without
+   * `videoPath`.
+   */
+  startTime?: number;
   width?: number | string;
   height?: number | string;
 }
 
 /**
- * Decorative match thumbnail placeholder used until Phase 3 provides real
- * frame captures. Deterministic pseudo-art derived from the match index.
+ * Match thumbnail. Phase 3 (#465) attempts to render a real WebP frame
+ * captured by ffmpeg via `generate_match_thumbnails`; the gradient
+ * placeholder (mirrored from `docs/design/bundle/project/shared/common.jsx`)
+ * is kept as a fallback for sample mode and any failure path so the layout
+ * never collapses.
  *
- * Mirror of MatchThumb in docs/design/bundle/project/shared/common.jsx.
+ * Hits the existing thumbnail cache (`~/.allaganeye/cache/<hash>/thumbs/`),
+ * so repeat renders re-use generated frames without re-spawning ffmpeg.
  */
-export function MatchThumb({ index, width = 96, height = 54 }: MatchThumbProps) {
+export function MatchThumb({
+  index,
+  videoPath,
+  startTime,
+  width = 96,
+  height = 54,
+}: MatchThumbProps) {
+  const [thumbUrl, setThumbUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    // videoPath が無い (sample mode) / 初期化前の場合は何もせず placeholder
+    // 描画に任せる。state を直接 reset すると `set-state-in-effect` ESLint
+    // が立つので、early return で処理しない。
+    if (!videoPath) return;
+    const t = startTime ?? 0;
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await invoke<ThumbnailEntry[]>(
+          'generate_match_thumbnails',
+          {
+            videoPath,
+            matchIndex: index,
+            boundaryTSeconds: t,
+            windowSeconds: 0,
+            count: 1,
+          },
+        );
+        if (cancelled) return;
+        if (result.length > 0) {
+          setThumbUrl(convertFileSrc(result[0].file_path));
+        }
+      } catch {
+        // Fall back to placeholder; list の描画を止めないよう error は飲む
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [videoPath, index, startTime]);
+
+  if (thumbUrl) {
+    return (
+      <div
+        className={styles.thumb}
+        style={{
+          width,
+          height,
+          backgroundImage: `url(${thumbUrl})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+        }}
+        role="img"
+        aria-label={`match ${index} thumbnail`}
+        data-testid="match-thumb"
+        data-real="true"
+      />
+    );
+  }
+
+  // Fallback: deterministic pseudo-art derived from the match index.
+  // Mirrors the original Phase 2 placeholder so layout stays identical.
   const hue = (index * 47) % 360;
-  const shimmerX = 30 + (index * 13) % 40;
-  const shimmerY = 40 + (index * 7) % 20;
+  const shimmerX = 30 + ((index * 13) % 40);
+  const shimmerY = 40 + ((index * 7) % 20);
   return (
     <div
       className={styles.thumb}
@@ -28,6 +115,7 @@ export function MatchThumb({ index, width = 96, height = 54 }: MatchThumbProps) 
       aria-label={`match ${index} thumbnail`}
       data-testid="match-thumb"
       data-hue={hue}
+      data-real="false"
     >
       <div className={styles.hudBar} />
       <div className={styles.hudDot} />

--- a/gui/src/data/sampleMetadata.ts
+++ b/gui/src/data/sampleMetadata.ts
@@ -1,17 +1,26 @@
 import type { Metadata } from '../types/metadata';
 
 /**
- * TypeScript-typed sample metadata used as a stand-in until Phase 3 (#465)
- * wires up real detect output. Sourced from docs/design/bundle/project/shared/metadata.js
- * (window.AE_META) — 9 matches from a 2:50:28 recording.
+ * TypeScript-typed sample metadata used as a stand-in until DropScreen is
+ * hooked to real detect output. Sourced from docs/design/bundle/project/shared/metadata.js
+ * (window.AE_META) -- 9 matches from a 2:50:28 recording.
  *
  * Phase 2 uses this via `useMetadataStore.loadSample()` when the dummy
  * detecting flow completes, so that the complete / preview / export screens
  * have data to display.
+ *
+ * #465: `source` points at the physical 2:50:28 recording kept on the
+ * development machine (path from the ALLAGANEYE_AUDIO_TEST_VIDEO convention,
+ * see docs/testing-guide.md). This lets `register_video` resolve a real
+ * file so the preview screen's `<video>` tag actually plays during
+ * `npm run tauri dev` smoke-tests. On machines without this path the
+ * preview panes fall back to the "video file not found" banner, which is
+ * the correct behaviour for that environment. Production builds do not
+ * invoke `loadSample()`.
  */
 export const sampleMetadata: Metadata = {
   schema_version: '1',
-  source: '2026-04-08 21-14-05.mkv',
+  source: 'E:/videos/2026-04-08 21-14-05.mkv',
   source_duration: 10228.735,
   source_duration_display: '2:50:28',
   detected_at: '2026-04-19T12:34:56Z',

--- a/gui/src/data/sampleMetadata.ts
+++ b/gui/src/data/sampleMetadata.ts
@@ -23,6 +23,7 @@ export const sampleMetadata: Metadata = {
   source: 'E:/videos/2026-04-08 21-14-05.mkv',
   source_duration: 10228.735,
   source_duration_display: '2:50:28',
+  source_fps: 60,
   detected_at: '2026-04-19T12:34:56Z',
   detection_params: {
     sample_interval: 2.0,

--- a/gui/src/screens/CompleteScreen.tsx
+++ b/gui/src/screens/CompleteScreen.tsx
@@ -26,6 +26,12 @@ export function CompleteScreen() {
   const navigate = useAppStateStore((s) => s.navigate);
   const appReset = useAppStateStore((s) => s.reset);
 
+  // #465 review (A,C): drop で確定した実 path を MatchThumb に渡し、
+  // generate_match_thumbnails で実フレーム WebP を表示する。sample mode
+  // (selectedVideoPath = null) では metadata.source にフォールバック。
+  const selectedVideoPath = useAppStateStore((s) => s.selectedVideoPath);
+  const thumbVideoPath = selectedVideoPath ?? metadata?.source ?? null;
+
   // On mount, if nothing is selected and matches exist, select first.
   useEffect(() => {
     if (metadata && metadata.matches.length > 0 && selectedMatchIndex === null) {
@@ -130,7 +136,13 @@ export function CompleteScreen() {
                   data-testid={`match-row-${m.index}`}
                   data-selected={isSel ? 'true' : 'false'}
                 >
-                  <MatchThumb index={m.index} width={48} height={27} />
+                  <MatchThumb
+                    index={m.index}
+                    videoPath={thumbVideoPath}
+                    startTime={m.start_time}
+                    width={48}
+                    height={27}
+                  />
                   <div className={styles.listItemBody}>
                     <div className={styles.listItemTitle}>
                       {m.name ?? `MATCH_${String(m.index).padStart(3, '0')}`}
@@ -154,7 +166,13 @@ export function CompleteScreen() {
           <div className={styles.previewPane}>
             <AllaganFrame className={styles.previewFrame}>
               <div className={styles.previewInner}>
-                <MatchThumb index={selectedMatch.index} width="100%" height="100%" />
+                <MatchThumb
+                  index={selectedMatch.index}
+                  videoPath={thumbVideoPath}
+                  startTime={selectedMatch.start_time}
+                  width="100%"
+                  height="100%"
+                />
                 <div className={styles.previewPlayOverlay}>
                   <div className={styles.previewPlayBadge} aria-hidden="true">
                     ▶

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -45,8 +45,12 @@ describe('DetectingScreen', () => {
     expect(useAppStateStore.getState().screen).toBe('complete');
     // sample metadata is loaded
     expect(useMetadataStore.getState().metadata).not.toBeNull();
-    // selectedVideoPath should be cleared after success
-    expect(useAppStateStore.getState().selectedVideoPath).toBeNull();
+    // #465 review (C): selectedVideoPath は detecting → preview / export まで
+    // 持ち越し、register_video / generate_match_thumbnails の引数として実 path
+    // を使う設計に変更。以前の null reset は廃止。
+    expect(useAppStateStore.getState().selectedVideoPath).toBe(
+      'C:/videos/test.mkv',
+    );
   });
 
   it('returns to drop when [中断] is clicked', () => {

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -20,7 +20,6 @@ const TICKS_TO_COMPLETE = 100;
 export function DetectingScreen() {
   const navigate = useAppStateStore((s) => s.navigate);
   const selectedVideoPath = useAppStateStore((s) => s.selectedVideoPath);
-  const setSelectedVideoPath = useAppStateStore((s) => s.setSelectedVideoPath);
   const loadSample = useMetadataStore((s) => s.loadSample);
 
   const [phase, dispatch] = useReducer(detectingReducer, 'running' as DetectingPhase);
@@ -44,13 +43,16 @@ export function DetectingScreen() {
   }, [phase]);
 
   // completed → load sample data + move to complete
+  // #465 review (C): selectedVideoPath は detecting → preview / export まで
+  // 持ち越し、PreviewScreen の register_video / generate_match_thumbnails の
+  // 引数として実 path を渡せるようにする。以前は ここで null reset していたが、
+  // 「drop で確定した path を後段が利用する」設計と矛盾していたため削除。
   useEffect(() => {
     if (phase === 'completed') {
       loadSample();
-      setSelectedVideoPath(null);
       navigate('complete');
     }
-  }, [phase, loadSample, navigate, setSelectedVideoPath]);
+  }, [phase, loadSample, navigate]);
 
   // cancelled → back to drop
   useEffect(() => {

--- a/gui/src/screens/DropScreen.test.tsx
+++ b/gui/src/screens/DropScreen.test.tsx
@@ -6,6 +6,23 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
   open: vi.fn(),
 }));
 
+// #465 review (B): DropScreen の default probeFn は Tauri `probe_video`
+// command を invoke する。テスト環境では Tauri runtime がないので、
+// `invoke('probe_video', ...)` をデフォルトで成功させる mock を入れる。
+// 個別 test で override したい場合は `probeFn` props を渡す。
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue({
+    path: 'C:/videos/x.mkv',
+    fileName: 'x.mkv',
+    sizeBytes: 38 * 1024 * 1024 * 1024,
+    durationSeconds: 10228.735,
+    width: 1920,
+    height: 1080,
+    fps: 60,
+    codec: 'h264',
+  }),
+}));
+
 import { DropScreen } from './DropScreen';
 import { useAppStateStore } from '../state/appStateStore';
 

--- a/gui/src/screens/DropScreen.tsx
+++ b/gui/src/screens/DropScreen.tsx
@@ -1,3 +1,4 @@
+import { invoke } from '@tauri-apps/api/core';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useReducer, useState } from 'react';
 
@@ -15,27 +16,19 @@ const RECENT_DUMMY = [
 ];
 
 /**
- * Phase 2 dummy probe. Sleeps briefly and returns hard-coded video metadata.
- * Phase 3 (#465) replaces this with an actual `invoke('probe_video', { path })`.
- * Exposed as a module-level function so tests can vi.spyOn it.
+ * #465 review (B): drop で確定した path を Rust 側 `probe_video` Tauri
+ * command (ffprobe) に渡し、実 metadata を取得する。Phase 2 の
+ * `dummyProbeVideo` を置換した。
+ *
+ * テスト時は `DropScreen({ probeFn })` で別実装を inject できるので、
+ * この関数自体は本物 (Tauri 必須) を保つ。
  */
-export async function dummyProbeVideo(path: string): Promise<VideoProbeInfo> {
-  await new Promise<void>((r) => setTimeout(r, 30));
-  const fileName = path.split(/[/\\]/).pop() ?? path;
-  return {
-    path,
-    fileName,
-    sizeBytes: 38 * 1024 * 1024 * 1024,
-    durationSeconds: 10228.735,
-    width: 1920,
-    height: 1080,
-    fps: 60,
-    codec: 'h264',
-  };
+export async function probeVideo(path: string): Promise<VideoProbeInfo> {
+  return await invoke<VideoProbeInfo>('probe_video', { path });
 }
 
 export interface DropScreenProps {
-  /** Injection hook for tests / Phase 3. Defaults to dummyProbeVideo. */
+  /** Injection hook for tests. Defaults to {@link probeVideo} (real ffprobe via Tauri). */
   probeFn?: (path: string) => Promise<VideoProbeInfo>;
   /** Injection hook for tests. Defaults to @tauri-apps/plugin-dialog open(). */
   openDialogFn?: () => Promise<string | null>;
@@ -66,7 +59,7 @@ export function DropScreen({ probeFn, openDialogFn }: DropScreenProps = {}) {
     }
     dispatch({ type: 'FILE_PICKED' });
     try {
-      const info = await (probeFn ?? dummyProbeVideo)(selected);
+      const info = await (probeFn ?? probeVideo)(selected);
       setProbeInfo(info);
       dispatch({ type: 'PROBE_OK' });
     } catch (e) {

--- a/gui/src/screens/PreviewScreen.module.css
+++ b/gui/src/screens/PreviewScreen.module.css
@@ -103,6 +103,39 @@
   overflow: hidden;
 }
 
+.paneVideoEl {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+  background: #000;
+}
+
+.paneVideoError {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ae-danger);
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  padding: 12px;
+  text-align: center;
+  word-break: break-all;
+}
+
+.paneVideoLoading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ae-text-dim);
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+}
+
 .tcInput {
   margin-top: 6px;
   width: 100%;

--- a/gui/src/screens/PreviewScreen.module.css
+++ b/gui/src/screens/PreviewScreen.module.css
@@ -2,7 +2,13 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 18px;
+  /*
+   * #465 review: StateSwitcher (position: absolute; top: 8px; right: 8px)
+   * が右上を覆い `fl_match ▼` と overlap するため、padding-top を増量して
+   * switcher 下に header を押し下げる。switcher の実効高 ≒ 8 + 4(padding)
+   * + 22(tab) + 4(padding) + border ≒ 40-44px。余裕を見て 56px を確保。
+   */
+  padding: 56px 18px 18px;
   gap: 12px;
   position: relative;
   min-height: 0;
@@ -194,6 +200,43 @@
   font-family: var(--ae-font-mono);
   font-size: 10px;
   cursor: pointer;
+}
+
+/*
+ * #465 review: キーボードショートカット hint (UX item 3)。stepRow の下に
+ * 薄めに表示しユーザーに操作方法を伝える。kbd は実際のキー入力を模した
+ * boxed スタイル。
+ */
+.keyHint {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 4px;
+  padding: 4px 8px;
+  font-family: var(--ae-font-ui);
+  font-size: 10px;
+  color: var(--ae-text-dim);
+}
+
+.keyHintItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  letter-spacing: 0.5px;
+}
+
+.kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  background: var(--ae-bg-deep);
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.27);
+  border-radius: 3px;
+  font-family: var(--ae-font-mono);
+  font-size: 10px;
+  color: var(--ae-gold);
+  line-height: 1.3;
 }
 
 .strip {

--- a/gui/src/screens/PreviewScreen.test.tsx
+++ b/gui/src/screens/PreviewScreen.test.tsx
@@ -179,4 +179,82 @@ describe('PreviewScreen', () => {
     // tc remains focused; ArrowRight is caret movement inside the input.
     expect(tc.value).toBe(initial);
   });
+
+  // #465 review (UX items 3/4): tooltip + visible key hint + click-to-play.
+
+  it('step buttons have tooltips with the keyboard equivalent', async () => {
+    render(<PreviewScreen />);
+    // ±1F / ±1s / ±10s ボタンそれぞれに対応するキー等価操作が title に含まれる
+    const plus1F = screen.getByRole('button', { name: /nudge \+1F/ });
+    expect(plus1F.getAttribute('title')).toContain('Alt');
+    expect(plus1F.getAttribute('title')).toContain('→');
+
+    const minus10s = screen.getByRole('button', { name: /nudge -10s/ });
+    expect(minus10s.getAttribute('title')).toContain('Shift');
+    expect(minus10s.getAttribute('title')).toContain('←');
+
+    const plus1s = screen.getByRole('button', { name: /nudge \+1s/ });
+    // ±1s は修飾キーなし
+    expect(plus1s.getAttribute('title')).toContain('→');
+    expect(plus1s.getAttribute('title')).not.toContain('Shift');
+    expect(plus1s.getAttribute('title')).not.toContain('Alt');
+  });
+
+  it('renders a visible keyboard hint bar describing the shortcuts', () => {
+    render(<PreviewScreen />);
+    const hint = screen.getByRole('note', { name: /keyboard shortcuts/i });
+    expect(hint).toBeInTheDocument();
+    // 主要キー名が hint に出ていること (視認性確保)
+    expect(hint.textContent).toMatch(/Shift/);
+    expect(hint.textContent).toMatch(/Alt/);
+    expect(hint.textContent).toMatch(/Space/);
+    expect(hint.textContent).toMatch(/1s/);
+    expect(hint.textContent).toMatch(/10s/);
+    expect(hint.textContent).toMatch(/1F/);
+  });
+
+  it('clicking the video on the active pane toggles play/pause', async () => {
+    render(<PreviewScreen />);
+    const video = (await screen.findByLabelText(
+      'IN (start) video',
+    )) as HTMLVideoElement;
+    // jsdom には play/pause のネイティブ実装が無いので spy を当てる
+    const playSpy = vi.spyOn(video, 'play').mockResolvedValue();
+    const pauseSpy = vi.spyOn(video, 'pause').mockImplementation(() => {});
+    // IN pane は default で active → クリックで play が呼ばれる
+    Object.defineProperty(video, 'paused', { value: true, configurable: true });
+    await userEvent.setup().click(video);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+
+    // 再度クリック: 今度は paused=false にして pause が呼ばれる
+    Object.defineProperty(video, 'paused', { value: false, configurable: true });
+    await userEvent.setup().click(video);
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking the video on an INACTIVE pane activates it instead of play/pause', async () => {
+    render(<PreviewScreen />);
+    const outVideo = (await screen.findByLabelText(
+      'OUT (end) video',
+    )) as HTMLVideoElement;
+    const playSpy = vi.spyOn(outVideo, 'play').mockResolvedValue();
+    const pauseSpy = vi
+      .spyOn(outVideo, 'pause')
+      .mockImplementation(() => {});
+    Object.defineProperty(outVideo, 'paused', {
+      value: true,
+      configurable: true,
+    });
+    // OUT は default で inactive → クリックで activate のみ。play は呼ばれない
+    await userEvent.setup().click(outVideo);
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(pauseSpy).not.toHaveBeenCalled();
+    // 2 回目のクリックで now-active な OUT が play へ
+    Object.defineProperty(outVideo, 'paused', {
+      value: true,
+      configurable: true,
+    });
+    await userEvent.setup().click(outVideo);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/gui/src/screens/PreviewScreen.test.tsx
+++ b/gui/src/screens/PreviewScreen.test.tsx
@@ -303,4 +303,64 @@ describe('PreviewScreen', () => {
     // paused 中は state を上書きしない → TC は初期値のまま
     expect(tc.value).toBe(initial);
   });
+
+  // #465 review: fps-aware frame stepping. sampleMetadata は source_fps=60。
+  // metadata を 120 / 240 に差し替えて Alt+Arrow が実 1 フレーム step に
+  // なることを確認する。
+
+  it('Alt+ArrowRight steps 1/120 sec when source_fps is 120', async () => {
+    // metadata.source_fps を 120 に上書き (state を直接書き換え)
+    const sample = useMetadataStore.getState().metadata!;
+    useMetadataStore.setState({
+      metadata: { ...sample, source_fps: 120 },
+    });
+    render(<PreviewScreen />);
+    const tc = screen.getByLabelText(
+      'IN (start) timecode',
+    ) as HTMLInputElement;
+    // current value を parse して比較するため初期値を読んでおく
+    const before = tc.value;
+    await userEvent.setup().keyboard('{Alt>}{ArrowRight}{/Alt}');
+    const after = tc.value;
+    // 実際の差分を解読: H:MM:SS.FF の FF (frame portion) が 1 進む or
+    // 120fps では sub-second 増分が 1/120 ≒ 0.00833s。
+    // 簡易検証: TC 値が変化していること + .FF 末尾がインクリメント傾向
+    expect(after).not.toBe(before);
+  });
+
+  it('Alt+ArrowRight steps 1/240 sec when source_fps is 240', async () => {
+    const sample = useMetadataStore.getState().metadata!;
+    useMetadataStore.setState({
+      metadata: { ...sample, source_fps: 240 },
+    });
+    render(<PreviewScreen />);
+    const tc = screen.getByLabelText(
+      'IN (start) timecode',
+    ) as HTMLInputElement;
+    const before = tc.value;
+    await userEvent.setup().keyboard('{Alt>}{ArrowRight}{/Alt}');
+    const after = tc.value;
+    expect(after).not.toBe(before);
+  });
+
+  it('falls back to DEFAULT_FPS=60 when metadata.source_fps is missing', () => {
+    // legacy metadata.json を simulate: source_fps なし
+    const sample = useMetadataStore.getState().metadata!;
+    const { source_fps: _ignored, ...legacy } = sample;
+    void _ignored;
+    useMetadataStore.setState({
+      metadata: legacy as typeof sample,
+    });
+    render(<PreviewScreen />);
+    // +1F ボタンの title に Alt+→ が含まれる (fps が存在さえすれば label 共通)
+    const plus1F = screen.getByRole('button', { name: /nudge \+1F/ });
+    expect(plus1F.getAttribute('title')).toContain('+1F');
+    expect(plus1F.getAttribute('title')).toContain('Alt');
+    // 60fps での frame portion 表示: 0.5s → .30
+    // 既存の +1s / +10s ボタンは fps-independent なので default 60 で動作
+    const tc = screen.getByLabelText(
+      'IN (start) timecode',
+    ) as HTMLInputElement;
+    expect(tc.value).toMatch(/^\d+:\d{2}:\d{2}\.\d{2}$/);
+  });
 });

--- a/gui/src/screens/PreviewScreen.test.tsx
+++ b/gui/src/screens/PreviewScreen.test.tsx
@@ -257,4 +257,50 @@ describe('PreviewScreen', () => {
     await userEvent.setup().click(outVideo);
     expect(playSpy).toHaveBeenCalledTimes(1);
   });
+
+  // #465 review 追加: 再生中の TC 表示は video.currentTime に追従する。
+
+  it('TC display follows video.currentTime during playback (timeupdate event)', async () => {
+    render(<PreviewScreen />);
+    const video = (await screen.findByLabelText(
+      'IN (start) video',
+    )) as HTMLVideoElement;
+    const tc = screen.getByLabelText('IN (start) timecode') as HTMLInputElement;
+    const initial = tc.value;
+
+    // video が再生中の状態を simulate: paused=false + currentTime を進める
+    Object.defineProperty(video, 'paused', { value: false, configurable: true });
+    Object.defineProperty(video, 'currentTime', {
+      value: 12.5,
+      configurable: true,
+    });
+    // dispatchEvent で timeupdate を発火
+    video.dispatchEvent(new Event('timeupdate'));
+
+    // state 更新を待つ
+    await new Promise((r) => setTimeout(r, 20));
+    expect(tc.value).not.toBe(initial);
+    // TC は 0:00:12.xx (fmtPreciseTime 形式) であるべき
+    expect(tc.value).toMatch(/^0:00:12/);
+  });
+
+  it('TC display does NOT update from timeupdate while paused (state remains user-controlled)', async () => {
+    render(<PreviewScreen />);
+    const video = (await screen.findByLabelText(
+      'IN (start) video',
+    )) as HTMLVideoElement;
+    const tc = screen.getByLabelText('IN (start) timecode') as HTMLInputElement;
+    const initial = tc.value;
+
+    // paused=true の状態で currentTime を変更 → timeupdate (pause 直前の最後の tick 等)
+    Object.defineProperty(video, 'paused', { value: true, configurable: true });
+    Object.defineProperty(video, 'currentTime', {
+      value: 30.0,
+      configurable: true,
+    });
+    video.dispatchEvent(new Event('timeupdate'));
+    await new Promise((r) => setTimeout(r, 20));
+    // paused 中は state を上書きしない → TC は初期値のまま
+    expect(tc.value).toBe(initial);
+  });
 });

--- a/gui/src/screens/PreviewScreen.test.tsx
+++ b/gui/src/screens/PreviewScreen.test.tsx
@@ -14,6 +14,19 @@ import { useMetadataStore } from '../state/metadataStore';
 
 beforeEach(() => {
   invokeMock.mockReset();
+  // #465: PreviewScreen kicks off register_video on mount. Default the
+  // mock so individual tests don't see "unmocked invoke" from that call.
+  invokeMock.mockImplementation((cmd: string) => {
+    if (cmd === 'register_video') {
+      return Promise.resolve({
+        url: 'http://127.0.0.1:0/video/test-token',
+        token: 'test-token',
+      });
+    }
+    if (cmd === 'generate_match_thumbnails') return Promise.resolve([]);
+    if (cmd === 'check_backup_exists') return Promise.resolve(false);
+    return Promise.reject(new Error(`unmocked: ${cmd}`));
+  });
   useAppStateStore.getState().reset();
   useMetadataStore.getState().clear();
   useMetadataStore.getState().loadSample();
@@ -105,5 +118,65 @@ describe('PreviewScreen', () => {
       screen.getByLabelText('IN (start) timecode') as HTMLInputElement
     ).value;
     expect(after).not.toBe(initial);
+  });
+
+  // #465 -- video player + keyboard.
+
+  it('renders a <video> element with the registered URL after mount', async () => {
+    render(<PreviewScreen />);
+    const video = await screen.findByLabelText<HTMLVideoElement>(
+      'IN (start) video',
+    );
+    expect(video.tagName).toBe('VIDEO');
+    expect(video.getAttribute('src')).toContain('/video/test-token');
+  });
+
+  it('falls back to an error banner when register_video rejects', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'register_video')
+        return Promise.reject(new Error('video server busted'));
+      if (cmd === 'check_backup_exists') return Promise.resolve(false);
+      return Promise.reject(new Error(`unmocked: ${cmd}`));
+    });
+    render(<PreviewScreen />);
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts.some((el) => el.textContent?.includes('video server busted')))
+      .toBe(true);
+  });
+
+  it('ArrowRight key nudges the active timestamp forward by 1s', async () => {
+    render(<PreviewScreen />);
+    const before = (
+      screen.getByLabelText('IN (start) timecode') as HTMLInputElement
+    ).value;
+    await userEvent.setup().keyboard('{ArrowRight}');
+    const after = (
+      screen.getByLabelText('IN (start) timecode') as HTMLInputElement
+    ).value;
+    expect(after).not.toBe(before);
+  });
+
+  it('Shift+ArrowLeft nudges the active timestamp (10s step) — different value from plain ArrowLeft', async () => {
+    render(<PreviewScreen />);
+    const before = (
+      screen.getByLabelText('IN (start) timecode') as HTMLInputElement
+    ).value;
+    await userEvent.setup().keyboard('{Shift>}{ArrowLeft}{/Shift}');
+    const after = (
+      screen.getByLabelText('IN (start) timecode') as HTMLInputElement
+    ).value;
+    expect(after).not.toBe(before);
+  });
+
+  it('keyboard shortcuts do not fire while the TC input is focused', async () => {
+    render(<PreviewScreen />);
+    const tc = screen.getByLabelText(
+      'IN (start) timecode',
+    ) as HTMLInputElement;
+    const initial = tc.value;
+    tc.focus();
+    await userEvent.setup().keyboard('{ArrowRight}');
+    // tc remains focused; ArrowRight is caret movement inside the input.
+    expect(tc.value).toBe(initial);
   });
 });

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -1,7 +1,13 @@
-import { useState } from 'react';
+import { convertFileSrc, invoke } from '@tauri-apps/api/core';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
-import { FrameStrip } from '../components/FrameStrip';
-import { MatchThumb } from '../components/MatchThumb';
+import { FrameStrip, type FrameStripThumb } from '../components/FrameStrip';
 import { RestoreButton } from '../components/RestoreButton';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
@@ -9,21 +15,33 @@ import type { MatchType, TypeOverride } from '../types/metadata';
 import { fmtPreciseTime } from '../utils/time';
 import styles from './PreviewScreen.module.css';
 
+interface RegisteredVideo {
+  url: string;
+  token: string;
+}
+
+interface ThumbnailEntry {
+  t_seconds: number;
+  file_path: string;
+}
+
+/** Default assumption for ±1 frame stepping. Real fps would come from probe
+ *  metadata, but Phase 3 keeps this as a simple constant until we expose fps
+ *  through the metadata contract. */
+const ASSUMED_FPS = 60;
+
 /**
- * Phase 2 preview screen — A1 Dual IN/OUT variant.
+ * Phase 3 preview screen -- video playback + keyboard seek + thumbnails.
  *
- * Local state:
- * - active 'start' | 'end' (which pane/timestamp is being edited)
- * - startT / endT (editable copies of the match boundaries)
- * - matchName / matchType (editable copies of the name and type override)
- *
- * On mount the local state is seeded from the store's current match (honoring
- * any prior `edited` / `name` / `type_override` patch). [適用] writes back via
- * updateMatch + apply. [一覧へ] navigates back (confirming if dirty). [元に戻す]
- * (#516) fires the restore flow and navigates back to complete.
- *
- * Phase 3 (#465) will replace the <MatchThumb> with a real `<video>` player
- * fed by the axum HTTP server, and the FrameStrip with real decoded thumbnails.
+ * Adds over Phase 2:
+ * - Real `<video>` elements for IN and OUT panes, fed by the axum-backed
+ *   `register_video` Tauri command (#465).
+ * - Keyboard shortcuts: ArrowLeft/Right = +-1s, Shift+arrow = +-10s,
+ *   Alt+arrow = +-1 frame, Space = play/pause on the active pane.
+ * - The active pane's video.currentTime follows the editable start/end,
+ *   giving frame-accurate seek preview.
+ * - FrameStrip still serves a cache of thumbnails around the boundary; the
+ *   Rust side generates them through `generate_match_thumbnails`.
  */
 export function PreviewScreen() {
   const metadata = useMetadataStore((s) => s.metadata);
@@ -39,10 +57,6 @@ export function PreviewScreen() {
 
   const match = metadata?.matches.find((m) => m.index === selectedMatchIndex);
 
-  // All local draft state is initialized from the current match on first
-  // render. Resetting the draft on match change is handled by `key=` in the
-  // parent App.tsx (React remounts → fresh useState values), per the React 19
-  // "Avoid setState in effect" guidance.
   const [editing, setEditing] = useState<'start' | 'end'>('start');
   const [startT, setStartT] = useState<number>(
     match ? (match.edited?.start_time ?? match.start_time) : 0,
@@ -59,6 +73,183 @@ export function PreviewScreen() {
     match ? (match.type_override ?? match.type) : 'fl_match',
   );
 
+  // #465: per-mount video URL fetched from the axum server. One registration
+  // covers both panes (HTMLVideoElement instances can share the same URL).
+  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  const [videoError, setVideoError] = useState<string | null>(null);
+
+  // #465: thumbnail cache fetched from the Rust `generate_match_thumbnails`
+  // command (via ffmpeg). Keyed per boundary side; falls back to [] while
+  // the request is in-flight or when register_video failed.
+  const [inThumbs, setInThumbs] = useState<readonly FrameStripThumb[]>([]);
+  const [outThumbs, setOutThumbs] = useState<readonly FrameStripThumb[]>([]);
+
+  const inVideoRef = useRef<HTMLVideoElement>(null);
+  const outVideoRef = useRef<HTMLVideoElement>(null);
+
+  const videoSource = metadata?.source ?? null;
+
+  useEffect(() => {
+    if (!videoSource) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const registered = await invoke<RegisteredVideo>('register_video', {
+          path: videoSource,
+        });
+        if (!cancelled) {
+          setVideoUrl(registered.url);
+          setVideoError(null);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setVideoUrl(null);
+          setVideoError(e instanceof Error ? e.message : String(e));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [videoSource]);
+
+  // Keep each video's currentTime in sync with the edit buffer so a keyboard
+  // nudge immediately seeks the frame preview. We only seek when the numeric
+  // value actually changes to avoid feedback loops with timeupdate events.
+  useEffect(() => {
+    const v = inVideoRef.current;
+    if (v && !Number.isNaN(startT) && Math.abs(v.currentTime - startT) > 0.001) {
+      try {
+        v.currentTime = startT;
+      } catch {
+        // ignore seek failure during initial load
+      }
+    }
+  }, [startT, videoUrl]);
+
+  useEffect(() => {
+    const v = outVideoRef.current;
+    if (v && !Number.isNaN(endT) && Math.abs(v.currentTime - endT) > 0.001) {
+      try {
+        v.currentTime = endT;
+      } catch {
+        // ignore
+      }
+    }
+  }, [endT, videoUrl]);
+
+  // #465: fetch candidate-frame thumbnails around the start boundary. Runs
+  // when the boundary moves by more than ~0.5s so ffmpeg calls aren't
+  // spammed on each single-frame nudge (cache hits handle the rest anyway).
+  useEffect(() => {
+    if (!videoSource || !videoUrl || !match) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const entries = await invoke<ThumbnailEntry[]>(
+          'generate_match_thumbnails',
+          {
+            videoPath: videoSource,
+            matchIndex: match.index,
+            boundaryTSeconds: match.edited?.start_time ?? match.start_time,
+            windowSeconds: 3,
+            count: 12,
+          },
+        );
+        if (!cancelled) {
+          setInThumbs(
+            entries.map((e) => ({
+              t: e.t_seconds,
+              url: convertFileSrc(e.file_path),
+            })),
+          );
+        }
+      } catch {
+        if (!cancelled) setInThumbs([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [videoSource, videoUrl, match]);
+
+  useEffect(() => {
+    if (!videoSource || !videoUrl || !match) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const entries = await invoke<ThumbnailEntry[]>(
+          'generate_match_thumbnails',
+          {
+            videoPath: videoSource,
+            matchIndex: match.index,
+            boundaryTSeconds: match.edited?.end_time ?? match.end_time,
+            windowSeconds: 3,
+            count: 12,
+          },
+        );
+        if (!cancelled) {
+          setOutThumbs(
+            entries.map((e) => ({
+              t: e.t_seconds,
+              url: convertFileSrc(e.file_path),
+            })),
+          );
+        }
+      } catch {
+        if (!cancelled) setOutThumbs([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [videoSource, videoUrl, match]);
+
+  const currentT = editing === 'start' ? startT : endT;
+  const setCurrentT = editing === 'start' ? setStartT : setEndT;
+  const activeVideoRef = editing === 'start' ? inVideoRef : outVideoRef;
+
+  const nudge = useCallback(
+    (sec: number) => {
+      setCurrentT((t: number) => Math.max(0, t + sec));
+    },
+    [setCurrentT],
+  );
+
+  // #465: keyboard shortcuts. ArrowLeft/Right = +-1s, Shift = +-10s,
+  // Alt = +-1 frame at ASSUMED_FPS, Space = play/pause on the active pane.
+  useEffect(() => {
+    const interactiveTags = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+    function handleKey(e: KeyboardEvent) {
+      // Let the TC input and other fields own their typing.
+      const target = e.target as HTMLElement | null;
+      if (target && interactiveTags.has(target.tagName)) return;
+
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        const sign = e.key === 'ArrowLeft' ? -1 : 1;
+        const magnitude = e.shiftKey ? 10 : e.altKey ? 1 / ASSUMED_FPS : 1;
+        nudge(sign * magnitude);
+        e.preventDefault();
+        return;
+      }
+      if (e.key === ' ') {
+        const v = activeVideoRef.current;
+        if (v) {
+          if (v.paused) void v.play().catch(() => undefined);
+          else v.pause();
+        }
+        e.preventDefault();
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [nudge, activeVideoRef]);
+
+  const matchLabel = useMemo(
+    () => (match ? `match_${String(match.index).padStart(3, '0')}` : ''),
+    [match],
+  );
+
   if (!match) {
     return (
       <div className={styles.screen} data-testid="preview-screen">
@@ -66,11 +257,6 @@ export function PreviewScreen() {
       </div>
     );
   }
-
-  const currentT = editing === 'start' ? startT : endT;
-  const setCurrentT = editing === 'start' ? setStartT : setEndT;
-  const nudge = (sec: number) =>
-    setCurrentT((t: number) => Math.max(0, t + sec));
 
   async function handleApply() {
     updateMatch(match!.index, {
@@ -122,6 +308,7 @@ export function PreviewScreen() {
               className={styles.nameInput}
               value={matchName}
               onChange={(e) => setMatchName(e.target.value)}
+              placeholder={matchLabel}
               aria-label="match name"
             />
             <span className={styles.meta}>
@@ -150,24 +337,29 @@ export function PreviewScreen() {
           label="IN (start)"
           active={editing === 'start'}
           t={startT}
-          onClick={() => setEditing('start')}
+          onActivate={() => setEditing('start')}
           onTChange={(v) => setStartT(v)}
-          index={match.index}
+          videoUrl={videoUrl}
+          videoError={videoError}
+          videoRef={inVideoRef}
         />
         <Pane
           label="OUT (end)"
           active={editing === 'end'}
           t={endT}
-          onClick={() => setEditing('end')}
+          onActivate={() => setEditing('end')}
           onTChange={(v) => setEndT(v)}
-          index={match.index}
+          videoUrl={videoUrl}
+          videoError={videoError}
+          videoRef={outVideoRef}
         />
       </div>
 
       <div className={styles.stepRow}>
-        {[-10, -1, -1 / 60, 1 / 60, 1, 10].map((step, i) => {
+        {[-10, -1, -1 / ASSUMED_FPS, 1 / ASSUMED_FPS, 1, 10].map((step, i) => {
           const label =
-            Math.abs(step) === 1 / 60
+            Math.abs(step - 1 / ASSUMED_FPS) < 1e-6 ||
+            Math.abs(step + 1 / ASSUMED_FPS) < 1e-6
               ? step > 0
                 ? '+1F'
                 : '−1F'
@@ -195,6 +387,7 @@ export function PreviewScreen() {
           windowSec={3}
           count={12}
           onSelectFrame={(t) => setCurrentT(t)}
+          thumbs={editing === 'start' ? inThumbs : outThumbs}
         />
       </div>
 
@@ -231,22 +424,50 @@ interface PaneProps {
   label: string;
   active: boolean;
   t: number;
-  onClick: () => void;
+  onActivate: () => void;
   onTChange: (v: number) => void;
-  index: number;
+  videoUrl: string | null;
+  videoError: string | null;
+  videoRef: React.RefObject<HTMLVideoElement | null>;
 }
 
-function Pane({ label, active, t, onClick, onTChange, index }: PaneProps) {
+function Pane({
+  label,
+  active,
+  t,
+  onActivate,
+  onTChange,
+  videoUrl,
+  videoError,
+  videoRef,
+}: PaneProps) {
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={onActivate}
       className={`${styles.pane}${active ? ` ${styles.paneActive}` : ''}`}
       aria-pressed={active}
     >
       <div className={styles.paneCaption}>{label}</div>
       <div className={styles.paneVideo}>
-        <MatchThumb index={index} width="100%" height="100%" />
+        {videoUrl ? (
+          <video
+            ref={videoRef}
+            src={videoUrl}
+            preload="metadata"
+            playsInline
+            controls={false}
+            className={styles.paneVideoEl}
+            aria-label={`${label} video`}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : videoError ? (
+          <div className={styles.paneVideoError} role="alert">
+            {videoError}
+          </div>
+        ) : (
+          <div className={styles.paneVideoLoading}>loading video…</div>
+        )}
       </div>
       <input
         className={styles.tcInput}
@@ -264,11 +485,14 @@ function Pane({ label, active, t, onClick, onTChange, index }: PaneProps) {
 
 /** Parse H:MM:SS.FF back into seconds. Returns null on malformed input. */
 function parseTimecode(value: string): number | null {
-  const match = value.trim().match(/^(-)?(\d+):(\d{1,2}):(\d{1,2})(?:\.(\d{1,3}))?$/);
+  const match = value
+    .trim()
+    .match(/^(-)?(\d+):(\d{1,2}):(\d{1,2})(?:\.(\d{1,3}))?$/);
   if (!match) return null;
   const [, sign, h, m, s, f] = match;
-  const frames = f ? parseInt(f, 10) / 60 : 0;
-  let total = parseInt(h, 10) * 3600 + parseInt(m, 10) * 60 + parseInt(s, 10) + frames;
+  const frames = f ? parseInt(f, 10) / ASSUMED_FPS : 0;
+  let total =
+    parseInt(h, 10) * 3600 + parseInt(m, 10) * 60 + parseInt(s, 10) + frames;
   if (sign === '-') total = -total;
   return total;
 }

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -119,7 +119,12 @@ export function PreviewScreen() {
   const inVideoRef = useRef<HTMLVideoElement>(null);
   const outVideoRef = useRef<HTMLVideoElement>(null);
 
-  const videoSource = metadata?.source ?? null;
+  // #465 review (C): drop で確定した実 path を最優先 source-of-truth として
+  // 使用する。sample mode (selectedVideoPath = null) では sampleMetadata.source
+  // にフォールバック、実フローでは drop が確定した実 path で
+  // register_video / generate_match_thumbnails を発行する。
+  const selectedVideoPath = useAppStateStore((s) => s.selectedVideoPath);
+  const videoSource = selectedVideoPath ?? metadata?.source ?? null;
 
   useEffect(() => {
     if (!videoSource) return;

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -12,6 +12,7 @@ import { RestoreButton } from '../components/RestoreButton';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
 import type { MatchType, TypeOverride } from '../types/metadata';
+import { DEFAULT_FPS } from '../types/metadata.schema';
 import { fmtPreciseTime } from '../utils/time';
 import styles from './PreviewScreen.module.css';
 
@@ -25,10 +26,15 @@ interface ThumbnailEntry {
   file_path: string;
 }
 
-/** Default assumption for ±1 frame stepping. Real fps would come from probe
- *  metadata, but Phase 3 keeps this as a simple constant until we expose fps
- *  through the metadata contract. */
-const ASSUMED_FPS = 60;
+/**
+ * #465 review: 1 フレームの step / TC display は録画固有の fps に従う。
+ * `metadata.source_fps` を最優先で読み、欠落時 (legacy metadata.json or
+ * sample mode) のみ {@link DEFAULT_FPS} (60) にフォールバック。
+ */
+function resolveFps(sourceFps: number | undefined): number {
+  if (sourceFps && sourceFps > 0) return sourceFps;
+  return DEFAULT_FPS;
+}
 
 /**
  * Phase 3 preview screen -- video playback + keyboard seek + thumbnails.
@@ -37,7 +43,10 @@ const ASSUMED_FPS = 60;
  * - Real `<video>` elements for IN and OUT panes, fed by the axum-backed
  *   `register_video` Tauri command (#465).
  * - Keyboard shortcuts: ArrowLeft/Right = +-1s, Shift+arrow = +-10s,
- *   Alt+arrow = +-1 frame, Space = play/pause on the active pane.
+ *   Alt+arrow = +-1 frame at the recording's source_fps (60 / 120 / 240
+ *   are all handled correctly via metadata.source_fps; legacy files
+ *   fall back to {@link DEFAULT_FPS}). Space = play/pause on the active
+ *   pane.
  * - The active pane's video.currentTime follows the editable start/end,
  *   giving frame-accurate seek preview.
  * - Click on the video toggles play/pause on the active pane (UX item 4).
@@ -91,6 +100,10 @@ export function PreviewScreen() {
   const [matchType, setMatchType] = useState<TypeOverride>(
     match ? (match.type_override ?? match.type) : 'fl_match',
   );
+
+  // #465 review: source-aware frame rate. Read once from metadata; legacy
+  // metadata.json (no `source_fps`) or sample mode falls back to DEFAULT_FPS.
+  const fps = resolveFps(metadata?.source_fps);
 
   // #465: per-mount video URL fetched from the axum server. One registration
   // covers both panes (HTMLVideoElement instances can share the same URL).
@@ -251,8 +264,24 @@ export function PreviewScreen() {
     [setCurrentT],
   );
 
+  // #465 review: frame-grid snap で 1F step を確実に進める。`t + 1/fps` は
+  // IEEE 754 の丸めで `Math.floor((t' - floor(t')) * fps)` が増分しない
+  // ことがある (例: 2438.75 + 1/120 → frame 表示 .90 のまま)。frame 番号
+  // ベースで step してから秒に戻すと丸め誤差を回避できる。
+  const nudgeFrame = useCallback(
+    (frames: number) => {
+      setCurrentT((t: number) => {
+        const currentFrame = Math.round(t * fps);
+        const nextFrame = Math.max(0, currentFrame + frames);
+        return nextFrame / fps;
+      });
+    },
+    [setCurrentT, fps],
+  );
+
   // #465: keyboard shortcuts. ArrowLeft/Right = +-1s, Shift = +-10s,
-  // Alt = +-1 frame at ASSUMED_FPS, Space = play/pause on the active pane.
+  // Alt = +-1 frame at fps (frame-grid snap), Space = play/pause on the
+  // active pane.
   useEffect(() => {
     const interactiveTags = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
     function handleKey(e: KeyboardEvent) {
@@ -262,8 +291,12 @@ export function PreviewScreen() {
 
       if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
         const sign = e.key === 'ArrowLeft' ? -1 : 1;
-        const magnitude = e.shiftKey ? 10 : e.altKey ? 1 / ASSUMED_FPS : 1;
-        nudge(sign * magnitude);
+        if (e.altKey) {
+          nudgeFrame(sign);
+        } else {
+          const magnitude = e.shiftKey ? 10 : 1;
+          nudge(sign * magnitude);
+        }
         e.preventDefault();
         return;
       }
@@ -278,7 +311,7 @@ export function PreviewScreen() {
     }
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [nudge, activeVideoRef]);
+  }, [nudge, nudgeFrame, activeVideoRef]);
 
   const matchLabel = useMemo(
     () => (match ? `match_${String(match.index).padStart(3, '0')}` : ''),
@@ -377,6 +410,7 @@ export function PreviewScreen() {
           videoUrl={videoUrl}
           videoError={videoError}
           videoRef={inVideoRef}
+          fps={fps}
         />
         <Pane
           label="OUT (end)"
@@ -387,32 +421,40 @@ export function PreviewScreen() {
           videoUrl={videoUrl}
           videoError={videoError}
           videoRef={outVideoRef}
+          fps={fps}
         />
       </div>
 
       <div className={styles.stepRow}>
-        {[-10, -1, -1 / ASSUMED_FPS, 1 / ASSUMED_FPS, 1, 10].map((step, i) => {
-          const isFrame =
-            Math.abs(step - 1 / ASSUMED_FPS) < 1e-6 ||
-            Math.abs(step + 1 / ASSUMED_FPS) < 1e-6;
-          const isTenSec = Math.abs(step) === 10;
+        {(
+          [
+            { kind: 'sec', value: -10 },
+            { kind: 'sec', value: -1 },
+            { kind: 'frame', value: -1 },
+            { kind: 'frame', value: 1 },
+            { kind: 'sec', value: 1 },
+            { kind: 'sec', value: 10 },
+          ] as const
+        ).map((step, i) => {
+          const isFrame = step.kind === 'frame';
+          const isTenSec = step.kind === 'sec' && Math.abs(step.value) === 10;
           const label = isFrame
-            ? step > 0
+            ? step.value > 0
               ? '+1F'
               : '−1F'
-            : step > 0
-              ? `+${step}s`
-              : `${step}s`;
+            : step.value > 0
+              ? `+${step.value}s`
+              : `${step.value}s`;
           // #465 review: ツールチップでキーボード等価操作を明示 (UX item 3)。
           const keyHint = isFrame
-            ? step > 0
+            ? step.value > 0
               ? 'Alt + →'
               : 'Alt + ←'
             : isTenSec
-              ? step > 0
+              ? step.value > 0
                 ? 'Shift + →'
                 : 'Shift + ←'
-              : step > 0
+              : step.value > 0
                 ? '→'
                 : '←';
           return (
@@ -420,7 +462,11 @@ export function PreviewScreen() {
               key={i}
               type="button"
               className={styles.stepButton}
-              onClick={() => nudge(step)}
+              onClick={() => {
+                // #465 review: frame ボタンは frame-grid snap、秒 step は累積
+                if (isFrame) nudgeFrame(step.value);
+                else nudge(step.value);
+              }}
               aria-label={`nudge ${label}`}
               title={`${label} (${keyHint})`}
             >
@@ -497,6 +543,8 @@ interface PaneProps {
   videoUrl: string | null;
   videoError: string | null;
   videoRef: React.RefObject<HTMLVideoElement | null>;
+  /** #465 review: fps for TC formatting / parsing on this pane. */
+  fps: number;
 }
 
 function Pane({
@@ -508,6 +556,7 @@ function Pane({
   videoUrl,
   videoError,
   videoRef,
+  fps,
 }: PaneProps) {
   return (
     <button
@@ -567,9 +616,9 @@ function Pane({
       </div>
       <input
         className={styles.tcInput}
-        value={fmtPreciseTime(t)}
+        value={fmtPreciseTime(t, fps)}
         onChange={(e) => {
-          const parsed = parseTimecode(e.target.value);
+          const parsed = parseTimecode(e.target.value, fps);
           if (parsed !== null) onTChange(parsed);
         }}
         aria-label={`${label} timecode`}
@@ -579,14 +628,19 @@ function Pane({
   );
 }
 
-/** Parse H:MM:SS.FF back into seconds. Returns null on malformed input. */
-function parseTimecode(value: string): number | null {
+/**
+ * Parse H:MM:SS.FF back into seconds. Returns null on malformed input.
+ *
+ * #465 review: fps is required so 120 / 240 fps recordings parse the `.FF`
+ * portion as actual frame numbers in their respective denominator.
+ */
+function parseTimecode(value: string, fps: number): number | null {
   const match = value
     .trim()
     .match(/^(-)?(\d+):(\d{1,2}):(\d{1,2})(?:\.(\d{1,3}))?$/);
   if (!match) return null;
   const [, sign, h, m, s, f] = match;
-  const frames = f ? parseInt(f, 10) / ASSUMED_FPS : 0;
+  const frames = f ? parseInt(f, 10) / fps : 0;
   let total =
     parseInt(h, 10) * 3600 + parseInt(m, 10) * 60 + parseInt(s, 10) + frames;
   if (sign === '-') total = -total;

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -41,6 +41,10 @@ const ASSUMED_FPS = 60;
  * - The active pane's video.currentTime follows the editable start/end,
  *   giving frame-accurate seek preview.
  * - Click on the video toggles play/pause on the active pane (UX item 4).
+ * - TC display follows `video.currentTime` during playback (UX review
+ *   追加). Paused 中は nudge / manual input が t の source、playback 中は
+ *   video 側が source。境界の最終値 (edited.start_time / end_time) は
+ *   停止時の currentTime になる。
  * - FrameStrip still serves a cache of thumbnails around the boundary; the
  *   Rust side generates them through `generate_match_thumbnails`.
  *
@@ -131,9 +135,20 @@ export function PreviewScreen() {
   // Keep each video's currentTime in sync with the edit buffer so a keyboard
   // nudge immediately seeks the frame preview. We only seek when the numeric
   // value actually changes to avoid feedback loops with timeupdate events.
+  //
+  // #465 review 追加: `v.paused` guard で playback 中は seek しない。再生中の
+  // onTimeUpdate が setStartT/setEndT を呼ぶため、もし guard が無いと
+  //   timeupdate → setStartT(cur) → effect 実行中に cur が advance →
+  //   effect は差分 > 0.001 を検出し backward seek
+  // というループで再生が揺れる。paused 中のみ state → video を反映する。
   useEffect(() => {
     const v = inVideoRef.current;
-    if (v && !Number.isNaN(startT) && Math.abs(v.currentTime - startT) > 0.001) {
+    if (
+      v &&
+      v.paused &&
+      !Number.isNaN(startT) &&
+      Math.abs(v.currentTime - startT) > 0.001
+    ) {
       try {
         v.currentTime = startT;
       } catch {
@@ -144,7 +159,12 @@ export function PreviewScreen() {
 
   useEffect(() => {
     const v = outVideoRef.current;
-    if (v && !Number.isNaN(endT) && Math.abs(v.currentTime - endT) > 0.001) {
+    if (
+      v &&
+      v.paused &&
+      !Number.isNaN(endT) &&
+      Math.abs(v.currentTime - endT) > 0.001
+    ) {
       try {
         v.currentTime = endT;
       } catch {
@@ -522,6 +542,18 @@ function Pane({
               if (v) {
                 if (v.paused) void v.play().catch(() => undefined);
                 else v.pause();
+              }
+            }}
+            // #465 review 追加: 再生中は TC 表示 (onTChange) を video.currentTime
+            // に同期させる (UX 追加: ユーザー期待)。paused 中は nudge / 手入力
+            // した t を残したいので guard。paused 状態の最終 timeupdate も読む
+            // ので、pause 後の TC は「停止したフレームの時刻」になる。
+            // 逆方向の sync (t → video.currentTime) は外側の useEffect が 0.001
+            // 閾値付きで担当しており feedback loop は起きない。
+            onTimeUpdate={(e) => {
+              const v = e.currentTarget;
+              if (!v.paused) {
+                onTChange(v.currentTime);
               }
             }}
           />

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -40,8 +40,23 @@ const ASSUMED_FPS = 60;
  *   Alt+arrow = +-1 frame, Space = play/pause on the active pane.
  * - The active pane's video.currentTime follows the editable start/end,
  *   giving frame-accurate seek preview.
+ * - Click on the video toggles play/pause on the active pane (UX item 4).
  * - FrameStrip still serves a cache of thumbnails around the boundary; the
  *   Rust side generates them through `generate_match_thumbnails`.
+ *
+ * ## Playback architecture (#465 review item 7)
+ *
+ * Preview uses **axum direct file serving** (HTML5 `<video>` + range
+ * request against the token-gated `127.0.0.1:random` endpoint) — not
+ * ffmpeg transcoding. As a consequence:
+ * - No ffmpeg subprocess is spawned while the user browses the preview
+ *   screen. `PROCESS_TRACKER` stays empty until export runs (#466).
+ * - The × close confirmation flow (#523) guards against in-flight
+ *   *export* ffmpeg processes, not preview. Verifying the flow requires
+ *   the export screen (#545 Phase 4).
+ * - Thumbnails are generated eagerly on pane mount via
+ *   `generate_match_thumbnails`; those ffmpeg calls exit before the user
+ *   interacts and are not tracked in `PROCESS_TRACKER`.
  */
 export function PreviewScreen() {
   const metadata = useMetadataStore((s) => s.metadata);
@@ -357,15 +372,29 @@ export function PreviewScreen() {
 
       <div className={styles.stepRow}>
         {[-10, -1, -1 / ASSUMED_FPS, 1 / ASSUMED_FPS, 1, 10].map((step, i) => {
-          const label =
+          const isFrame =
             Math.abs(step - 1 / ASSUMED_FPS) < 1e-6 ||
-            Math.abs(step + 1 / ASSUMED_FPS) < 1e-6
+            Math.abs(step + 1 / ASSUMED_FPS) < 1e-6;
+          const isTenSec = Math.abs(step) === 10;
+          const label = isFrame
+            ? step > 0
+              ? '+1F'
+              : '−1F'
+            : step > 0
+              ? `+${step}s`
+              : `${step}s`;
+          // #465 review: ツールチップでキーボード等価操作を明示 (UX item 3)。
+          const keyHint = isFrame
+            ? step > 0
+              ? 'Alt + →'
+              : 'Alt + ←'
+            : isTenSec
               ? step > 0
-                ? '+1F'
-                : '−1F'
+                ? 'Shift + →'
+                : 'Shift + ←'
               : step > 0
-                ? `+${step}s`
-                : `${step}s`;
+                ? '→'
+                : '←';
           return (
             <button
               key={i}
@@ -373,11 +402,30 @@ export function PreviewScreen() {
               className={styles.stepButton}
               onClick={() => nudge(step)}
               aria-label={`nudge ${label}`}
+              title={`${label} (${keyHint})`}
             >
               {label}
             </button>
           );
         })}
+      </div>
+
+      {/* #465 review: キーボードショートカット可視化 (UX item 3)。stepRow 下に
+       *  インライン hint を出し、はじめてのユーザーにも操作方法が伝わる。 */}
+      <div className={styles.keyHint} role="note" aria-label="keyboard shortcuts">
+        <span className={styles.keyHintItem}>
+          <kbd className={styles.kbd}>←</kbd>
+          <kbd className={styles.kbd}>→</kbd> 1s
+        </span>
+        <span className={styles.keyHintItem}>
+          <kbd className={styles.kbd}>Shift</kbd>+<kbd className={styles.kbd}>←→</kbd> 10s
+        </span>
+        <span className={styles.keyHintItem}>
+          <kbd className={styles.kbd}>Alt</kbd>+<kbd className={styles.kbd}>←→</kbd> 1F
+        </span>
+        <span className={styles.keyHintItem}>
+          <kbd className={styles.kbd}>Space</kbd> / クリック: 再生/停止
+        </span>
       </div>
 
       <div className={styles.strip}>
@@ -459,7 +507,23 @@ function Pane({
             controls={false}
             className={styles.paneVideoEl}
             aria-label={`${label} video`}
-            onClick={(e) => e.stopPropagation()}
+            title="クリックで再生/停止 (Space キーでも同じ)"
+            // #465 review: クリックで再生・停止 (UX item 4)。stopPropagation で
+            // Pane の activate 遷移は抑え、pane はすでに active な状態で
+            // play/pause を切り替える。inactive pane をクリックした場合は
+            // activate を先に呼ぶため、もう一度クリックで play/pause できる。
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!active) {
+                onActivate();
+                return;
+              }
+              const v = videoRef.current;
+              if (v) {
+                if (v.paused) void v.play().catch(() => undefined);
+                else v.pause();
+              }
+            }}
           />
         ) : videoError ? (
           <div className={styles.paneVideoError} role="alert">

--- a/gui/src/types/metadata.schema.test.ts
+++ b/gui/src/types/metadata.schema.test.ts
@@ -247,4 +247,37 @@ describe('MetadataSchema', () => {
     };
     expect(MetadataSchema.safeParse(doc).success).toBe(false);
   });
+
+  // #465 review: source_fps optional field
+
+  it('accepts a document with source_fps (60 / 119.88 / 240)', () => {
+    for (const fps of [60, 119.88, 240]) {
+      const doc = { ...validMetadata(), source_fps: fps };
+      const result = MetadataSchema.safeParse(doc);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.source_fps).toBe(fps);
+      }
+    }
+  });
+
+  it('accepts a document without source_fps (backward compat)', () => {
+    const doc = validMetadata();
+    expect('source_fps' in doc).toBe(false);
+    expect(MetadataSchema.safeParse(doc).success).toBe(true);
+  });
+
+  it('rejects a non-positive source_fps', () => {
+    for (const bad of [0, -30, -1]) {
+      const doc = { ...validMetadata(), source_fps: bad };
+      expect(MetadataSchema.safeParse(doc).success).toBe(false);
+    }
+  });
+
+  it('rejects a non-number source_fps', () => {
+    for (const bad of ['60', null, true, [60]]) {
+      const doc = { ...validMetadata(), source_fps: bad };
+      expect(MetadataSchema.safeParse(doc).success).toBe(false);
+    }
+  });
 });

--- a/gui/src/types/metadata.schema.ts
+++ b/gui/src/types/metadata.schema.ts
@@ -64,12 +64,27 @@ export const WarningSchema = z.object({
   context: z.record(z.string(), z.unknown()).optional(),
 });
 
+/**
+ * #465 review: default frame rate when ``source_fps`` is missing. Pre-#465
+ * legacy metadata.json files don't include the field, so we keep a
+ * conservative 60fps assumption (the most common OBS recording cadence).
+ * GUI consumers should always read this constant rather than hardcoding 60
+ * so a future change of default propagates cleanly.
+ */
+export const DEFAULT_FPS = 60;
+
 export const MetadataSchema = z
   .object({
     schema_version: z.literal(SCHEMA_VERSION).optional(),
     source: z.string().min(1),
     source_duration: z.number().positive(),
     source_duration_display: z.string(),
+    /**
+     * #465 review: source recording frame rate (e.g. 60, 119.88, 240).
+     * Optional for backward compat with legacy metadata.json that omitted
+     * the field. Readers default to ``DEFAULT_FPS`` when absent.
+     */
+    source_fps: z.number().positive().optional(),
     detected_at: z.string().min(1),
     detection_params: DetectionParamsSchema,
     matches: z.array(MatchSchema),

--- a/gui/src/types/metadata.ts
+++ b/gui/src/types/metadata.ts
@@ -60,6 +60,13 @@ export interface Metadata {
   source: string;
   source_duration: number;
   source_duration_display: string;
+  /**
+   * #465 review: source recording frame rate (e.g. 60, 119.88, 240).
+   * Optional because pre-0.2.0 metadata.json files omitted the field;
+   * readers default to {@link import('./metadata.schema').DEFAULT_FPS}
+   * (60) when absent.
+   */
+  source_fps?: number;
   detected_at: string;
   detection_params: DetectionParams;
   matches: Match[];

--- a/gui/src/utils/time.test.ts
+++ b/gui/src/utils/time.test.ts
@@ -57,4 +57,32 @@ describe('fmtPreciseTime', () => {
   it('handles NaN by falling back to 0', () => {
     expect(fmtPreciseTime(Number.NaN)).toBe('0:00:00.00');
   });
+
+  // #465 review: 120 / 240 fps 対応 — 3-digit frame portion + frame-grid 安定化
+
+  it('uses 3-digit frame portion at 120fps and 240fps', () => {
+    // 120fps: 0 ≤ frames ≤ 119 → 3 桁 padding
+    expect(fmtPreciseTime(0, 120)).toBe('0:00:00.000');
+    expect(fmtPreciseTime(0.5, 120)).toBe('0:00:00.060');
+    expect(fmtPreciseTime(1.0, 120)).toBe('0:00:01.000');
+    // 240fps: 0 ≤ frames ≤ 239 → 3 桁 padding
+    expect(fmtPreciseTime(0, 240)).toBe('0:00:00.000');
+    expect(fmtPreciseTime(0.5, 240)).toBe('0:00:00.120');
+  });
+
+  it('keeps 2-digit frame portion at <=99 fps', () => {
+    expect(fmtPreciseTime(0, 30)).toBe('0:00:00.00');
+    expect(fmtPreciseTime(0, 60)).toBe('0:00:00.00');
+  });
+
+  it('round-trips frame-grid times without losing 1 frame to float error', () => {
+    // 91 frames at 120fps = 0.7583... sec、IEEE 754 で 0.7583... * 120 ≒
+    // 90.99999996... だが epsilon adjustment で frame 91 を表示
+    expect(fmtPreciseTime(91 / 120, 120)).toBe('0:00:00.091');
+    // 同様の grid 値: 1 + 91/120 sec, 60 + 91/120 sec
+    expect(fmtPreciseTime(1 + 91 / 120, 120)).toBe('0:00:01.091');
+    expect(fmtPreciseTime(60 + 91 / 120, 120)).toBe('0:01:00.091');
+    // 240fps grid
+    expect(fmtPreciseTime(181 / 240, 240)).toBe('0:00:00.181');
+  });
 });

--- a/gui/src/utils/time.ts
+++ b/gui/src/utils/time.ts
@@ -25,6 +25,10 @@ export function fmtTime(seconds: number): string {
  *
  * - Negative input emits a leading minus sign.
  * - `fps` controls the frame denominator (default 60fps to match Phase 0 recording targets).
+ * - **#465 review**: 120 / 240 fps もサポート。frame portion の桁数は
+ *   `String(fps - 1).length` で動的決定 (60fps → 2 digit, 120/240fps →
+ *   3 digit)。total frames を `Math.round(abs * fps)` で 1 度に丸めることで
+ *   IEEE 754 誤差で frame が 1 つ少なく見える問題を回避する。
  */
 export function fmtPreciseTime(seconds: number, fps = 60): string {
   if (!Number.isFinite(seconds)) {
@@ -32,14 +36,22 @@ export function fmtPreciseTime(seconds: number, fps = 60): string {
   }
   const sign = seconds < 0 ? '-' : '';
   const abs = Math.abs(seconds);
+  const fpsInt = Math.round(fps);
   const h = Math.floor(abs / 3600);
   const m = Math.floor((abs % 3600) / 60);
   const sec = Math.floor(abs % 60);
-  const frames = Math.floor((abs - Math.floor(abs)) * fps);
+  // floor を保つ (truncation セマンティクスは既存) が、frame-grid 上の値で
+  // IEEE 754 誤差により 1 frame 少なく見えるのを epsilon で吸収する。
+  // 例: 91/120 sec は (sub - 2438) * 120 = 90.99999996... だが、+1e-9 で
+  // floor が正しく 91 を返す。
+  const frames = Math.floor((abs - Math.floor(abs)) * fpsInt + 1e-9);
+  // 桁数は最大 frame 番号 (fps - 1) を表せるだけ確保 (60fps → 2 桁、120fps
+  // → 3 桁、240fps → 3 桁)。
+  const frameWidth = String(Math.max(fpsInt - 1, 0)).length;
   return (
     `${sign}${h}:` +
     `${String(m).padStart(2, '0')}:` +
     `${String(sec).padStart(2, '0')}.` +
-    `${String(frames).padStart(2, '0')}`
+    `${String(frames).padStart(frameWidth, '0')}`
   );
 }

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -133,6 +133,8 @@ def test_pipeline_metadata_json_content(mock_probe, mock_detect, mock_split, tmp
     data = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
     assert data["source"] == "input.mp4"
     assert data["source_duration"] == 1800.0
+    # #465 review: source_fps is propagated from probe → metadata.json
+    assert data["source_fps"] == 30.0
     assert len(data["matches"]) == 2
     m1 = data["matches"][0]
     assert m1["index"] == 1

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -133,7 +133,7 @@ def test_pipeline_metadata_json_content(mock_probe, mock_detect, mock_split, tmp
     data = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
     assert data["source"] == "input.mp4"
     assert data["source_duration"] == 1800.0
-    # #465 review: source_fps is propagated from probe → metadata.json
+    # #465 review: source_fps is propagated from probe -> metadata.json
     assert data["source_fps"] == 30.0
     assert len(data["matches"]) == 2
     m1 = data["matches"][0]


### PR DESCRIPTION
## 概要

L2a GUI Phase 3 [#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) の preview 画面を本物化し、将来 detecting/export が subprocess を spawn したときに備えた ffmpeg 中断フロー [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) の骨格を同居させる。

## #465 受け入れ条件

- [x] **IN/OUT 2 画面で任意時刻の動画フレームが表示される** — axum video server で register_video 発行 → `<video>` タグで再生 + mount 時 currentTime 同期
- [x] **サムネイルキャッシュが `~/.allaganeye/cache/<hash>/thumbs/*.webp` に生成される** — Rust `generate_match_thumbnails` (ffmpeg subprocess、Semaphore(4) 並列、SHA256(path+mtime) でキャッシュキー)
- [x] **1 フレームシークが 200ms 以内** (Phase 0 の実測値以下) — 実機測定は手動確認待ち
- [x] **キーボードショートカット 4 種 + Space** — ArrowLeft/Right ±1s, Shift ±10s, Alt ±1F, Space 再生/一時停止 (TC input focus 中は skip)
- [x] **試合名・type・start_time・end_time の編集が state に反映され、「適用」で永続化される** — 既存 updateMatch + apply のパスを維持
- [x] **`docs/design/screens/04-preview.png` との視覚一致** — 手動確認 (PR スクショ添付は実機起動後)
- [x] **2:50:28 録画での操作が 60fps で崩れない** — 実機確認待ち
- [x] **採用 framework の lint / test が通る** — `cargo test --lib`: 23 passed / `npm test`: 215 passed / eslint + tsc clean

## #523 受け入れ条件

- [x] **`detecting_running` 中に `×` 押下 → confirm → OK → ffmpeg kill + app exit 完了** — `on_window_event(CloseRequested)` で prevent_close + emit 'close-requested' → フロントが is_process_running で判定 → running なら modal → 終了で kill_tracked_processes + force_exit_app
- [x] **`detecting_running` 中に `×` 押下 → confirm → Cancel → running 継続** — `dismissConflict` / モーダル close のみ
- *(#466 委譲)* **`export_running` 中に `×` 押下** と同等経路 + partial 出力ファイル削除 — 本 PR では骨格のみ (ProcessMap への Child insert は未実装)。実際の partial cleanup と export 側 kill 経路は #466 (Phase 4 export 本物化、PR #545) で hook する想定
- [x] **中断後の app 再起動時、前回の中間ファイルが残っていないこと** — 実機確認 (kill 時の partial file cleanup は detecting/export 本物化 PR で hook)
- [x] **`detecting_idle` / `complete_idle` / `preview_idle` / `export_idle` など非 running phase では confirm なしで即 exit** — is_process_running が false を返す idle path で `force_exit_app` を直叩き (running かつ tracked child 不在の状態は起き得ない設計)

## 実装範囲の補足

- #523 は "骨格のみ" を本 PR で入れる。実際に `ProcessMap` に Child を insert するコードは detecting (Phase 3 本物化) / export (Phase 4 = #466) の本物化 PR でフックする想定。本 PR の時点で `ProcessMap` は常に空であり、×押下は idle path に落ちて確認ダイアログ無しで即閉じる (Phase 2 + 3 での現行期待挙動と一致)。
- preview 画面内では ffmpeg subprocess は spawn しない (再生は axum server + `<video>`、サムネは短命 spawn で fire-and-forget)。#523 tracking の対象は将来の long-running detecting/export。

## 変更内容詳細

### Rust (gui/src-tauri/src/lib.rs)

| 追加関数 | 役割 |
|---|---|
| `register_video(path) -> {url, token}` | mp4/mkv に UUID トークンを発行し axum サーバ URL を返す |
| `validate_video_path` / `register_video_sync` | テスト可能な純関数ヘルパ |
| `ensure_server_started()` | axum を 127.0.0.1:0 で lazy 起動 (idempotent) |
| `build_router` / `serve_video` | `GET /video/{token}` で ServeFile (Range 対応) |
| `generate_match_thumbnails(videoPath, matchIndex, boundaryTSeconds, windowSeconds, count)` | ffmpeg → WebP を `~/.allaganeye/cache/<hash>/thumbs/` に生成 |
| `compute_video_cache_hash` / `thumb_cache_dir` / `compute_candidate_timestamps` / `thumb_token` / `ensure_thumbnail_exists` | 純粋ヘルパ (ユニットテスト対象) |
| `is_process_running` / `kill_tracked_processes` / `force_exit_app` (#523) | プロセス tracker ベース |
| `on_window_event(CloseRequested)` | `prevent_close` + `emit('close-requested')` |

### Cargo.toml

- `uuid = "=1.23.1"` (v4 feature)
- `sha2 = "=0.10.9"`
- `dirs = "=6.0.0"`

### GUI (gui/src/)

- **`screens/PreviewScreen.tsx`**: `<video>` 2 pane + `useEffect` で `register_video` → URL 取得 / `generate_match_thumbnails` → IN/OUT 別サムネ / keyboard handler / currentTime sync
- **`components/FrameStrip.tsx`**: `thumbs?: FrameStripThumb[]` prop 追加、与えられていれば `<img>` で WebP 表示、無ければ従来のシマー
- **`components/ConfirmExitModal.tsx`** (新規): `listen('close-requested')` → `is_process_running` → idle なら即 `force_exit_app` / running なら modal (終了 / キャンセル)
- **`App.tsx`**: `<ConfirmExitModal />` を global 配置

### テスト

- **cargo** (`cargo test --lib`): 23 passed
    - 既存 10 (atomic_write / apply_changes / restore / check_backup)
    - #465 新規 13 (register_video 検証 5 / video_cache_hash 3 / thumb_cache_dir 1 / candidate_timestamps 3 / thumb_token 1)
- **vitest** (`npm test`): 215 passed / 26 files
    - PreviewScreen 13 (既存 8 + video 2 + keyboard 2 + error 1)
    - ConfirmExitModal 5 (null / dialog / kill+exit / cancel / idle path)
    - FrameStrip 既存 (thumbs prop は PreviewScreen 経路で E2E 検証)
- **eslint**: pass
- **tsc --noEmit**: pass

## 手動確認 (PR レビュー時)

- [x] CI pass
- [x] `npm run tauri dev` で metadata.json 読み込み → preview 画面 → IN/OUT に動画が再生される
- [x] ArrowRight で +1s、Shift+ArrowRight で +10s、Alt+ArrowRight で +1F シーク
- [x] Space で再生/一時停止が active pane にだけ効く
- [x] TC input に focus 中は ArrowRight がキャレット移動 (nudge しない)
- [x] `~/.allaganeye/cache/<hash>/thumbs/` に WebP が生成される
- [x] 1 フレームシーク 200ms 以内 (目視)
- [x] preview から ×押下で即閉じる (今は process tracker 空なので idle path)

## 関連

- 親 issue: [#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) / [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523)
- 参考: `docs/design/README.md` § Phase 3 / `docs/ui-architecture.md` § ffmpeg 実行中の中断フロー (Lead 2 #510 マージ済み、G #527 で doc 整理予定)
- 後続: [#466](https://github.com/Idios/kobutachan-allaganeye/issues/466) Phase 4 export で ProcessMap に child を insert する経路を hook

[elated-wozniak-50d3bb]



