### PR TITLE
feat(installer): FFmpeg LGPLv3 LICENSE 同梱 + ソース入手経路明記 (Refs #509)

### DIFF
--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -332,6 +332,7 @@ CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージ�
 
 | 場所 | キー |
 |---|---|
-| `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` |
+| `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` (`$FFmpegSourceCommit` は asset 名から自動抽出) |
 | `.github/workflows/ci.yml` (`Install ffmpeg` ステップ) | `FFMPEG_URL` / `FFMPEG_SHA256` (linux64-lgpl 版) |
 | `docs/developer-setup.md` §1 | 「ffmpeg / ffprobe 8.1 LGPLv3 推奨」「推奨: ffmpeg 8.1 LGPLv3」の major version 記述 (系列変更時のみ) |
+| `docs/quickstart.md` §10 | 対応 FFmpeg コミット (例: `7f5c90f77e`) の記述 (upstream commit 変更時) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -139,3 +139,15 @@ Allagan Eye は FF14 フロントラインの一般的な録画に合わせて�
 ## 9. 開発者の方へ
 
 ソースコードから動かしたい、コードを修正したい、テストを追加したい場合は [Developer Setup Guide](developer-setup.md) を参照してください。
+
+## 10. ライセンス
+
+Portable ZIP には以下のソフトウェアが同梱されています。詳細な利用条件は各 LICENSE ファイルを参照してください。
+
+- **allaganeye 本体**: MIT License (リポジトリの `LICENSE` ファイル)
+- **Python**: PSF License (`python\LICENSE.txt`)
+- **FFmpeg**: LGPLv3 (`ffmpeg\LICENSE.txt` に全文)
+  - ビルド: [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) の win64-lgpl static build
+  - 対応 FFmpeg コミット: [git.ffmpeg.org](https://git.ffmpeg.org/ffmpeg.git) の commit `7f5c90f77e` (v8.1 系列)
+
+allaganeye 本体 (MIT) は FFmpeg バイナリをサブプロセスとしてのみ呼び出しているため、LGPLv3 の static linking 制約は allaganeye 本体には及びません。

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -102,20 +102,38 @@ New-Item -ItemType Directory -Force -Path $LibDir | Out-Null
     $RepoRoot
 
 # 4. FFmpeg LGPLv3 static, BtbN/FFmpeg-Builds (version-pinned)
+# LGPLv3 redistribution requires shipping the license text alongside the binary
+# and making the corresponding source available. We copy LICENSE.txt into the
+# payload and point README at the upstream source repo.
 $FFmpegZip = Join-Path $BuildDir 'ffmpeg.zip'
 Invoke-Download -Uri $FFmpegUrl -OutPath $FFmpegZip -ExpectedSha256 $FFmpegSha256
 $FFmpegExtract = Join-Path $BuildDir 'ffmpeg-extracted'
 Expand-Archive -Path $FFmpegZip -DestinationPath $FFmpegExtract -Force
-$FFmpegBin = Get-ChildItem -Path $FFmpegExtract -Directory |
-  Select-Object -First 1 |
-  ForEach-Object { Join-Path $_.FullName 'bin' }
-if (-not $FFmpegBin -or -not (Test-Path $FFmpegBin)) {
-  throw "FFmpeg bin directory not found under $FFmpegExtract"
+$FFmpegRoot = Get-ChildItem -Path $FFmpegExtract -Directory | Select-Object -First 1
+if (-not $FFmpegRoot) {
+  throw "FFmpeg root directory not found under $FFmpegExtract"
+}
+$FFmpegBin = Join-Path $FFmpegRoot.FullName 'bin'
+$FFmpegLicenseSrc = Join-Path $FFmpegRoot.FullName 'LICENSE.txt'
+if (-not (Test-Path $FFmpegBin)) {
+  throw "FFmpeg bin directory not found: $FFmpegBin"
+}
+if (-not (Test-Path $FFmpegLicenseSrc)) {
+  throw "FFmpeg LICENSE.txt not found: $FFmpegLicenseSrc"
+}
+# BtbN assets embed the upstream FFmpeg source commit hash in the filename:
+#   ffmpeg-n<version>-<count>-g<commit>-<target>-<variant>
+# Extract it so README can point users to the exact source they need under LGPLv3.
+if ($FFmpegAsset -match '^ffmpeg-n[^-]+-[^-]+-g([0-9a-f]+)-') {
+  $FFmpegSourceCommit = $matches[1]
+} else {
+  throw "Cannot extract upstream source commit from asset name: $FFmpegAsset"
 }
 $FFmpegDest = Join-Path $PayloadDir 'ffmpeg'
 New-Item -ItemType Directory -Force -Path $FFmpegDest | Out-Null
 Copy-Item -Path (Join-Path $FFmpegBin 'ffmpeg.exe') -Destination $FFmpegDest
 Copy-Item -Path (Join-Path $FFmpegBin 'ffprobe.exe') -Destination $FFmpegDest
+Copy-Item -Path $FFmpegLicenseSrc -Destination (Join-Path $FFmpegDest 'LICENSE.txt')
 
 # 5. Launcher
 # The launcher is ASCII-only so that it runs on any Windows code page without
@@ -198,7 +216,14 @@ See https://github.com/Idios/kobutachan-allaganeye for full documentation.
 
 - allaganeye: MIT (see the repository LICENSE file)
 - Python: PSF License (python\LICENSE.txt)
-- FFmpeg: LGPLv3 (ffmpeg n$FFmpegVersion win64-lgpl static build from BtbN/FFmpeg-Builds, tag $FFmpegBuildTag)
+- FFmpeg: LGPLv3 (full text in ffmpeg\LICENSE.txt)
+    Build:         ffmpeg n$FFmpegVersion win64-lgpl static build (BtbN/FFmpeg-Builds)
+    Build tag:     $FFmpegBuildTag
+    Source:        https://git.ffmpeg.org/ffmpeg.git (commit $FFmpegSourceCommit)
+    Build scripts: https://github.com/BtbN/FFmpeg-Builds
+
+allaganeye (MIT) invokes the FFmpeg binary as a separate subprocess only.
+Static linking restrictions of LGPLv3 therefore do not apply to allaganeye itself.
 "@
 Set-Content -Path (Join-Path $PayloadDir 'README.txt') -Value $Readme -Encoding UTF8
 


### PR DESCRIPTION
## Summary

#531 で切替済みの BtbN LGPLv3 FFmpeg について、LGPLv3 配布義務 (license 条文同梱 + ソース入手経路明示) を完結。Portable ZIP 展開後に `ffmpeg\LICENSE.txt` が閲覧でき、README / quickstart から upstream source 取得先が分かる構成にした。

## Refs

- #509 (主タスク)
- #531 / #510 (本 PR の前提、BtbN LGPLv3 切替)

## Changes

| ファイル | 変更内容 |
|---|---|
| `scripts/build-portable-zip.ps1` | §4 で `LICENSE.txt` を `ffmpeg/` にコピー、BtbN asset 名から upstream commit SHA (`$FFmpegSourceCommit`) を自動抽出、Root 取得を 1 回に集約。§6 README に build tag / source URL+commit / build scripts URL / subprocess 注記を追加 |
| `docs/quickstart.md` | §10 ライセンスセクションを追加 (MIT / PSF / LGPLv3 の 3 種別 + BtbN ビルド・upstream commit 参照) |
| `docs/developer-setup.md` | §9 FFmpeg bump 表に `docs/quickstart.md §10` 行を追加、`$FFmpegSourceCommit` が自動抽出される旨を注記 |

## #509 受け入れ条件の逐条対応

| 受け入れ条件 | 対応 |
|---|---|
| Gyan.dev essentials build の実ライセンスを一次資料で検証 | ✅ 実質 #531 で解消 (BtbN LGPLv3 に切替済み、GyanD は利用終了)。本 PR では現行 BtbN 配布の LICENSE.txt を一次資料として採用 |
| `scripts/build-portable-zip.ps1` で FFmpeg 展開元の `LICENSE` / 関連ファイルを `ffmpeg/` にコピーする改修 | ✅ §4 に `Copy-Item $FFmpegLicenseSrc ... ffmpeg\LICENSE.txt` 追加、存在しない場合 `throw` |
| Portable ZIP 展開後に `ffmpeg/LICENSE` (or 等価) が閲覧可能 | ✅ ローカルビルド検証: `build/portable/allaganeye-v0.2.0-test/ffmpeg/LICENSE.txt` に LGPLv3 全文 (165 行) 同梱 |
| `README.txt` / `docs/quickstart.md` / `scripts/build-portable-zip.ps1` の license 種別記載を実態 (LGPLv3) と一致 | ✅ 3 箇所すべて BtbN LGPLv3 を明記 (build tag / source commit / subprocess 呼び出し注記込み) |
| (GPL 適用時) subprocess 呼び出し形態の判断根拠 docs 記載 | N/A (BtbN LGPLv3 確定のため該当せず) |
| (LGPL 適用時) FFmpeg ソース版入手経路を README に明記 | ✅ README.txt に `Source: https://git.ffmpeg.org/ffmpeg.git (commit 7f5c90f77e)` / `Build scripts: https://github.com/BtbN/FFmpeg-Builds` を記載、quickstart.md §10 にも同内容 |

## 実機検証

- `powershell.exe ./scripts/build-portable-zip.ps1 -Version 0.2.0-test` → ビルド成功
- 生成物内 `ffmpeg/LICENSE.txt` を確認: 1 行目 `GNU LESSER GENERAL PUBLIC LICENSE`、2 行目 `Version 3, 29 June 2007` で LGPLv3 全文
- `README.txt` の Licenses セクションが以下で展開されることを確認:
  ```
  - FFmpeg: LGPLv3 (full text in ffmpeg\LICENSE.txt)
      Build:         ffmpeg n8.1 win64-lgpl static build (BtbN/FFmpeg-Builds)
      Build tag:     autobuild-2026-04-22-13-15
      Source:        https://git.ffmpeg.org/ffmpeg.git (commit 7f5c90f77e)
      Build scripts: https://github.com/BtbN/FFmpeg-Builds
  ```
- `$FFmpegSourceCommit` が `ffmpeg-n8.1-10-g7f5c90f77e-win64-lgpl-8.1` から `7f5c90f77e` に正しく抽出されていることを README 埋め込み経由で確認
- ローカル: `ruff check .` / `ruff format --check .` (64 files) 緑 (Python コード変更なし)

## Test plan (本 PR 内)

- [x] CI `python` ジョブが緑 (Python コード変更なし、BtbN 依存関係は #531 から継続)
- [x] CI `release.yml` `build-windows` ジョブが `allaganeye-v*-windows.zip` artifact を出す (LICENSE.txt 同梱を含む)
- [x] CI `markdownlint` が緑 (`docs/quickstart.md` §10 / `docs/developer-setup.md` §9 変更箇所)
- [x] ローカル: Portable ZIP ビルド成功、ffmpeg/LICENSE.txt 存在 + README に source commit 埋め込み済み

## マージ後の手動検証 (情報事項)

- 公開 Release 成果物を展開した際の LICENSE / README の見栄えを Idios が最終確認
- #509 issue クローズ判定

## スコープ外 (後続 PR)

- `#461 (release-process.md リネーム + 手動リリース手順追記)` — 別 PR
- `#528 (Pester 単体テスト)` — build-portable-zip.ps1 の Invoke-Download / 展開ロジック / README 生成のユニットテストは別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)