### PR TITLE
docs(arch): CLI+GUI 統合 system-architecture 新設 + dispatch 仕様 (Refs #527)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ FF14 PvPコンテンツ「フロントライン」の長時間録画動画（OBS
 
 ## コマンド
 
-詳細は [`docs/testing-guide.md`](docs/testing-guide.md) を参照（GPU テスト間インターバル、サンプルデータ設定等）。CLI 構文は [`docs/cli-spec.md`](docs/cli-spec.md)、オプション組み合わせごとの出力仕様は [`docs/output-spec.md`](docs/output-spec.md) (#405 マトリクス v2) を参照。
+詳細は [`docs/testing-guide.md`](docs/testing-guide.md) を参照（GPU テスト間インターバル、サンプルデータ設定等）。CLI 構文は [`docs/cli-spec.md`](docs/cli-spec.md)、オプション組み合わせごとの出力仕様は [`docs/output-spec.md`](docs/output-spec.md) (#405 マトリクス v2)、CLI と GUI の全体構成・起動経路は [`docs/system-architecture.md`](docs/system-architecture.md) (#527) を参照。
+
+> **配布物の起動経路**: Portable ZIP の `allaganeye.bat` = CLI 起動 / Tauri bundle の `Allagan Eye.exe` (将来) = GUI 起動。**別 exe 方式** (#527 で確定)。
 
 ```bash
 # テスト

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Windows 専用です。Python や FFmpeg の事前インストールは必要あ
 ### 開発者向け
 
 - [Developer Setup Guide](docs/developer-setup.md) — ソースコードから動かす手順（Git / Python / venv）
+- [System Architecture](docs/system-architecture.md) — CLI + GUI + installer の全体構成と起動経路 (#527)
 - [CLI コマンド仕様](docs/cli-spec.md)
+- [GUI UI Architecture](docs/ui-architecture.md) — L2a Tauri GUI の screen / phase state machine
 - [metadata.json 仕様](docs/metadata-spec.md) — CLI ↔ GUI の契約 (#463)
 - [出力仕様マトリクス](docs/output-spec.md)
-- [システムアーキテクチャ](docs/design-overview.md)
+- [システム設計概要](docs/design-overview.md)
 - [動画処理設計](docs/video-processing.md)
 - [リリース戦略](docs/release-strategy.md)
 - [バグ報告ガイド](docs/bug-report-guide.md)

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -1,5 +1,7 @@
 # CLI コマンド仕様
 
+> **スコープ**: 本 doc は CLI (`allaganeye` サブコマンド) の構文を扱う。GUI (Allagan Eye.exe) と CLI の起動経路・全体像は [system-architecture.md](system-architecture.md) を参照。
+
 CLI コマンド・引数・オプションの**構文**をまとめる。各オプション組み合わせごとの**出力側**の期待仕様は [`docs/output-spec.md`](output-spec.md) に分離して定義されており、新規 CLI オプション追加時はそちらのマトリクスも更新する (#405)。
 
 ## 前提条件

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -1,8 +1,10 @@
-# システムアーキテクチャ
+# システム設計概要 (レイヤ構造)
+
+> **スコープ**: 本 doc はレイヤ (L1〜L6) の役割と段階的ロードマップを扱う。現時点での CLI / GUI / installer の組み合わせ構成と起動経路は [system-architecture.md](system-architecture.md) を参照。
 
 ## 概要
 
-Allagan Eye は FF14 フロントラインの長時間録画動画を段階的に処理するCLIツール。
+Allagan Eye は FF14 フロントラインの長時間録画動画を段階的に処理するツール (L1 CLI / L2a GUI / L2b installer)。
 
 ## 段階的アーキテクチャ
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,0 +1,143 @@
+# Allagan Eye — System Architecture
+
+本 doc は Allagan Eye の CLI / GUI / installer がどう組み合わさって動作するかを記録する。個別の詳細仕様は以下に分かれている:
+
+- [CLI コマンド仕様](cli-spec.md) — `allaganeye` のサブコマンド / オプション
+- [GUI UI Architecture](ui-architecture.md) — L2a Tauri GUI の screen / phase state machine (Phase 2 基盤、Phase 3/4 で拡張)
+- [metadata.json 仕様](metadata-spec.md) — CLI ↔ GUI の唯一の契約
+- [リリース戦略](release-strategy.md) — develop-x.x.x / main のブランチ運用
+
+本 doc は上記を横断する「全体像」と「起動経路 (CUI/GUI dispatch)」を扱う。
+
+## 1. コンポーネント構成
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│ Allagan Eye                                                     │
+│                                                                  │
+│  L2b: Portable ZIP / Tauri bundle (配布形態)                    │
+│  ├── allaganeye.bat              ── CLI 起動 (Python ランタイム) │
+│  └── Allagan Eye.exe (future)    ── GUI 起動 (Tauri bundle)      │
+│       │                                                           │
+│       └─ subprocess spawn ─► allaganeye.exe / allaganeye.bat     │
+│                                                                   │
+│  L1: CLI (`allaganeye`, Python)                                  │
+│  ├── detect  ── metadata.json 生成 (ffmpeg / OpenCV)             │
+│  ├── split   ── metadata.json 生成 + MP4 分割                   │
+│  └── split --from-metadata ── metadata.json 読み込み + 分割     │
+│                                                                   │
+│  L2a: GUI (`Allagan Eye`, Tauri 2 + React 19)                    │
+│  ├── Zustand store ── metadata.json の in-memory 編集            │
+│  ├── axum 局所 HTTP サーバ ── <video> 再生用 (Rust 内 thread)    │
+│  └── tokio::process ── CLI を subprocess として呼び出し        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- **CLI (L1)** は standalone 動作し、GUI に依存しない
+- **GUI (L2a)** は CLI を subprocess として呼び出して detect / split を実行する
+- **Installer (L2b)** は両者を同梱する配布形態を提供する
+- **metadata.json** が CLI ↔ GUI の唯一の契約 ([metadata-spec.md](metadata-spec.md) #463)
+
+## 2. 起動経路 (CUI / GUI dispatch)
+
+Allagan Eye は **別 exe 方式**を採用する (2026-04-23 確定、#527)。単一バイナリに CLI / GUI の両モードを同居させる設計は採用しない。
+
+### 2.1 配布物と起動コマンド
+
+| 起動ターゲット | 起動方法 | 実体 | 状態 |
+|---|---|---|---|
+| `allaganeye.bat` (Portable ZIP) | Cmd / PowerShell で引数付き実行 | 同梱 Python + `python -m allaganeye` | リリース済み (v0.1.1) |
+| `allaganeye` (Python venv 内) | `python -m allaganeye <cmd>` | pyproject.toml の console_scripts | 開発時 |
+| `Allagan Eye.exe` (Tauri bundle) | ダブルクリック / start menu | Tauri 2 ランタイム | 将来 (現在 `tauri.conf.json` の `bundle.active = false`) |
+
+### 2.2 判断根拠
+
+- **ユーザー体験**: ダブルクリックで GUI が立ち上がるのは一般的な Windows アプリの感覚。CLI が混ざると「シェル出力を期待した」「GUI が出てほしい」の混乱が起きる
+- **Portable ZIP との整合**: `allaganeye.bat` は既存の Python ランタイム呼び出しラッパ。Windows Defender / SmartScreen で弾かれる運用課題が `.bat` 経由で抽象化済み (#507)
+- **bundle の独立性**: Tauri bundle は別 `.exe` なので、CLI の `.bat` と衝突しない。将来 MSIX 等のパッケージ化でも両者を並列同梱可能
+- **開発工数**: 単一バイナリ化するには Rust 側に Python interpreter embedding が必要。実質的に別実装と同等のコストで benefit が薄い
+
+### 2.3 GUI → CLI subprocess 経路
+
+GUI は以下のタイミングで CLI を subprocess として呼び出す (本仕様は Phase 3/4 の本物化で `tokio::process::Command` で実装される):
+
+| GUI 画面 | subprocess 引数 | 生成物 | 実装 PR |
+|---|---|---|---|
+| DetectingScreen (本物化予定) | `allaganeye detect <video> -o <output>` | metadata.json | [#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) Phase 3 |
+| ExportScreen (本物化予定) | `allaganeye split --from-metadata <meta>` | metadata.json + MP4 | [#466](https://github.com/Idios/kobutachan-allaganeye/issues/466) Phase 4 |
+
+spawn された CLI プロセスは `ProcessMap` (Rust side、#523) に登録される。ユーザーがウィンドウを閉じる (`×`) 前にプロセスが走っていれば、GUI 側が `kill_tracked_processes` で中断する ([ui-architecture.md §ffmpeg 実行中の中断フロー](ui-architecture.md))。
+
+### 2.4 GUI 内の video 配信 (subprocess ではない)
+
+preview 画面での `<video>` 再生には axum ベースの局所 HTTP サーバ (#465) が使われる。これは **subprocess ではなく Rust プロセス内の async task** で、token ベースの path allowlisting で 127.0.0.1 にのみ bind する。ffmpeg は呼ばず (ブラウザの native decode)、Range リクエストに対応する。
+
+詳細: [ui-architecture.md §video playback](ui-architecture.md) / `gui/src-tauri/src/lib.rs` の `register_video` / `serve_video`。
+
+## 3. データフロー
+
+### 3.1 detect → preview → export の典型フロー
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant GUI as Allagan Eye.exe
+    participant CLI as allaganeye detect/split
+    participant Disk as metadata.json + MP4
+
+    User ->> GUI: 動画ファイルをドラッグ
+    GUI ->> CLI: spawn: allaganeye detect <video>
+    CLI ->> Disk: metadata.json 書き込み
+    CLI -->> GUI: exit 0
+    GUI ->> Disk: metadata.json 読み込み (load_metadata)
+    User ->> GUI: 試合境界を調整 → [適用]
+    GUI ->> Disk: metadata.json 上書き + metadata.original.json 退避
+    User ->> GUI: [書き出し]
+    GUI ->> CLI: spawn: allaganeye split --from-metadata <meta>
+    CLI ->> Disk: match_NNN.mp4 生成
+    CLI -->> GUI: exit 0
+```
+
+### 3.2 ファイル配置 (実行時)
+
+```text
+<output_dir>/
+├── metadata.json                     # CLI ↔ GUI 契約 (#463)
+├── metadata.original.json            # GUI 初回 [適用] でバックアップ (#516)
+├── metadata.draft.json               # GUI 編集中の自動保存 (#517, オプション)
+├── match_001.mp4
+├── match_002.mp4
+└── .detection_cache.json             # CLI の内部キャッシュ (再実行高速化)
+```
+
+`~/.allaganeye/cache/<video_hash>/thumbs/*.webp` は GUI のサムネイルキャッシュ (#465)。出力ディレクトリとは別。
+
+## 4. 責務分離の原則
+
+| 原則 | 理由 |
+|---|---|
+| **CLI は GUI に依存しない** | CLI 単体で実行 / テストできる。CLI のユニットテストで GUI 関連 subprocess は不要 |
+| **GUI は CLI を subprocess として呼び出す** | 重いロジック (ffmpeg / 検知) は CLI に集約。GUI 本体は UI に集中 |
+| **metadata.json を唯一の契約にする** | GUI と CLI が直接プロセス間通信 (IPC / RPC) しない。ファイルベースで疎結合 |
+| **axum video server は GUI 内の async task** | subprocess でも外部サービスでもない。GUI プロセス終了時に自動で畳まれる |
+| **プライバシー・セキュリティは CLI 側** | 動画ファイルの検査 (allaganeye-guard) は独立ツール (#454 運用連携のみ、GUI 未統合) |
+
+## 5. 変更時の影響範囲
+
+新機能を追加する際の判断基準:
+
+- **metadata.json のスキーマ変更** → [metadata-spec.md §schema_version](metadata-spec.md) の migration policy に従う (#515)
+- **CLI の新サブコマンド** → [cli-spec.md](cli-spec.md) 更新 / GUI が spawn するなら本 doc §2.3 にも行追加
+- **GUI の新画面** → [ui-architecture.md §screen 遷移図](ui-architecture.md) の Mermaid 図更新
+- **起動経路の変更** (例: `Allagan Eye.exe` を別アーキでビルド) → 本 doc §2 の表を更新
+- **bundle 形態の変更** (例: MSIX 採用) → リリース戦略 ([release-strategy.md](release-strategy.md)) と本 doc §2.1 を同時更新
+
+## 6. 関連 issue / doc
+
+- [#527](https://github.com/Idios/kobutachan-allaganeye/issues/527) 本 doc の起票元 (GUI 限定性明記 + dispatch 仕様文書化)
+- [#463](https://github.com/Idios/kobutachan-allaganeye/issues/463) Phase 1 data layer (metadata.json 契約)
+- [#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) Phase 3 preview 本物化 (axum video server + subprocess 経路)
+- [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) ffmpeg 実行中の安全な中断 (ProcessMap)
+- [#466](https://github.com/Idios/kobutachan-allaganeye/issues/466) Phase 4 export 本物化 (subprocess 経路の本格利用)
+- [#451](https://github.com/Idios/kobutachan-allaganeye/issues/451) / [#452](https://github.com/Idios/kobutachan-allaganeye/issues/452) L2b installer (bundle 形態 / 配布)
+- [cli-spec.md](cli-spec.md) / [ui-architecture.md](ui-architecture.md) / [metadata-spec.md](metadata-spec.md) / [release-strategy.md](release-strategy.md)

--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -1,5 +1,7 @@
 # Allagan Eye GUI — UI Architecture (Phase 2)
 
+> **スコープ**: 本 doc は **L2a GUI (Tauri 2 + React 19) の UI 基盤のみ**を扱う。CLI (`allaganeye` サブコマンド) は [cli-spec.md](cli-spec.md)、CLI と GUI の全体構成・起動経路は [system-architecture.md](system-architecture.md) を参照。
+
 本 doc は L2a GUI Phase 2 (#464) で確立した UI 基盤を記録する。Phase 3/4 の実装が参照する source of truth。
 
 ## 1. 概要


### PR DESCRIPTION
## 概要

[#527](https://github.com/Idios/kobutachan-allaganeye/issues/527) — `docs/ui-architecture.md` が GUI 専用であることの明記、および `allaganeye` の CUI / GUI ディスパッチ仕様を文書化。ユーザー方針確認で「CLI と GUI を組み合わせた全体アーキテクチャ doc が曖昧」と指摘されたため、単なる注記追加ではなく **`docs/system-architecture.md` を新設**して CLI / GUI / installer を横断する全体像と起動経路を定義した。

## 受け入れ条件

- [x] **`docs/ui-architecture.md` が GUI 専用であることが、ファイル名またはファイル冒頭で一意に読み取れる** — 冒頭に「本 doc は L2a GUI (Tauri 2 + React 19) の UI 基盤のみを扱う。CLI は cli-spec.md、全体構成は system-architecture.md」と blockquote で明記
- [x] **`allaganeye` 起動時の CUI / GUI ディスパッチ仕様が文書化され、新規コントリビュータが起動挙動を推測せずに把握できる** — `docs/system-architecture.md` §2 に表形式で整理
- [x] **GUI と CLI の呼び分け (同一 exe の分岐 vs 別 exe) が明記されている** — §2「別 exe 方式」を判断根拠付きで明示
- [x] **関連する既存 doc (`CLAUDE.md` / `cli-spec.md` / `design/README.md`) に相互参照が追加されている** — CLAUDE.md / cli-spec.md / design-overview.md / README.md / ui-architecture.md に相互リンク

## 方針決定

ユーザーからの確認結果:

1. **ui-architecture.md の扱い**: リネームや注記追加ではなく「CLI+GUI+installer を組み合わせた統合アーキテクチャ doc が必要」と指摘 → 新 doc (system-architecture.md) 新設で対応
2. **dispatch 仕様の記載先**: ui-architecture.md / startup-dispatch.md / cli-spec.md のどこでもよいという柔軟回答 → **system-architecture.md に一本化** (CLI/GUI 横断の位置付けとして自然)
3. **dispatch 方針**: **別 exe 方式** (allaganeye.bat = CLI / Allagan Eye.exe = GUI)

## 実装内容

### 新規 doc: [docs/system-architecture.md](docs/system-architecture.md)

- §1 コンポーネント構成 (L1 CLI / L2a GUI / L2b installer の役割と相互関係)
- §2 起動経路 (CUI / GUI dispatch) — 配布物の表 + 判断根拠 + GUI→CLI subprocess 経路 + 内部 axum video server との区別
- §3 データフロー (detect→preview→export の Mermaid シーケンス、実行時ファイル配置)
- §4 責務分離の原則 (CLI standalone / GUI → CLI subprocess / metadata.json 唯一契約 / axum は async task / guard は独立)
- §5 変更時の影響範囲 (スキーマ変更 / 新サブコマンド / 新画面 / 起動経路変更の判断基準)
- §6 関連 issue / doc

### 既存 doc の相互参照追加

| doc | 変更 |
|---|---|
| `docs/ui-architecture.md` | 冒頭に「L2a GUI 専用」blockquote + cli-spec.md / system-architecture.md へのリンク |
| `docs/cli-spec.md` | 冒頭に「本 doc は CLI 構文。全体像は system-architecture.md」blockquote |
| `docs/design-overview.md` | 題を「システム設計概要 (レイヤ構造)」に整理し、CLI/GUI/installer の現時点詳細は system-architecture.md へ誘導 |
| `README.md` § 開発者向け | `system-architecture.md` + `ui-architecture.md` を doc 一覧に追加 |
| `CLAUDE.md` § コマンド | 起動経路 (allaganeye.bat / Allagan Eye.exe、別 exe 方式) を追記 + system-architecture.md リンク |

## テスト

- コード変更なし (doc のみ)
- `cd gui && npm test` / `cargo test --lib` / `pytest` は影響範囲外 (別 PR で確認)
- markdownlint は CI で検証される

## 手動確認 (PR レビュー時)

- [x] CI pass (markdownlint + python + gui-frontend + gui-rust 全 pass)
- [x] docs/system-architecture.md の記述が #527 issue の受け入れ条件 4 条すべてを満たす (ui-architecture.md 冒頭 blockquote で GUI 専用明記 / §2 で dispatch 仕様 + 別 exe 方式明記 / CLAUDE.md + cli-spec.md + design-overview.md + ui-architecture.md + README.md の 5 doc から相互参照)
- [x] 相互参照リンクが切れていない (system-architecture.md 内 15 件の相対リンクすべて resolve、逆方向 5 doc からの参照も `ls` で存在確認)

## 関連

- 起票元 issue: [#527](https://github.com/Idios/kobutachan-allaganeye/issues/527)
- 関連: Lead 2 [#510](https://github.com/Idios/kobutachan-allaganeye/issues/510) Python/FFmpeg 統一 (マージ済み) — installer 視点で system-architecture.md §5 に影響
- 後続予定: [#451](https://github.com/Idios/kobutachan-allaganeye/issues/451) L2b platform / [#452](https://github.com/Idios/kobutachan-allaganeye/issues/452) L2b installer 設計時に §2 を確認
- `docs/system-architecture.md` / `docs/cli-spec.md` / `docs/ui-architecture.md` / `docs/metadata-spec.md`

[elated-wozniak-50d3bb]

