### PR TITLE
feat(video): GPU mode UX 三点修正 (Refs #437 #438 #439)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,8 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 **GPU モード** (`--gpu`)
 
 - CPU モードの Pass 1 を GPU チャンク並列デコードで代替（`gpu_detector.py`）
-- 動画を N チャンク（`min(cpu_count, 16)`）に分割し、各チャンクで長寿命の ffmpeg プロセスを `-hwaccel auto` + `fps` フィルタで起動
+- 動画を N チャンク（短動画は `min(cpu_count, 16)`、長動画は `_TARGET_CHUNK_WALL_SECS=90s` を目安に `_MAX_CHUNKS=32` まで細分化 / #437）に分割し、各チャンクで長寿命の ffmpeg プロセスを `-hwaccel auto` + `fps` フィルタで起動
+- ffmpeg 並列上限は `max_parallel = min(cpu_count, 16)` で固定、長動画では chunks > max_parallel となり wave 実行（chunk 完了ごとにラベル更新頻度を確保）
 - GPU 初期化コストを分散し、1プロセスあたり多数フレームをデコードすることで効率化
 - Pass 1 以降の処理（transition expansion, Pass 2, フィルタリング）は CPU/GPU 共通
 - GPU 利用不可時は自動で CPU モードにフォールバック

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -571,7 +571,11 @@ def _run_detection(
         # vanish, #368) and the Pass 2 -> Scorebar transition no longer
         # mixes units (100% -> 99% rollover, #393).  ``try/finally`` guards
         # against exceptions leaving a bar dangling on the TTY.
-        detecting_bar = _eta_progressbar(estimated_samples, "Detecting")
+        detecting_bar = _eta_progressbar(
+            estimated_samples,
+            "Detecting",
+            suppress_click_eta=use_gpu,
+        )
         detecting_bar.__enter__()
         detecting_state = {"last_pos": 0, "closed": False}
         refine_state: dict = {"bar": None, "last": 0}
@@ -598,6 +602,17 @@ def _run_detection(
             if advance > 0:
                 detecting_bar.update(advance)
             detecting_state["last_pos"] = completed
+
+        def on_chunk_dispatch(num_chunks: int) -> None:
+            # First feedback before any chunk completes (#437).
+            # Long videos (2h+) used to sit at "Detecting 0%" for 2-3
+            # minutes while the first chunk decoded; this shows users
+            # the work has started and how many chunks to expect.
+            detecting_bar.label = (
+                f"Detecting [dispatching {num_chunks} chunks, "
+                f"first result pending...]".ljust(_PROGRESS_LABEL_WIDTH)
+            )
+            detecting_bar.render_progress()
 
         def on_chunk(done: int, total: int, eta_seconds: float) -> None:
             # Update label so users see movement between chunk completions
@@ -647,6 +662,7 @@ def _run_detection(
                 refine_progress_callback=on_refine,
                 scorebar_progress_callback=on_scorebar,
                 chunk_progress_callback=on_chunk,
+                chunk_dispatch_callback=on_chunk_dispatch,
             )
         finally:
             # Close in reverse open-order; if detection raised we still
@@ -752,11 +768,16 @@ _PROGRESS_LABEL_WIDTH = 11
 """Column width for progress bar labels (Detecting/Refining/Splitting)."""
 
 
-def _eta_progressbar(length: int, label: str):  # type: ignore[no-untyped-def]
+def _eta_progressbar(length: int, label: str, *, suppress_click_eta: bool = False):  # type: ignore[no-untyped-def]
     """Create a progress bar with explicit ETA label (#329).
 
     Labels are left-justified to ``_PROGRESS_LABEL_WIDTH`` so that
     Detecting / Refining / Splitting bars align vertically.
+
+    When ``suppress_click_eta`` is True (GPU mode, #438), click's own
+    ETA is hidden.  GPU chunk completion is non-linear so click's rate
+    estimator produces nonsense (e.g. ``3d 08:08:52``); the caller
+    supplies a self-computed ETA in the label instead.
     """
     import click
 
@@ -764,7 +785,7 @@ def _eta_progressbar(length: int, label: str):  # type: ignore[no-untyped-def]
         length=length,
         label=label.ljust(_PROGRESS_LABEL_WIDTH),
         bar_template="%(label)s%(bar)s %(info)s",
-        show_eta=True,
+        show_eta=not suppress_click_eta,
         show_percent=True,
     )
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -83,6 +83,7 @@ def detect_match_boundaries(
     audio_hits: Sequence[BgmHit] | None = None,
     stats: DetectionStats | None = None,
     chunk_progress_callback: Callable[[int, int, float], None] | None = None,
+    chunk_dispatch_callback: Callable[[int], None] | None = None,
 ) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
 
@@ -132,6 +133,7 @@ def detect_match_boundaries(
                 progress_callback,
                 codec=codec,
                 chunk_progress_callback=chunk_progress_callback,
+                chunk_dispatch_callback=chunk_dispatch_callback,
             )
             resolved_mode = "GPU"
         except VideoProcessingError:

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -1,6 +1,7 @@
 """GPU-accelerated match detection using chunked parallel ffmpeg decode."""
 
 import logging
+import math
 import os
 import subprocess
 import time
@@ -20,6 +21,16 @@ from allaganeye.video.detector import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Target wall-time per chunk for dynamic chunk sizing (#437).
+# Long videos would otherwise wait 2-3 minutes before the first chunk
+# completes with the old fixed 16 chunks; chopping into smaller pieces
+# lets the progress bar label update more frequently.
+_TARGET_CHUNK_WALL_SECS = 90.0
+
+# Upper bound on the number of chunks (#437). Too many chunks pay fixed
+# ffmpeg startup cost per chunk and can overwhelm GPU scheduling.
+_MAX_CHUNKS = 32
 
 _CUVID_CODEC_MAP: dict[str, str] = {
     "h264": "h264_cuvid",
@@ -41,6 +52,7 @@ def scan_gpu(
     progress_callback: Callable[[int, int, int], None] | None = None,
     codec: str | None = None,
     chunk_progress_callback: Callable[[int, int, float], None] | None = None,
+    chunk_dispatch_callback: Callable[[int], None] | None = None,
 ) -> dict[float, float]:
     """GPU mode: chunked parallel decode with cuvid hardware decoder.
 
@@ -57,9 +69,30 @@ def scan_gpu(
     completions.  Emitted BEFORE the per-frame ``progress_callback``
     burst so the UI label updates before the bar jumps (#333).
 
+    ``chunk_dispatch_callback`` is called once with the final chunk count
+    immediately BEFORE the decode threads start, so the caller can show
+    "[dispatching N chunks, first result pending...]" while users wait
+    for the first chunk to complete (#437, which was an incomplete fix
+    for #333 on long videos).
+
+    Chunk count scales with duration: long videos are broken into more
+    pieces so the UI label updates every ~90s wall time (controlled by
+    ``_TARGET_CHUNK_WALL_SECS``) capped at ``_MAX_CHUNKS``.  Short videos
+    keep the historical behavior (``min(cpu_count, 16)``) so their
+    dispatch overhead isn't inflated.
+
     Raises VideoProcessingError if GPU decode fails for all chunks.
     """
-    num_chunks = min(os.cpu_count() or 4, 16)
+    # Parallelism cap: number of ffmpeg processes running concurrently.
+    # Bounded by CPU count and 16 to keep GPU memory pressure sane.
+    max_parallel = min(os.cpu_count() or 4, 16)
+    # Chunk count: may exceed ``max_parallel`` for long videos, in which
+    # case chunks are processed in waves.  More chunks = more label
+    # updates during Pass 1 (#437).
+    target_from_duration = (
+        math.ceil(duration / _TARGET_CHUNK_WALL_SECS) if duration > 0 else 1
+    )
+    num_chunks = min(max(max_parallel, target_from_duration), _MAX_CHUNKS)
     chunk_duration = duration / num_chunks
 
     # Pre-compute the global sample grid (same one ``_scan_cpu`` uses) so
@@ -96,7 +129,13 @@ def scan_gpu(
     scan_start = time.monotonic()
     chunks_done = 0
 
-    with ThreadPoolExecutor(max_workers=num_chunks) as pool:
+    # #437: Notify the UI layer BEFORE any chunk starts so long-video
+    # users see movement (label update) instead of 0% stall for 2-3
+    # minutes while the first chunk decodes.
+    if chunk_dispatch_callback is not None:
+        chunk_dispatch_callback(num_chunks)
+
+    with ThreadPoolExecutor(max_workers=max_parallel) as pool:
         futures = {
             pool.submit(
                 _decode_chunk,
@@ -145,6 +184,20 @@ def scan_gpu(
 
     if gpu_failed:
         raise VideoProcessingError("GPU decode failed, falling back to CPU")
+
+    # #439: Force the progress bar to 100% when GPU chunk-boundary
+    # rounding leaves a few frames short of ``total_expected``.  Without
+    # this emit, the Detecting bar freezes at 99% until Refining opens
+    # on the next line -- cosmetic but confusing.
+    if progress_callback is not None and completed < total_expected:
+        dropped = total_expected - completed
+        logger.info(
+            "GPU decode returned %d of %d frames (%d boundary drop(s))",
+            completed,
+            total_expected,
+            dropped,
+        )
+        progress_callback(total_expected, total_expected, blackout_count)
 
     return results
 

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -103,7 +103,12 @@ ffmpeg -ss {timestamp} -i input.mkv -frames:v 1 -s 320x180 -pix_fmt gray -f rawv
 
 `--gpu` オプションにより Pass 1 の粗いスキャンを GPU チャンク並列デコードで実行できる（`gpu_detector.py`）。
 
-**方式**: 動画を N チャンク（`min(cpu_count, 16)`）に分割し、各チャンクで長寿命の ffmpeg プロセスを並列実行する。
+**方式**: 動画を N チャンクに分割し、各チャンクで長寿命の ffmpeg プロセスを並列実行する。chunk 数は動画長に応じて動的調整される (#437):
+
+- 短動画 (目安: 24 分以下): `max_parallel = min(cpu_count, 16)` を chunk 数として使用（従来通り）
+- 長動画: `math.ceil(duration / _TARGET_CHUNK_WALL_SECS)` (90s/chunk 目安) で細分化、上限 `_MAX_CHUNKS=32`
+- ffmpeg 並列上限は常に `max_parallel` で固定。chunks > max_parallel の場合は wave 実行となり、chunk 完了ごとのラベル更新頻度を確保する
+- 最初の chunk が完了する前に `chunk_dispatch_callback` で `Detecting [dispatching N chunks, ...]` を表示し、長時間動画での 0% 停滞誤解を回避
 
 ```bash
 ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -216,6 +216,121 @@ class TestScanGpu:
         assert chunk_calls == []
 
     # ------------------------------------------------------------
+    # Dynamic chunk sizing / dispatch callback / force 100% (#437, #439)
+    # ------------------------------------------------------------
+
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_chunk_dispatch_callback_fires_before_chunks(self, mock_decode):
+        """chunk_dispatch_callback fires exactly once before any chunk executes (#437).
+
+        Long videos used to sit at ``Detecting 0%`` for 2-3 minutes
+        while the first chunk decoded; this callback is the hook that
+        lets the UI show ``[dispatching N chunks, ...]`` immediately.
+        """
+        calls: list[str] = []
+
+        def _decode_mock(*args, **kwargs):
+            calls.append("chunk")
+            return ({0.0: 100.0}, "")
+
+        mock_decode.side_effect = _decode_mock
+
+        def dispatch_cb(n: int) -> None:
+            calls.append(f"dispatch:{n}")
+
+        scan_gpu(
+            Path("test.mp4"),
+            5.0,
+            1.0,
+            15.0,
+            chunk_dispatch_callback=dispatch_cb,
+        )
+
+        dispatch_events = [c for c in calls if c.startswith("dispatch")]
+        assert len(dispatch_events) == 1, "dispatch callback should fire exactly once"
+        assert calls[0].startswith("dispatch"), (
+            "dispatch callback should fire before any chunk runs"
+        )
+
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_num_chunks_scales_with_duration(self, mock_decode):
+        """Long videos break into more chunks than the old fixed 16 (#437).
+
+        Short videos stay at the historical ``max_parallel`` cap; long
+        videos push chunk count up toward ``_MAX_CHUNKS`` so the
+        Detecting label can update every ~90s wall time instead of
+        every 10 minutes.
+        """
+        from allaganeye.video.gpu_detector import _MAX_CHUNKS
+
+        mock_decode.return_value = ({}, "")
+
+        scan_gpu(Path("short.mp4"), 10.0, 1.0, 15.0)
+        short_chunks = mock_decode.call_count
+        mock_decode.reset_mock()
+
+        # 10000s (~2h47m) is well past the _TARGET_CHUNK_WALL_SECS budget
+        # so the ceiling engages.
+        scan_gpu(Path("long.mp4"), 10000.0, 1.0, 15.0)
+        long_chunks = mock_decode.call_count
+
+        assert long_chunks > short_chunks, (
+            "long videos must break into more chunks than short ones"
+        )
+        assert long_chunks == _MAX_CHUNKS, (
+            f"long videos should hit the _MAX_CHUNKS ceiling "
+            f"(got {long_chunks}, expected {_MAX_CHUNKS})"
+        )
+
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_progress_callback_reaches_total_even_with_drops(self, mock_decode):
+        """Final emit equalizes completed with total so bar hits 100% (#439).
+
+        Returning only 1 frame per chunk simulates the frame-drop
+        pattern where completed < total_expected naturally.  Without
+        the fix, the Detecting bar stopped at 99% and the next line
+        (Refining) opened before the user saw completion.
+        """
+        mock_decode.return_value = ({0.0: 100.0}, "")
+
+        events: list[tuple[int, int]] = []
+
+        scan_gpu(
+            Path("test.mp4"),
+            20.0,
+            1.0,
+            15.0,
+            progress_callback=lambda c, t, bc: events.append((c, t)),
+        )
+
+        assert events, "progress_callback should fire at least once"
+        final_completed, final_total = events[-1]
+        assert final_completed == final_total, (
+            f"last emit must equalize completed with total "
+            f"(got {final_completed}/{final_total})"
+        )
+
+    @patch("allaganeye.video.gpu_detector._decode_chunk")
+    def test_frame_drop_warning_logged(self, mock_decode, caplog):
+        """Dropped frames trigger an info log so verbose users can see (#439)."""
+        import logging
+
+        mock_decode.return_value = ({0.0: 100.0}, "")
+
+        with caplog.at_level(logging.INFO, logger="allaganeye.video.gpu_detector"):
+            scan_gpu(
+                Path("test.mp4"),
+                20.0,
+                1.0,
+                15.0,
+                progress_callback=lambda c, t, bc: None,
+            )
+
+        assert any("boundary drop" in rec.message for rec in caplog.records), (
+            "dropped-frame info log not emitted"
+        )
+
+    # ------------------------------------------------------------
     # Global sample grid labeling (#392)
     # ------------------------------------------------------------
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -646,15 +646,20 @@ def test_splitting_bar_shown_in_normal_run(
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
 def test_progressbar_shows_eta_label(mock_probe, mock_detect, mock_split, tmp_path):
-    """Progress bars enable ETA and percent display (#329).
+    """Progress bars enable ETA and percent display in CPU mode (#329).
 
     Guards the contract from issue #329: the user must be able to tell
     that the time shown is ETA, via ``show_eta=True`` on click.progressbar.
+    GPU mode deliberately suppresses click's ETA on the Detecting bar
+    (#438); that variant is covered by
+    :func:`test_progressbar_suppresses_click_eta_on_detecting_in_gpu_mode`.
     """
     mock_probe.return_value = PROBE_RESULT
     mock_detect.return_value = BOUNDARIES
     mock_split.return_value = _output_files(tmp_path)
-    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    # CPU mode explicitly -- avoid codec auto-select pulling in GPU path
+    # (which would suppress click ETA on Detecting per #438).
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, use_gpu=False)
 
     with patch("click.progressbar") as mock_bar:
         mock_bar.return_value.__enter__ = lambda s: s
@@ -669,6 +674,69 @@ def test_progressbar_shows_eta_label(mock_probe, mock_detect, mock_split, tmp_pa
             f"Expected show_eta=True, got {call.kwargs}"
         )
         assert call.kwargs.get("show_percent") is True
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_progressbar_suppresses_click_eta_on_detecting_in_gpu_mode(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """GPU mode sets ``show_eta=False`` on the Detecting bar only (#438).
+
+    GPU chunk completion is non-linear (long stall, then burst) so
+    click's rate estimator produces absurd ETAs like ``3d 08:08:52``.
+    The Detecting bar supplies its own ETA in the label; click's
+    built-in ETA must be off.  Refining / Scorebar / Splitting stay
+    at ``show_eta=True`` because their progress is linear.
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, use_gpu=True)
+
+    with patch("click.progressbar") as mock_bar:
+        mock_bar.return_value.__enter__ = lambda s: s
+        mock_bar.return_value.__exit__ = lambda s, *a: None
+        mock_bar.return_value.update = lambda n: None
+        run_split(Path("input.mp4"), config)
+
+    assert mock_bar.call_count >= 1
+
+    # Partition bar creations by label prefix for cleaner assertions.
+    detecting_calls = [
+        c
+        for c in mock_bar.call_args_list
+        if c.kwargs.get("label", "").strip().startswith("Detecting")
+    ]
+    non_detecting_calls = [
+        c
+        for c in mock_bar.call_args_list
+        if not c.kwargs.get("label", "").strip().startswith("Detecting")
+    ]
+
+    assert detecting_calls, "Detecting bar was not created"
+    for call in detecting_calls:
+        assert call.kwargs.get("show_eta") is False, (
+            "GPU mode must disable click's built-in ETA on Detecting "
+            f"(#438); got {call.kwargs}"
+        )
+
+    for call in non_detecting_calls:
+        assert call.kwargs.get("show_eta") is True, (
+            f"Non-Detecting bars keep click ETA even in GPU mode (got {call.kwargs})"
+        )
+
+
+def test_eta_progressbar_suppress_click_eta_flag():
+    """_eta_progressbar(suppress_click_eta=True) toggles click's show_eta off (#438)."""
+    from allaganeye.commands.split_matches import _eta_progressbar
+
+    suppressed = _eta_progressbar(100, "Detecting", suppress_click_eta=True)
+    default = _eta_progressbar(100, "Detecting")
+
+    assert suppressed.show_eta is False
+    assert default.show_eta is True
 
 
 @patch(f"{MODULE}.split_video")


### PR DESCRIPTION
## 概要

GPU mode UX の 3 件の不具合を単一 PR で統合対応 (plan で "案 a+c+a" を採用):

- **#437**: 長時間動画 (2h+) で Detecting 0% が 2-3 分停滞しフリーズと誤解
- **#438**: label 内 chunk ETA と click 標準 ETA の二重表示 (後者は 3d 等の非現実値)
- **#439**: 全 chunk 完了しても Detecting バーが 99% で止まり 100% 到達せず

## 変更内容

### #437 初期 0% 待機解消 (案 a + 案 c)

**allaganeye/video/gpu_detector.py**:
- `_TARGET_CHUNK_WALL_SECS = 90.0` / `_MAX_CHUNKS = 32` 定数を導入
- `num_chunks` を動画長ベースで動的調整
  - 短動画: 従来の `max_parallel = min(cpu_count, 16)` を維持
  - 長動画: `math.ceil(duration / 90)` で細分化、`_MAX_CHUNKS` まで
- `max_parallel` (ffmpeg 並列上限) と `num_chunks` (分割数) を分離
  - 長動画で chunks 多い分、chunk 完了ごとのラベル更新が高頻度になる (wave 処理)
- `chunk_dispatch_callback` 引数を追加、chunk 開始前に UI へ通知

**allaganeye/commands/split_matches.py**:
- `on_chunk_dispatch(num_chunks)` コールバックを追加
  - 初回ラベル: `Detecting [dispatching N chunks, first result pending...]`

**allaganeye/video/detector.py**:
- `detect_match_boundaries` signature に `chunk_dispatch_callback` 追加、GPU path に forward

### #438 ETA 二重表示解消 (案 a)

**allaganeye/commands/split_matches.py**:
- `_eta_progressbar` に `suppress_click_eta: bool = False` 引数追加
  - `True` のとき click の `show_eta=False`
- GPU mode の `detecting_bar` のみ `suppress_click_eta=use_gpu` で呼び出し
- CPU mode / Refining / Scorebar / Splitting は現状維持 (`show_eta=True`)

### #439 強制 100% 到達 (案 a)

**allaganeye/video/gpu_detector.py**:
- `as_completed` ループ終了後に `completed < total_expected` なら
  `progress_callback(total_expected, total_expected, blackout_count)` で強制 100%
- frame drop 時は `logger.info("GPU decode returned X of Y frames (N boundary drop(s))")` で警告

## テスト

### `tests/test_gpu_detector.py` 追加 (4 件)

- `test_chunk_dispatch_callback_fires_before_chunks`: dispatch callback が chunk 開始前に exactly 1 回呼ばれる
- `test_num_chunks_scales_with_duration`: 短動画と長動画で num_chunks が変化、長動画で `_MAX_CHUNKS` 到達
- `test_progress_callback_reaches_total_even_with_drops`: 最終 emit で completed == total を保証
- `test_frame_drop_warning_logged`: drop 時に logger.info 発火

### `tests/test_split_matches.py` 追加 (2 件) + 修正 (1 件)

- `test_progressbar_suppresses_click_eta_on_detecting_in_gpu_mode` (新規): GPU mode で Detecting のみ `show_eta=False`、他は True
- `test_eta_progressbar_suppress_click_eta_flag` (新規): `_eta_progressbar(suppress_click_eta=True)` の直接検証
- `test_progressbar_shows_eta_label` (既存): `use_gpu=False` を明示し CPU mode 検証に固定 (従来は codec h264 で auto GPU に falling、GPU 修正の巻き添えで壊れていた)

## 実機検証結果

### 対象動画

- パス: `E:/videos/2026-04-08 21-14-05.mkv`
- duration: 10228.7s (2h50m28s), 1920x1080 60fps, codec: av1
- GPU: NVIDIA RTX 5090 (32GB VRAM)
- 実行: `allaganeye split --gpu --verbose --no-cache --dry-run`

### 結果 (tmp/gpu-ux-test/run.log より抜粋)

```
Detecting match boundaries (interval=3.0s, threshold=15.0, workers=auto (32), min_match=300.0s, min_blackout=3.0s, audio=frozen)
Detecting
Detecting [dispatching 32 chunks, first result pending...]   ← #437 案 c
Detecting [chunk 1/32, ETA ~49m11s]                          ← #437 案 a (細分化)
Detecting [chunk 2/32, ETA ~23m56s]
...
Detecting [chunk 31/32, ETA ~8s]
Detecting [chunk 32/32]                                      ← #439 (完結、99% 停止なし)
Refining
Scorebar
  Pass 1 (GPU): 3410 samples, 31 blackout frames (0.9%), 4m36s
  Pass 2: 18 regions refined, 1m08s
  Scorebar: 15 match_boundary, 2 in_match, 1 non_fl, 0m50s
Detected 8 match(es) in 2026-04-08 21-14-05.mkv (2:50:28)
Total: 6m35s
```

- `#437` 初期 0% 待機解消: ✅ `[dispatching 32 chunks, ...]` が chunk 1 完了前に表示、32 chunks に細分化で chunk ごとのラベル更新間隔が短縮
- `#438` ETA 二重表示解消: ✅ 各行とも label 内 `ETA ~XmYs` のみ、末尾の click ETA (`3d 08:08:52` 型) 無し
- `#439` 強制 100% 到達: ✅ `chunk 32/32` まで出て Refining に正常移行
- 短時間動画での動作: PR #539 検証時 (AV1 20 分動画) で 16 chunks (従来通り) で正常動作確認済み

### 自動テスト

```
pytest: 726 passed, 37 deselected
ruff check .: All checks passed!
ruff format --check .: 64 files already formatted
pyright: 0 errors, 0 warnings, 0 informations
```

## 受け入れ条件 (逐条、issue からの引用)

### #437

| # | 条件 | 実証 | 判定 |
|---|---|---|---|
| 1 | 長時間動画 (2 時間以上) で初期 0% 待機が体感許容範囲 (30 秒以内に何らかの更新) | `Detecting [dispatching 32 chunks, ...]` を chunk 1 完了前に表示 (ThreadPoolExecutor 開始直前に同期コールバック) | ○ |
| 2 | 短時間動画で表示が破壊されない | 20 分動画 (AV1 native) で 16 chunks = 従来動作、PR #539 検証ログ + `test_num_chunks_scales_with_duration` | ○ |
| 3 | GPU 並列モデルとの整合維持 | Pass 1 (GPU) 3410 samples 正常完了、既存 `test_chunks_receive_global_grid_timestamps` 等のテスト全 pass | ○ |

### #438

| # | 条件 | 実証 | 判定 |
|---|---|---|---|
| 1 | GPU mode で 1 つの ETA のみ表示 | 実機ログの各 Detecting 行に label ETA のみ、末尾 click ETA 無し | ○ |
| 2 | CPU mode の ETA 表示が破壊されない | `test_progressbar_shows_eta_label` (CPU mode 固定) pass、Refining / Scorebar / Splitting は GPU mode でも `show_eta=True` 維持 (`test_progressbar_suppresses_click_eta_on_detecting_in_gpu_mode`) | ○ |
| 3 | label と info の重複が解消 | 実機ログに `Detecting [...] %(bar)s <click_ETA>` のような重複無し | ○ |

### #439

| # | 条件 | 実証 | 判定 |
|---|---|---|---|
| 1 | GPU mode で全 chunk 完了時にバーが 100% 到達 | `chunk 32/32` まで出て次行 Refining に移行、`test_progress_callback_reaches_total_even_with_drops` | ○ |
| 2 | CPU mode の表示が破壊されない | 強制 100% は GPU path 内のみ、CPU path 既存テスト全 pass | ○ |
| 3 | frame drop 時の表示が誤解を招かない | `test_frame_drop_warning_logged` で drop 時 `logger.info("boundary drop")` 警告発火確認 | ○ |

## 関連

- Refs #437, #438, #439 (親 issue 3 件)
- Refs #333 (PR #345 での案 B 不完全修正の本格対応)
- #392 (GPU/CPU 境界一致 fix、既に解消済み)
- #538 (VP9 GPU fallback、#414 派生、本 PR 範囲外)

[kind-banzai-d4cd21]
