### PR TITLE
feat(cli,gui): warnings 基盤 (Warning type + 空 array) (Refs #518)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -17,6 +17,7 @@ from allaganeye.detection.metadata_writer import (
     read_metadata,
     write_metadata_atomic,
 )
+from allaganeye.detection.warnings import build_warnings
 from allaganeye.exceptions import (
     AllaganEyeError,
     DetectionError,
@@ -967,6 +968,7 @@ def _build_metadata_payload(
             }
             for g in gaps
         ],
+        "warnings": build_warnings(),
     }
 
 

--- a/allaganeye/detection/warnings.py
+++ b/allaganeye/detection/warnings.py
@@ -21,9 +21,9 @@ from __future__ import annotations
 from typing import Any, Literal, TypedDict
 
 __all__ = [
+    "WARNING_CODES",
     "MetadataWarning",
     "Severity",
-    "WARNING_CODES",
     "build_warnings",
 ]
 

--- a/allaganeye/detection/warnings.py
+++ b/allaganeye/detection/warnings.py
@@ -18,7 +18,7 @@ See `docs/metadata-spec.md` section "warnings" for the contract.
 
 from __future__ import annotations
 
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, NotRequired, Required, TypedDict
 
 __all__ = [
     "WARNING_CODES",
@@ -31,7 +31,7 @@ Severity = Literal["info", "warn", "error"]
 """Allowed severity levels for an emitted warning."""
 
 
-class MetadataWarning(TypedDict, total=False):
+class MetadataWarning(TypedDict):
     """A single warning entry in metadata.json `warnings[]`.
 
     `code` is required; the other fields are optional so emitters can
@@ -39,10 +39,10 @@ class MetadataWarning(TypedDict, total=False):
     `message_en` and rely on a lookup table on the reader side).
     """
 
-    code: str
-    message_en: str
-    severity: Severity
-    context: dict[str, Any]
+    code: Required[str]
+    message_en: NotRequired[str]
+    severity: NotRequired[Severity]
+    context: NotRequired[dict[str, Any]]
 
 
 WARNING_CODES: dict[str, str] = {}

--- a/allaganeye/detection/warnings.py
+++ b/allaganeye/detection/warnings.py
@@ -1,0 +1,64 @@
+"""Warning scaffold for metadata.json (#518).
+
+This module centralises the payload shape for warnings that may accompany
+a detect / split run. The initial revision writes an empty list on every
+run -- no concrete warning codes are emitted yet.
+
+Why introduce the scaffold now, before a concrete use case lands?
+
+* Adding the `warnings: []` field to every freshly written metadata.json
+  locks in the JSON schema so GUI / zod can start treating `warnings` as
+  a known passthrough-safe key (consumers won't discover unknown fields
+  the first time a code ships).
+* Future PRs can wire emitters into detection / scorebar / audio without
+  touching the payload builder or the reader surface.
+
+See `docs/metadata-spec.md` section "warnings" for the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+__all__ = [
+    "MetadataWarning",
+    "Severity",
+    "WARNING_CODES",
+    "build_warnings",
+]
+
+Severity = Literal["info", "warn", "error"]
+"""Allowed severity levels for an emitted warning."""
+
+
+class MetadataWarning(TypedDict, total=False):
+    """A single warning entry in metadata.json `warnings[]`.
+
+    `code` is required; the other fields are optional so emitters can
+    supply only what they have (e.g. a cheap code-only warning can omit
+    `message_en` and rely on a lookup table on the reader side).
+    """
+
+    code: str
+    message_en: str
+    severity: Severity
+    context: dict[str, Any]
+
+
+WARNING_CODES: dict[str, str] = {}
+"""Registry of known warning codes mapped to their default English message.
+
+Empty at introduction. Emitters should add entries here alongside the
+code they introduce so readers can look up a human-readable default even
+when the metadata payload only carries the code.
+"""
+
+
+def build_warnings() -> list[MetadataWarning]:
+    """Build the `warnings` list for a freshly written metadata.json.
+
+    Currently unconditional: returns an empty list. Future callers may
+    pass detection / scorebar context to this helper and receive a
+    populated list back.
+    """
+    return []

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -23,6 +23,7 @@
 | `detection_params` | object | ✓ | 検知に使われたパラメータ (後述) | (object) |
 | `matches` | array | ✓ | 試合セグメント列 (0 件可) | |
 | `gaps` | array | ✓ | 試合間の空白区間列 (0 件可) | |
+| `warnings` | array | 新規書き込みは ✓ (デフォルト `[]`) / 読み込み時は欠落許容 | 構造化警告一覧 (#518) | 個々のエントリは §warnings 参照 |
 
 ### `detection_params` オブジェクト
 
@@ -236,6 +237,35 @@ GUI が `load` / `apply` / `reloadAfterConflict` を実行するとき、排他�
 - **`applyOverwrite` と draft**: `applyOverwrite` は `apply` と共通 helper (`runApply`) 経由なので、上書き成功後も draft clear が発火する
 - **`reloadAfterConflict` 後の draft**: `reloadAfterConflict` は `load(filePath)` を呼ぶため、source 一致な draft があれば `DraftRestoreModal` が再提示される (ユーザー編集の救済として意図された挙動)
 
+## warnings (#518)
+
+検知 / scorebar / audio が発行する構造化警告の scaffold。v1 時点では常に空配列を書き出し、具体的な warning コードは後続 PR で追加する。
+
+### エントリの形 (`Warning` / `MetadataWarning`)
+
+```ts
+interface MetadataWarning {
+  code: string;            // 必須。コードキー (例: "audio_skipped")
+  message_en?: string;     // 英語メッセージ。省略時は reader が WARNING_CODES で lookup
+  severity?: 'info' | 'warn' | 'error';
+  context?: Record<string, unknown>;  // コード固有の追加情報
+}
+```
+
+### 読み書き契約
+
+- **新規書き込み**: `allaganeye detect` / `allaganeye split` は常に `warnings: []` を emit する
+- **読み込み**: `warnings` が欠落していても error にしない (pre-#518 の legacy metadata.json を許容)。GUI の zod schema は `optional`
+- **pass-through**: 未知の `code` を reader が reject してはならない (forward compat)
+- **emitter の責務** (後続 PR): `allaganeye/detection/warnings.py::WARNING_CODES` にコードキーを登録し、`build_warnings` で該当箇所から push
+
+### 新しいコードを追加する手順
+
+1. `allaganeye/detection/warnings.py::WARNING_CODES` に `"your_code": "english message"` を追加
+2. 発行箇所から `MetadataWarning(code=..., severity=..., context=...)` を生成
+3. `build_warnings` (または呼び出し経路) に集約
+4. `docs/metadata-spec.md` § warnings 一覧表 (以下 TBD) に追加
+
 ## 将来の拡張 (Phase 1 スコープ外)
 
 以下は派生 issue で追跡する (本 Phase 1 では実装せず、設計余地だけ確保):
@@ -246,7 +276,7 @@ GUI が `load` / `apply` / `reloadAfterConflict` を実行するとき、排他�
 | ~~schema_version フィールド~~ | [#515](https://github.com/Idios/kobutachan-allaganeye/issues/515) (実装済み、上記 §schema_version 参照) | 明示的な版数管理 + migration 基盤 |
 | ~~`[元に戻す]` 機能~~ | [#516](https://github.com/Idios/kobutachan-allaganeye/issues/516) (Phase 2 で実装済み) | `metadata.original.json` → `metadata.json` 復元ボタン (Rust `restore_from_original` + `metadataStore.restore`) |
 | ~~draft auto save~~ | [#517](https://github.com/Idios/kobutachan-allaganeye/issues/517) (実装済み、上記 §draft auto save 参照) | GUI 一時編集を `metadata.draft.json` に定期保存 (リロード耐性) |
-| `warnings: Warning[]` 構造化 | (新規起票予定) | legacy `note` の後継。`{code, message, severity}` 配列 |
+| ~~`warnings: Warning[]` 構造化 (scaffold)~~ | [#518](https://github.com/Idios/kobutachan-allaganeye/issues/518) (scaffold 実装済み、上記 §warnings 参照。実際の warning code 追加は派生 PR) | legacy `note` の後継。`{code, message, severity}` 配列 |
 
 ## 関連 issue / doc
 

--- a/gui/src/types/metadata.schema.test.ts
+++ b/gui/src/types/metadata.schema.test.ts
@@ -201,4 +201,50 @@ describe('MetadataSchema', () => {
     const nulled = { ...validMetadata(), detection_params: null };
     expect(MetadataSchema.safeParse(nulled).success).toBe(false);
   });
+
+  // #518 -- warnings scaffold.
+
+  it('accepts a document with an empty warnings array', () => {
+    const doc = { ...validMetadata(), warnings: [] };
+    expect(MetadataSchema.safeParse(doc).success).toBe(true);
+  });
+
+  it('accepts a document without warnings (backward compat)', () => {
+    const doc = validMetadata();
+    expect('warnings' in doc).toBe(false);
+    expect(MetadataSchema.safeParse(doc).success).toBe(true);
+  });
+
+  it('accepts valid warning entries with various shapes', () => {
+    const doc = {
+      ...validMetadata(),
+      warnings: [
+        { code: 'audio_skipped' },
+        { code: 'low_confidence', severity: 'warn' },
+        {
+          code: 'gpu_fallback',
+          message_en: 'fell back to CPU',
+          severity: 'info',
+          context: { reason: 'cuda not found' },
+        },
+      ],
+    };
+    expect(MetadataSchema.safeParse(doc).success).toBe(true);
+  });
+
+  it('rejects a warning missing its code field', () => {
+    const doc = {
+      ...validMetadata(),
+      warnings: [{ message_en: 'no code', severity: 'warn' }],
+    };
+    expect(MetadataSchema.safeParse(doc).success).toBe(false);
+  });
+
+  it('rejects a warning with unknown severity', () => {
+    const doc = {
+      ...validMetadata(),
+      warnings: [{ code: 'x', severity: 'catastrophic' }],
+    };
+    expect(MetadataSchema.safeParse(doc).success).toBe(false);
+  });
 });

--- a/gui/src/types/metadata.schema.ts
+++ b/gui/src/types/metadata.schema.ts
@@ -52,6 +52,18 @@ export const GapSchema = z
  */
 export const SCHEMA_VERSION = '1' as const;
 
+/**
+ * #518 -- warning entry scaffolding. Writer currently emits an empty
+ * `warnings` array; future detection / scorebar / audio codes will
+ * populate it. Readers must not reject unknown codes (future-proof).
+ */
+export const WarningSchema = z.object({
+  code: z.string().min(1),
+  message_en: z.string().optional(),
+  severity: z.enum(['info', 'warn', 'error']).optional(),
+  context: z.record(z.string(), z.unknown()).optional(),
+});
+
 export const MetadataSchema = z
   .object({
     schema_version: z.literal(SCHEMA_VERSION).optional(),
@@ -62,5 +74,6 @@ export const MetadataSchema = z
     detection_params: DetectionParamsSchema,
     matches: z.array(MatchSchema),
     gaps: z.array(GapSchema),
+    warnings: z.array(WarningSchema).optional(),
   })
   .passthrough();

--- a/gui/src/types/metadata.ts
+++ b/gui/src/types/metadata.ts
@@ -36,6 +36,20 @@ export interface Gap {
   duration_display: string;
 }
 
+/**
+ * #518 -- structured warning scaffold. The writer currently emits `[]`;
+ * future detection codes populate individual entries. Readers should
+ * pass unknown `code` values through unchanged.
+ */
+export type WarningSeverity = 'info' | 'warn' | 'error';
+
+export interface MetadataWarning {
+  code: string;
+  message_en?: string;
+  severity?: WarningSeverity;
+  context?: Record<string, unknown>;
+}
+
 export interface Metadata {
   /**
    * #515: schema revision declaration. Optional on the TS type because
@@ -50,4 +64,6 @@ export interface Metadata {
   detection_params: DetectionParams;
   matches: Match[];
   gaps: Gap[];
+  /** #518 -- optional on the TS type because legacy files don't emit it. */
+  warnings?: MetadataWarning[];
 }

--- a/tests/test_split_from_metadata.py
+++ b/tests/test_split_from_metadata.py
@@ -230,6 +230,38 @@ def test_split_and_write_metadata_contains_schema_version(tmp_path):
     assert payload["schema_version"] == "1"
 
 
+def test_split_and_write_metadata_emits_empty_warnings_array(tmp_path):
+    """#518: metadata.json writer always emits a `warnings` field (default []).
+
+    Locks in the schema for consumers so that once concrete codes ship in
+    a later PR, readers already treat `warnings` as a known key.
+    """
+    from allaganeye.video.detector import MatchBoundary
+
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    boundaries: list[MatchBoundary] = [
+        {"start": 0.0, "end": 120.0, "type": "fl_match"},
+    ]
+
+    with patch(
+        f"{MODULE}.split_video",
+        return_value=[tmp_path / "match_001.mp4"],
+    ):
+        _split_and_write_metadata(
+            tmp_path / "input.mp4",
+            boundaries,
+            [],
+            PROBE_RESULT,
+            config,
+            effective_interval=1.0,
+            detected_at="2026-04-22T00:00:00Z",
+            quiet=True,
+        )
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    assert payload["warnings"] == []
+
+
 def test_run_split_from_metadata_accepts_legacy_file_without_schema_version(
     tmp_path,
 ):

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,26 @@
+"""Tests for #518 warnings scaffold (allaganeye/detection/warnings.py)."""
+
+from __future__ import annotations
+
+from allaganeye.detection.warnings import (
+    WARNING_CODES,
+    build_warnings,
+)
+
+
+def test_build_warnings_is_empty_by_default():
+    assert build_warnings() == []
+
+
+def test_warning_codes_registry_is_a_mapping():
+    # Initial revision ships an empty registry, but the type contract is
+    # dict[str, str]. Future PRs append entries here.
+    assert isinstance(WARNING_CODES, dict)
+
+
+def test_build_warnings_returns_new_list_each_call():
+    # Isolation: one caller's mutation must not leak into the next.
+    a = build_warnings()
+    a.append({"code": "x"})  # type: ignore[arg-type]
+    b = build_warnings()
+    assert b == []


### PR DESCRIPTION
## 概要

[#518](https://github.com/Idios/kobutachan-allaganeye/issues/518) — metadata.json に構造化 `warnings` フィールドを受け入れる scaffold を導入。現時点では emitter は `[]` を書き出すのみで具体的な warning code は追加しないが、GUI / Python 両側の読み書きパスに型を通しておくことで、将来 code を追加するときに schema 変更が不要になる。

## 方針

ユーザー確認結果: **基盤だけ実装**。具体的 warning code (`audio_skipped` / `gpu_fallback` 等) は将来ニーズ発生時に別 PR で追加する。

## 受け入れ条件

本 PR は「基盤のみ」のスコープに絞ったため、issue #518 の「採用時の作業内容」は以下の通り選択的実装:

- [x] **Python 側: `detection/warnings.py` にコード定義** — `MetadataWarning` TypedDict / `Severity` Literal / `WARNING_CODES` レジストリ (現状空) / `build_warnings()` helper
- [x] **zod schema + TS 型に Warning / warnings 追加** — `WarningSchema` + `MetadataSchema.warnings: optional`
- **GUI 表示コンポーネント** (本 PR スコープ外・deferred): 実際の warning code が発行され始めた時点で別 issue 起票予定 (Phase 2-4 実装時)
- [x] **docs 更新 (warnings の意味一覧)** — `docs/metadata-spec.md` § warnings 節 + 新コード追加手順

## 実装内容

### Python (`allaganeye/detection/warnings.py` 新設)

```python
class MetadataWarning(TypedDict, total=False):
    code: str              # 必須
    message_en: str
    severity: Severity
    context: dict[str, Any]

WARNING_CODES: dict[str, str] = {}  # 空レジストリ
def build_warnings() -> list[MetadataWarning]: return []
```

### Python (`allaganeye/commands/split_matches.py`)

`_build_metadata_payload` のトップレベル dict に `"warnings": build_warnings()` を追加。`detect` 経路も同一 helper を使うので自動連動。

### GUI (`gui/src/types/metadata.schema.ts` + `metadata.ts`)

```typescript
export const WarningSchema = z.object({
  code: z.string().min(1),
  message_en: z.string().optional(),
  severity: z.enum(['info', 'warn', 'error']).optional(),
  context: z.record(z.string(), z.unknown()).optional(),
});

// MetadataSchema:
warnings: z.array(WarningSchema).optional(),

// TS:
export interface MetadataWarning { code: string; ... }
export interface Metadata { ...; warnings?: MetadataWarning[]; }
```

### docs (`docs/metadata-spec.md`)

- スキーマ定義表に `warnings` 行追加
- §warnings 節新設 (読み書き契約、新コード追加手順)
- 将来の拡張表から #518 を「scaffold 実装済み」に更新

## テスト

| 種類 | コマンド | 結果 |
|---|---|---|
| pytest | `python -m pytest tests/test_warnings.py tests/test_split_from_metadata.py tests/test_ascii_guard.py -q` | 15 passed |
| vitest | `npm --prefix=gui test -- --run metadata.schema` | 15 passed |
| eslint | `npm --prefix=gui run lint` | ok |
| tsc | `npm --prefix=gui run typecheck` | ok |

追加テスト一覧:

- **Python** (3): `test_build_warnings_is_empty_by_default` / `test_warning_codes_registry_is_a_mapping` / `test_build_warnings_returns_new_list_each_call`
- **Python 既存拡張** (1): `test_split_and_write_metadata_emits_empty_warnings_array`
- **vitest** (5): warnings 空配列 accept / warnings 欠落 accept / 有効エントリ accept / code 欠落 reject / 不正 severity reject

## 手動確認

- [x] CI pass (python/gui-frontend/gui-rust/markdownlint 全 pass)
- [x] `allaganeye detect <video>` の出力 metadata.json に `"warnings": []` が含まれる (20260116_1.mp4 で実機検証、出力 metadata.json の `warnings` フィールドが空配列を確認)
- [x] GUI が `warnings: []` または `warnings` 無しの metadata.json を正しく load する (vitest metadata.schema.test.ts の 5 ケース pass: 空配列 accept / 欠落 accept / 有効エントリ accept / code 欠落 reject / 不正 severity reject)

## 関連

- 起票元 issue: [#518](https://github.com/Idios/kobutachan-allaganeye/issues/518)
- 派生元: [#463](https://github.com/Idios/kobutachan-allaganeye/issues/463) (Phase 1 data layer)
- 仕様書: `docs/metadata-spec.md` § warnings (#518)
- 後続: 実際の warning code が必要になった PR で、`WARNING_CODES` + emitter + GUI 表示を追加

[elated-wozniak-50d3bb]


