### PR TITLE
feat(gui): Phase 4 export 本物化 (ffmpeg 呼び出し + 進捗) (Refs #466)

### DIFF
--- a/gui/src-tauri/capabilities/default.json
+++ b/gui/src-tauri/capabilities/default.json
@@ -6,11 +6,13 @@
   "permissions": [
     "core:default",
     "dialog:default",
+    "dialog:allow-open",
     "fs:default",
     "fs:allow-read-file",
     "fs:allow-stat",
     "shell:default",
     "shell:allow-execute",
-    "shell:allow-spawn"
+    "shell:allow-spawn",
+    "shell:allow-open"
   ]
 }

--- a/gui/src-tauri/capabilities/default.json
+++ b/gui/src-tauri/capabilities/default.json
@@ -12,7 +12,6 @@
     "fs:allow-stat",
     "shell:default",
     "shell:allow-execute",
-    "shell:allow-spawn",
-    "shell:allow-open"
+    "shell:allow-spawn"
   ]
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::{Arc, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use axum::{
     extract::{Path as AxumPath, State},
@@ -16,6 +17,7 @@ use futures::future::join_all;
 use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{Mutex, Semaphore};
 use tower_http::services::ServeFile;
 use uuid::Uuid;
@@ -850,6 +852,387 @@ async fn force_exit_app(app: tauri::AppHandle) {
     app.exit(0);
 }
 
+/// #466 -- codec selection for a single-match export. `Copy` is fast and
+/// keyframe-aligned (no re-encode); `H264` re-encodes with libx264 for
+/// accurate seek boundaries at the cost of wall time.
+#[derive(Debug, serde::Deserialize)]
+pub enum ExportCodec {
+    #[serde(rename = "copy")]
+    Copy,
+    #[serde(rename = "h264")]
+    H264,
+}
+
+/// #466 -- terminal payload returned to the frontend when a single match
+/// finishes exporting. `duration_ms` is wall time; the frontend uses it to
+/// show "exported in Ns" per match.
+#[derive(Debug, serde::Serialize)]
+pub struct ExportResult {
+    pub match_index: u32,
+    pub output_path: String,
+    pub duration_ms: u64,
+}
+
+/// #466 -- progress event emitted on channel `export-progress`. One event
+/// per ffmpeg `out_time_ms` line during encoding, plus a terminal
+/// `stage="done"` on success or `stage="error"` on failure.
+#[derive(Debug, serde::Serialize, Clone)]
+pub struct ExportProgress {
+    pub match_index: u32,
+    pub percent: f64,
+    pub stage: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// #466 -- pure validator for export arguments. Split out so unit tests can
+/// exercise the error paths without spawning ffmpeg. The caller is expected
+/// to pass the resolved `video_path` (no path-resolution done here).
+fn validate_export_request(
+    video_path: &Path,
+    start_seconds: f64,
+    end_seconds: f64,
+) -> Result<(), String> {
+    if !video_path.exists() {
+        return Err(format!(
+            "video file not found: {}",
+            video_path.display()
+        ));
+    }
+    let meta = fs::metadata(video_path)
+        .map_err(|e| format!("stat failed ({}): {}", video_path.display(), e))?;
+    if !meta.is_file() {
+        return Err(format!(
+            "video path is not a regular file: {}",
+            video_path.display()
+        ));
+    }
+    if !start_seconds.is_finite() || start_seconds < 0.0 {
+        return Err(format!(
+            "start_seconds must be >= 0 (got {})",
+            start_seconds
+        ));
+    }
+    if !end_seconds.is_finite() || end_seconds <= start_seconds {
+        return Err(format!(
+            "end_seconds must be > start_seconds (got start={}, end={})",
+            start_seconds, end_seconds
+        ));
+    }
+    Ok(())
+}
+
+/// #466 -- assemble the ffmpeg argv for a single export. Pulled out of
+/// `export_match` so unit tests can verify flag ordering and codec choices
+/// without spawning a process.
+///
+/// Note: `-ss` is placed BEFORE `-i` so ffmpeg does a fast keyframe-based
+/// seek rather than decoding from t=0. `-to` / `-t` interpretation after
+/// `-ss -i` is "duration from the seek point", so we pass
+/// `end_seconds - start_seconds` as a duration via `-t`.
+fn ffmpeg_args_for_export(
+    video_path: &Path,
+    start_seconds: f64,
+    end_seconds: f64,
+    output_path: &Path,
+    codec: &ExportCodec,
+) -> Vec<String> {
+    let duration = (end_seconds - start_seconds).max(0.0);
+    let start_str = format!("{:.3}", start_seconds.max(0.0));
+    let duration_str = format!("{:.3}", duration);
+
+    let mut args: Vec<String> = Vec::new();
+    args.push("-y".to_string());
+    args.push("-hide_banner".to_string());
+    args.push("-loglevel".to_string());
+    args.push("error".to_string());
+    args.push("-progress".to_string());
+    args.push("pipe:2".to_string());
+    args.push("-ss".to_string());
+    args.push(start_str);
+    args.push("-i".to_string());
+    args.push(video_path.to_string_lossy().to_string());
+    args.push("-t".to_string());
+    args.push(duration_str);
+
+    match codec {
+        ExportCodec::Copy => {
+            args.push("-c".to_string());
+            args.push("copy".to_string());
+            args.push("-avoid_negative_ts".to_string());
+            args.push("make_zero".to_string());
+        }
+        ExportCodec::H264 => {
+            args.push("-c:v".to_string());
+            args.push("libx264".to_string());
+            args.push("-crf".to_string());
+            args.push("18".to_string());
+            args.push("-preset".to_string());
+            args.push("medium".to_string());
+            args.push("-c:a".to_string());
+            args.push("copy".to_string());
+        }
+    }
+
+    args.push(output_path.to_string_lossy().to_string());
+    args
+}
+
+/// #466 -- insert a spawned ffmpeg child into the global PROCESS_TRACKER so
+/// the CloseRequested flow (#523) can kill it on app exit. Returns the UUID
+/// used as the map key; the caller must pass it back to `untrack_child` on
+/// process completion.
+async fn track_child(child: tokio::process::Child) -> Uuid {
+    let tracker = process_tracker();
+    let mut guard = tracker.lock().await;
+    let id = Uuid::new_v4();
+    guard.insert(id, child);
+    id
+}
+
+/// #466 -- remove a tracked child from PROCESS_TRACKER. Returns the child
+/// so the caller can still `.wait()` / `.kill()` it outside the tracker
+/// lock. Returns None if the entry was already drained (e.g. by
+/// `kill_tracked_processes`).
+async fn untrack_child(id: Uuid) -> Option<tokio::process::Child> {
+    let tracker = process_tracker();
+    let mut guard = tracker.lock().await;
+    guard.remove(&id)
+}
+
+/// #466 -- parse a single ffmpeg `-progress` line. ffmpeg emits key=value
+/// lines once per second (out_time, out_time_ms, speed, bitrate, ...) and
+/// a terminal `progress=end` or `progress=continue`. We only care about
+/// `out_time_ms` (for the percent bar) and `progress=end` (for the terminal
+/// event). Returns None for every other key.
+fn parse_progress_line(line: &str) -> Option<ProgressSignal> {
+    let line = line.trim();
+    if let Some(rest) = line.strip_prefix("out_time_ms=") {
+        rest.trim().parse::<i64>().ok().map(ProgressSignal::OutTimeMs)
+    } else if let Some(rest) = line.strip_prefix("out_time_us=") {
+        // Newer ffmpeg builds emit out_time_us instead of out_time_ms even
+        // though the unit is still microseconds. Accept both so we don't
+        // miss progress on future releases.
+        rest.trim().parse::<i64>().ok().map(ProgressSignal::OutTimeMs)
+    } else if line == "progress=end" {
+        Some(ProgressSignal::End)
+    } else {
+        None
+    }
+}
+
+/// #466 -- internal enum for parsed progress lines.
+#[derive(Debug, PartialEq)]
+enum ProgressSignal {
+    /// ffmpeg's `out_time_ms` is actually in microseconds (the name is a
+    /// historical artifact). Caller must divide by 1_000_000 to get seconds.
+    OutTimeMs(i64),
+    End,
+}
+
+/// #466 -- keep the last `max_bytes` bytes of `buf` as a UTF-8 lossy
+/// string. Used so the error message returned to the frontend stays
+/// bounded even if ffmpeg dumps pages of diagnostics.
+fn tail_string(buf: &[u8], max_bytes: usize) -> String {
+    let start = buf.len().saturating_sub(max_bytes);
+    String::from_utf8_lossy(&buf[start..]).trim().to_string()
+}
+
+/// #466 -- export a single match to `output_path` by invoking ffmpeg.
+///
+/// Spawns with stderr piped, reads `-progress pipe:2` lines, and emits one
+/// `export-progress` event per `out_time_ms=` or terminal `progress=end`
+/// line. Non-progress stderr lines (e.g. real ffmpeg errors under
+/// `-loglevel error`) are accumulated into a ring buffer and folded into
+/// the Err message on non-zero exit.
+///
+/// The spawned child is registered in PROCESS_TRACKER for the duration of
+/// the call so the CloseRequested flow can kill it before app exit.
+#[tauri::command]
+async fn export_match(
+    app: tauri::AppHandle,
+    video_path: String,
+    start_seconds: f64,
+    end_seconds: f64,
+    output_path: String,
+    codec: ExportCodec,
+    match_index: u32,
+) -> Result<ExportResult, String> {
+    let video = PathBuf::from(&video_path);
+    validate_export_request(&video, start_seconds, end_seconds)?;
+
+    let output = PathBuf::from(&output_path);
+    if let Some(parent) = output.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("create dir {} failed: {}", parent.display(), e))?;
+        }
+    }
+
+    let duration_seconds = end_seconds - start_seconds;
+    let args = ffmpeg_args_for_export(&video, start_seconds, end_seconds, &output, &codec);
+
+    let started = Instant::now();
+    let mut cmd = tokio::process::Command::new("ffmpeg");
+    for a in &args {
+        cmd.arg(a);
+    }
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("spawn ffmpeg failed: {}", e))?;
+
+    // Take stderr off the child before registering it in the tracker --
+    // `track_child` moves the Child and we need the pipe handle here.
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "failed to capture ffmpeg stderr".to_string())?;
+
+    let tracked_id = track_child(child).await;
+
+    let mut reader = BufReader::new(stderr).lines();
+    let mut stderr_tail: Vec<u8> = Vec::with_capacity(4096);
+    let max_tail = 2048; // 2 KB of tail context for error reporting
+    let mut saw_end = false;
+
+    loop {
+        match reader.next_line().await {
+            Ok(Some(line)) => {
+                match parse_progress_line(&line) {
+                    Some(ProgressSignal::OutTimeMs(us)) => {
+                        let seconds = (us as f64) / 1_000_000.0;
+                        let mut percent = if duration_seconds > 0.0 {
+                            seconds / duration_seconds * 100.0
+                        } else {
+                            0.0
+                        };
+                        if !percent.is_finite() {
+                            percent = 0.0;
+                        }
+                        if percent < 0.0 {
+                            percent = 0.0;
+                        }
+                        if percent > 100.0 {
+                            percent = 100.0;
+                        }
+                        let _ = app.emit(
+                            "export-progress",
+                            ExportProgress {
+                                match_index,
+                                percent,
+                                stage: "encoding".to_string(),
+                                message: None,
+                            },
+                        );
+                    }
+                    Some(ProgressSignal::End) => {
+                        saw_end = true;
+                        let _ = app.emit(
+                            "export-progress",
+                            ExportProgress {
+                                match_index,
+                                percent: 100.0,
+                                stage: "done".to_string(),
+                                message: None,
+                            },
+                        );
+                    }
+                    None => {
+                        // Non-progress stderr -- capture into ring buffer
+                        // for error reporting on non-zero exit.
+                        stderr_tail.extend_from_slice(line.as_bytes());
+                        stderr_tail.push(b'\n');
+                        if stderr_tail.len() > max_tail * 2 {
+                            let keep_from = stderr_tail.len() - max_tail;
+                            stderr_tail.drain(0..keep_from);
+                        }
+                    }
+                }
+            }
+            Ok(None) => break, // EOF
+            Err(e) => {
+                stderr_tail.extend_from_slice(
+                    format!("stderr read error: {}\n", e).as_bytes(),
+                );
+                break;
+            }
+        }
+    }
+
+    // Reclaim the child from the tracker so we can wait on it. If it was
+    // already drained by kill_tracked_processes, treat that as a
+    // user-initiated cancel and surface an error.
+    let mut child = match untrack_child(tracked_id).await {
+        Some(c) => c,
+        None => {
+            let msg = "export cancelled (process tracker drained)".to_string();
+            let _ = app.emit(
+                "export-progress",
+                ExportProgress {
+                    match_index,
+                    percent: 0.0,
+                    stage: "error".to_string(),
+                    message: Some(msg.clone()),
+                },
+            );
+            return Err(msg);
+        }
+    };
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("wait ffmpeg failed: {}", e))?;
+
+    if !status.success() {
+        let tail = tail_string(&stderr_tail, max_tail);
+        let msg = if tail.is_empty() {
+            format!("ffmpeg exited with status {:?}", status.code())
+        } else {
+            format!("ffmpeg exited with status {:?}: {}", status.code(), tail)
+        };
+        let _ = app.emit(
+            "export-progress",
+            ExportProgress {
+                match_index,
+                percent: 0.0,
+                stage: "error".to_string(),
+                message: Some(msg.clone()),
+            },
+        );
+        return Err(msg);
+    }
+
+    // Some ffmpeg builds close stderr without flushing the final
+    // `progress=end` line -- synthesize a terminal "done" so the frontend
+    // always sees one.
+    if !saw_end {
+        let _ = app.emit(
+            "export-progress",
+            ExportProgress {
+                match_index,
+                percent: 100.0,
+                stage: "done".to_string(),
+                message: None,
+            },
+        );
+    }
+
+    let output_str = fs::canonicalize(&output)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| output.to_string_lossy().to_string());
+
+    Ok(ExportResult {
+        match_index,
+        output_path: output_str,
+        duration_ms: started.elapsed().as_millis() as u64,
+    })
+}
+
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -880,6 +1263,7 @@ pub fn run() {
             is_process_running,
             kill_tracked_processes,
             force_exit_app,
+            export_match,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -1564,5 +1948,207 @@ mod tests {
             "unexpected error: {}",
             err
         );
+    }
+
+    /// #466 -- `copy` codec must emit `-c copy`, not `libx264`. The
+    /// `-avoid_negative_ts make_zero` flag prevents negative timestamp
+    /// errors common when seeking into a stream whose first packet after
+    /// the seek point has a non-zero PTS.
+    #[test]
+    fn ffmpeg_args_for_export_copy_uses_c_copy() {
+        let args = ffmpeg_args_for_export(
+            Path::new("C:/videos/in.mp4"),
+            10.0,
+            40.0,
+            Path::new("C:/out/match1.mp4"),
+            &ExportCodec::Copy,
+        );
+        let joined = args.join(" ");
+        assert!(joined.contains("-c copy"), "args: {}", joined);
+        assert!(
+            joined.contains("-avoid_negative_ts make_zero"),
+            "args: {}",
+            joined
+        );
+        assert!(!joined.contains("libx264"), "args: {}", joined);
+    }
+
+    /// #466 -- `h264` codec must use libx264 with the documented crf/preset
+    /// tuning so the frontend's "high quality" toggle lands a consistent
+    /// encode. Audio must be copied (not re-encoded) to avoid silent loss
+    /// of quality.
+    #[test]
+    fn ffmpeg_args_for_export_h264_uses_libx264() {
+        let args = ffmpeg_args_for_export(
+            Path::new("C:/videos/in.mp4"),
+            0.0,
+            30.0,
+            Path::new("C:/out/match1.mp4"),
+            &ExportCodec::H264,
+        );
+        let joined = args.join(" ");
+        assert!(joined.contains("-c:v libx264"), "args: {}", joined);
+        assert!(joined.contains("-crf 18"), "args: {}", joined);
+        assert!(joined.contains("-preset medium"), "args: {}", joined);
+        assert!(joined.contains("-c:a copy"), "args: {}", joined);
+    }
+
+    /// #466 -- ffmpeg's seek semantics differ dramatically depending on
+    /// whether `-ss` appears before or after `-i`. Before `-i`: fast
+    /// keyframe-based seek. After `-i`: slow decode-and-discard. We rely
+    /// on the fast path, so guard the ordering.
+    #[test]
+    fn ffmpeg_args_include_ss_before_input_for_keyframe_seek() {
+        let args = ffmpeg_args_for_export(
+            Path::new("C:/videos/in.mp4"),
+            15.5,
+            45.5,
+            Path::new("C:/out/match1.mp4"),
+            &ExportCodec::Copy,
+        );
+        let ss_pos = args.iter().position(|a| a == "-ss").expect("-ss present");
+        let i_pos = args.iter().position(|a| a == "-i").expect("-i present");
+        assert!(
+            ss_pos < i_pos,
+            "-ss (at {}) must precede -i (at {}): {:?}",
+            ss_pos,
+            i_pos,
+            args
+        );
+    }
+
+    /// #466 -- argv must include a `-t <duration>` pair whose value equals
+    /// `end_seconds - start_seconds`. This is the cross-check that
+    /// `export_match` actually delivers the requested clip length, not
+    /// trailing footage from the source.
+    #[test]
+    fn ffmpeg_args_encode_duration_as_t_flag() {
+        let args = ffmpeg_args_for_export(
+            Path::new("C:/videos/in.mp4"),
+            10.0,
+            40.5,
+            Path::new("C:/out/match1.mp4"),
+            &ExportCodec::Copy,
+        );
+        let t_pos = args.iter().position(|a| a == "-t").expect("-t present");
+        let duration = args.get(t_pos + 1).expect("value after -t");
+        let parsed: f64 = duration.parse().expect("parse duration");
+        assert!(
+            (parsed - 30.5).abs() < 1e-6,
+            "expected 30.5, got {} (all: {:?})",
+            parsed,
+            args
+        );
+    }
+
+    /// #466 -- a missing video path must fail validation before ffmpeg is
+    /// touched. The error message must contain "not found" so the frontend
+    /// can distinguish it from generic ffmpeg errors.
+    #[test]
+    fn export_match_rejects_missing_video_path() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("nope.mp4");
+        let err = validate_export_request(&missing, 0.0, 10.0).unwrap_err();
+        assert!(err.contains("not found"), "got: {}", err);
+    }
+
+    /// #466 -- `end <= start` must fail immediately (otherwise ffmpeg's
+    /// `-t` flag would receive 0 or negative and silently write an empty
+    /// file).
+    #[test]
+    fn export_match_rejects_end_le_start() {
+        let tmp = TempDir::new().unwrap();
+        let video = tmp.path().join("clip.mp4");
+        fs::write(&video, b"fake mp4").unwrap();
+        let err_equal = validate_export_request(&video, 10.0, 10.0).unwrap_err();
+        assert!(err_equal.contains("end_seconds"), "got: {}", err_equal);
+        let err_lt = validate_export_request(&video, 20.0, 10.0).unwrap_err();
+        assert!(err_lt.contains("end_seconds"), "got: {}", err_lt);
+    }
+
+    /// #466 -- negative start times are rejected. ffmpeg treats `-ss <0`
+    /// inconsistently across builds; better to refuse up front.
+    #[test]
+    fn export_match_rejects_negative_start() {
+        let tmp = TempDir::new().unwrap();
+        let video = tmp.path().join("clip.mp4");
+        fs::write(&video, b"fake mp4").unwrap();
+        let err = validate_export_request(&video, -1.0, 10.0).unwrap_err();
+        assert!(err.contains("start_seconds"), "got: {}", err);
+    }
+
+    /// #466 -- NaN / non-finite values are rejected (they would otherwise
+    /// propagate into ffmpeg argv as "NaN" and fail opaquely).
+    #[test]
+    fn export_match_rejects_non_finite_values() {
+        let tmp = TempDir::new().unwrap();
+        let video = tmp.path().join("clip.mp4");
+        fs::write(&video, b"fake mp4").unwrap();
+        let err_nan_start = validate_export_request(&video, f64::NAN, 10.0).unwrap_err();
+        assert!(err_nan_start.contains("start_seconds"), "got: {}", err_nan_start);
+        let err_inf_end = validate_export_request(&video, 0.0, f64::INFINITY).unwrap_err();
+        assert!(err_inf_end.contains("end_seconds"), "got: {}", err_inf_end);
+    }
+
+    /// #466 -- happy path: real file, sane start/end, validator returns Ok.
+    #[test]
+    fn export_match_accepts_valid_request() {
+        let tmp = TempDir::new().unwrap();
+        let video = tmp.path().join("clip.mp4");
+        fs::write(&video, b"fake mp4").unwrap();
+        validate_export_request(&video, 0.0, 10.0).unwrap();
+        validate_export_request(&video, 5.5, 6.25).unwrap();
+    }
+
+    /// #466 -- `out_time_ms=` (actually microseconds per the ffmpeg
+    /// `-progress` contract) parses to the numeric value. Leading/trailing
+    /// whitespace and a trailing `\r` (Windows line endings) are handled.
+    #[test]
+    fn parse_progress_line_accepts_out_time_ms() {
+        assert_eq!(
+            parse_progress_line("out_time_ms=1500000"),
+            Some(ProgressSignal::OutTimeMs(1_500_000))
+        );
+        assert_eq!(
+            parse_progress_line("  out_time_ms=42  "),
+            Some(ProgressSignal::OutTimeMs(42))
+        );
+        // Newer ffmpeg builds use out_time_us
+        assert_eq!(
+            parse_progress_line("out_time_us=2000000"),
+            Some(ProgressSignal::OutTimeMs(2_000_000))
+        );
+    }
+
+    /// #466 -- `progress=end` is the terminal signal; everything else
+    /// (bitrate, speed, fps, ...) must return None so we don't emit noise.
+    #[test]
+    fn parse_progress_line_detects_end_and_ignores_others() {
+        assert_eq!(parse_progress_line("progress=end"), Some(ProgressSignal::End));
+        assert_eq!(parse_progress_line("progress=continue"), None);
+        assert_eq!(parse_progress_line("bitrate=512.0kbits/s"), None);
+        assert_eq!(parse_progress_line("speed=1.5x"), None);
+        assert_eq!(parse_progress_line(""), None);
+        assert_eq!(parse_progress_line("random unrelated line"), None);
+    }
+
+    /// #466 -- `tail_string` must bound the returned length at `max_bytes`.
+    /// Exercising with a string larger than the bound ensures we always
+    /// drop the oldest bytes, never the newest (the tail is what matters
+    /// for error diagnostics).
+    #[test]
+    fn tail_string_respects_max_bytes() {
+        let big: Vec<u8> = (0..5000).map(|i| b'a' + (i % 26) as u8).collect();
+        let tail = tail_string(&big, 100);
+        assert!(tail.len() <= 100, "tail too long: {}", tail.len());
+        assert!(tail.ends_with(big[big.len() - 1] as char), "tail lost end");
+    }
+
+    /// #466 -- `tail_string` returns the whole buffer when it already fits
+    /// under the limit, with leading/trailing whitespace trimmed.
+    #[test]
+    fn tail_string_returns_whole_buffer_when_small() {
+        let buf = b"  short message\n";
+        assert_eq!(tail_string(buf, 2048), "short message");
     }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -930,6 +930,26 @@ fn validate_export_request(
 /// seek rather than decoding from t=0. `-to` / `-t` interpretation after
 /// `-ss -i` is "duration from the seek point", so we pass
 /// `end_seconds - start_seconds` as a duration via `-t`.
+/// #466 review #4: 出力先の親ディレクトリが存在することを検証する。
+///
+/// 以前は `export_match` 内で `create_dir_all` を呼んでいたが、ユーザーが
+/// タイポしたパスに静かにディレクトリツリーが作られて混乱を招くため、
+/// 明示拒否に変更した。ディレクトリ作成はユーザーが事前に行う前提。
+///
+/// `output_path` がルート / 親なし (file_name only など) の場合は no-op で
+/// Ok を返す (現在のディレクトリを意味すると解釈)。
+fn validate_output_parent_exists(output_path: &Path) -> Result<(), String> {
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            return Err(format!(
+                "output directory does not exist: {}",
+                parent.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn ffmpeg_args_for_export(
     video_path: &Path,
     start_seconds: f64,
@@ -1062,12 +1082,7 @@ async fn export_match(
     validate_export_request(&video, start_seconds, end_seconds)?;
 
     let output = PathBuf::from(&output_path);
-    if let Some(parent) = output.parent() {
-        if !parent.as_os_str().is_empty() && !parent.exists() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("create dir {} failed: {}", parent.display(), e))?;
-        }
-    }
+    validate_output_parent_exists(&output)?;
 
     let duration_seconds = end_seconds - start_seconds;
     let args = ffmpeg_args_for_export(&video, start_seconds, end_seconds, &output, &codec);
@@ -2088,6 +2103,31 @@ mod tests {
         assert!(err_nan_start.contains("start_seconds"), "got: {}", err_nan_start);
         let err_inf_end = validate_export_request(&video, 0.0, f64::INFINITY).unwrap_err();
         assert!(err_inf_end.contains("end_seconds"), "got: {}", err_inf_end);
+    }
+
+    /// #466 review #4: 出力先親ディレクトリが存在しなければエラー。
+    /// 以前の `create_dir_all` (silent mkdir) は廃止されたので、存在しない
+    /// パスを渡すと「does not exist」エラーを返す。
+    #[test]
+    fn validate_output_parent_exists_rejects_missing_parent() {
+        let tmp = TempDir::new().unwrap();
+        let nested = tmp.path().join("nope").join("clip.mp4");
+        let err = validate_output_parent_exists(&nested).unwrap_err();
+        assert!(err.contains("does not exist"), "got: {}", err);
+    }
+
+    /// #466 review #4: 親ディレクトリが存在すれば Ok。
+    #[test]
+    fn validate_output_parent_exists_accepts_existing_parent() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("clip.mp4");
+        validate_output_parent_exists(&target).unwrap();
+    }
+
+    /// #466 review #4: 親なしパス (filename だけ) は Ok (現在のディレクトリ)。
+    #[test]
+    fn validate_output_parent_exists_accepts_bare_filename() {
+        validate_output_parent_exists(Path::new("clip.mp4")).unwrap();
     }
 
     /// #466 -- happy path: real file, sane start/end, validator returns Ok.

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -950,6 +950,56 @@ fn validate_output_parent_exists(output_path: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// `open_folder_in_explorer` の path 検証ロジックを spawn から分離した
+/// 単体テスト用ヘルパ。
+///
+/// - 存在しない path は明示エラー
+/// - 非 Windows 環境では unsupported エラー
+/// - 上記をパスしたら Ok (caller は spawn を試みる)
+fn validate_open_folder_request(path: &str) -> Result<(), String> {
+    if !Path::new(path).exists() {
+        return Err(format!("path does not exist: {}", path));
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        return Err(
+            "open_folder_in_explorer is only supported on Windows".to_string(),
+        );
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Ok(())
+    }
+}
+
+/// `path` をプラットフォーム固有のファイルマネージャ (Windows: explorer.exe)
+/// で開く。
+///
+/// 旧実装は `tauri-plugin-shell` の `open` を使っていたが、`shell:allow-open`
+/// permission の default scope が URL (`mailto:` / `tel:` / `https?://`) しか
+/// 許可せず、ローカル path は `Scoped command argument failed regex
+/// validation` で reject される。`open` の scope を path 許可に拡張する代わ
+/// りに、Windows の `explorer.exe` を直接 spawn する独自 command を用意して
+/// 確実に動かす (#545 review、2026-04-25)。
+///
+/// Windows のみ対応 (CLAUDE.md に「対応プラットフォーム: Windows のみ」と
+/// 明記)。将来 Linux / macOS 対応する際は `xdg-open` / `open` で分岐する。
+#[tauri::command]
+fn open_folder_in_explorer(path: String) -> Result<(), String> {
+    validate_open_folder_request(&path)?;
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::process::Command;
+        Command::new("explorer.exe")
+            .arg(&path)
+            .spawn()
+            .map_err(|e| format!("failed to launch explorer: {}", e))?;
+    }
+
+    Ok(())
+}
+
 fn ffmpeg_args_for_export(
     video_path: &Path,
     start_seconds: f64,
@@ -1279,6 +1329,7 @@ pub fn run() {
             kill_tracked_processes,
             force_exit_app,
             export_match,
+            open_folder_in_explorer,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -2128,6 +2179,36 @@ mod tests {
     #[test]
     fn validate_output_parent_exists_accepts_bare_filename() {
         validate_output_parent_exists(Path::new("clip.mp4")).unwrap();
+    }
+
+    /// #545 review #6: 存在しないパスを渡したら明示エラー (explorer 起動前に
+    /// validate)。spawn を含まない validator の単体テスト。
+    #[test]
+    fn validate_open_folder_request_rejects_missing_path() {
+        let tmp = TempDir::new().unwrap();
+        let bogus = tmp.path().join("does-not-exist");
+        let err = validate_open_folder_request(&bogus.to_string_lossy()).unwrap_err();
+        assert!(err.contains("does not exist"), "got: {}", err);
+    }
+
+    /// #545 review #6: 存在するディレクトリは accept (Windows のみ Ok、
+    /// 非 Windows は unsupported エラー)。spawn 副作用なしで分岐確認。
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn validate_open_folder_request_accepts_existing_dir_on_windows() {
+        let tmp = TempDir::new().unwrap();
+        validate_open_folder_request(&tmp.path().to_string_lossy()).unwrap();
+    }
+
+    /// #545 review #6: 非 Windows 環境では path が存在しても unsupported
+    /// エラーを返す。CI (Linux) でも安定して走る回帰テスト。
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn validate_open_folder_request_returns_unsupported_on_non_windows() {
+        let tmp = TempDir::new().unwrap();
+        let err =
+            validate_open_folder_request(&tmp.path().to_string_lossy()).unwrap_err();
+        assert!(err.contains("Windows"), "got: {}", err);
     }
 
     /// #466 -- happy path: real file, sane start/end, validator returns Ok.

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2211,6 +2211,71 @@ mod tests {
         assert!(err.contains("Windows"), "got: {}", err);
     }
 
+    /// #545 mystifying-ptolemy-d112b5 review (2026-04-25): track_child →
+    /// untrack_child の往復で正しく Some が返ること。`export_match` の
+    /// happy-path cleanup の core ロジック。
+    ///
+    /// Windows 用 dummy プロセスとして `cmd /c rem` を spawn (即終了 no-op)、
+    /// 非 Windows は `true` を spawn する。spawn 直後に track → untrack して
+    /// Some を確認、最後に kill して残留を防ぐ。
+    #[tokio::test]
+    async fn track_child_then_untrack_returns_some() {
+        // PROCESS_TRACKER は process-global の OnceCell なので、別 test の
+        // 残留を念のため drain。失敗しても無害。
+        let _ = kill_tracked_processes().await;
+
+        let mut spawn = if cfg!(target_os = "windows") {
+            tokio::process::Command::new("cmd")
+        } else {
+            tokio::process::Command::new("true")
+        };
+        if cfg!(target_os = "windows") {
+            spawn.args(["/c", "rem"]);
+        }
+        let child = spawn.spawn().expect("spawn dummy child failed");
+
+        let id = track_child(child).await;
+        let recovered = untrack_child(id).await;
+        assert!(
+            recovered.is_some(),
+            "untrack_child should return Some right after track"
+        );
+        // recovered Child は drop で OS 側に handle が返るが、念のため明示
+        // wait しておく (zombie 防止)。
+        if let Some(mut c) = recovered {
+            let _ = c.wait().await;
+        }
+    }
+
+    /// #545 mystifying-ptolemy-d112b5 review (2026-04-25): track_child のあと
+    /// `kill_tracked_processes` が drain した場合、untrack_child は None を
+    /// 返す。`export_match` の cancel 検出 (`untrack` 結果が None なら
+    /// 既に kill された = 中断) のセマンティクス確認。
+    #[tokio::test]
+    async fn untrack_child_after_kill_tracked_returns_none() {
+        // 別 test の残留があれば drain。
+        let _ = kill_tracked_processes().await;
+
+        let mut spawn = if cfg!(target_os = "windows") {
+            tokio::process::Command::new("cmd")
+        } else {
+            tokio::process::Command::new("true")
+        };
+        if cfg!(target_os = "windows") {
+            spawn.args(["/c", "rem"]);
+        }
+        let child = spawn.spawn().expect("spawn dummy child failed");
+
+        let id = track_child(child).await;
+        // kill_tracked_processes が tracker を drain して全 child を kill する
+        let _killed = kill_tracked_processes().await.unwrap();
+        let recovered = untrack_child(id).await;
+        assert!(
+            recovered.is_none(),
+            "untrack_child should return None after kill_tracked_processes drained the tracker"
+        );
+    }
+
     /// #466 -- happy path: real file, sane start/end, validator returns Ok.
     #[test]
     fn export_match_accepts_valid_request() {

--- a/gui/src/__tests__/flow.integration.test.tsx
+++ b/gui/src/__tests__/flow.integration.test.tsx
@@ -121,6 +121,15 @@ function configureHappyInvoke() {
         return Promise.resolve(0);
       case 'force_exit_app':
         return Promise.resolve();
+      // #466 -- Phase 4 export
+      case 'export_match': {
+        const a = args as { matchIndex: number; outputPath: string };
+        return Promise.resolve({
+          match_index: a.matchIndex,
+          output_path: a.outputPath,
+          duration_ms: 100,
+        });
+      }
       default:
         return Promise.resolve();
     }
@@ -237,41 +246,48 @@ describe('flow G: detecting [中断] returns to drop', () => {
   });
 });
 
-describe('flow H: export dummy progress + cancel', () => {
-  it('starts export and cancels mid-flight', () => {
+describe('flow H: export cancel mid-flight (#466 + #523)', () => {
+  it('kill_tracked_processes is invoked when 中断 is clicked', async () => {
+    // Make export_match hang so we can observe the cancel path.
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'export_match') return new Promise(() => undefined);
+      if (cmd === 'kill_tracked_processes') return Promise.resolve(0);
+      return Promise.resolve(undefined);
+    });
     useMetadataStore.getState().loadSample();
+    useMetadataStore.setState({ filePath: '/tmp/x/metadata.json' });
     useAppStateStore.getState().navigate('export');
-    vi.useFakeTimers();
     render(<App />);
-    act(() => {
-      fireEvent.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('running');
     });
-    expect(screen.getByTestId('export-screen').dataset.phase).toBe('running');
-    act(() => {
-      vi.advanceTimersByTime(400);
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: '中断' }));
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('kill_tracked_processes');
     });
-    act(() => {
-      fireEvent.click(screen.getByRole('button', { name: '中断' }));
-    });
-    expect(screen.getByTestId('export-screen').dataset.phase).toBe('idle');
   });
 });
 
-describe('flow I: export completes and opens folder', () => {
-  it('runs through progress to 100% and shows フォルダを開く', () => {
+describe('flow I: export completes (#466)', () => {
+  it('walks through every match and surfaces the フォルダを開く button', async () => {
+    configureHappyInvoke();
     useMetadataStore.getState().loadSample();
+    useMetadataStore.setState({ filePath: '/tmp/x/metadata.json' });
     useAppStateStore.getState().navigate('export');
-    vi.useFakeTimers();
     render(<App />);
-    act(() => {
-      fireEvent.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await userEvent
+      .setup()
+      .click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe(
+        'completed',
+      );
     });
-    act(() => {
-      vi.advanceTimersByTime(9000);
-    });
-    expect(screen.getByTestId('export-screen').dataset.phase).toBe(
-      'completed',
-    );
     expect(
       screen.getByRole('button', { name: /フォルダを開く/ }),
     ).toBeInTheDocument();

--- a/gui/src/screens/ExportScreen.module.css
+++ b/gui/src/screens/ExportScreen.module.css
@@ -206,6 +206,19 @@
   box-shadow: none;
 }
 
+/*
+ * #545 review #7: 進捗バー直下の経過 / 残り時間 (design mock 準拠)。
+ * progressHeader と同じ font-family / 色だが少し小さく抑えてサブ情報感を出す。
+ */
+.progressTime {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  font-family: var(--ae-font-mono);
+  font-size: 9px;
+  color: var(--ae-text-dim);
+}
+
 .primaryButton {
   width: 100%;
   padding: 12px 16px;
@@ -254,13 +267,49 @@
   overflow: hidden;
 }
 
+/*
+ * #545 review #3: 一覧 caption の隣に bulk 操作ボタン (全選択/全解除) を
+ * 並べる横並びレイアウト。
+ */
+.listHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  padding: 4px 4px 0;
+}
+
 .listCaption {
   font-family: var(--ae-font-ui);
   font-size: 9px;
   letter-spacing: 2px;
   color: var(--ae-gold-dim);
-  margin-bottom: 6px;
-  padding: 4px 4px 0;
+}
+
+.listBulkActions {
+  display: flex;
+  gap: 4px;
+}
+
+.listBulkButton {
+  background: transparent;
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.27);
+  color: var(--ae-gold);
+  padding: 2px 8px;
+  font-family: var(--ae-font-ui);
+  font-size: 9px;
+  letter-spacing: 1px;
+  cursor: pointer;
+}
+
+.listBulkButton:hover:not(:disabled) {
+  background: rgba(var(--ae-gold-rgb), 0.08);
+  color: var(--ae-gold-bright);
+}
+
+.listBulkButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .listBody {

--- a/gui/src/screens/ExportScreen.module.css
+++ b/gui/src/screens/ExportScreen.module.css
@@ -291,6 +291,21 @@
   color: var(--ae-cyan);
 }
 
+.listMarkError {
+  color: var(--ae-danger);
+}
+
+.listError {
+  font-family: var(--ae-font-mono);
+  font-size: 9px;
+  color: var(--ae-danger);
+  margin-left: 8px;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .listName {
   flex: 1;
   overflow: hidden;

--- a/gui/src/screens/ExportScreen.module.css
+++ b/gui/src/screens/ExportScreen.module.css
@@ -282,6 +282,22 @@
   color: var(--ae-text);
 }
 
+/*
+ * #466 review #1: per-match include/exclude checkbox。disabled 時は
+ * type_override === 'skip' (preview で永続 skip 設定済) を意味するので
+ * 視覚的に分かるよう dim にする。
+ */
+.listCheckbox {
+  margin: 0 4px 0 0;
+  accent-color: var(--ae-gold);
+  cursor: pointer;
+}
+
+.listCheckbox:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
 .listMark {
   color: var(--ae-gold);
   width: 16px;

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -517,6 +517,54 @@ describe('ExportScreen (Phase 4 #466)', () => {
     expect(screen.getByText(/残り/)).toBeInTheDocument();
   });
 
+  // 5 回目テスト #4 (2026-04-25): per-file 進捗を overall に合算して進捗バー
+  // を滑らかに動かす。旧実装は `doneCount / total` のみで 1 ファイル目 encode
+  // 中は 0% 固定だった。ffmpeg `out_time_ms` 由来の per-file percent を
+  // running 中の試合に対して加算する。
+  it('reflects per-file running progress in the overall progress bar', async () => {
+    let progressHandler: ((e: {
+      payload: {
+        match_index: number;
+        percent: number;
+        stage: string;
+        message?: string;
+      };
+    }) => void) | null = null;
+    listenMock.mockImplementation(
+      async (_name: string, handler: (e: unknown) => void) => {
+        progressHandler = handler as typeof progressHandler;
+        return () => undefined;
+      },
+    );
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'export_match') return new Promise(() => undefined); // never resolves
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('running');
+    });
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+    // match 1 が 50% encoding 中 → overall = 50 / 9 ≈ 6%
+    progressHandler!({
+      payload: { match_index: 1, percent: 50, stage: 'encoding' },
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/6%/)).toBeInTheDocument();
+    });
+    // match 1 が 100% (まだ done event は来ていない、percent だけ)
+    // → overall = 100 / 9 ≈ 11% (Rust 側 done event がないと status='running'
+    //    のまま、percent=100 を加算)
+    progressHandler!({
+      payload: { match_index: 1, percent: 100, stage: 'encoding' },
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/11%/)).toBeInTheDocument();
+    });
+  });
+
   it('errors surface as export-progress events update list items', async () => {
     let progressHandler: ((e: {
       payload: {

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -1,11 +1,24 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+const { invokeMock, listenMock, openDialogMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  listenMock: vi.fn(),
+  openDialogMock: vi.fn(),
+}));
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: invokeMock,
+}));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => {
+    listenMock(...args);
+    return Promise.resolve(() => undefined);
+  },
+}));
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: openDialogMock,
 }));
 
 import { ExportScreen } from './ExportScreen';
@@ -14,18 +27,19 @@ import { useMetadataStore } from '../state/metadataStore';
 
 beforeEach(() => {
   invokeMock.mockReset();
+  listenMock.mockReset();
+  openDialogMock.mockReset();
+  // Default: any invoke resolves with undefined; the per-test callers
+  // override `export_match` / `kill_tracked_processes` as needed.
   invokeMock.mockResolvedValue(undefined);
   useAppStateStore.getState().reset();
   useMetadataStore.getState().clear();
   useMetadataStore.getState().loadSample();
+  useMetadataStore.setState({ filePath: '/tmp/x/metadata.json' });
   useAppStateStore.getState().navigate('export');
 });
 
-afterEach(() => {
-  vi.useRealTimers();
-});
-
-describe('ExportScreen', () => {
+describe('ExportScreen (Phase 4 #466)', () => {
   it('renders empty state when metadata is null', () => {
     useMetadataStore.getState().clear();
     render(<ExportScreen />);
@@ -35,7 +49,19 @@ describe('ExportScreen', () => {
   it('renders with idle phase and [書き出し開始] button', () => {
     render(<ExportScreen />);
     expect(screen.getByTestId('export-screen').dataset.phase).toBe('idle');
-    expect(screen.getByRole('button', { name: /書き出し開始/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /書き出し開始/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('subscribes to the export-progress event on mount', async () => {
+    render(<ExportScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalledWith(
+        'export-progress',
+        expect.any(Function),
+      );
+    });
   });
 
   it('[◀ プレビュー] returns to preview when idle', async () => {
@@ -45,52 +71,6 @@ describe('ExportScreen', () => {
     expect(useAppStateStore.getState().screen).toBe('preview');
   });
 
-  it('[書き出し開始] transitions to running and advances dummy progress', () => {
-    vi.useFakeTimers();
-    render(<ExportScreen />);
-    const button = screen.getByRole('button', { name: /書き出し開始/ });
-    act(() => {
-      button.click();
-    });
-    expect(screen.getByTestId('export-screen').dataset.phase).toBe('running');
-    act(() => {
-      vi.advanceTimersByTime(500);
-    });
-    // Progress has started — we should see the progress label
-    expect(screen.getByText(/分割・書き出し中/)).toBeInTheDocument();
-  });
-
-  it('[中断] transitions running -> cancelling -> idle (progress reset)', () => {
-    vi.useFakeTimers();
-    render(<ExportScreen />);
-    act(() => {
-      screen.getByRole('button', { name: /書き出し開始/ }).click();
-    });
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
-    act(() => {
-      screen.getByRole('button', { name: '中断' }).click();
-    });
-    // effects resolve synchronously in act
-    expect(screen.getByTestId('export-screen').dataset.phase).toBe('idle');
-  });
-
-  it('running progress completes to 100% → shows [✓ フォルダを開く]', () => {
-    vi.useFakeTimers();
-    render(<ExportScreen />);
-    act(() => {
-      screen.getByRole('button', { name: /書き出し開始/ }).click();
-    });
-    act(() => {
-      vi.advanceTimersByTime(9000);
-    });
-    expect(screen.getByTestId('export-screen').dataset.phase).toBe('completed');
-    expect(
-      screen.getByRole('button', { name: /フォルダを開く/ }),
-    ).toBeInTheDocument();
-  });
-
   it('codec selection toggles via aria-pressed', async () => {
     render(<ExportScreen />);
     const user = userEvent.setup();
@@ -98,5 +78,133 @@ describe('ExportScreen', () => {
     expect(h264.getAttribute('aria-pressed')).toBe('false');
     await user.click(h264);
     expect(h264.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('[参照…] invokes the Tauri directory picker and sets outDir', async () => {
+    openDialogMock.mockResolvedValue('/picked/output');
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /参照/ }));
+    await waitFor(() => {
+      const input = screen.getByLabelText(
+        'output directory',
+      ) as HTMLInputElement;
+      expect(input.value).toBe('/picked/output');
+    });
+    expect(openDialogMock).toHaveBeenCalledWith({
+      directory: true,
+      multiple: false,
+    });
+  });
+
+  it('[書き出し開始] invokes export_match per non-skipped match and completes', async () => {
+    invokeMock.mockImplementation((cmd: string, args: unknown) => {
+      if (cmd === 'export_match') {
+        const a = args as { matchIndex: number; outputPath: string };
+        return Promise.resolve({
+          match_index: a.matchIndex,
+          output_path: a.outputPath,
+          duration_ms: 100,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('completed');
+    });
+    // sampleMetadata has 9 matches, none marked skip -> 9 invocations
+    const exportCalls = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'export_match',
+    );
+    expect(exportCalls.length).toBe(9);
+    expect(screen.getByRole('button', { name: /フォルダを開く/ }))
+      .toBeInTheDocument();
+  });
+
+  it('continues after a single match failure (per-match error isolation)', async () => {
+    invokeMock.mockImplementation((cmd: string, args: unknown) => {
+      if (cmd === 'export_match') {
+        const a = args as { matchIndex: number; outputPath: string };
+        if (a.matchIndex === 3) return Promise.reject(new Error('ffmpeg said no'));
+        return Promise.resolve({
+          match_index: a.matchIndex,
+          output_path: a.outputPath,
+          duration_ms: 100,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('completed');
+    });
+    const exportCalls = invokeMock.mock.calls.filter(
+      (c) => c[0] === 'export_match',
+    );
+    expect(exportCalls.length).toBe(9); // kept going through match 3
+    // UI shows the error for match 3
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts.some((el) => el.textContent?.includes('ffmpeg said no')))
+      .toBe(true);
+  });
+
+  it('[中断] calls kill_tracked_processes and stops the loop', async () => {
+    // Make export_match slow so we can hit the cancel button before the
+    // whole queue drains.
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'export_match') {
+        return new Promise(() => undefined); // never resolves
+      }
+      if (cmd === 'kill_tracked_processes') return Promise.resolve(0);
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('running');
+    });
+    await user.click(screen.getByRole('button', { name: '中断' }));
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('kill_tracked_processes');
+    });
+  });
+
+  it('errors surface as export-progress events update list items', async () => {
+    let progressHandler: ((e: {
+      payload: {
+        match_index: number;
+        percent: number;
+        stage: string;
+        message?: string;
+      };
+    }) => void) | null = null;
+    // Override listen to capture the handler.
+    listenMock.mockImplementation(
+      async (_name: string, handler: (e: unknown) => void) => {
+        progressHandler = handler as typeof progressHandler;
+        return () => undefined;
+      },
+    );
+    render(<ExportScreen />);
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+    progressHandler!({
+      payload: {
+        match_index: 1,
+        percent: 50,
+        stage: 'encoding',
+      },
+    });
+    // No phase transition (still idle until START_CLICKED) but the list
+    // item picks up the state.
+    await waitFor(() => {
+      const items = screen.getAllByRole('listitem');
+      expect(items[0]).toBeTruthy();
+    });
   });
 });

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -278,6 +278,84 @@ describe('ExportScreen (Phase 4 #466)', () => {
     ).toBe(false);
   });
 
+  // 2026-04-25 修正: dummy detect (loadSample のみ) で filePath=null のまま
+  // export 画面に来た場合でも、書き出し開始ボタンが disable されず、かつ
+  // クリックで export_match が走ること。Phase 3 dummy フローのバグ。
+  it('still triggers export_match when filePath is null but videoSource is set', async () => {
+    // beforeEach の filePath setState を打ち消して null にする (loadSample
+    // 直後の状態を再現)。selectedVideoPath は drop screen 経由でセット。
+    useMetadataStore.setState({ filePath: null });
+    useAppStateStore.getState().setSelectedVideoPath('C:/videos/x.mkv');
+    invokeMock.mockImplementation((cmd: string, args: unknown) => {
+      if (cmd === 'export_match') {
+        const a = args as { matchIndex: number; outputPath: string };
+        return Promise.resolve({
+          match_index: a.matchIndex,
+          output_path: a.outputPath,
+          duration_ms: 100,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const startBtn = screen.getByRole('button', { name: /書き出し開始/ });
+    expect((startBtn as HTMLButtonElement).disabled).toBe(false);
+    const user = userEvent.setup();
+    await user.click(startBtn);
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('completed');
+    });
+    const calls = invokeMock.mock.calls.filter((c) => c[0] === 'export_match');
+    expect(calls.length).toBe(9);
+    // videoPath が selectedVideoPath を反映している
+    expect(calls[0][1]).toMatchObject({ videoPath: 'C:/videos/x.mkv' });
+  });
+
+  // 2026-04-25 修正: 書き出し開始ボタンは videoSource なし (selectedVideoPath
+  // も metadata.source も null) の場合のみ disable される。
+  it('disables [書き出し開始] button when both selectedVideoPath and metadata.source are absent', () => {
+    useMetadataStore.setState({ filePath: null });
+    // sampleMetadata.source は固定文字列が入っているので一旦 clear して
+    // 空 metadata を組み立てる
+    useMetadataStore.setState({
+      metadata: {
+        ...useMetadataStore.getState().metadata!,
+        source: '' as unknown as string,
+      },
+    });
+    useAppStateStore.getState().setSelectedVideoPath(null);
+    render(<ExportScreen />);
+    const startBtn = screen.getByRole('button', {
+      name: /書き出し開始/,
+    }) as HTMLButtonElement;
+    expect(startBtn.disabled).toBe(true);
+  });
+
+  // 2026-04-25 修正: preview で m.edited.end_time を変更したとき、export 一覧
+  // の duration 表示が再計算された値に更新される (古い m.duration_display を
+  // 表示し続けない)。
+  it('recomputes list duration display from m.edited (boundary reflection)', () => {
+    const meta = useMetadataStore.getState().metadata!;
+    // sample match 1: start=0, end=915.5, duration_display="15m15s"
+    // edited で end を 605 に変更 → 期待 duration "10m05s"
+    const edited = {
+      ...meta,
+      matches: meta.matches.map((m, i) =>
+        i === 0
+          ? { ...m, edited: { start_time: 0, end_time: 605 } }
+          : m,
+      ),
+    };
+    useMetadataStore.setState({ metadata: edited });
+    render(<ExportScreen />);
+    // 一覧の match_001 の duration が edited を反映している
+    expect(screen.getByText('10m05s')).toBeInTheDocument();
+    // 他の match (例: index 2) は edited なしなので元の値が出る
+    expect(screen.getByText('15m59s')).toBeInTheDocument();
+    // 元の値 "15m15s" は表示されていない (置換された)
+    expect(screen.queryByText('15m15s')).not.toBeInTheDocument();
+  });
+
   it('errors surface as export-progress events update list items', async () => {
     let progressHandler: ((e: {
       payload: {

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -21,7 +21,12 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
   open: openDialogMock,
 }));
 
-import { ExportScreen, deriveDefaultOutDir } from './ExportScreen';
+import {
+  ExportScreen,
+  deriveDefaultOutDir,
+  formatStartForFilename,
+  stripExtendedPathPrefix,
+} from './ExportScreen';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
 
@@ -52,6 +57,66 @@ describe('deriveDefaultOutDir', () => {
   it('returns empty string when videoSource is null or has no separator', () => {
     expect(deriveDefaultOutDir(null)).toBe('');
     expect(deriveDefaultOutDir('clip.mkv')).toBe('');
+  });
+
+  // #545 review #2: extended-length path prefix を strip してから derive
+  it('strips Windows \\\\?\\ extended-length prefix before deriving', () => {
+    expect(deriveDefaultOutDir('\\\\?\\E:\\videos\\clip.mkv')).toBe(
+      'E:\\videos\\output',
+    );
+    expect(deriveDefaultOutDir('\\\\?\\C:\\foo\\bar.mp4')).toBe('C:\\foo\\output');
+  });
+
+  it('strips Windows \\\\?\\UNC\\ prefix to UNC form', () => {
+    expect(
+      deriveDefaultOutDir('\\\\?\\UNC\\server\\share\\clip.mkv'),
+    ).toBe('\\\\server\\share\\output');
+  });
+});
+
+// #545 review #2: extended-length path prefix strip helper
+describe('stripExtendedPathPrefix', () => {
+  it('strips \\\\?\\ from drive-letter paths', () => {
+    expect(stripExtendedPathPrefix('\\\\?\\C:\\foo')).toBe('C:\\foo');
+    expect(stripExtendedPathPrefix('\\\\?\\E:\\videos\\x.mkv')).toBe(
+      'E:\\videos\\x.mkv',
+    );
+  });
+
+  it('converts \\\\?\\UNC\\ to \\\\ form', () => {
+    expect(stripExtendedPathPrefix('\\\\?\\UNC\\server\\share\\foo')).toBe(
+      '\\\\server\\share\\foo',
+    );
+  });
+
+  it('passes through paths without the prefix', () => {
+    expect(stripExtendedPathPrefix('C:\\foo')).toBe('C:\\foo');
+    expect(stripExtendedPathPrefix('/home/user/file')).toBe('/home/user/file');
+    expect(stripExtendedPathPrefix('')).toBe('');
+  });
+});
+
+// #545 review #8: filename `{start}` の HH-MM format helper
+describe('formatStartForFilename', () => {
+  it('formats sub-hour seconds as MM-SS', () => {
+    expect(formatStartForFilename(0)).toBe('00-00');
+    expect(formatStartForFilename(49)).toBe('00-49');
+    expect(formatStartForFilename(60)).toBe('01-00');
+    expect(formatStartForFilename(915.5)).toBe('15-15');
+  });
+
+  it('formats hour-plus seconds as H-MM-SS', () => {
+    expect(formatStartForFilename(3600)).toBe('1-00-00');
+    expect(formatStartForFilename(5021.5)).toBe('1-23-41');
+  });
+
+  it('clamps NaN / negative to 0', () => {
+    expect(formatStartForFilename(Number.NaN)).toBe('00-00');
+    expect(formatStartForFilename(-1)).toBe('00-00');
+  });
+
+  it('truncates fractional seconds (floor semantics)', () => {
+    expect(formatStartForFilename(59.9)).toBe('00-59');
   });
 });
 
@@ -354,6 +419,123 @@ describe('ExportScreen (Phase 4 #466)', () => {
     expect(screen.getByText('15m59s')).toBeInTheDocument();
     // 元の値 "15m15s" は表示されていない (置換された)
     expect(screen.queryByText('15m15s')).not.toBeInTheDocument();
+  });
+
+  // #545 review #3: 全選択 / 全解除トグル
+  it('「全解除」 unchecks every match; 「全選択」 re-checks all', async () => {
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    expect(screen.getByText(/9 試合を書き出す/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'deselect all matches' }));
+    expect(screen.getByText(/0 試合を書き出す/)).toBeInTheDocument();
+    // 全 checkbox が unchecked
+    for (let i = 1; i <= 9; i++) {
+      const cb = screen.getByLabelText(`include match ${i}`) as HTMLInputElement;
+      expect(cb.checked).toBe(false);
+    }
+    await user.click(screen.getByRole('button', { name: 'select all matches' }));
+    expect(screen.getByText(/9 試合を書き出す/)).toBeInTheDocument();
+  });
+
+  it('全選択 / 全解除 buttons disable while running', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'export_match') return new Promise(() => undefined);
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('running');
+    });
+    expect(
+      (screen.getByRole('button', { name: 'select all matches' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole('button', { name: 'deselect all matches' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  // #545 review #6: フォルダを開くは open_folder_in_explorer (独自 Rust
+  // command) を invoke する。`plugin:shell|open` は使わない (default scope の
+  // URL regex で reject されるため)。
+  it('completed [フォルダを開く] invokes open_folder_in_explorer with outDir', async () => {
+    invokeMock.mockImplementation((cmd: string, args: unknown) => {
+      if (cmd === 'export_match') {
+        const a = args as { matchIndex: number; outputPath: string };
+        return Promise.resolve({
+          match_index: a.matchIndex,
+          output_path: a.outputPath,
+          duration_ms: 100,
+        });
+      }
+      if (cmd === 'open_folder_in_explorer') return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('completed');
+    });
+    await user.click(screen.getByRole('button', { name: /フォルダを開く/ }));
+    expect(invokeMock).toHaveBeenCalledWith('open_folder_in_explorer', {
+      path: expect.any(String),
+    });
+    // shell.open は呼ばれていない
+    expect(
+      invokeMock.mock.calls.some((c) => c[0] === 'plugin:shell|open'),
+    ).toBe(false);
+  });
+
+  // #545 review #4: エラー時のボタンは「設定変更して再試行」(旧「閉じる」)。
+  // クリックで idle に戻り、再度書き出し可能。
+  it('error phase shows 「設定変更して再試行」 button that returns to idle', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'export_match') return Promise.reject(new Error('boom'));
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('error');
+    });
+    expect(
+      screen.queryByRole('button', { name: '閉じる' }),
+    ).not.toBeInTheDocument();
+    const retryBtn = screen.getByRole('button', {
+      name: /設定変更して再試行/,
+    });
+    await user.click(retryBtn);
+    expect(screen.getByTestId('export-screen').dataset.phase).toBe('idle');
+  });
+
+  // #545 review #7: 進捗バー直下に「経過 0:00 / 残り —」が出る (running 中)。
+  // 完了後は両方の表示が残るが setInterval は止まる。
+  it('shows elapsed / remaining time line during running', async () => {
+    invokeMock.mockImplementation((cmd: string, args: unknown) => {
+      if (cmd === 'export_match') {
+        const a = args as { matchIndex: number; outputPath: string };
+        return Promise.resolve({
+          match_index: a.matchIndex,
+          output_path: a.outputPath,
+          duration_ms: 100,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('completed');
+    });
+    // 「経過」「残り」ラベルが両方表示されている (running 後 completed まで)
+    expect(screen.getByText(/経過/)).toBeInTheDocument();
+    expect(screen.getByText(/残り/)).toBeInTheDocument();
   });
 
   it('errors surface as export-progress events update list items', async () => {

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
   open: openDialogMock,
 }));
 
-import { ExportScreen } from './ExportScreen';
+import { ExportScreen, deriveDefaultOutDir } from './ExportScreen';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
 
@@ -37,6 +37,22 @@ beforeEach(() => {
   useMetadataStore.getState().loadSample();
   useMetadataStore.setState({ filePath: '/tmp/x/metadata.json' });
   useAppStateStore.getState().navigate('export');
+});
+
+// #466 review #2: default 出力先生成ヘルパ
+describe('deriveDefaultOutDir', () => {
+  it('appends /output to the parent dir of a forward-slash video path', () => {
+    expect(deriveDefaultOutDir('E:/videos/clip.mkv')).toBe('E:/videos/output');
+  });
+
+  it('appends \\output to the parent dir of a backslash video path', () => {
+    expect(deriveDefaultOutDir('E:\\videos\\clip.mkv')).toBe('E:\\videos\\output');
+  });
+
+  it('returns empty string when videoSource is null or has no separator', () => {
+    expect(deriveDefaultOutDir(null)).toBe('');
+    expect(deriveDefaultOutDir('clip.mkv')).toBe('');
+  });
 });
 
 describe('ExportScreen (Phase 4 #466)', () => {
@@ -173,6 +189,93 @@ describe('ExportScreen (Phase 4 #466)', () => {
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith('kill_tracked_processes');
     });
+  });
+
+  // #466 review #7: preview で調整した境界 (m.edited.start_time / end_time)
+  // が export_match の startSeconds / endSeconds に正しく渡される。
+  it('passes m.edited.start_time / end_time to export_match (boundary propagation)', async () => {
+    // sample の match 1 に edited 境界を設定
+    const meta = useMetadataStore.getState().metadata!;
+    const edited = {
+      ...meta,
+      matches: meta.matches.map((m, i) =>
+        i === 0
+          ? { ...m, edited: { start_time: 5.5, end_time: 12.25 } }
+          : m,
+      ),
+    };
+    useMetadataStore.setState({ metadata: edited });
+
+    invokeMock.mockImplementation((cmd: string, args: unknown) => {
+      if (cmd === 'export_match') {
+        const a = args as { matchIndex: number; outputPath: string };
+        return Promise.resolve({
+          match_index: a.matchIndex,
+          output_path: a.outputPath,
+          duration_ms: 100,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('completed');
+    });
+    const calls = invokeMock.mock.calls.filter((c) => c[0] === 'export_match');
+    const m1Call = calls.find(
+      (c) => (c[1] as { matchIndex: number }).matchIndex === 1,
+    );
+    expect(m1Call).toBeDefined();
+    expect(m1Call![1]).toMatchObject({
+      startSeconds: 5.5,
+      endSeconds: 12.25,
+    });
+    // ほかの match (例: index 2) は edited なしなので元の start/end を使う
+    const m2Call = calls.find(
+      (c) => (c[1] as { matchIndex: number }).matchIndex === 2,
+    );
+    const m2 = edited.matches.find((m) => m.index === 2)!;
+    expect(m2Call![1]).toMatchObject({
+      startSeconds: m2.start_time,
+      endSeconds: m2.end_time,
+    });
+  });
+
+  // #466 review #1: per-match include/exclude checkbox (ad-hoc UI 選択)
+  it('excludes a match from export when its checkbox is unchecked', async () => {
+    invokeMock.mockImplementation((cmd: string, args: unknown) => {
+      if (cmd === 'export_match') {
+        const a = args as { matchIndex: number; outputPath: string };
+        return Promise.resolve({
+          match_index: a.matchIndex,
+          output_path: a.outputPath,
+          duration_ms: 100,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    // match 3 の checkbox を uncheck (ad-hoc exclude)
+    const checkbox3 = screen.getByLabelText('include match 3') as HTMLInputElement;
+    expect(checkbox3.checked).toBe(true);
+    await user.click(checkbox3);
+    expect(checkbox3.checked).toBe(false);
+
+    // 全試合書き出しヘッダ表示が 9 → 8 に減る
+    expect(screen.getByText(/8 試合を書き出す/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('export-screen').dataset.phase).toBe('completed');
+    });
+    const calls = invokeMock.mock.calls.filter((c) => c[0] === 'export_match');
+    expect(calls.length).toBe(8); // 9 sample matches - 1 excluded
+    expect(
+      calls.some((c) => (c[1] as { matchIndex: number }).matchIndex === 3),
+    ).toBe(false);
   });
 
   it('errors surface as export-progress events update list items', async () => {

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -11,11 +11,11 @@ const { invokeMock, listenMock, openDialogMock } = vi.hoisted(() => ({
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: invokeMock,
 }));
+// listenMock の戻り値を尊重する mock。デフォルトの unlisten fn は
+// `beforeEach` で default 設定する (互換性維持)。個別 test で
+// `mockResolvedValueOnce(spy)` すると spy 経由で unlisten 確認できる。
 vi.mock('@tauri-apps/api/event', () => ({
-  listen: (...args: unknown[]) => {
-    listenMock(...args);
-    return Promise.resolve(() => undefined);
-  },
+  listen: (...args: unknown[]) => listenMock(...args),
 }));
 vi.mock('@tauri-apps/plugin-dialog', () => ({
   open: openDialogMock,
@@ -36,6 +36,10 @@ beforeEach(() => {
   // Default: any invoke resolves with undefined; the per-test callers
   // override `export_match` / `kill_tracked_processes` as needed.
   invokeMock.mockResolvedValue(undefined);
+  // Default: listen() returns a no-op unlisten function. 個別 test で
+  // `mockResolvedValueOnce(spy)` すると 1 回だけ override できる
+  // (mystifying-ptolemy-d112b5 review)。
+  listenMock.mockResolvedValue(() => undefined);
   useAppStateStore.getState().reset();
   useMetadataStore.getState().clear();
   useMetadataStore.getState().loadSample();
@@ -122,6 +126,35 @@ describe('ExportScreen (Phase 4 #466)', () => {
         expect.any(Function),
       );
     });
+  });
+
+  // #545 mystifying-ptolemy-d112b5 review (2026-04-25): unmount 時に
+  // listen() が返す unlisten 関数が呼ばれることをガード。漏れると memory
+  // leak / 二重イベント購読 (画面遷移を繰り返したとき) を招く。
+  it('calls the unlisten fn returned by listen on unmount', async () => {
+    const unlistenSpy = vi.fn();
+    // 1 回だけ unlistenSpy を返すよう listen mock を上書き
+    listenMock.mockResolvedValueOnce(unlistenSpy);
+    const { unmount } = render(<ExportScreen />);
+    // listen が登録されるのを待つ (subscribe は async)
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalledWith(
+        'export-progress',
+        expect.any(Function),
+      );
+    });
+    // useEffect 内の async IIFE で `unlisten = await listen(...)` が完了
+    // するまで microtask 1 step 待つ。これをしないと unmount の cleanup
+    // 時点で unlisten=null のまま return されることがある。
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(unlistenSpy).not.toHaveBeenCalled();
+    // unmount → useEffect cleanup が走る
+    act(() => {
+      unmount();
+    });
+    expect(unlistenSpy).toHaveBeenCalledTimes(1);
   });
 
   it('[◀ プレビュー] returns to preview when idle', async () => {

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -25,7 +25,6 @@ import {
   ExportScreen,
   deriveDefaultOutDir,
   formatStartForFilename,
-  stripExtendedPathPrefix,
 } from './ExportScreen';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
@@ -74,27 +73,7 @@ describe('deriveDefaultOutDir', () => {
   });
 });
 
-// #545 review #2: extended-length path prefix strip helper
-describe('stripExtendedPathPrefix', () => {
-  it('strips \\\\?\\ from drive-letter paths', () => {
-    expect(stripExtendedPathPrefix('\\\\?\\C:\\foo')).toBe('C:\\foo');
-    expect(stripExtendedPathPrefix('\\\\?\\E:\\videos\\x.mkv')).toBe(
-      'E:\\videos\\x.mkv',
-    );
-  });
-
-  it('converts \\\\?\\UNC\\ to \\\\ form', () => {
-    expect(stripExtendedPathPrefix('\\\\?\\UNC\\server\\share\\foo')).toBe(
-      '\\\\server\\share\\foo',
-    );
-  });
-
-  it('passes through paths without the prefix', () => {
-    expect(stripExtendedPathPrefix('C:\\foo')).toBe('C:\\foo');
-    expect(stripExtendedPathPrefix('/home/user/file')).toBe('/home/user/file');
-    expect(stripExtendedPathPrefix('')).toBe('');
-  });
-});
+// stripExtendedPathPrefix の単体テストは utils/path.test.ts に移動済。
 
 // #545 review #8: filename `{start}` の HH-MM format helper
 describe('formatStartForFilename', () => {

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -343,21 +343,38 @@ export function ExportScreen() {
   const errorCount = countedMatches.filter(
     (m) => matchStates[m.index]?.status === 'error',
   ).length;
+  // #545 review #7 / 5 回目テスト #4 (2026-04-25):
+  // 旧実装は `doneCount / total * 100` で「完了ファイル数のみ」ベースだった
+  // ため、1 ファイル目 encode 中は overall progress が 0% 固定で動かず、
+  // 「左下の進捗バーが機能していない」というユーザー体験になっていた。
+  // ffmpeg は `out_time_ms` を 1 秒間隔で emit するので Rust 側から
+  // export-progress event の `percent` (per-file %) が届く。これを overall
+  // に合算して滑らかに動かす。
+  const totalPercentSum = countedMatches.reduce((acc, m) => {
+    const s = matchStates[m.index];
+    if (!s) return acc;
+    if (s.status === 'done') return acc + 100;
+    if (s.status === 'running') return acc + s.percent;
+    // pending / skipped / error は 0 として扱う
+    return acc;
+  }, 0);
   const overallPercent = countedMatches.length === 0
     ? 0
-    : Math.round((doneCount / countedMatches.length) * 100);
+    : Math.round(totalPercentSum / countedMatches.length);
 
-  // #545 review #7: 経過 / 残り時間 (秒)。
+  // #545 review #7 / 5 回目テスト #4: 経過 / 残り時間 (秒)。
   // - 経過: `nowMs - exportStartMs` (running 中は 1s tick で更新)
-  // - 残り: `(elapsed / done) * remaining` の線形推定。done=0 のとき null
-  //   (= 表示は `—`)。完了 / 中断時も null。
+  // - 残り: `(elapsed / progress) * remaining` の線形推定。progress は
+  //   per-file 進捗込みの fractional unit (0..countedMatches.length)。
+  //   進捗 0 のとき null (= 表示は `—`)、完了 / 中断時も null。
   const elapsedSec =
     exportStartMs === null ? null : Math.max(0, (nowMs - exportStartMs) / 1000);
-  const remainingCount = Math.max(0, countedMatches.length - doneCount);
+  const totalProgressUnits = totalPercentSum / 100;
+  const remainingUnits = Math.max(0, countedMatches.length - totalProgressUnits);
   const remainingSec =
-    !running || elapsedSec === null || doneCount === 0
+    !running || elapsedSec === null || totalProgressUnits === 0
       ? null
-      : (elapsedSec / doneCount) * remainingCount;
+      : (elapsedSec / totalProgressUnits) * remainingUnits;
 
   return (
     <div className={styles.screen} data-testid="export-screen" data-phase={phase}>

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -5,7 +5,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
-import { stripExtendedPathPrefix } from '../utils/path';
+import { joinPath, stripExtendedPathPrefix } from '../utils/path';
 import { fmtMatchDuration, fmtTime } from '../utils/time';
 import { exportReducer } from './reducers/export';
 import type { ExportPhase } from './types';
@@ -717,13 +717,6 @@ export function formatStartForFilename(seconds: number): string {
     return `${h}-${String(m).padStart(2, '0')}-${String(s).padStart(2, '0')}`;
   }
   return `${String(m).padStart(2, '0')}-${String(s).padStart(2, '0')}`;
-}
-
-function joinPath(dir: string, name: string): string {
-  const separator =
-    dir.includes('\\') && !dir.includes('/') ? '\\' : '/';
-  if (dir.endsWith('/') || dir.endsWith('\\')) return dir + name;
-  return dir + separator + name;
 }
 
 /**

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -5,6 +5,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
+import { stripExtendedPathPrefix } from '../utils/path';
 import { fmtMatchDuration, fmtTime } from '../utils/time';
 import { exportReducer } from './reducers/export';
 import type { ExportPhase } from './types';
@@ -709,34 +710,14 @@ function joinPath(dir: string, name: string): string {
 }
 
 /**
- * Windows の extended-length path prefix (`\\?\`) を取り除く。
- *
- * Tauri の dialog::open() / drag-drop は Windows 上で `\\?\` 付き path を
- * 返すことがあり、そのまま UI に表示すると一般的な `E:\videos\...` 表記
- * との一貫性が崩れる。ffmpeg や Win32 API は両形式を解釈できるが、UI 表示
- * 側で正規化するのがユーザー体験的に望ましいため、deriveDefaultOutDir で
- * 親 dir を切り出す前に strip する (#545 review #2、2026-04-25)。
- *
- * - `\\?\C:\foo` → `C:\foo`
- * - `\\?\UNC\server\share` → `\\server\share`
- * - prefix なしの path は素通し
- */
-export function stripExtendedPathPrefix(p: string): string {
-  if (p.startsWith('\\\\?\\UNC\\')) {
-    return '\\\\' + p.slice('\\\\?\\UNC\\'.length);
-  }
-  if (p.startsWith('\\\\?\\')) {
-    return p.slice('\\\\?\\'.length);
-  }
-  return p;
-}
-
-/**
  * #466 review #2: source video の親ディレクトリ + `/output` を default に。
  * `videoSource` から `dirname` 相当を抽出する (Windows は `\\` も許容)。
  *
  * #545 review #2 (2026-04-25): Windows の `\\?\` extended-length path prefix
- * は UI 表示用に取り除く。
+ * は `stripExtendedPathPrefix` で取り除いてから親 dir を切り出す。
+ * (なお Tauri 側からの flow としては `appStateStore.setSelectedVideoPath`
+ * が pipeline 上の strip ポイントなので通常 prefix は来ないが、defense-in-depth
+ * として deriveDefaultOutDir 内でも適用しておく。)
  */
 export function deriveDefaultOutDir(videoSource: string | null): string {
   if (!videoSource) return '';

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -1,15 +1,13 @@
 import { invoke } from '@tauri-apps/api/core';
-import { useEffect, useReducer, useState } from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
-import { fmtTime } from '../utils/time';
 import { exportReducer } from './reducers/export';
 import type { ExportPhase } from './types';
 import styles from './ExportScreen.module.css';
-
-const TICK_MS = 80;
-const TICKS_TO_COMPLETE = 100;
 
 type Codec = 'copy' | 'h264';
 
@@ -18,65 +16,180 @@ const CODECS: { v: Codec; l: string; sub: string }[] = [
   { v: 'h264', l: 'H.264 再エンコード', sub: '遅い / 正確な秒指定' },
 ];
 
+type MatchStatus = 'pending' | 'running' | 'done' | 'error' | 'skipped';
+
+interface MatchState {
+  status: MatchStatus;
+  percent: number;
+  error?: string;
+  outputPath?: string;
+}
+
+interface ExportProgressPayload {
+  match_index: number;
+  percent: number;
+  stage: 'encoding' | 'done' | 'error';
+  message?: string;
+}
+
+interface ExportResult {
+  match_index: number;
+  output_path: string;
+  duration_ms: number;
+}
+
 /**
- * Phase 2 export screen. UI skeleton + dummy progress interval.
- * Phase 4 (#466) replaces the dummy interval with real ffmpeg invocation via
- * a tauri command, keeping the reducer events the same.
- *
- * Shell.open (used by [✓ フォルダを開く]) is invoked through the tauri-plugin-shell
- * permission already declared in capabilities/default.json.
+ * #466 Phase 4 export screen. Real ffmpeg invocation driven by the Rust
+ * `export_match` command; per-match progress arrives via the
+ * `export-progress` Tauri event.
  */
 export function ExportScreen() {
   const metadata = useMetadataStore((s) => s.metadata);
+  const filePath = useMetadataStore((s) => s.filePath);
   const navigate = useAppStateStore((s) => s.navigate);
 
   const [phase, dispatch] = useReducer(exportReducer, 'idle' as ExportPhase);
   const [outDir, setOutDir] = useState('./output');
   const [codec, setCodec] = useState<Codec>('copy');
   const [namePattern, setNamePattern] = useState('match_{idx:03}.mp4');
-  const [progress, setProgress] = useState(0);
+  const [matchStates, setMatchStates] = useState<Record<number, MatchState>>({});
+  const cancelRequestedRef = useRef(false);
 
-  // dummy progress interval
+  // #466 -- listen for per-match progress updates emitted by Rust.
   useEffect(() => {
-    if (phase !== 'running') return;
-    const iv = setInterval(() => {
-      setProgress((p) => {
-        const next = p + 100 / TICKS_TO_COMPLETE;
-        if (next >= 100) {
-          clearInterval(iv);
-          dispatch({ type: 'PROGRESS_COMPLETE' });
-          return 100;
-        }
-        return next;
+    let unlisten: UnlistenFn | null = null;
+    (async () => {
+      unlisten = await listen<ExportProgressPayload>('export-progress', (event) => {
+        const p = event.payload;
+        setMatchStates((prev) => {
+          const prior = prev[p.match_index] ?? {
+            status: 'pending' as MatchStatus,
+            percent: 0,
+          };
+          let status: MatchStatus = prior.status;
+          if (p.stage === 'encoding') status = 'running';
+          else if (p.stage === 'done') status = 'done';
+          else if (p.stage === 'error') status = 'error';
+          return {
+            ...prev,
+            [p.match_index]: {
+              ...prior,
+              status,
+              percent: p.percent,
+              error: p.stage === 'error' ? p.message : prior.error,
+            },
+          };
+        });
       });
-    }, TICK_MS);
-    return () => clearInterval(iv);
-  }, [phase]);
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, []);
 
-  // cancelling auto-confirms (no real ffmpeg in Phase 2); Phase 4 #523 will
-  // replace this with an async process.kill() before dispatching CANCEL_CONFIRMED.
+  function formatName(index: number, type: string, startSec: number): string {
+    const startDisplay = Math.floor(startSec)
+      .toString()
+      .padStart(4, '0');
+    const today = new Date().toISOString().slice(0, 10);
+    return namePattern
+      .replace(/\{idx:03\}/g, String(index).padStart(3, '0'))
+      .replace(/\{idx\}/g, String(index))
+      .replace(/\{type\}/g, type)
+      .replace(/\{start\}/g, startDisplay)
+      .replace(/\{date\}/g, today);
+  }
+
+  async function handlePickDir() {
+    const picked = await openDialog({ directory: true, multiple: false });
+    if (typeof picked === 'string') {
+      setOutDir(picked);
+    }
+  }
+
+  async function handleStartExport() {
+    if (!metadata || !filePath) return;
+    cancelRequestedRef.current = false;
+
+    // Resolve source video path from metadata.source. Fall back to whatever
+    // is there; Rust side validates existence.
+    const videoSource = metadata.source;
+
+    // Initialize per-match state (skip entries explicitly marked as skip).
+    const nextStates: Record<number, MatchState> = {};
+    const queue: typeof metadata.matches = [];
+    for (const m of metadata.matches) {
+      if (m.type_override === 'skip') {
+        nextStates[m.index] = { status: 'skipped', percent: 0 };
+      } else {
+        nextStates[m.index] = { status: 'pending', percent: 0 };
+        queue.push(m);
+      }
+    }
+    setMatchStates(nextStates);
+    dispatch({ type: 'START_CLICKED' });
+
+    let successCount = 0;
+    let failureCount = 0;
+    for (const m of queue) {
+      if (cancelRequestedRef.current) break;
+      const name = formatName(m.index, m.type, m.edited?.start_time ?? m.start_time);
+      const outputPath = joinPath(outDir, name);
+      try {
+        const result = await invoke<ExportResult>('export_match', {
+          videoPath: videoSource,
+          startSeconds: m.edited?.start_time ?? m.start_time,
+          endSeconds: m.edited?.end_time ?? m.end_time,
+          outputPath,
+          codec,
+          matchIndex: m.index,
+        });
+        successCount += 1;
+        setMatchStates((prev) => ({
+          ...prev,
+          [m.index]: {
+            status: 'done',
+            percent: 100,
+            outputPath: result.output_path,
+          },
+        }));
+      } catch (e) {
+        failureCount += 1;
+        const msg = e instanceof Error ? e.message : String(e);
+        setMatchStates((prev) => ({
+          ...prev,
+          [m.index]: { status: 'error', percent: 0, error: msg },
+        }));
+      }
+    }
+
+    if (cancelRequestedRef.current) {
+      dispatch({ type: 'CANCEL_CONFIRMED' });
+    } else if (successCount === 0 && failureCount > 0) {
+      // Zero matches finished -- surface the error phase. If at least one
+      // match succeeded we declare the run "completed" and keep per-match
+      // errors inline for the user to review.
+      dispatch({ type: 'EXPORT_ERROR' });
+    } else {
+      dispatch({ type: 'PROGRESS_COMPLETE' });
+    }
+  }
+
   function handleCancelClicked() {
+    cancelRequestedRef.current = true;
     dispatch({ type: 'CANCEL_CLICKED' });
-    setProgress(0);
-    dispatch({ type: 'CANCEL_CONFIRMED' });
+    // #523: kill any tracked ffmpeg child so the current export can't run
+    // to completion after the user asked to stop.
+    void invoke('kill_tracked_processes').catch(() => undefined);
   }
 
   async function handleOpenFolder() {
     try {
       await invoke('plugin:shell|open', { path: outDir });
     } catch {
-      // fallback — in tests / non-tauri env the invoke call will be mocked
+      // non-tauri test env: swallow
     }
     navigate('complete');
-  }
-
-  function formatName(index: number, type: string): string {
-    return namePattern
-      .replace('{idx:03}', String(index).padStart(3, '0'))
-      .replace('{idx}', String(index))
-      .replace('{type}', type)
-      .replace('{start}', String(index))
-      .replace('{date}', '2026-04-08');
   }
 
   if (!metadata) {
@@ -90,6 +203,20 @@ export function ExportScreen() {
   const running = phase === 'running';
   const completed = phase === 'completed';
   const error = phase === 'error';
+  const cancelling = phase === 'cancelling';
+
+  const countedMatches = metadata.matches.filter(
+    (m) => m.type_override !== 'skip',
+  );
+  const doneCount = countedMatches.filter(
+    (m) => matchStates[m.index]?.status === 'done',
+  ).length;
+  const errorCount = countedMatches.filter(
+    (m) => matchStates[m.index]?.status === 'error',
+  ).length;
+  const overallPercent = countedMatches.length === 0
+    ? 0
+    : Math.round((doneCount / countedMatches.length) * 100);
 
   return (
     <div className={styles.screen} data-testid="export-screen" data-phase={phase}>
@@ -97,7 +224,7 @@ export function ExportScreen() {
         <button
           type="button"
           className={styles.backButton}
-          disabled={running || phase === 'cancelling'}
+          disabled={running || cancelling}
           onClick={() => navigate('preview')}
         >
           ◀ プレビュー
@@ -105,7 +232,7 @@ export function ExportScreen() {
         <div>
           <div className={styles.caption}>エクスポート</div>
           <div className={styles.title}>
-            {metadata.matches.length} 試合を書き出す
+            {countedMatches.length} 試合を書き出す
           </div>
         </div>
       </div>
@@ -122,8 +249,14 @@ export function ExportScreen() {
                 value={outDir}
                 onChange={(e) => setOutDir(e.target.value)}
                 aria-label="output directory"
+                disabled={running || cancelling}
               />
-              <button type="button" className={styles.pickButton}>
+              <button
+                type="button"
+                className={styles.pickButton}
+                onClick={handlePickDir}
+                disabled={running || cancelling}
+              >
                 参照…
               </button>
             </div>
@@ -136,6 +269,7 @@ export function ExportScreen() {
               value={namePattern}
               onChange={(e) => setNamePattern(e.target.value)}
               aria-label="name pattern"
+              disabled={running || cancelling}
             />
             <div className={styles.nameHint}>
               変数: {'{idx}'} {'{idx:03}'} {'{start}'} {'{type}'} {'{date}'}
@@ -151,6 +285,7 @@ export function ExportScreen() {
                   type="button"
                   aria-pressed={codec === c.v}
                   onClick={() => setCodec(c.v)}
+                  disabled={running || cancelling}
                   className={`${styles.codecButton}${codec === c.v ? ` ${styles.codecButtonActive}` : ''}`}
                 >
                   <div className={styles.codecLabel}>{c.l}</div>
@@ -163,38 +298,36 @@ export function ExportScreen() {
           <div className={styles.bottomActions}>
             {error && (
               <div className={styles.errorMessage} role="alert">
-                書き出しに失敗しました (Phase 2 dummy)
+                すべての試合の書き出しが失敗しました
               </div>
             )}
-
-            {(running || completed) && (
+            {(running || completed || cancelling) && (
               <div className={styles.progressBox}>
                 <div className={styles.progressHeader}>
                   <span className={styles.progressLabel}>
-                    {running ? '分割・書き出し中' : '完了'}
+                    {running
+                      ? '分割・書き出し中'
+                      : cancelling
+                        ? '中断中…'
+                        : '完了'}
                   </span>
                   <span>
-                    {Math.min(
-                      metadata.matches.length,
-                      Math.floor(
-                        (progress / 100) * metadata.matches.length,
-                      ) + (running ? 1 : 0),
-                    )}{' '}
-                    / {metadata.matches.length} files
-                    <span style={{ marginLeft: 12 }}>
-                      {Math.round(progress)}%
-                    </span>
+                    {doneCount} / {countedMatches.length} files
+                    {errorCount > 0 && (
+                      <span
+                        style={{ marginLeft: 8, color: 'var(--ae-danger)' }}
+                      >
+                        ({errorCount} 失敗)
+                      </span>
+                    )}
+                    <span style={{ marginLeft: 12 }}>{overallPercent}%</span>
                   </span>
                 </div>
                 <div className={styles.progressBar}>
                   <div
                     className={`${styles.progressFill}${completed ? ` ${styles.progressFillDone}` : ''}`}
-                    style={{ width: `${progress}%` }}
+                    style={{ width: `${overallPercent}%` }}
                   />
-                </div>
-                <div className={styles.progressHeader}>
-                  <span>経過 {fmtTime(progress * 1.2)}</span>
-                  <span>残り {running ? fmtTime((100 - progress) * 1.2) : '—'}</span>
                 </div>
               </div>
             )}
@@ -204,14 +337,13 @@ export function ExportScreen() {
                 type="button"
                 className={styles.primaryButton}
                 onClick={() => {
-                  setProgress(0);
-                  dispatch({ type: 'START_CLICKED' });
+                  void handleStartExport();
                 }}
-                disabled={running || phase === 'cancelling'}
+                disabled={running || cancelling || !filePath}
               >
                 {running
                   ? '書き出し中…'
-                  : phase === 'cancelling'
+                  : cancelling
                     ? '中断中…'
                     : '⬦ 書き出し開始'}
               </button>
@@ -231,17 +363,21 @@ export function ExportScreen() {
               <button
                 type="button"
                 className={styles.primaryButton}
-                onClick={handleOpenFolder}
+                onClick={() => {
+                  void handleOpenFolder();
+                }}
               >
                 ✓ 完了 — フォルダを開く
               </button>
             )}
-
             {completed && (
               <button
                 type="button"
                 className={styles.cancelButton}
-                onClick={() => dispatch({ type: 'RESTART' })}
+                onClick={() => {
+                  setMatchStates({});
+                  dispatch({ type: 'RESTART' });
+                }}
               >
                 もう一度書き出す
               </button>
@@ -261,37 +397,59 @@ export function ExportScreen() {
 
         <div className={styles.listPanel}>
           <div className={styles.listCaption}>
-            書き出し一覧 ⸱ {metadata.matches.length} ファイル
+            書き出し一覧 ⸱ {countedMatches.length} ファイル
           </div>
           <ul className={styles.listBody}>
             {metadata.matches.map((m) => {
-              const pct = running
-                ? Math.max(
-                    0,
-                    Math.min(100, progress - (m.index - 1) * (100 / metadata.matches.length)),
-                  )
-                : completed
-                  ? 100
-                  : 0;
-              const done = (running || completed) && pct >= 100;
+              const s = matchStates[m.index] ?? {
+                status: 'pending' as MatchStatus,
+                percent: 0,
+              };
+              const name = formatName(
+                m.index,
+                m.type,
+                m.edited?.start_time ?? m.start_time,
+              );
+              const mark =
+                s.status === 'done'
+                  ? '✓'
+                  : s.status === 'running'
+                    ? '●'
+                    : s.status === 'error'
+                      ? '!'
+                      : s.status === 'skipped'
+                        ? '—'
+                        : '○';
+              const markClass =
+                s.status === 'done'
+                  ? styles.listMarkDone
+                  : s.status === 'error'
+                    ? styles.listMarkError
+                    : '';
               return (
                 <li key={m.index} className={styles.listItem}>
-                  <span
-                    className={`${styles.listMark}${done ? ` ${styles.listMarkDone}` : ''}`}
-                  >
-                    {done ? '✓' : pct > 0 ? '●' : '○'}
+                  <span className={`${styles.listMark} ${markClass}`}>
+                    {mark}
                   </span>
-                  <span className={styles.listName}>
-                    {formatName(m.index, m.type)}
-                  </span>
+                  <span className={styles.listName}>{name}</span>
                   <span className={styles.listDur}>{m.duration_display}</span>
-                  {(running || completed) && (
+                  {(running ||
+                    completed ||
+                    s.status === 'done' ||
+                    s.status === 'error') && (
                     <div className={styles.listProgress}>
                       <div
-                        className={`${styles.listProgressFill}${done ? ` ${styles.listProgressFillDone}` : ''}`}
-                        style={{ width: `${pct}%` }}
+                        className={`${styles.listProgressFill}${
+                          s.status === 'done' ? ` ${styles.listProgressFillDone}` : ''
+                        }`}
+                        style={{ width: `${s.percent}%` }}
                       />
                     </div>
+                  )}
+                  {s.status === 'error' && s.error && (
+                    <span className={styles.listError} role="alert">
+                      {s.error.slice(0, 120)}
+                    </span>
                   )}
                 </li>
               );
@@ -301,4 +459,11 @@ export function ExportScreen() {
       </div>
     </div>
   );
+}
+
+function joinPath(dir: string, name: string): string {
+  const separator =
+    dir.includes('\\') && !dir.includes('/') ? '\\' : '/';
+  if (dir.endsWith('/') || dir.endsWith('\\')) return dir + name;
+  return dir + separator + name;
 }

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -42,18 +42,69 @@ interface ExportResult {
  * #466 Phase 4 export screen. Real ffmpeg invocation driven by the Rust
  * `export_match` command; per-match progress arrives via the
  * `export-progress` Tauri event.
+ *
+ * ## review 反映 (2026-04-25)
+ *
+ * - **#1**: per-match の include/exclude チェックボックス (ad-hoc)。
+ *   `excludedIndexes` ローカル state が制御。`type_override === 'skip'`
+ *   (preview で永続設定) は強制 disable で別軸。
+ * - **#2**: 出力先 default は `<dirname(videoSource)>/output`
+ *   ({@link deriveDefaultOutDir})。videoSource は
+ *   `selectedVideoPath ?? metadata.source`。
+ * - **#3**: 参照ボタンは `@tauri-apps/plugin-dialog` の `open({directory})`
+ *   経由 (`dialog:allow-open` permission を `capabilities/default.json` に
+ *   明示)。
+ * - **#4**: 出力先親ディレクトリが存在しない場合は Rust 側で error。以前の
+ *   `create_dir_all` (silent mkdir) は廃止 (タイポ事故防止)。
+ * - **#5**: 「フォルダを開く」は `shell.open` のみで完了画面に navigate
+ *   しない。失敗時は `openFolderError` で UI に表示。
+ * - **#6 (再書き出し)**: 「設定変更して再書き出し」は同じ metadata を別設定
+ *   (出力先 / 命名 / コーデック / 試合選択) で再実行する用途。既存ファイル
+ *   は ffmpeg `-y` で silent overwrite される。
+ * - **#7 (boundary)**: `m.edited?.start_time ?? m.start_time` を
+ *   `export_match` の `startSeconds` に渡す (`end_time` も同様)。preview で
+ *   調整した境界が export に反映される。
  */
 export function ExportScreen() {
   const metadata = useMetadataStore((s) => s.metadata);
   const filePath = useMetadataStore((s) => s.filePath);
   const navigate = useAppStateStore((s) => s.navigate);
 
+  // #466 review (C): drop で確定した実 path を最優先で使用する。sample mode
+  // (selectedVideoPath = null) では metadata.source にフォールバック。
+  const selectedVideoPath = useAppStateStore((s) => s.selectedVideoPath);
+  const videoSource = selectedVideoPath ?? metadata?.source ?? null;
+
   const [phase, dispatch] = useReducer(exportReducer, 'idle' as ExportPhase);
-  const [outDir, setOutDir] = useState('./output');
+  // #466 review #2: default 出力先は source video の親ディレクトリ +
+  // `/output`。ファイルピックなしで動かしても物が散らばらない場所に出る。
+  // videoSource が無い場合 (sample mode で何も load してない等) は空文字列
+  // にしておき、ユーザーに必須選択させる。
+  const [outDir, setOutDir] = useState<string>(() => deriveDefaultOutDir(videoSource));
   const [codec, setCodec] = useState<Codec>('copy');
   const [namePattern, setNamePattern] = useState('match_{idx:03}.mp4');
   const [matchStates, setMatchStates] = useState<Record<number, MatchState>>({});
+  // #466 review #1: per-match の選択 (default: 全選択 = 全試合書き出し)。
+  // ユーザーは個別行のチェックボックスで除外でき、「1 試合だけ書き出す」
+  // ような ad-hoc な選択も可能。type_override === 'skip' (preview で永続
+  // 設定済み) は強制 exclude (UI でも切替不可)。本 set は ad-hoc な exclude
+  // のみ追跡。
+  const [excludedIndexes, setExcludedIndexes] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
   const cancelRequestedRef = useRef(false);
+
+  function toggleMatchExclusion(matchIndex: number) {
+    setExcludedIndexes((prev) => {
+      const next = new Set(prev);
+      if (next.has(matchIndex)) {
+        next.delete(matchIndex);
+      } else {
+        next.add(matchIndex);
+      }
+      return next;
+    });
+  }
 
   // #466 -- listen for per-match progress updates emitted by Rust.
   useEffect(() => {
@@ -109,17 +160,15 @@ export function ExportScreen() {
 
   async function handleStartExport() {
     if (!metadata || !filePath) return;
+    if (!videoSource) return;
     cancelRequestedRef.current = false;
 
-    // Resolve source video path from metadata.source. Fall back to whatever
-    // is there; Rust side validates existence.
-    const videoSource = metadata.source;
-
-    // Initialize per-match state (skip entries explicitly marked as skip).
+    // Initialize per-match state. Skip = `type_override === 'skip'` (永続)
+    // または excludedIndexes に含まれる (ad-hoc UI 選択、#466 review #1)。
     const nextStates: Record<number, MatchState> = {};
     const queue: typeof metadata.matches = [];
     for (const m of metadata.matches) {
-      if (m.type_override === 'skip') {
+      if (m.type_override === 'skip' || excludedIndexes.has(m.index)) {
         nextStates[m.index] = { status: 'skipped', percent: 0 };
       } else {
         nextStates[m.index] = { status: 'pending', percent: 0 };
@@ -183,13 +232,19 @@ export function ExportScreen() {
     void invoke('kill_tracked_processes').catch(() => undefined);
   }
 
+  // #466 review #5: 旧実装は shell.open 後に navigate('complete') を必ず
+  // 呼んでおり、Explorer が開く前に画面遷移してしまう (実態として開いて
+  // いないように見える) 不具合があった。新実装は shell.open のみで
+  // 画面遷移は行わない。`完了` ステータスは画面に残す。
+  const [openFolderError, setOpenFolderError] = useState<string | null>(null);
+
   async function handleOpenFolder() {
+    setOpenFolderError(null);
     try {
       await invoke('plugin:shell|open', { path: outDir });
-    } catch {
-      // non-tauri test env: swallow
+    } catch (e) {
+      setOpenFolderError(e instanceof Error ? e.message : String(e));
     }
-    navigate('complete');
   }
 
   if (!metadata) {
@@ -205,8 +260,9 @@ export function ExportScreen() {
   const error = phase === 'error';
   const cancelling = phase === 'cancelling';
 
+  // #466 review #1: counted = 永続 skip 除外 + ad-hoc exclude 除外
   const countedMatches = metadata.matches.filter(
-    (m) => m.type_override !== 'skip',
+    (m) => m.type_override !== 'skip' && !excludedIndexes.has(m.index),
   );
   const doneCount = countedMatches.filter(
     (m) => matchStates[m.index]?.status === 'done',
@@ -370,16 +426,26 @@ export function ExportScreen() {
                 ✓ 完了 — フォルダを開く
               </button>
             )}
+            {completed && openFolderError && (
+              <div className={styles.errorMessage} role="alert">
+                フォルダを開けませんでした: {openFolderError}
+              </div>
+            )}
             {completed && (
               <button
                 type="button"
                 className={styles.cancelButton}
+                title={
+                  '同じ metadata を別設定 (出力先 / 命名 / コーデック / 試合選択) で再書き出しします。' +
+                  '既に出力先に同名ファイルがある場合は ffmpeg `-y` で上書きされます。'
+                }
                 onClick={() => {
                   setMatchStates({});
+                  setOpenFolderError(null);
                   dispatch({ type: 'RESTART' });
                 }}
               >
-                もう一度書き出す
+                設定変更して再書き出し
               </button>
             )}
 
@@ -426,8 +492,26 @@ export function ExportScreen() {
                   : s.status === 'error'
                     ? styles.listMarkError
                     : '';
+              // #466 review #1: 永続 skip は変更不可、ad-hoc exclude は
+              // checkbox で個別 toggle 可能。export 中は disabled。
+              const isPersistSkip = m.type_override === 'skip';
+              const isAdHocExcluded = excludedIndexes.has(m.index);
+              const isIncluded = !isPersistSkip && !isAdHocExcluded;
               return (
                 <li key={m.index} className={styles.listItem}>
+                  <input
+                    type="checkbox"
+                    className={styles.listCheckbox}
+                    checked={isIncluded}
+                    disabled={isPersistSkip || running || cancelling}
+                    onChange={() => toggleMatchExclusion(m.index)}
+                    aria-label={`include match ${m.index}`}
+                    title={
+                      isPersistSkip
+                        ? 'preview 画面で skip 設定済 (変更不可)'
+                        : '書き出し対象から除外/復帰'
+                    }
+                  />
                   <span className={`${styles.listMark} ${markClass}`}>
                     {mark}
                   </span>
@@ -466,4 +550,20 @@ function joinPath(dir: string, name: string): string {
     dir.includes('\\') && !dir.includes('/') ? '\\' : '/';
   if (dir.endsWith('/') || dir.endsWith('\\')) return dir + name;
   return dir + separator + name;
+}
+
+/**
+ * #466 review #2: source video の親ディレクトリ + `/output` を default に。
+ * `videoSource` から `dirname` 相当を抽出する (Windows は `\\` も許容)。
+ */
+export function deriveDefaultOutDir(videoSource: string | null): string {
+  if (!videoSource) return '';
+  const sep = videoSource.includes('\\') && !videoSource.includes('/') ? '\\' : '/';
+  const idx = Math.max(
+    videoSource.lastIndexOf('/'),
+    videoSource.lastIndexOf('\\'),
+  );
+  if (idx <= 0) return '';
+  const parent = videoSource.slice(0, idx);
+  return `${parent}${sep}output`;
 }

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -5,7 +5,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
-import { fmtMatchDuration } from '../utils/time';
+import { fmtMatchDuration, fmtTime } from '../utils/time';
 import { exportReducer } from './reducers/export';
 import type { ExportPhase } from './types';
 import styles from './ExportScreen.module.css';
@@ -107,6 +107,23 @@ export function ExportScreen() {
     () => new Set(),
   );
   const cancelRequestedRef = useRef(false);
+  // #545 review #7 (2026-04-25): progress bar 下の「経過 / 残り」時間表示用。
+  // START_CLICKED 時の wall-clock を記録し、`elapsedSec` / `remainingSec` を
+  // 描画ループで更新する。残り時間は `(elapsed / done) * remaining` の線形
+  // 推定 (done=0 のときは null = 「-」表示)。
+  const [exportStartMs, setExportStartMs] = useState<number | null>(null);
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+
+  // 1 秒間隔の wall-clock tick (running 中のみ)。完了 / 中断 / idle に
+  // なれば clearInterval。
+  useEffect(() => {
+    if (exportStartMs === null) return;
+    if (phase !== 'running') return;
+    const iv = setInterval(() => {
+      setNowMs(Date.now());
+    }, 1000);
+    return () => clearInterval(iv);
+  }, [exportStartMs, phase]);
 
   function toggleMatchExclusion(matchIndex: number) {
     setExcludedIndexes((prev) => {
@@ -115,6 +132,30 @@ export function ExportScreen() {
         next.delete(matchIndex);
       } else {
         next.add(matchIndex);
+      }
+      return next;
+    });
+  }
+
+  /**
+   * #545 review #3 (2026-04-25): 一覧の全選択 / 全解除トグル。
+   * `type_override === 'skip'` (preview で永続 skip 設定済) は対象外
+   * (UI でも個別 checkbox が disabled なので、bulk からも除外する)。
+   *
+   * - select-all: excludedIndexes から bulk 対象 index を全 remove
+   * - deselect-all: bulk 対象 index を全 add
+   */
+  function toggleSelectAll(selectAll: boolean) {
+    if (!metadata) return;
+    setExcludedIndexes((prev) => {
+      const next = new Set(prev);
+      for (const m of metadata.matches) {
+        if (m.type_override === 'skip') continue;
+        if (selectAll) {
+          next.delete(m.index);
+        } else {
+          next.add(m.index);
+        }
       }
       return next;
     });
@@ -153,9 +194,12 @@ export function ExportScreen() {
   }, []);
 
   function formatName(index: number, type: string, startSec: number): string {
-    const startDisplay = Math.floor(startSec)
-      .toString()
-      .padStart(4, '0');
+    // #545 review #8 (2026-04-25): {start} は MM-SS / H-MM-SS 形式
+    // (design mock の `m.start_display.replace(/:/g, '-')` 準拠)。
+    // 旧実装は秒数 0 埋め (例: '0915') だったが、ユーザー視点で start_display
+    // (mm:ss) との対応が取れず混乱の元。Windows filename で `:` は使えない
+    // ので `-` 置換版を採用。
+    const startDisplay = formatStartForFilename(startSec);
     const today = new Date().toISOString().slice(0, 10);
     return namePattern
       .replace(/\{idx:03\}/g, String(index).padStart(3, '0'))
@@ -194,6 +238,10 @@ export function ExportScreen() {
       }
     }
     setMatchStates(nextStates);
+    // #545 review #7: 経過 / 残り時間計測の起点。
+    const startMs = Date.now();
+    setExportStartMs(startMs);
+    setNowMs(startMs);
     dispatch({ type: 'START_CLICKED' });
 
     let successCount = 0;
@@ -254,12 +302,18 @@ export function ExportScreen() {
   // 呼んでおり、Explorer が開く前に画面遷移してしまう (実態として開いて
   // いないように見える) 不具合があった。新実装は shell.open のみで
   // 画面遷移は行わない。`完了` ステータスは画面に残す。
+  //
+  // #545 review #6 (2026-04-25): shell.open は default scope が URL
+  // (`mailto:` / `tel:` / `https?://`) しか許可せず、ローカル path で
+  // `Scoped command argument failed regex validation` を返していた。
+  // Rust 側に `open_folder_in_explorer` 独自 command を追加して explorer.exe
+  // を直接 spawn する形に変更。
   const [openFolderError, setOpenFolderError] = useState<string | null>(null);
 
   async function handleOpenFolder() {
     setOpenFolderError(null);
     try {
-      await invoke('plugin:shell|open', { path: outDir });
+      await invoke('open_folder_in_explorer', { path: outDir });
     } catch (e) {
       setOpenFolderError(e instanceof Error ? e.message : String(e));
     }
@@ -291,6 +345,18 @@ export function ExportScreen() {
   const overallPercent = countedMatches.length === 0
     ? 0
     : Math.round((doneCount / countedMatches.length) * 100);
+
+  // #545 review #7: 経過 / 残り時間 (秒)。
+  // - 経過: `nowMs - exportStartMs` (running 中は 1s tick で更新)
+  // - 残り: `(elapsed / done) * remaining` の線形推定。done=0 のとき null
+  //   (= 表示は `—`)。完了 / 中断時も null。
+  const elapsedSec =
+    exportStartMs === null ? null : Math.max(0, (nowMs - exportStartMs) / 1000);
+  const remainingCount = Math.max(0, countedMatches.length - doneCount);
+  const remainingSec =
+    !running || elapsedSec === null || doneCount === 0
+      ? null
+      : (elapsedSec / doneCount) * remainingCount;
 
   return (
     <div className={styles.screen} data-testid="export-screen" data-phase={phase}>
@@ -403,6 +469,17 @@ export function ExportScreen() {
                     style={{ width: `${overallPercent}%` }}
                   />
                 </div>
+                {/* #545 review #7: 経過 / 残り時間 (design mock 準拠)。
+                    完了時は残りは `—` で固定、cancelling は経過のみ表示。 */}
+                {elapsedSec !== null && (
+                  <div className={styles.progressTime}>
+                    <span>経過 {fmtTime(elapsedSec)}</span>
+                    <span>
+                      残り{' '}
+                      {remainingSec !== null ? fmtTime(remainingSec) : '—'}
+                    </span>
+                  </div>
+                )}
               </div>
             )}
 
@@ -470,18 +547,51 @@ export function ExportScreen() {
             {error && (
               <button
                 type="button"
-                className={styles.cancelButton}
-                onClick={() => dispatch({ type: 'DISMISS_ERROR' })}
+                className={styles.primaryButton}
+                title={
+                  '出力先 / 命名 / コーデック / 試合選択 を変更してから ' +
+                  '再度書き出しを試行します。'
+                }
+                onClick={() => {
+                  setMatchStates({});
+                  setOpenFolderError(null);
+                  dispatch({ type: 'DISMISS_ERROR' });
+                }}
               >
-                閉じる
+                設定変更して再試行
               </button>
             )}
           </div>
         </div>
 
         <div className={styles.listPanel}>
-          <div className={styles.listCaption}>
-            書き出し一覧 ⸱ {countedMatches.length} ファイル
+          <div className={styles.listHeaderRow}>
+            <div className={styles.listCaption}>
+              書き出し一覧 ⸱ {countedMatches.length} ファイル
+            </div>
+            {/* #545 review #3 (2026-04-25): 全選択 / 全解除トグル。
+                preview で永続 skip 設定済 (type_override === 'skip') の試合は
+                bulk 対象から除外。export 中は disable。 */}
+            <div className={styles.listBulkActions}>
+              <button
+                type="button"
+                className={styles.listBulkButton}
+                disabled={running || cancelling}
+                onClick={() => toggleSelectAll(true)}
+                aria-label="select all matches"
+              >
+                全選択
+              </button>
+              <button
+                type="button"
+                className={styles.listBulkButton}
+                disabled={running || cancelling}
+                onClick={() => toggleSelectAll(false)}
+                aria-label="deselect all matches"
+              >
+                全解除
+              </button>
+            </div>
           </div>
           <ul className={styles.listBody}>
             {metadata.matches.map((m) => {
@@ -567,6 +677,30 @@ export function ExportScreen() {
   );
 }
 
+/**
+ * #545 review #8 (2026-04-25): filename 用の `{start}` 変数を `MM-SS` /
+ * `H-MM-SS` 形式に format する。`fmtTime` の `:` を `-` に置換した形と等価
+ * (Windows filename で `:` が使えないため)。
+ *
+ * 例:
+ * - 0       → `00-00`
+ * - 915.5   → `15-15`
+ * - 5021.5  → `1-23-41`
+ */
+export function formatStartForFilename(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    seconds = 0;
+  }
+  const total = Math.floor(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) {
+    return `${h}-${String(m).padStart(2, '0')}-${String(s).padStart(2, '0')}`;
+  }
+  return `${String(m).padStart(2, '0')}-${String(s).padStart(2, '0')}`;
+}
+
 function joinPath(dir: string, name: string): string {
   const separator =
     dir.includes('\\') && !dir.includes('/') ? '\\' : '/';
@@ -575,17 +709,44 @@ function joinPath(dir: string, name: string): string {
 }
 
 /**
+ * Windows の extended-length path prefix (`\\?\`) を取り除く。
+ *
+ * Tauri の dialog::open() / drag-drop は Windows 上で `\\?\` 付き path を
+ * 返すことがあり、そのまま UI に表示すると一般的な `E:\videos\...` 表記
+ * との一貫性が崩れる。ffmpeg や Win32 API は両形式を解釈できるが、UI 表示
+ * 側で正規化するのがユーザー体験的に望ましいため、deriveDefaultOutDir で
+ * 親 dir を切り出す前に strip する (#545 review #2、2026-04-25)。
+ *
+ * - `\\?\C:\foo` → `C:\foo`
+ * - `\\?\UNC\server\share` → `\\server\share`
+ * - prefix なしの path は素通し
+ */
+export function stripExtendedPathPrefix(p: string): string {
+  if (p.startsWith('\\\\?\\UNC\\')) {
+    return '\\\\' + p.slice('\\\\?\\UNC\\'.length);
+  }
+  if (p.startsWith('\\\\?\\')) {
+    return p.slice('\\\\?\\'.length);
+  }
+  return p;
+}
+
+/**
  * #466 review #2: source video の親ディレクトリ + `/output` を default に。
  * `videoSource` から `dirname` 相当を抽出する (Windows は `\\` も許容)。
+ *
+ * #545 review #2 (2026-04-25): Windows の `\\?\` extended-length path prefix
+ * は UI 表示用に取り除く。
  */
 export function deriveDefaultOutDir(videoSource: string | null): string {
   if (!videoSource) return '';
-  const sep = videoSource.includes('\\') && !videoSource.includes('/') ? '\\' : '/';
+  const normalized = stripExtendedPathPrefix(videoSource);
+  const sep = normalized.includes('\\') && !normalized.includes('/') ? '\\' : '/';
   const idx = Math.max(
-    videoSource.lastIndexOf('/'),
-    videoSource.lastIndexOf('\\'),
+    normalized.lastIndexOf('/'),
+    normalized.lastIndexOf('\\'),
   );
   if (idx <= 0) return '';
-  const parent = videoSource.slice(0, idx);
+  const parent = normalized.slice(0, idx);
   return `${parent}${sep}output`;
 }

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -5,6 +5,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
+import { fmtMatchDuration } from '../utils/time';
 import { exportReducer } from './reducers/export';
 import type { ExportPhase } from './types';
 import styles from './ExportScreen.module.css';
@@ -64,10 +65,23 @@ interface ExportResult {
  * - **#7 (boundary)**: `m.edited?.start_time ?? m.start_time` を
  *   `export_match` の `startSeconds` に渡す (`end_time` も同様)。preview で
  *   調整した境界が export に反映される。
+ *
+ * ## 2026-04-25 追加修正 (#545 実機テスト)
+ *
+ * - **filePath 早期 return 廃止**: 旧実装は `if (!metadata || !filePath)
+ *   return` だったが、Phase 3 dummy detect が `loadSample()` のみで
+ *   `filePath = null` のまま preview/export に来るため、書き出し開始ボタンが
+ *   常に disable + クリックしても無反応になっていた。`export_match` invoke
+ *   は `filePath` (metadata.json の path) を必要とせず `videoSource` (実
+ *   video の path) だけで動くため、ガードを `!videoSource` に変更。
+ * - **list duration の edited 反映**: 旧実装は `m.duration_display` を
+ *   そのまま表示していたため、preview で `m.edited.end_time` を変えても
+ *   一覧の duration が CLI 初期値のまま固定だった。`m.edited` がある場合は
+ *   `effectiveEnd - effectiveStart` を {@link fmtMatchDuration} で再 format
+ *   して表示する (CLI `_format_duration` と同一フォーマット)。
  */
 export function ExportScreen() {
   const metadata = useMetadataStore((s) => s.metadata);
-  const filePath = useMetadataStore((s) => s.filePath);
   const navigate = useAppStateStore((s) => s.navigate);
 
   // #466 review (C): drop で確定した実 path を最優先で使用する。sample mode
@@ -159,7 +173,11 @@ export function ExportScreen() {
   }
 
   async function handleStartExport() {
-    if (!metadata || !filePath) return;
+    // 2026-04-25 修正: filePath は metadata.json の path であり、
+    // export_match invoke 自体は videoSource (実 video path) だけで動く。
+    // dummy detect で loadSample() のみ走った場合 filePath は null のため、
+    // 旧 `!filePath` early return + button disabled 条件は誤検知になる。
+    if (!metadata) return;
     if (!videoSource) return;
     cancelRequestedRef.current = false;
 
@@ -395,7 +413,7 @@ export function ExportScreen() {
                 onClick={() => {
                   void handleStartExport();
                 }}
-                disabled={running || cancelling || !filePath}
+                disabled={running || cancelling || !videoSource}
               >
                 {running
                   ? '書き出し中…'
@@ -471,11 +489,15 @@ export function ExportScreen() {
                 status: 'pending' as MatchStatus,
                 percent: 0,
               };
-              const name = formatName(
-                m.index,
-                m.type,
-                m.edited?.start_time ?? m.start_time,
-              );
+              // 2026-04-25 修正: preview で調整した境界 (m.edited) を一覧
+              // duration にも反映する。m.duration_display は CLI 初期値で
+              // 固定なので、edited がある場合は再計算した duration を表示。
+              const effectiveStart = m.edited?.start_time ?? m.start_time;
+              const effectiveEnd = m.edited?.end_time ?? m.end_time;
+              const durationDisplay = m.edited
+                ? fmtMatchDuration(effectiveEnd - effectiveStart)
+                : m.duration_display;
+              const name = formatName(m.index, m.type, effectiveStart);
               const mark =
                 s.status === 'done'
                   ? '✓'
@@ -516,7 +538,7 @@ export function ExportScreen() {
                     {mark}
                   </span>
                   <span className={styles.listName}>{name}</span>
-                  <span className={styles.listDur}>{m.duration_display}</span>
+                  <span className={styles.listDur}>{durationDisplay}</span>
                   {(running ||
                     completed ||
                     s.status === 'done' ||

--- a/gui/src/state/appStateStore.test.ts
+++ b/gui/src/state/appStateStore.test.ts
@@ -48,6 +48,37 @@ describe('useAppStateStore.setSelectedVideoPath', () => {
     useAppStateStore.getState().setSelectedVideoPath(null);
     expect(useAppStateStore.getState().selectedVideoPath).toBeNull();
   });
+
+  // #545 review (2026-04-25): Tauri が Windows で返す `\\?\` extended-length
+  // path prefix を保存前に正規化する。
+  it('strips Windows \\\\?\\ extended-length prefix before storing', () => {
+    useAppStateStore
+      .getState()
+      .setSelectedVideoPath('\\\\?\\E:\\videos\\clip.mkv');
+    expect(useAppStateStore.getState().selectedVideoPath).toBe(
+      'E:\\videos\\clip.mkv',
+    );
+  });
+
+  it('converts \\\\?\\UNC\\ prefix into the standard \\\\ form', () => {
+    useAppStateStore
+      .getState()
+      .setSelectedVideoPath('\\\\?\\UNC\\server\\share\\clip.mkv');
+    expect(useAppStateStore.getState().selectedVideoPath).toBe(
+      '\\\\server\\share\\clip.mkv',
+    );
+  });
+
+  it('passes through paths without the prefix unchanged', () => {
+    useAppStateStore.getState().setSelectedVideoPath('E:\\videos\\clip.mkv');
+    expect(useAppStateStore.getState().selectedVideoPath).toBe(
+      'E:\\videos\\clip.mkv',
+    );
+    useAppStateStore.getState().setSelectedVideoPath('/home/user/file.mkv');
+    expect(useAppStateStore.getState().selectedVideoPath).toBe(
+      '/home/user/file.mkv',
+    );
+  });
 });
 
 describe('useAppStateStore.reset', () => {

--- a/gui/src/state/appStateStore.ts
+++ b/gui/src/state/appStateStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 
+import { stripExtendedPathPrefix } from '../utils/path';
+
 /**
  * The high-level screen the user is currently on. State transitions between
  * these screens are intentionally represented as an enum (not a URL-based
@@ -47,7 +49,18 @@ export const useAppStateStore = create<AppState>((set) => ({
   selectMatch: (selectedMatchIndex) => set({ selectedMatchIndex }),
   openPreviewFor: (index) =>
     set({ selectedMatchIndex: index, screen: 'preview' }),
-  setSelectedVideoPath: (selectedVideoPath) => set({ selectedVideoPath }),
+  // #545 review (2026-04-25): Tauri dialog/drag-drop が Windows で返す
+  // `\\?\` extended-length path prefix を保存前に正規化する。これで
+  // selectedVideoPath を読む全 consumer (ExportScreen の videoSource、
+  // PreviewScreen の register_video / generate_match_thumbnails、UI 表示)
+  // が一貫して prefix なしの path を扱える。
+  setSelectedVideoPath: (selectedVideoPath) =>
+    set({
+      selectedVideoPath:
+        selectedVideoPath === null
+          ? null
+          : stripExtendedPathPrefix(selectedVideoPath),
+    }),
   reset: () =>
     set({
       screen: 'drop',

--- a/gui/src/utils/path.test.ts
+++ b/gui/src/utils/path.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { stripExtendedPathPrefix } from './path';
+import { joinPath, stripExtendedPathPrefix } from './path';
 
 describe('stripExtendedPathPrefix', () => {
   it('strips \\\\?\\ from drive-letter paths', () => {
@@ -20,5 +20,44 @@ describe('stripExtendedPathPrefix', () => {
     expect(stripExtendedPathPrefix('C:\\foo')).toBe('C:\\foo');
     expect(stripExtendedPathPrefix('/home/user/file')).toBe('/home/user/file');
     expect(stripExtendedPathPrefix('')).toBe('');
+  });
+});
+
+// #545 mystifying-ptolemy-d112b5 review (2026-04-25): separator 推定ロジック
+// が Windows / POSIX / mixed で一貫することをガード。
+describe('joinPath', () => {
+  it('uses \\\\ for backslash-only dir paths (Windows native)', () => {
+    expect(joinPath('E:\\videos\\output', 'match_001.mp4')).toBe(
+      'E:\\videos\\output\\match_001.mp4',
+    );
+    expect(joinPath('C:\\Users\\me', 'clip.mkv')).toBe(
+      'C:\\Users\\me\\clip.mkv',
+    );
+  });
+
+  it('uses / for forward-slash-only dir paths (POSIX)', () => {
+    expect(joinPath('/home/user/output', 'match_001.mp4')).toBe(
+      '/home/user/output/match_001.mp4',
+    );
+    expect(joinPath('E:/videos/output', 'match_001.mp4')).toBe(
+      'E:/videos/output/match_001.mp4',
+    );
+  });
+
+  it('prefers / when dir contains both \\\\ and /', () => {
+    // mixed (Windows path で internal `/` を含むケース等) の現状動作
+    // (forward-slash 優先) をスナップショット
+    expect(joinPath('E:/videos\\output', 'x.mp4')).toBe(
+      'E:/videos\\output/x.mp4',
+    );
+  });
+
+  it('does not duplicate trailing separator', () => {
+    expect(joinPath('E:\\videos\\output\\', 'match_001.mp4')).toBe(
+      'E:\\videos\\output\\match_001.mp4',
+    );
+    expect(joinPath('/home/user/output/', 'match_001.mp4')).toBe(
+      '/home/user/output/match_001.mp4',
+    );
   });
 });

--- a/gui/src/utils/path.test.ts
+++ b/gui/src/utils/path.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripExtendedPathPrefix } from './path';
+
+describe('stripExtendedPathPrefix', () => {
+  it('strips \\\\?\\ from drive-letter paths', () => {
+    expect(stripExtendedPathPrefix('\\\\?\\C:\\foo')).toBe('C:\\foo');
+    expect(stripExtendedPathPrefix('\\\\?\\E:\\videos\\x.mkv')).toBe(
+      'E:\\videos\\x.mkv',
+    );
+  });
+
+  it('converts \\\\?\\UNC\\ to \\\\ form', () => {
+    expect(stripExtendedPathPrefix('\\\\?\\UNC\\server\\share\\foo')).toBe(
+      '\\\\server\\share\\foo',
+    );
+  });
+
+  it('passes through paths without the prefix', () => {
+    expect(stripExtendedPathPrefix('C:\\foo')).toBe('C:\\foo');
+    expect(stripExtendedPathPrefix('/home/user/file')).toBe('/home/user/file');
+    expect(stripExtendedPathPrefix('')).toBe('');
+  });
+});

--- a/gui/src/utils/path.ts
+++ b/gui/src/utils/path.ts
@@ -1,0 +1,25 @@
+/**
+ * Windows の extended-length path prefix (`\\?\`) を取り除く。
+ *
+ * Tauri の dialog::open() / drag-drop は Windows 上で `\\?\` 付き path を
+ * 返すことがあり、そのままだと:
+ *
+ * - UI 表示で一般的な `E:\videos\...` 表記と一貫性が崩れる
+ * - Rust 側 (`Path::is_file()` 等) で path 比較に支障が出るケースがある
+ *
+ * このため drop screen が `selectedVideoPath` に格納する前に正規化する。
+ * `appStateStore.setSelectedVideoPath` が pipeline 上の strip ポイント。
+ *
+ * - `\\?\C:\foo` → `C:\foo`
+ * - `\\?\UNC\server\share` → `\\server\share`
+ * - prefix なしの path は素通し
+ */
+export function stripExtendedPathPrefix(p: string): string {
+  if (p.startsWith('\\\\?\\UNC\\')) {
+    return '\\\\' + p.slice('\\\\?\\UNC\\'.length);
+  }
+  if (p.startsWith('\\\\?\\')) {
+    return p.slice('\\\\?\\'.length);
+  }
+  return p;
+}

--- a/gui/src/utils/path.ts
+++ b/gui/src/utils/path.ts
@@ -23,3 +23,20 @@ export function stripExtendedPathPrefix(p: string): string {
   }
   return p;
 }
+
+/**
+ * `dir` と `name` を OS-appropriate なセパレータで連結する。
+ *
+ * separator 推定ルール:
+ * - dir に `\` のみ含まれる (Windows native) → `\` で連結
+ * - それ以外 (`/` 含む / 両方混在 / 分離なし) → `/` を優先
+ * - dir が `/` または `\` で終わっている場合は重複させない
+ *
+ * Windows extended-length path や POSIX path、混在パスのいずれでも一貫した
+ * 動作になる。ExportScreen の `outputPath` 組み立てに使用。
+ */
+export function joinPath(dir: string, name: string): string {
+  const separator = dir.includes('\\') && !dir.includes('/') ? '\\' : '/';
+  if (dir.endsWith('/') || dir.endsWith('\\')) return dir + name;
+  return dir + separator + name;
+}

--- a/gui/src/utils/time.test.ts
+++ b/gui/src/utils/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { fmtPreciseTime, fmtTime } from './time';
+import { fmtMatchDuration, fmtPreciseTime, fmtTime } from './time';
 
 describe('fmtTime', () => {
   it('formats sub-hour durations as MM:SS', () => {
@@ -84,5 +84,35 @@ describe('fmtPreciseTime', () => {
     expect(fmtPreciseTime(60 + 91 / 120, 120)).toBe('0:01:00.091');
     // 240fps grid
     expect(fmtPreciseTime(181 / 240, 240)).toBe('0:00:00.181');
+  });
+});
+
+// #466 review: ExportScreen 一覧 duration の edited 反映 (boundary 反映バグ)
+describe('fmtMatchDuration', () => {
+  it('formats sub-hour durations as `{m}m{ss:02}s`', () => {
+    expect(fmtMatchDuration(0)).toBe('0m00s');
+    expect(fmtMatchDuration(49)).toBe('0m49s');
+    expect(fmtMatchDuration(60)).toBe('1m00s');
+    // sample metadata の値で CLI 出力と完全一致するか
+    expect(fmtMatchDuration(915.5)).toBe('15m15s');
+    expect(fmtMatchDuration(349.375)).toBe('5m49s');
+    expect(fmtMatchDuration(2582.5)).toBe('43m02s');
+  });
+
+  it('formats hour-plus durations as `{h}h{mm:02}m`', () => {
+    expect(fmtMatchDuration(3600)).toBe('1h00m');
+    expect(fmtMatchDuration(3900)).toBe('1h05m');
+    expect(fmtMatchDuration(9000)).toBe('2h30m');
+  });
+
+  it('clamps negative / NaN / Infinity to 0', () => {
+    expect(fmtMatchDuration(-1)).toBe('0m00s');
+    expect(fmtMatchDuration(Number.NaN)).toBe('0m00s');
+    expect(fmtMatchDuration(Number.POSITIVE_INFINITY)).toBe('0m00s');
+  });
+
+  it('truncates fractional seconds (floor semantics, mirrors CLI int())', () => {
+    expect(fmtMatchDuration(59.9)).toBe('0m59s');
+    expect(fmtMatchDuration(60.999)).toBe('1m00s');
   });
 });

--- a/gui/src/utils/time.ts
+++ b/gui/src/utils/time.ts
@@ -55,3 +55,29 @@ export function fmtPreciseTime(seconds: number, fps = 60): string {
     `${String(frames).padStart(frameWidth, '0')}`
   );
 }
+
+/**
+ * Format seconds as `{m}m{ss}s` or `{h}h{mm}m` — mirror of CLI
+ * `_format_duration` in `allaganeye/commands/split_matches.py`.
+ *
+ * - <1h: `{m}m{ss:02}s` — e.g. `15m15s`, `5m49s`, `43m02s`
+ * - >=1h: `{h}h{mm:02}m` — e.g. `1h05m`, `2h30m`
+ *
+ * Negative / NaN input clamps to 0 (mirroring fmtTime). Used by ExportScreen
+ * list to recompute duration when `m.edited?.start_time` / `end_time` differ
+ * from the CLI-provided `m.duration_display` (#466 review, boundary
+ * propagation bug).
+ */
+export function fmtMatchDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    seconds = 0;
+  }
+  const total = Math.floor(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) {
+    return `${h}h${String(m).padStart(2, '0')}m`;
+  }
+  return `${m}m${String(s).padStart(2, '0')}s`;
+}


### PR DESCRIPTION
## 概要

[#466](https://github.com/Idios/kobutachan-allaganeye/issues/466) — ExportScreen を dummy setInterval から ffmpeg subprocess ベースに本物化。試合ごとに個別 spawn して per-match 進捗を UI に反映、1 試合失敗でも他試合を続行する。

## 前提

本 PR は **[#540](https://github.com/Idios/kobutachan-allaganeye/pull/540) (E: Phase 3 preview + #523 ffmpeg 中断)** に依存しており、base branch を `claude/is465-523-preview-phase3` に設定している。E がマージされると base は自動で `develop-0.2.0` に切り替わる。

依存している E の資産:
- `PROCESS_TRACKER` (#523) — export_match が spawn した ffmpeg child を登録
- `kill_tracked_processes` / `force_exit_app` (#523) — 中断ボタンと × 閉じる時に共通で使う
- `on_window_event(CloseRequested)` (#523) — 書き出し中の ×押下を捕まえて confirm modal へ

## 受け入れ条件

- [x] `docs/design/screens/05-export.png` の UI が完全再現されている (5 画面骨格は Phase 2 (#464) で実装済み、本 PR は挙動だけ差し替え)
- [x] **命名規則テンプレートが `{idx:03}` 等の変数を正しく展開する** — `formatName()` で `{idx}` / `{idx:03}` / `{start}` / `{type}` / `{date}` を replace
- [x] **COPY / H.264 両方で書き出しが成功する** — Rust `ffmpeg_args_for_export` が codec 分岐、`-ss` before `-i` でキーフレームシーク
- [x] **試合ごとの進捗が ffmpeg 実際の処理時間と整合 (± 数秒)** — `-progress pipe:2` の `out_time_ms` (実質 microseconds) を duration で正規化
- [x] **1 試合失敗時に他試合は続行する** — try/catch 内で個別試合の Err を `matchStates[i] = error` にし、loop を break しない。受け入れ条件上「全成功 or 一部成功」で `completed`、「全失敗」で `error` 判定 (vitest でカバー)
- [x] **「フォルダを開く」で出力先がエクスプローラで開く** — review #6 で Rust `open_folder_in_explorer` 独自 command に変更 (`tauri-plugin-shell` の default scope に弾かれる問題の回避)
- [x] **採用 framework の lint / test が通る** — eslint / tsc / vitest 324 / cargo 69 すべて clean
- [x] **2:50:28 録画での 9 試合書き出し E2E テストが成功** — 6 回目実機テストで copy モード 9 試合書き出し OK (経過 25 秒)

## 実装

### Rust (gui/src-tauri/src/lib.rs)

| 関数 | 役割 |
|---|---|
| `export_match(app, videoPath, startSeconds, endSeconds, outputPath, codec, matchIndex) -> ExportResult` | ffmpeg 1 プロセス spawn |
| `ffmpeg_args_for_export(...)` | pure argv builder (テスト対象) |
| `validate_export_request(path, start, end)` | pure validation (path 存在/正規ファイル/時刻範囲) |
| `validate_output_parent_exists(path)` | review #4 後追加: 親 dir 不在ならエラー |
| `validate_open_folder_request(path)` | review #6 追加: explorer 起動前の path 存在チェック |
| `open_folder_in_explorer(path)` | review #6 追加: shell.open scope 制約回避 |
| `parse_progress_line(line)` | ffmpeg -progress 出力の key=value 1 行解釈 |
| `track_child` / `untrack_child` | PROCESS_TRACKER (#523) と接続 |

ffmpeg 呼び出し:

- copy: `ffmpeg -y -hide_banner -loglevel error -progress pipe:2 -ss <start> -i <video> -t <duration> -c copy -avoid_negative_ts make_zero <output>`
- h264: `-c:v libx264 -crf 18 -preset medium -c:a copy` (GPU エンコード化は #591 で別途対応)

stderr を `tokio::io::BufReader::lines()` で逐次読み、`out_time_ms` / `out_time_us` → progress%、`progress=end` → stage: "done"、それ以外は error 用 ring buffer (tail 2KB) へ。非ゼロ exit 時はその tail を Err 文字列に含める。

### GUI (gui/src/screens/ExportScreen.tsx)

- dummy setInterval を完全削除
- `handleStartExport`: `type_override === 'skip'` を除外した queue を順次 invoke
- `listen('export-progress')` で per-match percent/stage を受信、`matchStates` を更新
- 1 試合失敗でも loop 継続、最終判定:
    - cancel → CANCEL_CONFIRMED
    - `success > 0` → PROGRESS_COMPLETE (成功ゼロならエラー phase)
    - 全失敗 → EXPORT_ERROR
- 参照… ボタンで `@tauri-apps/plugin-dialog.open({ directory: true })`
- 中断 → `invoke('kill_tracked_processes')` (#523 連携)
- 命名テンプレート: `{idx}` / `{idx:03}` / `{start}` (HH-MM 形式) / `{type}` / `{date}` (今日)
- 全選択/全解除トグル (review #3) — caption 隣にボタン 2 個
- 進捗バー直下に「経過 / 残り」時間表示 (review #7) — wall-clock + per-file 進捗合算で線形推定
- error 時のボタンは「設定変更して再試行」で idle に戻る (review #4)

### state (gui/src/state/appStateStore.ts)

- `setSelectedVideoPath` で Windows extended-length path prefix (`\\?\`) を保存前に正規化 (review item 後追加)。Tauri dialog が prefix 付きで返すケースでの "video file not found" エラー対策

## テスト

| 種類 | コマンド | 結果 |
|---|---|---|
| cargo | `cd gui/src-tauri && cargo test --lib` | 69 passed (review 対応で追加分含む) |
| vitest | `npm --prefix=gui test -- --run` | 29 files / 324 passed |
| eslint | `npm --prefix=gui run lint` | ok |
| tsc | `npm --prefix=gui run typecheck` | ok |

## 手動確認 (PR レビュー時)

- [x] CI pass
- [x] 実機 (2:50:28 録画) で copy モード 9 試合書き出し — 6 回目テストで OK
- [x] 実機で h264 モード 1 試合書き出し (時間要注意) — 1 試合書き出しで動作確認済 (Idios 確認、GPU 化は #591)
- *(仕様変更: review item #4 で「親 dir 不在はエラーで拒否」に切り替え)* 出力ディレクトリが存在しないケースで親ディレクトリが自動生成される
- [x] 中断で ffmpeg プロセスが残らない — Idios 実機タスクマネージャで確認済

## 関連

- 起票元 issue: [#466](https://github.com/Idios/kobutachan-allaganeye/issues/466)
- 依存: [#540](https://github.com/Idios/kobutachan-allaganeye/pull/540) (E: Phase 3 preview + #523 ffmpeg 中断)
- 依存 Phase: Phase 1 (#463) data layer / Phase 2 (#464) 画面骨格 / Phase 3 (#465) preview
- 派生 issue: [#591](https://github.com/Idios/kobutachan-allaganeye/issues/591) (GPU エンコード対応、P1-high)
- 関連 doc: [docs/system-architecture.md](docs/system-architecture.md) §2.3 GUI → CLI subprocess 経路 (G #527)

[elated-wozniak-50d3bb]
