### PR TITLE
fix(video): VP9 を NVDEC cuvid から外し soft decode 経路に (Refs #538)

### DIFF
--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -36,7 +36,12 @@ _CUVID_CODEC_MAP: dict[str, str] = {
     "h264": "h264_cuvid",
     "hevc": "hevc_cuvid",
     "av1": "av1_cuvid",
-    "vp9": "vp9_cuvid",
+    # vp9: #538 で除外。ffmpeg 8.1 の vp9_cuvid は frame を
+    # nv12 + csp:gbr (非標準) で tag し、後段 swscaler の
+    # gray 変換が EOPNOTSUPP (-129) で必ず失敗する。soft decode
+    # (-hwaccel auto 経路) は実測 speed 2.64x で chunk 並列に
+    # 耐えるため、vp9 はデフォルトで cuvid を強制しない。
+    # ffmpeg 側で color space tag が修正された時点で復活検討。
     "vp8": "vp8_cuvid",
     "mpeg1video": "mpeg1_cuvid",
     "mpeg2video": "mpeg2_cuvid",

--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -189,7 +189,7 @@ GPU 対応環境（NVIDIA CUDA, Intel QSV 等）では、暗転検知の処理�
 | H.264 | GPU (`--gpu`) | GPU デコード支援が最も成熟しており、恩恵が大きい |
 | HEVC (H.265) | GPU (`--gpu`) | GPU 支援あり。AV1 より効率的 |
 | AV1 | GPU (`--gpu`) (NVDEC RTX 30+ / QSV Arc・Gen12+ / VCN 4.0+) | #414 で GPU auto-select 対象に追加。対応 GPU で decode 成功、未対応環境では自動で CPU フォールバック |
-| VP9 | GPU (`--gpu`) (NVDEC Maxwell+ / QSV Gen9+ / VCN 1.0+) | #414 で GPU auto-select 対象に追加。環境によっては fallback (#538 で調査中) |
+| VP9 | GPU (`--gpu`) — 実 decode は soft (#538) | #414 で GPU auto-select 対象、ただし #538 で `vp9_cuvid` + swscaler gray 変換の非互換が判明したため `_decode_chunk` は `-hwaccel auto` 経路で soft decode を選ぶ。CPU モード相当の速度 (speed 2.64x 実測) だが chunk 並列で十分高速 |
 
 低コア数 CPU（4-8 コア）では、GPU モードが有利になりやすい傾向があります。
 

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -132,9 +132,10 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 | H.264 | GPU | 全世代 | 全世代 | 全世代 |
 | HEVC | GPU | Maxwell GM206+ | Skylake+ | VCN 1.0+ |
 | AV1 | GPU (#414) | RTX 30 (Ampere) 以降 | Arc / Gen12 以降 | VCN 4.0 以降 |
-| VP9 | GPU (#414) | Maxwell 以降 | Gen9+ | VCN 1.0+ |
+| VP9 | GPU (#414) — 実 decode は soft (#538) | N/A | N/A | N/A |
 | その他 (mpeg2video, vc1, prores 等) | CPU | — | — | — |
 
+- VP9 は `_GPU_PREFERRED_CODECS` に残すが `_CUVID_CODEC_MAP` から除外 (#538)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x で chunk 並列に十分)。`vp9_cuvid` の ffmpeg 側修正が入った時点で復活検討。
 - ハードウェアが新 codec に未対応の場合、ffmpeg の `-hwaccel auto` が GPU decode に失敗 → 上記フォールバック経路で CPU に自動切替
 - 明示的に GPU を使いたい場合は `--gpu` フラグで強制可能（対応しない codec では起動時に GPU decode 失敗で exit）
 - `_CUVID_CODEC_MAP` には mpeg2video / mpeg4 / vp8 / mpeg1video も登録済みだが、`_GPU_PREFERRED_CODECS` に含めず auto では CPU (`--gpu` 明示時のみ GPU decode 経路)

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -57,6 +57,27 @@ class TestDecodeChunk:
         assert cmd[cv_idx + 1] == "av1_cuvid"
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_hwaccel_auto_for_vp9_codec(self, mock_run):
+        """VP9 は #538 で cuvid を強制しない。
+
+        ffmpeg 8.1 の vp9_cuvid は nv12+csp:gbr を出力し swscaler gray 変換が
+        EOPNOTSUPP で失敗するため、_CUVID_CODEC_MAP から vp9 を除外。
+        codec=vp9 時は else branch に落ち、``-hwaccel auto`` (soft decode 相当) で
+        動作する。`-c:v vp9_cuvid` は cmd に含まれない。
+        """
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="vp9")
+
+        cmd = mock_run.call_args[0][0]
+        assert "-hwaccel" in cmd
+        hw_idx = cmd.index("-hwaccel")
+        assert cmd[hw_idx + 1] == "auto", (
+            f"Expected -hwaccel auto for vp9 (soft decode fallback), "
+            f"got -hwaccel {cmd[hw_idx + 1]}"
+        )
+        assert "vp9_cuvid" not in cmd, "vp9_cuvid must not appear in ffmpeg args (#538)"
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_nonzero_returncode_raises(self, mock_run):
         mock_run.return_value = MagicMock(stdout=b"", stderr=b"error", returncode=1)
         with pytest.raises(VideoProcessingError, match="GPU decode failed"):


### PR DESCRIPTION
## 概要

#538 (VP9 GPU decode fallback 根本原因調査) の調査結果に基づく fix。

### 根本原因

ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` (非標準 color space tag) で出力し、allaganeye の swscaler gray 変換が `EOPNOTSUPP (-129)` として reject する。av1_cuvid は `bt709` で tag するためこの問題は発生しない。

```
[swscaler] Unsupported input (Error number -129 occurred):
  fmt:nv12 csp:gbr prim:reserved trc:reserved
  -> fmt:gray csp:unknown prim:unknown trc:reserved
```

([#538 comment](https://github.com/Idios/kobutachan-allaganeye/issues/538#issuecomment-4301406058) で workaround A-F を検証、F (vp9_cuvid 指定を省略 → soft decode) のみ成功)

### 修正内容

- `allaganeye/video/gpu_detector.py:_CUVID_CODEC_MAP` から **vp9 を削除**
  - `_GPU_PREFERRED_CODECS = {"h264", "hevc", "av1", "vp9"}` は **維持**
  - VP9 を auto-select で GPU mode に振るが、`_decode_chunk` の else branch (`-hwaccel auto`) を通り、ffmpeg 側で soft decode (native) が選ばれる
  - 実測 speed 2.64x で chunk 並列動作に十分 (短動画 30s で wall 0.75s、fallback overhead 3-5s が解消)
  - 将来 ffmpeg 側で `vp9_cuvid` の color space tag が修正された時点で `_CUVID_CODEC_MAP` へ復活検討

### テスト

- `tests/test_gpu_detector.py::test_hwaccel_auto_for_vp9_codec` (新規)
  - `codec="vp9"` 時に ffmpeg cmd に `-c:v vp9_cuvid` が含まれず `-hwaccel auto` に振られることを検証 (回帰防止)

### ドキュメント

- `docs/video-processing.md` §コーデック自動選択: VP9 行を `GPU (#414) — 実 decode は soft (#538)` に更新、理由説明を追加
- `docs/tuning-guide.md` §CPU と GPU の使い分け: VP9 行を同様に更新

### CI

```
pytest: 741 passed, 1 skipped, 37 deselected
ruff check: All checks passed
ruff format --check: 64 files already formatted
pyright: 0 errors
```

## 受け入れ条件 (#538 相当)

| # | 条件 | 実証 | 判定 |
|---|---|---|---|
| 1 | VP9 GPU fallback の根本原因特定 | [#538 comment](https://github.com/Idios/kobutachan-allaganeye/issues/538#issuecomment-4301406058) で `nv12+csp:gbr → gray` の EOPNOTSUPP を特定、workaround 6 案を検証 | ○ |
| 2 | fallback 経路の 3-5 秒 overhead 解消 | `_CUVID_CODEC_MAP` から vp9 削除で始めから soft decode 経路に振る | ○ |
| 3 | docs 整合 (VP9 GPU auto-select の実挙動) | docs/video-processing.md + docs/tuning-guide.md 更新 | ○ |
| 4 | 回帰テスト | `test_hwaccel_auto_for_vp9_codec` 追加 | ○ |

## 関連

- Refs #538 (親 issue: VP9 GPU decode fallback 根本原因調査)
- Refs #414 (AV1/VP9 auto-select 追加)
- 今後: ffmpeg 9.x リリース時に `vp9_cuvid` の color space tag 修正を watch、修正入れば復活 PR を検討

[kind-banzai-d4cd21]
