### PR TITLE
fix(scorebar): classify_blackout に対称 re-probe fallback (Refs #524)

### DIFF
--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -247,6 +247,16 @@ def classify_blackout(
     ``"match_boundary"``.  This prevents loading screens that pass the
     A1+A2 checks from being misclassified as in-match.  (#201)
 
+    Re-probe fallback (#524): when both pre and post probes return
+    ``False`` or ``None`` (i.e. the region would classify as ``non_fl``
+    or ``unknown``), re-probes pre/post symmetrically at
+    ``region_width + 1/2/3s`` further out.  4K Windows Game DVR has a
+    ~3s fade-in/out that pushes ``+1/2/3s`` probes inside the blackout,
+    causing scorebar detection to fail.  Offsetting by ``region_width``
+    pushes the probes safely past the fade.  Re-probe results override
+    the original only when not ``None``; sides that already returned
+    ``True`` are not re-probed.
+
     Returns one of:
     - ``"in_match"``: both sides have scorebar -> in-match blackout (#107)
     - ``"match_boundary"``: one side has scorebar -> match start/end
@@ -265,6 +275,66 @@ def classify_blackout(
 
     pre_has = _majority_scorebar(pre_results)
     post_has = _majority_scorebar(post_results)
+
+    # Re-probe fallback when neither side detected scorebar (#524).
+    # Long fade-in/out on 4K Game DVR pushes the +1/2/3s probes inside
+    # the blackout; offsetting by region_width clears the fade band.
+    if pre_has is not True and post_has is not True:
+        region_width = region[1] - region[0]
+        existing_pre_ts = set(pre_timestamps)
+        existing_post_ts = set(post_timestamps)
+        pre_re_timestamps = [
+            t
+            for t in sorted(
+                set(max(0.0, region[0] - (region_width + d)) for d in (3.0, 2.0, 1.0))
+            )
+            if t not in existing_pre_ts
+        ]
+        post_re_timestamps = [
+            t
+            for t in sorted(
+                set(
+                    min(duration, region[1] + (region_width + d))
+                    for d in (1.0, 2.0, 3.0)
+                )
+            )
+            if t not in existing_post_ts
+        ]
+
+        pre_re_results: list[bool | None] = []
+        post_re_results: list[bool | None] = []
+        if pre_re_timestamps:
+            pre_re_results, _ = _probe_scorebar_context(
+                video_path, pre_re_timestamps, height, workers
+            )
+        if post_re_timestamps:
+            post_re_results, _ = _probe_scorebar_context(
+                video_path, post_re_timestamps, height, workers
+            )
+        pre_has_re = _majority_scorebar(pre_re_results)
+        post_has_re = _majority_scorebar(post_re_results)
+
+        if pre_has_re is not None:
+            pre_has = pre_has_re
+        if post_has_re is not None:
+            post_has = post_has_re
+
+        logger.debug(
+            "classify re-probe region [%.1f-%.1f] (%.1fs): "
+            "pre_re_ts=%s pre_re=%s votes=%s "
+            "post_re_ts=%s post_re=%s votes=%s -> pre=%s post=%s",
+            region[0],
+            region[1],
+            region_width,
+            pre_re_timestamps,
+            pre_has_re,
+            pre_re_results,
+            post_re_timestamps,
+            post_has_re,
+            post_re_results,
+            pre_has,
+            post_has,
+        )
 
     # Override scorebar detection on static screens (loading/result).
     # Loading screens can pass _has_scorebar A1+A2 checks due to complex

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -279,21 +279,25 @@ class TestClassifyBlackout:
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_non_fl(self, mock_probe):
-        """Neither side has scorebar -> non_fl."""
+        """Neither side has scorebar -> non_fl (re-probe also confirms)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False, False, False], [f, f, f]),  # pre
-            ([False, False, False], [f, f, f]),  # post
+            ([False, False, False], [f, f, f]),  # pre initial
+            ([False, False, False], [f, f, f]),  # post initial
+            ([False, False], [f, f]),  # pre re-probe (#524)
+            ([False, False], [f, f]),  # post re-probe (#524)
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "non_fl"
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_all_probes_failed(self, mock_probe):
-        """All probes failed -> unknown."""
+        """All probes failed (initial+re-probe) -> unknown."""
         mock_probe.side_effect = [
-            ([None, None, None], [None, None, None]),  # pre
-            ([None, None, None], [None, None, None]),  # post
+            ([None, None, None], [None, None, None]),  # pre initial
+            ([None, None, None], [None, None, None]),  # post initial
+            ([None, None], [None, None]),  # pre re-probe (#524)
+            ([None, None], [None, None]),  # post re-probe (#524)
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "unknown"
@@ -849,11 +853,18 @@ class TestClassifyBlackoutBoundary:
 
     @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
     def test_region_at_video_end(self, mock_probe):
-        """Region near end -> post timestamps clamp to duration."""
+        """Region near end -> post timestamps clamp to duration.
+
+        Re-probe (#524) fires because both sides are not-True.  Pre re-probe
+        runs (291.5/292.5/293.5 are well clear of duration); post re-probe
+        timestamps all collapse to 300.0 which dedupes against existing
+        post probe -> empty list, so post re-probe is skipped.
+        """
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False, False, False], [f, f, f]),  # pre
-            ([False], [f]),  # post: collapsed
+            ([False, False, False], [f, f, f]),  # pre initial
+            ([False], [f]),  # post initial: collapsed
+            ([False, False, False], [f, f, f]),  # pre re-probe
         ]
         result = classify_blackout(Path("v.mp4"), (297.0, 299.5), 300.0, _HEIGHT)
         assert result == "non_fl"
@@ -861,6 +872,130 @@ class TestClassifyBlackoutBoundary:
         post_call_args = mock_probe.call_args_list[1]
         post_ts = post_call_args[0][1]
         assert len(post_ts) < 3
+
+
+# --- classify_blackout re-probe fallback (#524) ---
+
+
+class TestClassifyBlackoutReProbe:
+    @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_re_probe_post_recovers_match_boundary(self, mock_probe, _mock_static):
+        """Both pre/post initial=False -> re-probe finds post=True -> match_boundary."""
+        f = _FAKE_FRAME
+        mock_probe.side_effect = [
+            ([False, False, False], [f, f, f]),  # pre initial
+            ([False, False, False], [f, f, f]),  # post initial
+            ([False, False, False], [f, f, f]),  # pre re-probe
+            ([True, True, True], [f, f, f]),  # post re-probe
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
+        assert result == "match_boundary"
+        assert mock_probe.call_count == 4
+        # post re-probe offsets = region_end + (region_width + 1/2/3)
+        # = 108 + 9/10/11 = 117/118/119
+        post_re_call = mock_probe.call_args_list[3]
+        post_re_ts = post_re_call[0][1]
+        assert post_re_ts == [117.0, 118.0, 119.0]
+
+    @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_re_probe_pre_recovers_match_boundary(self, mock_probe, _mock_static):
+        """Initial both None -> re-probe pre=True, post=False -> match_boundary.
+
+        Post must succeed (False) on re-probe; if it stays None the
+        existing "either side None -> unknown" rule keeps the result
+        unknown for safety.
+        """
+        f = _FAKE_FRAME
+        mock_probe.side_effect = [
+            ([None, None, None], [None, None, None]),  # pre initial
+            ([None, None, None], [None, None, None]),  # post initial
+            ([True, True, True], [f, f, f]),  # pre re-probe
+            ([False, False, False], [f, f, f]),  # post re-probe success False
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
+        assert result == "match_boundary"
+        # pre re-probe offsets = region_start - (region_width + 3/2/1)
+        # = 100 - 11/10/9 = 89/90/91
+        pre_re_call = mock_probe.call_args_list[2]
+        pre_re_ts = pre_re_call[0][1]
+        assert pre_re_ts == [89.0, 90.0, 91.0]
+
+    @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_re_probe_skipped_when_pre_true(self, mock_probe, _mock_static):
+        """Initial pre=True (any-side True) -> re-probe skipped."""
+        f = _FAKE_FRAME
+        mock_probe.side_effect = [
+            ([True, True, True], [f, f, f]),  # pre initial
+            ([False, False, False], [f, f, f]),  # post initial
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
+        assert result == "match_boundary"
+        assert mock_probe.call_count == 2
+
+    @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_re_probe_skipped_when_post_true(self, mock_probe, _mock_static):
+        """Initial post=True -> re-probe skipped."""
+        f = _FAKE_FRAME
+        mock_probe.side_effect = [
+            ([False, False, False], [f, f, f]),  # pre initial
+            ([True, True, True], [f, f, f]),  # post initial
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
+        assert result == "match_boundary"
+        assert mock_probe.call_count == 2
+
+    @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_re_probe_no_change_keeps_non_fl(self, mock_probe, _mock_static):
+        """Initial both False + re-probe both False -> non_fl preserved."""
+        f = _FAKE_FRAME
+        mock_probe.side_effect = [
+            ([False, False, False], [f, f, f]),  # pre initial
+            ([False, False, False], [f, f, f]),  # post initial
+            ([False, False, False], [f, f, f]),  # pre re-probe
+            ([False, False, False], [f, f, f]),  # post re-probe
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
+        assert result == "non_fl"
+        assert mock_probe.call_count == 4
+
+    @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_re_probe_promotes_unknown_to_non_fl(self, mock_probe, _mock_static):
+        """Initial both None + re-probe both False -> non_fl (unknown -> non_fl)."""
+        f = _FAKE_FRAME
+        mock_probe.side_effect = [
+            ([None, None, None], [None, None, None]),  # pre initial
+            ([None, None, None], [None, None, None]),  # post initial
+            ([False, False, False], [f, f, f]),  # pre re-probe success False
+            ([False, False, False], [f, f, f]),  # post re-probe success False
+        ]
+        result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
+        assert result == "non_fl"
+
+    @patch(f"{SCOREBAR_MODULE}._is_static_from_frames", return_value=False)
+    @patch(f"{SCOREBAR_MODULE}._probe_scorebar_context")
+    def test_re_probe_clamps_at_video_bounds(self, mock_probe, _mock_static):
+        """Pre re-probe collapses to existing 0.0 -> skipped; post re-probe runs."""
+        f = _FAKE_FRAME
+        mock_probe.side_effect = [
+            ([False], [f]),  # pre initial (all 3 collapse to 0.0)
+            ([False, False, False], [f, f, f]),  # post initial
+            # pre re-probe: max(0, 0-(5+3/2/1)) = 0.0 -> dedupe vs {0.0} -> empty
+            # post re-probe: 5+(5+1/2/3) = 11/12/13
+            ([True, True, True], [f, f, f]),  # post re-probe
+        ]
+        # region (0.0, 5.0), duration=15, region_width=5.0
+        result = classify_blackout(Path("v.mp4"), (0.0, 5.0), 15.0, _HEIGHT)
+        assert result == "match_boundary"
+        assert mock_probe.call_count == 3
+        post_re_call = mock_probe.call_args_list[2]
+        post_re_ts = post_re_call[0][1]
+        assert post_re_ts == [11.0, 12.0, 13.0]
 
 
 # --- _scaled_height tests ---


### PR DESCRIPTION
## 概要
4K Windows/Xbox Game DVR 録画で `classify_blackout` の post probes (`region_end + 1/2/3s`) が長い fade-in/out (~3s) に hit し、scorebar 検出が両側 False/None になって試合境界が `non_fl` 誤分類される問題 (Refs #524) を修正。pre/post とも True でない場合のみ `region_width + 1/2/3s` の offset で対称 re-probe を行う。

## 修正方針 (Option D: 失敗時 re-probe)

`classify_blackout` 内に以下の fallback を追加:

- **trigger 条件**: `pre_has is not True and post_has is not True` (片側でも True なら re-probe しない)
- **offset**: `region_width + 1/2/3s` (fade 帯が region 幅と相関する 4K DVR の特性に対応する動的設計)
- **対称適用**: pre 側にも `region_start - (region_width + 3/2/1)s` で同じロジックを適用
- **上書きルール**: re-probe 結果が `None` でない場合のみ採用 (既知の True を侵さない設計と整合)
- **境界 clamp & dedupe**: `max(0, ...)` / `min(duration, ...)` + 既存 timestamp との dedupe で動画端と無駄 probe を防ぐ

## Before / After (M1wa_zeromus 4K DVR 実測, --gpu --no-cache)

| # | 録画 | Codec | Before scorebar (MB/IM/non_fl) | Before match | After scorebar (MB/IM/non_fl) | After match |
|---|---|---|---|---|---|---|
| 1 | 2026.02.22 | AV1 | (cached, n/a) | 1 full [unknown] | **1 / 0 / 0** | **2 [unknown]** ✓ |
| 2 | 2026.03.24 21:02 | AV1 | 0 / 0 / 2 | 1 full [unknown] | **2 / 0 / 0** | **1 fl_match** ✓ |
| 3 | 2026.03.24 21:18 | AV1 | 1 / 0 / 1 | 1 full | **2 / 0 / 0** | **1 fl_match** ✓ |
| 4 | 2024.02.14 ARR | h264 | 0 / 0 / 2 | 1 full [unknown] | **2 / 0 / 0** | **1 fl_match** ✓ |
| 5 | 2024.07.01 ARR | h264 | 0 / 0 / 1 | 1 full [unknown] | 0 / 0 / 1 | 1 [unknown] (FL 試合非含有と推定) |

5 ファイル中 4 ファイルで scorebar 分類が改善。File 1 は match_count 1→2、File 2-4 は型 `unknown→fl_match` に格上げ。

### File 1 のメカニズム (issue 内 region 例)

- region: Pass 2 refined (367.5, 375.5) 8s, 真の暗転 364.5-378.5 14s
- region_width = 8.0
- pre re-probe: `367.5 - (8 + 3/2/1)` = 356.5 / 357.5 / 358.5 (前 match 内 = scorebar あり)
- post re-probe: `375.5 + (8 + 1/2/3)` = 384.5 / 385.5 / 386.5 (試合開始後 = scorebar あり)
- 結果: `non_fl` → `match_boundary` 救済 (実測 scorebar 1 match_boundary)

## 受け入れ条件 (Refs #524)

- [x] M1wa_zeromus 5 ファイルのうち少なくとも 1 ファイルで複数 match 検出に改善 (File 1: 1→2 + File 2-4: unknown→fl_match で 4 件改善)
- [x] tests/baselines/*.json の 1080p OBS baseline で match_count / boundary 時刻が無回帰 (`pytest -m slow tests/test_scorebar_regression.py` 33 件全 pass、20260116/118/119, 1:13:04 cache MISS)
- [x] V1/V2 routing 契約は維持 (`tests/test_scorebar_v2.py` 32 件全 pass)
- [x] 修正方針と実測根拠 (before/after の probe offset ごとの挙動) を本文で提示
- [x] 1080p OBS の短 gap 連続境界で match_boundary が in_match に誤分類される副作用なし (TestBaselineComparison + TestMatchDurations 全 pass、boundary 時刻も無変化)

## テスト

- 既存単体 92 件 pass
- 新規 `TestClassifyBlackoutReProbe` 7 件追加 pass:
  - test_re_probe_post_recovers_match_boundary (post で True 救済)
  - test_re_probe_pre_recovers_match_boundary (pre で True 救済、post 成功 False で match_boundary 確定)
  - test_re_probe_skipped_when_pre_true (pre True なら re-probe しない)
  - test_re_probe_skipped_when_post_true (post True なら re-probe しない)
  - test_re_probe_no_change_keeps_non_fl (両側 False のままなら non_fl 維持)
  - test_re_probe_promotes_unknown_to_non_fl (None+None → False+False で unknown→non_fl)
  - test_re_probe_clamps_at_video_bounds (動画端 clamp と dedupe で空 probe スキップ)
- 既存テスト 3 件 (test_non_fl, test_all_probes_failed, test_region_at_video_end) の mock を re-probe trigger 後の追加 call 分に拡張 (期待値は不変)
- ruff check . / ruff format --check . / pyright (scorebar.py) / pytest 738 件 (slow 除く) 全 pass
- pytest -m slow tests/test_scorebar_regression.py: 33 件 (20260116/118/119, 1:13:04) 全 pass

## Test plan

- [x] ruff check + format check
- [x] pyright (scorebar.py)
- [x] pytest (slow 除く) + 新規 7 件
- [x] pytest -m slow tests/test_scorebar_regression.py (1080p baseline 無回帰)
- [x] M1wa_zeromus 5 ファイル `--gpu --no-cache -v` 実測

## スコープ外

- baseline *.json の V2 基準 regenerate (#524 内で除外)
- 配信者動画対応 (#480)
- File 5 (2024.07.01 ARR) の改善: 元々 FL 試合を含まない動画と推定、本 PR の責務外

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 追加検証 (レビューコメント対応)

`pytest -m "slow or baseline_regen" tests/test_scorebar_regression.py` で 42 件 (全マーカー) を実行 (1:19:35)。

### 性能退行 — TestPerformance::test_overhead_within_budget

scorebar フィルタ ON/OFF の elapsed 比を測定し overhead < 30% を assert。

| 録画 | 結果 |
|---|---|
| 20260116 | **PASS** |
| 20260118 | **PASS** |
| 20260119 | **PASS** |

re-probe は trigger 条件 (両側 not True) のときのみ最大 6 追加 ffmpeg call。1080p OBS では match_boundary の片側 True が多く trigger 機会限定的、overhead 予算内に収まることを実機で確認。

### 下位互換 — TestNoResolutionCompat

| 録画 | test_same_count_as_baseline | test_boundaries_match_baseline |
|---|---|---|
| 20260116 | PASS | PASS |
| 20260118 | PASS | **FAIL** (Match 8 end: 6465.2 vs legacy 6184.0、281s ずれ) |
| 20260119 | PASS | PASS |

### 失敗 1 件の独立性

`TestNoResolutionCompat::test_boundaries_match_baseline[20260118]` は `src_resolution=None` (scorebar フィルタなし) パスを検証するテスト。本 PR の `classify_blackout` re-probe は `filter_blackouts_with_scorebar` 経由 = scorebar フィルタあり時のみ呼ばれるため、コードパス上 **本 PR の影響範囲外**。

推定原因は rebase で取り込んだ b7f7be8 (#543, Refs #437) GPU mode UX 三点修正の動的 chunk sizing (gpu_detector.py 57 行変更、長動画 8234s が chunk 細分化対象)。子 issue #560 として起票済み、本 PR スコープ外として進行する (Iron Law 3 整合)。

scorebar あり経路 (本 PR の対象パス) は TestBaselineComparison / TestDetectionCount / TestMatchDurations / TestMetadataIntegrity 全 33 件 pass で無回帰を確認済み。
