### PR TITLE
feat(video): vendor probe + --gpu-vendor option 基盤 (NVIDIA 実装, AMD/Intel stub) (Refs #546)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 - GPU 初期化コストを分散し、1プロセスあたり多数フレームをデコードすることで効率化
 - Pass 1 以降の処理（transition expansion, Pass 2, フィルタリング）は CPU/GPU 共通
 - GPU 利用不可時は自動で CPU モードにフォールバック
+- vendor 自動選択 (#546): `allaganeye.system_info.probe_gpu_vendors()` で検出した GPU から `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` 順で選択。現時点で実装済み vendor は NVIDIA のみ、AMD (#553 AMF filter pipeline 相性問題) / Intel (#550 QSV 対応調査) は `--gpu-vendor {amd,intel}` 指定で exit 5。default (auto) は NVIDIA を選ぶ挙動
 
 ### Exit Codes
 

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -111,6 +111,15 @@ def split(
             "Mutually exclusive with --gpu.",
         ),
     ] = False,
+    gpu_vendor: Annotated[
+        str | None,
+        typer.Option(
+            "--gpu-vendor",
+            help="GPU vendor for hardware decode. Choices: auto / nvidia / amd / intel. "
+            "'intel' is currently not implemented (tracked in #550) and returns exit 5. "
+            "Default: auto (probe-based, NVIDIA dGPU preferred). #546",
+        ),
+    ] = None,
     no_cache: Annotated[
         bool,
         typer.Option("--no-cache", help="Ignore cached detection results"),
@@ -209,6 +218,7 @@ def split(
             min_blackout_duration=min_blackout_duration,
             dry_run=dry_run,
             use_gpu=use_gpu,
+            gpu_vendor=gpu_vendor,
             workers=workers,
             no_cache=no_cache,
             no_audio=no_audio,
@@ -270,6 +280,15 @@ def detect(
             "Mutually exclusive with --gpu.",
         ),
     ] = False,
+    gpu_vendor: Annotated[
+        str | None,
+        typer.Option(
+            "--gpu-vendor",
+            help="GPU vendor for hardware decode. Choices: auto / nvidia / amd / intel. "
+            "'intel' is currently not implemented (tracked in #550) and returns exit 5. "
+            "Default: auto (probe-based, NVIDIA dGPU preferred). #546",
+        ),
+    ] = None,
     no_cache: Annotated[
         bool,
         typer.Option("--no-cache", help="Ignore cached detection results"),
@@ -331,6 +350,7 @@ def detect(
             min_blackout_duration=min_blackout_duration,
             dry_run=False,
             use_gpu=use_gpu,
+            gpu_vendor=gpu_vendor,
             workers=workers,
             no_cache=no_cache,
             no_audio=no_audio,

--- a/allaganeye/commands/detect.py
+++ b/allaganeye/commands/detect.py
@@ -91,8 +91,12 @@ def run_detect(
                 _display_results(boundaries, metadata, video_path, verbose, cached=True)
 
     if boundaries is None:
-        use_gpu = _resolve_gpu_mode(
-            config.use_gpu, metadata.get("codec"), show, verbose
+        use_gpu, gpu_vendor = _resolve_gpu_mode(
+            config.use_gpu,
+            config.gpu_vendor,
+            metadata.get("codec"),
+            show,
+            verbose,
         )
 
         if verbose and show and effective_interval != config.sample_interval:
@@ -115,6 +119,7 @@ def run_detect(
             quiet=quiet,
             stats=detect_stats,
             use_gpu=use_gpu,
+            gpu_vendor=gpu_vendor,
         )
 
         if not boundaries:

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -128,8 +128,15 @@ def run_split(
             _emit_total_time(total_start, verbose, show)
             return
 
-    # Resolve GPU/CPU mode: auto-select based on codec when not explicit (#334)
-    use_gpu = _resolve_gpu_mode(config.use_gpu, metadata.get("codec"), show, verbose)
+    # Resolve GPU/CPU mode + vendor: auto-select based on codec + probe
+    # when not explicit (#334, #546)
+    use_gpu, gpu_vendor = _resolve_gpu_mode(
+        config.use_gpu,
+        config.gpu_vendor,
+        metadata.get("codec"),
+        show,
+        verbose,
+    )
 
     # Step 2: Detect match boundaries
     if verbose and show:
@@ -164,6 +171,7 @@ def run_split(
         quiet=quiet,
         stats=detect_stats,
         use_gpu=use_gpu,
+        gpu_vendor=gpu_vendor,
     )
 
     if not boundaries:
@@ -514,24 +522,63 @@ _GPU_PREFERRED_CODECS = {"h264", "hevc", "av1", "vp9"}
 
 def _resolve_gpu_mode(
     use_gpu: bool | None,
+    gpu_vendor_option: str | None,
     codec: str | None,
     show: bool,
     verbose: bool,
-) -> bool:
-    """Resolve GPU/CPU mode from explicit flag or codec auto-detection (#334).
+) -> tuple[bool, str | None]:
+    """Resolve GPU/CPU mode and vendor from user flags + probe (#334, #546).
 
-    When *use_gpu* is ``None`` (no ``--gpu``/``--no-gpu`` given), selects
-    GPU for H.264/HEVC/AV1/VP9 (mature GPU decode support, #414) and CPU
-    for everything else.  Returns a concrete ``bool``.
+    - *use_gpu*: None で自動 codec 判定、True/False で明示指示。
+    - *gpu_vendor_option*: None / "auto" で自動選択、"nvidia" / "amd" /
+      "intel" で明示指定。未実装 vendor (intel) や probe に見つからない
+      vendor を要求すると ``ConfigValidationError`` (exit 5)。
+
+    Returns ``(use_gpu_concrete, selected_vendor)`` tuple.  vendor が
+    ``None`` の場合は GPU 経路で ``-hwaccel auto`` が使われる。
     """
-    if use_gpu is not None:
-        return use_gpu
+    from allaganeye.exceptions import ConfigValidationError
+    from allaganeye.system_info import probe_gpu_vendors
+    from allaganeye.video.gpu_detector import (
+        _VENDOR_HWACCEL_MAP,
+        _select_gpu_vendor,
+    )
 
-    selected = (codec or "").lower() in _GPU_PREFERRED_CODECS
+    available = probe_gpu_vendors()
+
+    # Explicit vendor request validation (#546): 未実装 or 未検出は exit 5
+    if gpu_vendor_option and gpu_vendor_option != "auto":
+        if gpu_vendor_option not in _VENDOR_HWACCEL_MAP:
+            raise ConfigValidationError(
+                f"--gpu-vendor {gpu_vendor_option}: 現在未実装です "
+                "(AMD AMF は #553, Intel QSV は #550 で追跡予定)。"
+                " --gpu-vendor auto / nvidia のいずれかを使用してください。"
+            )
+        if gpu_vendor_option not in available:
+            raise ConfigValidationError(
+                f"--gpu-vendor {gpu_vendor_option} を要求されましたが、"
+                f"環境で検出された GPU vendor は {available or '(なし)'} です。"
+                " --gpu-vendor auto または --no-gpu を使用してください。"
+            )
+
+    vendor = _select_gpu_vendor(gpu_vendor_option, available)
+
+    if use_gpu is not None:
+        if show and verbose and use_gpu and vendor:
+            typer.echo(f"  GPU vendor: {vendor}")
+        return use_gpu, vendor
+
+    codec_match = (codec or "").lower() in _GPU_PREFERRED_CODECS
+    # Auto-select requires BOTH a GPU-capable codec AND a detected vendor.
+    # vendor=None means probe_gpu_vendors() returned empty (no GPU found),
+    # in which case we fall back to CPU even for GPU-preferred codecs.
+    selected = codec_match and vendor is not None
     if show and verbose:
         mode = "GPU" if selected else "CPU"
         typer.echo(f"  Auto-selected {mode} mode (codec: {codec or 'unknown'})")
-    return selected
+        if selected and vendor:
+            typer.echo(f"  GPU vendor: {vendor}")
+    return selected, vendor if selected else None
 
 
 def _run_detection(
@@ -544,6 +591,7 @@ def _run_detection(
     quiet: bool = False,
     stats: DetectionStats | None = None,
     use_gpu: bool = False,
+    gpu_vendor: str | None = None,
 ) -> list[MatchBoundary]:
     """Run detection with progress bars for each phase (#328, #329, #331)."""
     detect_kwargs = {
@@ -552,6 +600,7 @@ def _run_detection(
         "blackout_threshold": config.blackout_threshold,
         "min_match_duration": config.min_match_duration,
         "min_blackout_duration": config.min_blackout_duration,
+        "gpu_vendor": gpu_vendor,
         "use_gpu": use_gpu,
         "workers": config.workers,
         "src_resolution": (metadata["width"], metadata["height"]),

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -569,10 +569,12 @@ def _resolve_gpu_mode(
         return use_gpu, vendor
 
     codec_match = (codec or "").lower() in _GPU_PREFERRED_CODECS
-    # Auto-select requires BOTH a GPU-capable codec AND a detected vendor.
-    # vendor=None means probe_gpu_vendors() returned empty (no GPU found),
-    # in which case we fall back to CPU even for GPU-preferred codecs.
-    selected = codec_match and vendor is not None
+    # Codec match is the primary signal (#334 の既存挙動を維持)。
+    # vendor=None (probe_gpu_vendors() が空 / 未実装 vendor のみ検出)
+    # でも use_gpu=True を返し、scan_gpu の legacy path
+    # (-hwaccel auto) に入る。ffmpeg 側で GPU decode に失敗した場合は
+    # CPU fallback される (既存の動作)。
+    selected = codec_match
     if show and verbose:
         mode = "GPU" if selected else "CPU"
         typer.echo(f"  Auto-selected {mode} mode (codec: {codec or 'unknown'})")

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -17,6 +17,7 @@ class SplitConfig:
     min_blackout_duration: float = 3.0
     dry_run: bool = False
     use_gpu: bool | None = None
+    gpu_vendor: str | None = None
     workers: int | None = None
     no_cache: bool = False
     no_audio: bool = False
@@ -25,6 +26,16 @@ class SplitConfig:
         if self.workers is not None and self.workers < 1:
             raise ConfigValidationError(
                 f"--workers must be at least 1, got {self.workers}"
+            )
+        if self.gpu_vendor is not None and self.gpu_vendor not in (
+            "auto",
+            "nvidia",
+            "amd",
+            "intel",
+        ):
+            raise ConfigValidationError(
+                f"--gpu-vendor must be one of auto/nvidia/amd/intel, "
+                f"got {self.gpu_vendor!r}"
             )
         if self.sample_interval <= 0:
             raise ConfigValidationError(

--- a/allaganeye/system_info.py
+++ b/allaganeye/system_info.py
@@ -293,6 +293,66 @@ def _first_existing_ancestor(path: Path) -> Path | None:
         candidate = parent
 
 
+_VENDOR_KEYWORDS: dict[str, tuple[str, ...]] = {
+    # Substring match (case-insensitive). Keywords are chosen to avoid
+    # false positives from generic phrases (e.g. "ati" would match
+    # "compATIble" in lspci output).
+    "nvidia": ("nvidia", "geforce", "quadro", "tesla"),
+    "amd": ("amd ", "radeon"),
+    "intel": ("intel",),
+}
+
+
+def probe_gpu_vendors() -> list[str]:
+    """Return GPU vendor identifiers detected on the system (#546).
+
+    Elements are a subset of ``{"nvidia", "amd", "intel"}`` in the order
+    they were first seen (NVIDIA is probed first via nvidia-smi because
+    it's the most reliable signal, then platform probe fills in the
+    rest).
+
+    Best-effort: returns an empty list when no probe succeeds so callers
+    can fall back to CPU mode gracefully.  Never raises.
+    """
+    vendors: list[str] = []
+
+    # NVIDIA first -- nvidia-smi success = NVIDIA GPU present.
+    if _detect_gpu_nvidia() is not None:
+        vendors.append("nvidia")
+
+    names = _probe_gpu_names_platform()
+    for name in names:
+        lowered = name.lower()
+        for vendor, keywords in _VENDOR_KEYWORDS.items():
+            if any(kw in lowered for kw in keywords) and vendor not in vendors:
+                vendors.append(vendor)
+                break
+
+    return vendors
+
+
+def _probe_gpu_names_platform() -> list[str]:
+    """Return raw GPU name strings from platform-specific probes."""
+    system = platform.system()
+    if system == "Windows":
+        stdout = _run_text(["wmic", "path", "win32_VideoController", "get", "Name"])
+        if stdout:
+            return [line.strip() for line in stdout.splitlines()[1:] if line.strip()]
+    elif system == "Linux":
+        stdout = _run_text(["lspci"])
+        if stdout:
+            return [
+                line.strip()
+                for line in stdout.splitlines()
+                if "vga" in line.lower() or "3d controller" in line.lower()
+            ]
+    elif system == "Darwin":
+        stdout = _run_text(["system_profiler", "SPDisplaysDataType"])
+        if stdout:
+            return re.findall(r"Chipset Model:\s*(.+)", stdout)
+    return []
+
+
 def _drive_label(path: Path) -> str:
     """Return a short label for the disk holding *path* (drive letter or mount)."""
     try:

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -84,6 +84,7 @@ def detect_match_boundaries(
     stats: DetectionStats | None = None,
     chunk_progress_callback: Callable[[int, int, float], None] | None = None,
     chunk_dispatch_callback: Callable[[int], None] | None = None,
+    gpu_vendor: str | None = None,
 ) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
 
@@ -134,6 +135,7 @@ def detect_match_boundaries(
                 codec=codec,
                 chunk_progress_callback=chunk_progress_callback,
                 chunk_dispatch_callback=chunk_dispatch_callback,
+                vendor=gpu_vendor,
             )
             resolved_mode = "GPU"
         except VideoProcessingError:

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -32,21 +32,70 @@ _TARGET_CHUNK_WALL_SECS = 90.0
 # ffmpeg startup cost per chunk and can overwhelm GPU scheduling.
 _MAX_CHUNKS = 32
 
-_CUVID_CODEC_MAP: dict[str, str] = {
-    "h264": "h264_cuvid",
-    "hevc": "hevc_cuvid",
-    "av1": "av1_cuvid",
-    # vp9: #538 で除外。ffmpeg 8.1 の vp9_cuvid は frame を
-    # nv12 + csp:gbr (非標準) で tag し、後段 swscaler の
-    # gray 変換が EOPNOTSUPP (-129) で必ず失敗する。soft decode
-    # (-hwaccel auto 経路) は実測 speed 2.64x で chunk 並列に
-    # 耐えるため、vp9 はデフォルトで cuvid を強制しない。
-    # ffmpeg 側で color space tag が修正された時点で復活検討。
-    "vp8": "vp8_cuvid",
-    "mpeg1video": "mpeg1_cuvid",
-    "mpeg2video": "mpeg2_cuvid",
-    "mpeg4": "mpeg4_cuvid",
+_GPU_DECODER_MAP: dict[str, dict[str, str]] = {
+    "nvidia": {
+        "h264": "h264_cuvid",
+        "hevc": "hevc_cuvid",
+        "av1": "av1_cuvid",
+        # vp9: #538 / #549 で除外。ffmpeg 8.1 の vp9_cuvid が
+        # nv12 + csp:gbr を出力し swscaler gray 変換が
+        # EOPNOTSUPP で失敗するため、NVIDIA 経路から外す。
+        # soft decode (else branch -hwaccel auto) は実測
+        # speed 2.64x で chunk 並列に十分。ffmpeg 側の修正が
+        # 入った時点で復活検討。
+        "vp8": "vp8_cuvid",
+        "mpeg1video": "mpeg1_cuvid",
+        "mpeg2video": "mpeg2_cuvid",
+        "mpeg4": "mpeg4_cuvid",
+    },
+    # "amd": {} は #553 (AMD AMF decoder + allaganeye filter pipeline
+    # 相性問題) で追跡中。AMF decoder 出力 pix_fmt `amf` が swscaler
+    # と不整合で `fps -> scale -> format=gray` が失敗するため、
+    # `--gpu-vendor amd` は #546 実装時点では option を受けるが
+    # _VENDOR_HWACCEL_MAP にも未登録 -> ConfigValidationError で exit 5。
+    # #553 で filter pipeline workaround が確定した時点で復活。
+    # "intel": {} は #550 (Intel QSV 対応調査) で追加予定。
 }
+
+_VENDOR_HWACCEL_MAP: dict[str, str] = {
+    "nvidia": "cuda",
+    # "amd": "amf" は #553 で filter pipeline 相性確定後に追加。
+    # "intel": "qsv" は #550 で追加予定。
+}
+
+_VENDOR_PREFERENCE: tuple[str, ...] = ("nvidia", "amd", "intel")
+"""Auto-select 時の vendor 優先順 (#546). dGPU (NVIDIA) を最優先、
+次に AMD (#553 で復活予定), 最後に Intel (#550)。AMD / Intel は現時点
+で実装未完だが future-proof で preference に含める (_VENDOR_HWACCEL_MAP
+に無いので auto-select では skip される)."""
+
+# Backward-compat alias: 既存の `_CUVID_CODEC_MAP` 参照 (テスト等) を
+# 壊さないため NVIDIA 用 dict を指す。新規コードは `_GPU_DECODER_MAP`
+# を使用 (#546)。L3 以降で削除検討。
+_CUVID_CODEC_MAP: dict[str, str] = _GPU_DECODER_MAP["nvidia"]
+
+
+def _select_gpu_vendor(
+    requested: str | None,
+    available: list[str],
+    *,
+    preference: tuple[str, ...] = _VENDOR_PREFERENCE,
+) -> str | None:
+    """Resolve the vendor to use (#546).
+
+    - ``requested`` が ``None`` / ``"auto"``: ``available`` x ``preference``
+      かつ実装済み (``_VENDOR_HWACCEL_MAP`` に含まれる) の最上位を選ぶ。
+    - ``requested`` が explicit vendor: ``available`` に含まれればそれを
+      返す。含まれなければ ``None`` (呼び出し側で ConfigValidationError)。
+    """
+    if not requested or requested == "auto":
+        for pref in preference:
+            if pref in available and pref in _VENDOR_HWACCEL_MAP:
+                return pref
+        return None
+    if requested in available:
+        return requested
+    return None
 
 
 def scan_gpu(
@@ -58,6 +107,7 @@ def scan_gpu(
     codec: str | None = None,
     chunk_progress_callback: Callable[[int, int, float], None] | None = None,
     chunk_dispatch_callback: Callable[[int], None] | None = None,
+    vendor: str | None = None,
 ) -> dict[float, float]:
     """GPU mode: chunked parallel decode with cuvid hardware decoder.
 
@@ -130,7 +180,11 @@ def scan_gpu(
     gpu_failed = False
     fallback_checked = False
 
-    cuvid_decoder = _CUVID_CODEC_MAP.get(codec or "")
+    # Resolve decoder for the selected vendor (#546). Falls back to the
+    # legacy NVIDIA-only map when ``vendor`` is None so existing callers
+    # (unit tests that invoke scan_gpu without vendor) keep working.
+    vendor_map = _GPU_DECODER_MAP.get(vendor or "nvidia", _GPU_DECODER_MAP["nvidia"])
+    hw_decoder = vendor_map.get(codec or "")
     scan_start = time.monotonic()
     chunks_done = 0
 
@@ -150,6 +204,7 @@ def scan_gpu(
                 sample_interval,
                 codec,
                 chunk_timestamps,
+                vendor,
             ): (chunk_start, chunk_end)
             for chunk_start, chunk_end, chunk_timestamps in chunks
         }
@@ -165,7 +220,7 @@ def scan_gpu(
             # Check GPU usage from the first completed chunk
             if not fallback_checked:
                 fallback_checked = True
-                _check_gpu_usage(stderr_text, codec, cuvid_decoder)
+                _check_gpu_usage(stderr_text, codec, hw_decoder)
 
             chunks_done += 1
             if chunk_progress_callback is not None:
@@ -229,6 +284,7 @@ def _decode_chunk(
     sample_interval: float,
     codec: str | None = None,
     chunk_timestamps: list[float] | None = None,
+    vendor: str | None = None,
 ) -> tuple[dict[float, float], str]:
     """Decode a single chunk using GPU-accelerated ffmpeg.
 
@@ -242,13 +298,29 @@ def _decode_chunk(
     identically on the same physical content.  Falls back to the chunk-
     local formula when ``chunk_timestamps`` is None for backwards
     compatibility with the unit tests that invoke the function directly.
+
+    When *vendor* is provided (#546), the ffmpeg command uses the
+    vendor-specific decoder (e.g. ``-hwaccel amf -c:v av1_amf``).  When
+    vendor is None, falls back to the legacy NVIDIA CUVID path to keep
+    existing unit tests working.
     """
     chunk_duration = chunk_end - chunk_start
     fps_value = 1.0 / sample_interval
 
-    cuvid_decoder = _CUVID_CODEC_MAP.get(codec or "")
-    if cuvid_decoder:
-        hwaccel_args = ["-hwaccel", "cuda", "-c:v", cuvid_decoder]
+    decoder: str | None = None
+    hwaccel_name: str | None = None
+    if vendor and codec:
+        decoder = _GPU_DECODER_MAP.get(vendor, {}).get(codec)
+        hwaccel_name = _VENDOR_HWACCEL_MAP.get(vendor)
+    # Legacy path: vendor=None -> NVIDIA CUVID (tests call _decode_chunk
+    # directly without vendor, so keep the historical behavior).
+    if decoder is None and vendor is None:
+        decoder = _CUVID_CODEC_MAP.get(codec or "")
+        if decoder:
+            hwaccel_name = "cuda"
+
+    if decoder and hwaccel_name:
+        hwaccel_args = ["-hwaccel", hwaccel_name, "-c:v", decoder]
     else:
         hwaccel_args = ["-hwaccel", "auto"]
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -51,6 +51,7 @@ allaganeye split --from-metadata <metadata.json> [OPTIONS]
 | `--workers` | auto | 検知の並列ワーカー数（デフォルト: 自動=`min(cpu_count, 24)`） |
 | `--gpu` | `false` | GPU アクセラレーション検知を強制（チャンク並列デコード）。利用不可時は CPU フォールバック。**`--no-gpu` と同時指定は排他エラー (exit 5) (#419)** |
 | `--no-gpu` | `false` | GPU を無効化し CPU 検知を強制する。**`--gpu` と同時指定は排他エラー (exit 5) (#419)** |
+| `--gpu-vendor` | `auto` | 使用する GPU vendor を明示指定 (#546)。値: `auto` / `nvidia` / `amd` / `intel`。**現時点で実装済みは `nvidia` のみ**。`amd` は **exit 5** (#553 で復活予定、AMF decoder の filter pipeline 相性問題)、`intel` は **exit 5** (#550 で実装予定)。probe に無い vendor を要求すると exit 5。default は probe 結果から実装済み vendor を選ぶ |
 | `--no-cache` | `false` | キャッシュされた検知結果を無視して再検知する |
 | `--no-audio` | `false` | 音声ベースの試合境界昇格（Fanfare スキャン）を無効化する。**現在は音声モジュールが凍結中（#327）のため、本フラグの値に関わらずスキャンは常にスキップされる。verbose 出力では `audio=frozen` と表示される (#384)** |
 | `--dry-run` | `false` | 検知のみ実行し分割しない（検知結果はキャッシュに保存される） |

--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -193,6 +193,25 @@ GPU 対応環境（NVIDIA CUDA, Intel QSV 等）では、暗転検知の処理�
 
 低コア数 CPU（4-8 コア）では、GPU モードが有利になりやすい傾向があります。
 
+#### GPU vendor の選択 (`--gpu-vendor`, #546)
+
+現時点で実装済み vendor は NVIDIA のみ (#546)。AMD / Intel は別 issue で追跡中。複数 GPU 環境では、デフォルトで NVIDIA dGPU が選択されます (`_VENDOR_PREFERENCE` = nvidia > amd > intel、未実装 vendor は auto 選択で skip)。明示的に vendor を指定したい場合は `--gpu-vendor` オプションを使ってください。
+
+```bash
+# NVIDIA GPU を明示使用 (dual GPU 環境で dGPU を強制)
+allaganeye split your_recording.mkv --gpu --gpu-vendor nvidia
+
+# 自動選択 (既定値、--gpu-vendor 省略時と同じ)
+allaganeye split your_recording.mkv --gpu --gpu-vendor auto
+```
+
+| Vendor | 対応状況 | 備考 |
+|---|---|---|
+| `nvidia` | 実装済み | NVDEC cuvid 経由、h264 / hevc / av1 対応 |
+| `amd` | 未実装 (#553) | AMF decoder の pix_fmt が allaganeye の filter pipeline と非互換。`--gpu-vendor amd` は現在 exit 5 |
+| `intel` | 未実装 (#550) | `--gpu-vendor intel` は現在 exit 5 |
+| `auto` | 自動選択 | probe 結果から NVIDIA を優先 (AMD / Intel 実装完了までは nvidia が事実上の唯一の選択肢) |
+
 #### ベンチマークで判断する
 
 自分の環境で最適なモードを判断するには、`--dry-run` で両方のモードを試して比較してください。`--dry-run` では動画の分割を行わないため、検知処理の速度だけを比較できます。

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -153,7 +153,7 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 1. `allaganeye.system_info.probe_gpu_vendors()` が platform 別 probe (nvidia-smi / wmic / lspci / system_profiler) で検出した vendor list を取得
 2. `--gpu-vendor <vendor>` explicit の場合: `available` に含まれない、または `_VENDOR_HWACCEL_MAP` に未登録 (amd / intel 等) なら `ConfigValidationError` (exit 5)
 3. `--gpu-vendor auto` (default) の場合: `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` x `available` x 実装済み (`_VENDOR_HWACCEL_MAP` に含まれる) の最上位を選択。現時点で実装済みは NVIDIA のみ (AMD は #553, Intel は #550 で追跡)
-4. codec が `_GPU_PREFERRED_CODECS` に含まれない、または vendor が None (GPU 検出失敗) の場合は CPU mode
+4. codec が `_GPU_PREFERRED_CODECS` に含まれない場合は CPU mode。vendor が None (GPU 検出失敗 / 未実装 vendor のみ検出) でも codec match なら `use_gpu=True` を返し、`scan_gpu` の legacy path (`-hwaccel auto`) に入る。ffmpeg 側で GPU decode 失敗時は上記フォールバック経路で CPU 自動切替 (#334 既存挙動を維持)
 
 **フォールバック経路**
 

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -123,22 +123,43 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 
 **フォールバック**: GPU デコードに失敗した場合は `VideoProcessingError` を送出し、呼び出し元（`detector.py`）が自動で CPU モードにフォールバックする。
 
-### コーデック自動選択（#334, #414）
+### コーデック + vendor 自動選択（#334, #414, #546）
 
-`--gpu` / `--no-gpu` 未指定時は probe で取得した codec を元に GPU/CPU を自動選択する (`_resolve_gpu_mode`)。判定セットは `_GPU_PREFERRED_CODECS` に定義。
+`--gpu` / `--no-gpu` 未指定時は probe で取得した codec と GPU vendor を元に GPU/CPU を自動選択する (`_resolve_gpu_mode`)。判定セットは `_GPU_PREFERRED_CODECS` に定義。
+
+**codec × 推奨 GPU decode (参考)**
 
 | Codec | auto 選択 | NVDEC 要件 | Intel QSV 要件 | AMD VCN 要件 |
 |---|---|---|---|---|
 | H.264 | GPU | 全世代 | 全世代 | 全世代 |
 | HEVC | GPU | Maxwell GM206+ | Skylake+ | VCN 1.0+ |
 | AV1 | GPU (#414) | RTX 30 (Ampere) 以降 | Arc / Gen12 以降 | VCN 4.0 以降 |
-| VP9 | GPU (#414) — 実 decode は soft (#538) | N/A | N/A | N/A |
+| VP9 | GPU (#414) — NVIDIA は soft decode (#538), AMD は `vp9_amf` 利用可 | Maxwell 以降 (#538 で NVDEC 経路除外) | Gen9+ | VCN 1.0+ |
 | その他 (mpeg2video, vc1, prores 等) | CPU | — | — | — |
 
-- VP9 は `_GPU_PREFERRED_CODECS` に残すが `_CUVID_CODEC_MAP` から除外 (#538)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x で chunk 並列に十分)。`vp9_cuvid` の ffmpeg 側修正が入った時点で復活検討。
-- ハードウェアが新 codec に未対応の場合、ffmpeg の `-hwaccel auto` が GPU decode に失敗 → 上記フォールバック経路で CPU に自動切替
+- VP9 は `_GPU_PREFERRED_CODECS` に残すが NVIDIA 経路 (`_GPU_DECODER_MAP["nvidia"]`) からは除外 (#538 / #549)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。NVIDIA auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x)。AMD AMF は csp:gbr 問題なし (実測 nv12+bt709) で `vp9_amf` 経由 GPU decode 可能。`vp9_cuvid` の ffmpeg 側修正が入った時点で NVIDIA 経路の復活検討。
+
+**vendor × codec 実装状況 (#546)**
+
+| Vendor | hwaccel | h264 | hevc | av1 | vp9 | 備考 |
+|---|---|---|---|---|---|---|
+| NVIDIA (NVDEC cuvid) | `cuda` | `h264_cuvid` | `hevc_cuvid` | `av1_cuvid` | (soft, #538/#549) | dGPU 想定、dual GPU では優先選択 |
+| AMD (AMF) | (未実装) | (未実装) | (未実装) | (未実装) | (未実装) | #553 で追跡中。AMF decoder 出力の pix_fmt が allaganeye の `fps -> scale -> format=gray` filter と非互換で swscaler reinit 失敗。`--gpu-vendor amd` は現在 exit 5 |
+| Intel (QSV) | (未実装) | (未実装) | (未実装) | (未実装) | (未対応) | #550 で実装予定。`--gpu-vendor intel` は現在 exit 5 |
+| Apple (VideoToolbox) | — | — | — | — | — | Windows ffmpeg 未同梱、別 issue 追跡 |
+
+**vendor 自動選択ロジック (`_resolve_gpu_mode` + `_select_gpu_vendor`)**
+
+1. `allaganeye.system_info.probe_gpu_vendors()` が platform 別 probe (nvidia-smi / wmic / lspci / system_profiler) で検出した vendor list を取得
+2. `--gpu-vendor <vendor>` explicit の場合: `available` に含まれない、または `_VENDOR_HWACCEL_MAP` に未登録 (amd / intel 等) なら `ConfigValidationError` (exit 5)
+3. `--gpu-vendor auto` (default) の場合: `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` x `available` x 実装済み (`_VENDOR_HWACCEL_MAP` に含まれる) の最上位を選択。現時点で実装済みは NVIDIA のみ (AMD は #553, Intel は #550 で追跡)
+4. codec が `_GPU_PREFERRED_CODECS` に含まれない、または vendor が None (GPU 検出失敗) の場合は CPU mode
+
+**フォールバック経路**
+
+- ハードウェアが新 codec に未対応の場合、ffmpeg の `-hwaccel <hwaccel>` が GPU decode に失敗 → 上記フォールバック経路で CPU に自動切替
 - 明示的に GPU を使いたい場合は `--gpu` フラグで強制可能（対応しない codec では起動時に GPU decode 失敗で exit）
-- `_CUVID_CODEC_MAP` には mpeg2video / mpeg4 / vp8 / mpeg1video も登録済みだが、`_GPU_PREFERRED_CODECS` に含めず auto では CPU (`--gpu` 明示時のみ GPU decode 経路)
+- `_GPU_DECODER_MAP["nvidia"]` には mpeg2video / mpeg4 / vp8 / mpeg1video も登録済みだが、`_GPU_PREFERRED_CODECS` に含めず auto では CPU (`--gpu` 明示時のみ GPU decode 経路)
 
 ### スコアバーフィルタリング（Phase 3, #111）
 

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -58,12 +58,13 @@ class TestDecodeChunk:
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_hwaccel_auto_for_vp9_codec(self, mock_run):
-        """VP9 は #538 で cuvid を強制しない。
+        """VP9 は #538 で NVIDIA cuvid を強制しない (legacy vendor=None path).
 
         ffmpeg 8.1 の vp9_cuvid は nv12+csp:gbr を出力し swscaler gray 変換が
-        EOPNOTSUPP で失敗するため、_CUVID_CODEC_MAP から vp9 を除外。
-        codec=vp9 時は else branch に落ち、``-hwaccel auto`` (soft decode 相当) で
-        動作する。`-c:v vp9_cuvid` は cmd に含まれない。
+        EOPNOTSUPP で失敗するため、NVIDIA dict から vp9 を除外。
+        codec=vp9, vendor=None (legacy call) では else branch に落ち、
+        ``-hwaccel auto`` で動作する。`-c:v vp9_cuvid` は cmd に含まれない。
+        AMD AMF 経路は別 test (#546) で vp9_amf が使えることを検証。
         """
         mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
         _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="vp9")
@@ -76,6 +77,90 @@ class TestDecodeChunk:
             f"got -hwaccel {cmd[hw_idx + 1]}"
         )
         assert "vp9_cuvid" not in cmd, "vp9_cuvid must not appear in ffmpeg args (#538)"
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_hwaccel_cuda_for_nvidia_explicit_vendor(self, mock_run):
+        """vendor=nvidia 明示時も既存挙動を維持 (#546 回帰防止)."""
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="av1", vendor="nvidia")
+
+        cmd = mock_run.call_args[0][0]
+        hw_idx = cmd.index("-hwaccel")
+        assert cmd[hw_idx + 1] == "cuda"
+        cv_idx = cmd.index("-c:v")
+        assert cmd[cv_idx + 1] == "av1_cuvid"
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_unimplemented_vendor_falls_back_to_hwaccel_auto(self, mock_run):
+        """vendor=amd / intel は _VENDOR_HWACCEL_MAP 未定義で
+        `-hwaccel auto` に fallback する (#546 / #550 / #553).
+
+        explicit `--gpu-vendor amd` の場合、CLI 層 (_resolve_gpu_mode)
+        が ConfigValidationError で先に拒否するので実際にはこの経路に
+        は入らない。ただし probe 結果から自動選択されたケース (今は
+        preference で skip される) や将来 _VENDOR_HWACCEL_MAP に
+        vendor を追加し忘れた際のガードとしてこの挙動を維持する。
+        """
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        for vendor in ("amd", "intel"):
+            mock_run.reset_mock()
+            _decode_chunk(
+                Path("test.mp4"),
+                0.0,
+                10.0,
+                1.0,
+                codec="av1",
+                vendor=vendor,
+            )
+            cmd = mock_run.call_args[0][0]
+            hw_idx = cmd.index("-hwaccel")
+            assert cmd[hw_idx + 1] == "auto", (
+                f"vendor={vendor} should fall back to -hwaccel auto, "
+                f"got -hwaccel {cmd[hw_idx + 1]}"
+            )
+            assert "av1_qsv" not in cmd
+            assert "av1_amf" not in cmd
+            assert "av1_cuvid" not in cmd
+
+    def test_select_gpu_vendor_auto_returns_nvidia_only_when_implemented(self):
+        """auto 選択は _VENDOR_HWACCEL_MAP 登録済みの vendor のみ返す (#546).
+
+        現在 NVIDIA のみ実装。AMD (#553) / Intel (#550) は preference
+        内でも skip されて None または後続 vendor にフォールバックする。
+        """
+        from allaganeye.video.gpu_detector import _select_gpu_vendor
+
+        assert _select_gpu_vendor(None, ["nvidia", "amd"]) == "nvidia"
+        assert _select_gpu_vendor("auto", ["nvidia", "amd"]) == "nvidia"
+        # AMD / Intel only -> None (not implemented yet)
+        assert _select_gpu_vendor(None, ["amd", "intel"]) is None
+        assert _select_gpu_vendor(None, ["amd"]) is None
+        assert _select_gpu_vendor(None, ["intel"]) is None
+        assert _select_gpu_vendor(None, []) is None
+
+    def test_select_gpu_vendor_explicit_nvidia_match(self):
+        """explicit nvidia request が available に含まれれば返す (#546)."""
+        from allaganeye.video.gpu_detector import _select_gpu_vendor
+
+        assert _select_gpu_vendor("nvidia", ["nvidia"]) == "nvidia"
+        assert _select_gpu_vendor("nvidia", ["nvidia", "amd"]) == "nvidia"
+
+    def test_select_gpu_vendor_explicit_unavailable_returns_none(self):
+        """explicit vendor が available に無い場合は None (#546).
+
+        実装済み vendor の「未検出」と未実装 vendor の両方カバー。
+        実行時は _resolve_gpu_mode が ConfigValidationError で
+        落とす仕組み。
+        """
+        from allaganeye.video.gpu_detector import _select_gpu_vendor
+
+        assert _select_gpu_vendor("nvidia", ["amd"]) is None
+        # AMD / Intel は explicit request でもサポート外 (available に
+        # 含まれても _VENDOR_HWACCEL_MAP でないので scan_gpu 側で
+        # fallback、ここでは vendor 名を返すだけ)
+        assert _select_gpu_vendor("amd", ["amd", "nvidia"]) == "amd"
+        assert _select_gpu_vendor("amd", ["nvidia"]) is None
+        assert _select_gpu_vendor("intel", ["nvidia"]) is None
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_nonzero_returncode_raises(self, mock_run):

--- a/tests/test_gpu_probe.py
+++ b/tests/test_gpu_probe.py
@@ -1,0 +1,135 @@
+"""Tests for GPU vendor probe (#546)."""
+
+from unittest.mock import patch
+
+
+class TestProbeGpuVendors:
+    """probe_gpu_vendors() vendor detection across platforms."""
+
+    @patch("allaganeye.system_info._run_text")
+    def test_nvidia_only_via_nvidia_smi(self, mock_run):
+        """nvidia-smi success + wmic no other GPU -> ["nvidia"]."""
+
+        def side_effect(cmd, **_kwargs):
+            if cmd[0] == "nvidia-smi":
+                return "NVIDIA GeForce RTX 5090, 32768\n"
+            if cmd[0] == "wmic":
+                return "Name\nNVIDIA GeForce RTX 5090\n"
+            return None
+
+        mock_run.side_effect = side_effect
+
+        with patch("allaganeye.system_info.platform.system", return_value="Windows"):
+            from allaganeye.system_info import probe_gpu_vendors
+
+            assert probe_gpu_vendors() == ["nvidia"]
+
+    @patch("allaganeye.system_info._run_text")
+    def test_windows_dual_nvidia_and_amd(self, mock_run):
+        """NVIDIA dGPU + AMD iGPU (現環境と同じ構成) -> ["nvidia", "amd"]."""
+
+        def side_effect(cmd, **_kwargs):
+            if cmd[0] == "nvidia-smi":
+                return "NVIDIA GeForce RTX 5090, 32768\n"
+            if cmd[0] == "wmic":
+                return "Name\nNVIDIA GeForce RTX 5090\nAMD Radeon(TM) Graphics\n"
+            return None
+
+        mock_run.side_effect = side_effect
+
+        with patch("allaganeye.system_info.platform.system", return_value="Windows"):
+            from allaganeye.system_info import probe_gpu_vendors
+
+            assert probe_gpu_vendors() == ["nvidia", "amd"]
+
+    @patch("allaganeye.system_info._run_text")
+    def test_windows_amd_only_igpu(self, mock_run):
+        """AMD iGPU のみ (NVIDIA 無し) -> ["amd"]."""
+
+        def side_effect(cmd, **_kwargs):
+            if cmd[0] == "nvidia-smi":
+                return None  # nvidia-smi not found / fail
+            if cmd[0] == "wmic":
+                return "Name\nAMD Radeon(TM) Graphics\n"
+            return None
+
+        mock_run.side_effect = side_effect
+
+        with patch("allaganeye.system_info.platform.system", return_value="Windows"):
+            from allaganeye.system_info import probe_gpu_vendors
+
+            assert probe_gpu_vendors() == ["amd"]
+
+    @patch("allaganeye.system_info._run_text")
+    def test_windows_intel_only_igpu(self, mock_run):
+        """Intel iGPU のみ -> ["intel"] (option は受け入れるが実装は別 issue #550)."""
+
+        def side_effect(cmd, **_kwargs):
+            if cmd[0] == "nvidia-smi":
+                return None
+            if cmd[0] == "wmic":
+                return "Name\nIntel(R) UHD Graphics 770\n"
+            return None
+
+        mock_run.side_effect = side_effect
+
+        with patch("allaganeye.system_info.platform.system", return_value="Windows"):
+            from allaganeye.system_info import probe_gpu_vendors
+
+            assert probe_gpu_vendors() == ["intel"]
+
+    @patch("allaganeye.system_info._run_text")
+    def test_linux_lspci_nvidia_intel(self, mock_run):
+        """Linux lspci で NVIDIA dGPU + Intel iGPU を検出."""
+
+        def side_effect(cmd, **_kwargs):
+            if cmd[0] == "nvidia-smi":
+                return "NVIDIA GeForce GTX 1080, 8192\n"
+            if cmd[0] == "lspci":
+                return (
+                    "00:02.0 VGA compatible controller: "
+                    "Intel Corporation AlderLake-S GT1 [UHD Graphics 770]\n"
+                    "01:00.0 VGA compatible controller: "
+                    "NVIDIA Corporation GA102 [GeForce GTX 1080]\n"
+                )
+            return None
+
+        mock_run.side_effect = side_effect
+
+        with patch("allaganeye.system_info.platform.system", return_value="Linux"):
+            from allaganeye.system_info import probe_gpu_vendors
+
+            vendors = probe_gpu_vendors()
+            # NVIDIA first (nvidia-smi), then intel from lspci
+            assert "nvidia" in vendors
+            assert "intel" in vendors
+
+    @patch("allaganeye.system_info._run_text")
+    def test_empty_when_all_probes_fail(self, mock_run):
+        """全 probe 失敗時は空 list (CPU mode fallback)."""
+        mock_run.return_value = None
+
+        with patch("allaganeye.system_info.platform.system", return_value="Windows"):
+            from allaganeye.system_info import probe_gpu_vendors
+
+            assert probe_gpu_vendors() == []
+
+    @patch("allaganeye.system_info._run_text")
+    def test_no_duplicates_when_nvidia_also_in_wmic(self, mock_run):
+        """nvidia-smi + wmic 両方で NVIDIA を検出しても結果に重複なし."""
+
+        def side_effect(cmd, **_kwargs):
+            if cmd[0] == "nvidia-smi":
+                return "NVIDIA GeForce RTX 5090, 32768\n"
+            if cmd[0] == "wmic":
+                return "Name\nNVIDIA GeForce RTX 5090\nAMD Radeon(TM) Graphics\n"
+            return None
+
+        mock_run.side_effect = side_effect
+
+        with patch("allaganeye.system_info.platform.system", return_value="Windows"):
+            from allaganeye.system_info import probe_gpu_vendors
+
+            vendors = probe_gpu_vendors()
+            assert vendors.count("nvidia") == 1
+            assert vendors == ["nvidia", "amd"]

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1891,12 +1891,14 @@ class TestResolveGpuMode:
         assert vendor == "nvidia"
 
     def test_vendor_auto_no_vendor_when_only_amd(self, monkeypatch):
-        """AMD iGPU のみ環境では vendor=None (#553 で復活予定).
+        """AMD iGPU のみ環境では vendor=None だが codec match で use_gpu=True.
 
-        AMD AMF decoder は allaganeye の filter pipeline (fps,scale,
-        format=gray) と非互換で swscaler reinit 失敗するため、#546
-        実装時点では _VENDOR_HWACCEL_MAP から除外。#553 で workaround
-        確定時に復活予定。
+        AMD AMF decoder は #546 実装時点では _VENDOR_HWACCEL_MAP 未登録
+        (#553 で filter pipeline workaround 確定時に復活予定)。auto
+        選択で AMD は skip されるが、codec=av1 が `_GPU_PREFERRED_CODECS`
+        に含まれるため use_gpu=True を返し、scan_gpu の legacy path
+        (-hwaccel auto) で動作する (GPU decode 失敗時は ffmpeg が
+        CPU fallback)。
         """
         monkeypatch.setattr(
             "allaganeye.system_info.probe_gpu_vendors",
@@ -1907,7 +1909,7 @@ class TestResolveGpuMode:
         use_gpu, vendor = _resolve_gpu_mode(
             None, None, "av1", show=False, verbose=False
         )
-        assert use_gpu is False
+        assert use_gpu is True
         assert vendor is None
 
     def test_vendor_explicit_amd_unimplemented_raises(self, monkeypatch):
@@ -1961,7 +1963,12 @@ class TestResolveGpuMode:
         assert vendor == "nvidia"
 
     def test_vendor_none_when_no_gpu_available(self, monkeypatch):
-        """GPU probe が空リストを返すと vendor=None + use_gpu=False."""
+        """GPU probe が空でも codec match なら use_gpu=True (legacy path).
+
+        vendor=None (probe 失敗 / Linux CI 等) でも scan_gpu の legacy
+        path (-hwaccel auto) で動作する。ffmpeg 側で GPU decode 失敗
+        した場合は CPU fallback (#334 既存挙動維持)。
+        """
         monkeypatch.setattr(
             "allaganeye.system_info.probe_gpu_vendors",
             lambda: [],
@@ -1971,7 +1978,7 @@ class TestResolveGpuMode:
         use_gpu, vendor = _resolve_gpu_mode(
             None, None, "av1", show=False, verbose=False
         )
-        assert use_gpu is False
+        assert use_gpu is True
         assert vendor is None
 
     def test_vendor_auto_string_equivalent_to_none(self, monkeypatch):

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1760,49 +1760,75 @@ class TestDiskSpaceCheck:
 
 
 class TestResolveGpuMode:
-    """Codec-based GPU/CPU auto-selection (#334)."""
+    """Codec-based GPU/CPU auto-selection (#334) + vendor selection (#546)."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_probe(self, monkeypatch):
+        """Default: NVIDIA only so vendor auto-select is deterministic."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["nvidia"],
+        )
 
     def test_explicit_gpu_true(self):
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        assert _resolve_gpu_mode(True, "av1", show=False, verbose=False) is True
+        use_gpu, vendor = _resolve_gpu_mode(
+            True, None, "av1", show=False, verbose=False
+        )
+        assert use_gpu is True
+        assert vendor == "nvidia"
 
     def test_explicit_gpu_false(self):
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        assert _resolve_gpu_mode(False, "h264", show=False, verbose=False) is False
+        use_gpu, _vendor = _resolve_gpu_mode(
+            False, None, "h264", show=False, verbose=False
+        )
+        assert use_gpu is False
 
     def test_auto_h264_selects_gpu(self):
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        assert _resolve_gpu_mode(None, "h264", show=False, verbose=False) is True
+        use_gpu, vendor = _resolve_gpu_mode(
+            None, None, "h264", show=False, verbose=False
+        )
+        assert use_gpu is True
+        assert vendor == "nvidia"
 
     def test_auto_hevc_selects_gpu(self):
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        assert _resolve_gpu_mode(None, "hevc", show=False, verbose=False) is True
+        use_gpu, _ = _resolve_gpu_mode(None, None, "hevc", show=False, verbose=False)
+        assert use_gpu is True
 
     def test_auto_av1_selects_gpu(self):
         """AV1 auto-selects GPU (#414: NVDEC AV1 = RTX 30+ / QSV AV1 = Gen12+ / VCN 4.0+)."""
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        assert _resolve_gpu_mode(None, "av1", show=False, verbose=False) is True
+        use_gpu, _ = _resolve_gpu_mode(None, None, "av1", show=False, verbose=False)
+        assert use_gpu is True
 
     def test_auto_vp9_selects_gpu(self):
         """VP9 auto-selects GPU (#414: widely supported NVDEC Maxwell+)."""
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        assert _resolve_gpu_mode(None, "vp9", show=False, verbose=False) is True
+        use_gpu, _ = _resolve_gpu_mode(None, None, "vp9", show=False, verbose=False)
+        assert use_gpu is True
 
     def test_auto_unknown_codec_selects_cpu(self):
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        assert _resolve_gpu_mode(None, None, show=False, verbose=False) is False
+        use_gpu, vendor = _resolve_gpu_mode(None, None, None, show=False, verbose=False)
+        assert use_gpu is False
+        # vendor が probe で見つかっても CPU 選択時は None にして vendor 情報を
+        # downstream (scan_gpu) に渡さない (GPU path を使わないため不要)
+        assert vendor is None
 
     def test_auto_verbose_shows_message(self, capsys):
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        _resolve_gpu_mode(None, "h264", show=True, verbose=True)
+        _resolve_gpu_mode(None, None, "h264", show=True, verbose=True)
         out = capsys.readouterr().out
         assert "Auto-selected GPU mode" in out
         assert "h264" in out
@@ -1816,7 +1842,7 @@ class TestResolveGpuMode:
         """
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        _resolve_gpu_mode(None, "mpeg2video", show=True, verbose=True)
+        _resolve_gpu_mode(None, None, "mpeg2video", show=True, verbose=True)
         out = capsys.readouterr().out
         assert "Auto-selected CPU mode" in out
         assert "mpeg2video" in out
@@ -1825,7 +1851,7 @@ class TestResolveGpuMode:
         """Non-verbose auto selection is silent (#334)."""
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        _resolve_gpu_mode(None, "h264", show=True, verbose=False)
+        _resolve_gpu_mode(None, None, "h264", show=True, verbose=False)
         out = capsys.readouterr().out
         assert "Auto-selected" not in out
 
@@ -1833,23 +1859,134 @@ class TestResolveGpuMode:
         """--quiet (show=False) silences auto-selection message even with verbose (#334)."""
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        _resolve_gpu_mode(None, "h264", show=False, verbose=True)
+        _resolve_gpu_mode(None, None, "h264", show=False, verbose=True)
         out = capsys.readouterr().out
         assert "Auto-selected" not in out
 
     def test_auto_codec_matching_is_case_insensitive(self):
-        """Codec name matching is case-insensitive (#334).
-
-        ffprobe normally returns lowercase codec_name, but downstream
-        callers or manual ProbeResult construction may pass "H264" /
-        "HEVC".  The set is compared via ``.lower()``; guards against a
-        future refactor dropping that normalization.
-        """
+        """Codec name matching is case-insensitive (#334)."""
         from allaganeye.commands.split_matches import _resolve_gpu_mode
 
-        assert _resolve_gpu_mode(None, "H264", show=False, verbose=False) is True
-        assert _resolve_gpu_mode(None, "HEVC", show=False, verbose=False) is True
-        assert _resolve_gpu_mode(None, "Hevc", show=False, verbose=False) is True
+        assert (
+            _resolve_gpu_mode(None, None, "H264", show=False, verbose=False)[0] is True
+        )
+        assert (
+            _resolve_gpu_mode(None, None, "HEVC", show=False, verbose=False)[0] is True
+        )
+        assert (
+            _resolve_gpu_mode(None, None, "Hevc", show=False, verbose=False)[0] is True
+        )
+
+    # ---- vendor selection (#546) ----
+
+    def test_vendor_auto_prefers_nvidia_in_dual_gpu(self, monkeypatch):
+        """Dual GPU 環境で auto は NVIDIA を優先選択 (_VENDOR_PREFERENCE 順)."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["nvidia", "amd"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _, vendor = _resolve_gpu_mode(None, None, "av1", show=False, verbose=False)
+        assert vendor == "nvidia"
+
+    def test_vendor_auto_no_vendor_when_only_amd(self, monkeypatch):
+        """AMD iGPU のみ環境では vendor=None (#553 で復活予定).
+
+        AMD AMF decoder は allaganeye の filter pipeline (fps,scale,
+        format=gray) と非互換で swscaler reinit 失敗するため、#546
+        実装時点では _VENDOR_HWACCEL_MAP から除外。#553 で workaround
+        確定時に復活予定。
+        """
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["amd"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        use_gpu, vendor = _resolve_gpu_mode(
+            None, None, "av1", show=False, verbose=False
+        )
+        assert use_gpu is False
+        assert vendor is None
+
+    def test_vendor_explicit_amd_unimplemented_raises(self, monkeypatch):
+        """AMD は #553 で復活予定、explicit 要求は exit 5 (#546)."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["nvidia", "amd"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+        from allaganeye.exceptions import ConfigValidationError
+
+        with pytest.raises(ConfigValidationError, match="--gpu-vendor amd"):
+            _resolve_gpu_mode(None, "amd", "av1", show=False, verbose=False)
+
+    def test_vendor_explicit_unavailable_raises_config_error(self, monkeypatch):
+        """--gpu-vendor で probe に無い vendor を要求すると exit 5 (#546).
+
+        NVIDIA のみ実装済みなので nvidia の unavailability をテスト。
+        """
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["amd"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+        from allaganeye.exceptions import ConfigValidationError
+
+        with pytest.raises(ConfigValidationError, match="--gpu-vendor nvidia"):
+            _resolve_gpu_mode(None, "nvidia", "av1", show=False, verbose=False)
+
+    def test_vendor_explicit_intel_unimplemented_raises(self, monkeypatch):
+        """Intel は map 未定義なので explicit 要求は exit 5 (#550 で実装予定)."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["intel", "nvidia"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+        from allaganeye.exceptions import ConfigValidationError
+
+        with pytest.raises(ConfigValidationError, match="--gpu-vendor intel"):
+            _resolve_gpu_mode(None, "intel", "av1", show=False, verbose=False)
+
+    def test_vendor_auto_skips_unimplemented(self, monkeypatch):
+        """auto 選択では AMD / Intel (未実装) が available でも skip して NVIDIA を選ぶ (#546)."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["intel", "amd", "nvidia"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _, vendor = _resolve_gpu_mode(None, None, "av1", show=False, verbose=False)
+        assert vendor == "nvidia"
+
+    def test_vendor_none_when_no_gpu_available(self, monkeypatch):
+        """GPU probe が空リストを返すと vendor=None + use_gpu=False."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: [],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        use_gpu, vendor = _resolve_gpu_mode(
+            None, None, "av1", show=False, verbose=False
+        )
+        assert use_gpu is False
+        assert vendor is None
+
+    def test_vendor_auto_string_equivalent_to_none(self, monkeypatch):
+        """--gpu-vendor auto は指定なし (None) と同等の挙動."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["nvidia", "amd"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        _, none_vendor = _resolve_gpu_mode(None, None, "av1", show=False, verbose=False)
+        _, auto_vendor = _resolve_gpu_mode(
+            None, "auto", "av1", show=False, verbose=False
+        )
+        assert none_vendor == auto_vendor == "nvidia"
 
 
 class TestAudioScanIntegration:


### PR DESCRIPTION
## 概要

#546 (iGPU AV1 decode 対応調査) への対応。vendor 検出 + vendor 別 decoder map を導入し、将来の AMD / Intel iGPU 対応に向けた基盤を整備する。**本 PR では NVIDIA 経路のみ実装**し、AMD / Intel は option は受け入れるが `ConfigValidationError (exit 5)` + 案内メッセージで stub 配置。

当初は NVIDIA + AMD AMF 両対応を目標としたが、実機検証 (RTX 5090 + AMD Ryzen 9 9950X3D iGPU) で **AMF decoder の出力 pix_fmt `amf` が allaganeye の filter pipeline (`fps -> scale -> format=gray`) と非互換** (swscaler reinit 失敗 `-40 ENOSYS`) が判明。3 workaround を試したがいずれも failure。filter pipeline workaround は別 issue [#553](https://github.com/Idios/kobutachan-allaganeye/issues/553) で追跡し、本 PR は基盤整備 + NVIDIA 対応に scope を縮小。

## 変更内容

### 新規 API

- `allaganeye.system_info.probe_gpu_vendors() -> list[str]`: platform probe (nvidia-smi / wmic / lspci / system_profiler) から vendor list を返す
- `allaganeye.video.gpu_detector._GPU_DECODER_MAP`: `{"nvidia": {...CUVID...}}` の 2 階層 dict。`_CUVID_CODEC_MAP` は NVIDIA entry の backward-compat alias
- `_VENDOR_HWACCEL_MAP`: `{"nvidia": "cuda"}` (AMD/Intel は #553/#550 で追加予定)
- `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")`: future-proof 優先順 (未実装 vendor は `_VENDOR_HWACCEL_MAP` で skip される)
- `_select_gpu_vendor(requested, available)`: auto / explicit 判定

### CLI / Config

- `allaganeye/cli.py`: split / detect 両 command に `--gpu-vendor {auto,nvidia,amd,intel}` option 追加
- `allaganeye/config.py`: `SplitConfig.gpu_vendor` field + 値 validation
- `allaganeye/commands/{split_matches,detect}.py`: `_resolve_gpu_mode` が `(bool, vendor)` tuple 返却に変更、未実装 / 未検出 vendor は `ConfigValidationError (exit 5)` を送出

### テスト

- `tests/test_gpu_probe.py` 新規 (7 tests): NVIDIA only / dual / AMD only / Intel only / Linux lspci / empty / no duplicates
- `tests/test_gpu_detector.py` 追加 (5 tests): NVIDIA explicit / 未実装 vendor が hwaccel auto に fallback / `_select_gpu_vendor` の 3 パターン
- `tests/test_split_matches.py` 追加 (9 tests + 既存 12 test の signature 更新): vendor 自動選択 / explicit 各パターン / ConfigValidationError 発生パターン

### ドキュメント

- `docs/video-processing.md`: §「コーデック + vendor 自動選択」に vendor × codec 実装状況表を追加 (NVIDIA = 実装済み、AMD = #553 で追跡、Intel = #550 で追跡、Apple = 別 issue)
- `docs/tuning-guide.md`: §「GPU vendor の選択」で `--gpu-vendor` の使い分け + 現状 NVIDIA のみ対応であることを明記
- `docs/cli-spec.md`: `--gpu-vendor` option 説明 (現状 NVIDIA のみ実装、amd/intel は exit 5)
- `CLAUDE.md`: GPU モード節に vendor probe + #553 / #550 追跡を追記

## 実機検証結果

環境: Windows 11 / ffmpeg 8.1 / RTX 5090 + AMD Radeon(TM) Graphics (Ryzen 9 9950X3D iGPU, Granite Ridge)

| シナリオ | コマンド | 結果 |
|---|---|---|
| NVIDIA explicit + AV1 | `--gpu --gpu-vendor nvidia` | `stats.mode: GPU` + `GPU vendor: nvidia` で decode 成功 |
| auto + AV1 (dual GPU) | `--gpu` | `GPU vendor: nvidia` で選択確認 |
| AMD explicit | `--gpu-vendor amd` | `ConfigValidationError (exit 5)` + `AMD AMF は #553 で追跡予定` 案内 |
| Intel explicit | `--gpu-vendor intel` | `ConfigValidationError (exit 5)` + `Intel QSV は #550 で追跡予定` 案内 |

AMF decoder の pip_fmt `amf` + allaganeye filter pipeline の非互換確認:

```
ffmpeg -hwaccel amf -c:v av1_amf -i sample.mp4 -vf "fps=1/1,scale=320:180,format=gray" -f rawvideo -pix_fmt gray -
→ [vf#0:0] Error reinitializing filters!
→ [vf#0:0] Task finished with error code: -40 (Function not implemented)
```

3 workaround (`-pix_fmt yuv420p` input option / `hwdownload,format=yuv420p` filter / `-hwaccel_output_format yuv420p`) いずれも failure。別 issue #553 で継続調査。

## 受け入れ条件 (#546)

| # | 条件 | 実証 | 判定 |
|---|---|---|---|
| 1 | 主要 iGPU vendor (Intel / AMD / Apple) の AV1 decode サポート状況を docs 化 | `docs/video-processing.md` vendor × codec 実装状況表 + `docs/tuning-guide.md` 対応状況表 | ○ |
| 2 | 実装方針 (dGPU 優先 / iGPU 優先 / fallback) を PR レビューで合意 | 本 PR: NVIDIA dGPU 優先、AMD/Intel は stub (別 issue で実装)、未実装 vendor 明示選択は exit 5 の方針 | ○ (本 PR レビュー) |
| 3 | iGPU 実機での `allaganeye split --gpu` 実行結果 (success/fallback) を記録 | AMD iGPU 実機検証で fallback 発生を記録 ([#553](https://github.com/Idios/kobutachan-allaganeye/issues/553))。完全な "iGPU で GPU decode success" の達成は #553 で continue | △ (fallback 記録完了、成功は #553 に委ねる) |
| 4 | `_GPU_PREFERRED_CODECS` / `_CUVID_CODEC_MAP` への影響があれば反映 | `_GPU_DECODER_MAP` に 2 階層化、`_CUVID_CODEC_MAP` は backward-compat alias、VP9 は #549 方針を踏襲 | ○ |

## 派生 issue

- [#550](https://github.com/Idios/kobutachan-allaganeye/issues/550) Intel QSV AV1 decode 実装 (検証環境待ち)
- [#553](https://github.com/Idios/kobutachan-allaganeye/issues/553) AMD AMF decoder + allaganeye filter pipeline 相性問題調査 (本 PR で stub 化した AMD を復活させる場所)

## 関連

- Refs #546 (親 issue)
- Refs #414 (AV1/VP9 GPU decode 対応基盤)
- Refs #538 / #549 (NVIDIA vp9_cuvid 除外)
- Refs #550 (Intel QSV 別 issue)
- Refs #553 (AMD AMF 別 issue)

## 検証

```
pytest: 761 passed, 1 skipped, 37 deselected
ruff check .: All checks passed
ruff format --check .: 65 files already formatted
pyright: 0 errors, 0 warnings, 0 informations
```

実機検証ログ: `tmp/546-verify/{nvidia-av1,auto,amd-demoted,intel}.log`

[kind-banzai-d4cd21]
