### PR TITLE
[task] CI/Release 軽量化: 二重zip+shared FFmpeg+cache (Refs #551)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,33 @@ jobs:
         with:
           python-version: "3.11.9"
 
-      - name: Install ffmpeg (BtbN LGPLv3 n8.1 static, pinned)
+      - name: Cache FFmpeg archive
+        id: cache-ffmpeg
+        uses: actions/cache@v4
+        with:
+          path: /tmp/ffmpeg.tar.xz
+          key: btbn-ffmpeg-linux64-lgpl-shared-8.1-d3b400378b8180fcc59249331ce03c75520404d9e62f950e4eb827f810cc7c53
+
+      - name: Download FFmpeg archive (cache miss)
+        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-22-13-15/ffmpeg-n8.1-10-g7f5c90f77e-linux64-lgpl-8.1.tar.xz"
-          FFMPEG_SHA256="863a5eb145a06529f3ce3c1ee4908abb24ac60d63b47659af9d696abbca9257e"
-          curl -fsSL -o /tmp/ffmpeg.tar.xz "$FFMPEG_URL"
+          curl -fsSL -o /tmp/ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-22-13-15/ffmpeg-n8.1-10-g7f5c90f77e-linux64-lgpl-shared-8.1.tar.xz"
+
+      - name: Install ffmpeg (BtbN LGPLv3 n8.1 shared, pinned)
+        shell: bash
+        run: |
+          set -euo pipefail
+          FFMPEG_SHA256="d3b400378b8180fcc59249331ce03c75520404d9e62f950e4eb827f810cc7c53"
           echo "$FFMPEG_SHA256  /tmp/ffmpeg.tar.xz" | sha256sum -c -
           mkdir -p /tmp/ffmpeg
           tar -xJf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg --strip-components=1
           echo "/tmp/ffmpeg/bin" >> "$GITHUB_PATH"
-          /tmp/ffmpeg/bin/ffmpeg -version
-          /tmp/ffmpeg/bin/ffprobe -version
+          # Shared build: exe wrappers load DLL/SO siblings from ../lib.
+          echo "LD_LIBRARY_PATH=/tmp/ffmpeg/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+          LD_LIBRARY_PATH="/tmp/ffmpeg/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" /tmp/ffmpeg/bin/ffmpeg -version
+          LD_LIBRARY_PATH="/tmp/ffmpeg/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" /tmp/ffmpeg/bin/ffprobe -version
 
       - name: Install dependencies
         run: pip install -e ".[dev]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
   build-windows:
     needs: version-check
     runs-on: windows-latest
+    env:
+      # build-portable-zip.ps1 reuses the BtbN FFmpeg zip from this directory
+      # when the digest matches, and saves freshly downloaded copies here.
+      # actions/cache persists the directory across runs keyed by asset SHA256.
+      ALLAGANEYE_BUILD_CACHE_DIR: ${{ github.workspace }}/build-cache
     steps:
       - uses: actions/checkout@v4
 
@@ -61,22 +66,23 @@ jobs:
         with:
           python-version: '3.11.9'
 
-      - name: Build Portable ZIP
-        shell: pwsh
-        run: ./scripts/build-portable-zip.ps1 -Version '${{ needs.version-check.outputs.version }}'
+      - name: Cache FFmpeg archive
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/build-cache
+          key: btbn-ffmpeg-win64-lgpl-shared-8.1-fef865cab8a097f07f1dcba66d73be94742b79d952cf6fd8643bd42c18995034
 
-      - name: Smoke test (extract ZIP and run launcher --version)
+      - name: Build Portable ZIP (skip archive)
+        shell: pwsh
+        run: ./scripts/build-portable-zip.ps1 -Version '${{ needs.version-check.outputs.version }}' -SkipArchive
+
+      - name: Smoke test (run launcher --version from built payload)
         shell: pwsh
         run: |
           $version = '${{ needs.version-check.outputs.version }}'
-          $zip = "dist/allaganeye-v$version-windows.zip"
-          if (-not (Test-Path $zip)) {
-            throw "ZIP not found: $zip"
-          }
-          Expand-Archive -Path $zip -DestinationPath 'smoke-extract' -Force
-          $payload = Join-Path 'smoke-extract' "allaganeye-v$version"
+          $payload = "build/portable/allaganeye-v$version"
           if (-not (Test-Path $payload)) {
-            throw "Extracted payload directory not found: $payload"
+            throw "Payload directory not found: $payload"
           }
           Push-Location $payload
           try {
@@ -99,10 +105,12 @@ jobs:
             Pop-Location
           }
 
+      # Upload the expanded payload folder; actions/upload-artifact zips it once
+      # on its own, which avoids the previous "zip inside a zip" artifact.
       - uses: actions/upload-artifact@v4
         with:
           name: allaganeye-portable-windows
-          path: dist/allaganeye-v*-windows.zip
+          path: build/portable/allaganeye-v${{ needs.version-check.outputs.version }}
           if-no-files-found: error
 
   release:
@@ -121,7 +129,17 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: allaganeye-portable-windows
-          path: dist
+          path: dist/allaganeye-v${{ needs.version-check.outputs.version }}
+
+      # Re-create the single release archive from the payload folder. Keeping
+      # the top-level allaganeye-v<version>/ directory inside the zip preserves
+      # the extraction layout users have relied on since v0.1.0.
+      - name: Create release archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          zip -r "allaganeye-v${{ needs.version-check.outputs.version }}-windows.zip" "allaganeye-v${{ needs.version-check.outputs.version }}"
 
       - name: Extract release notes from CHANGELOG
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ package-lock.json
 *.mov
 output/
 tmp/
+build-cache/
 
 # Node / GUI (gui/)
 node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 
 ### 外部依存
 
-- **ffmpeg / ffprobe**: 4.1 以上。PATH、`ALLAGANEYE_FFMPEG` 環境変数、または OS 別既知パスから自動検索（`allaganeye/ffmpeg_path.py`）。配布版・開発環境ともに LGPLv3 版 (BtbN FFmpeg-Builds `win64-lgpl` static、libdav1d 入り) の使用を推奨 (#508)
+- **ffmpeg / ffprobe**: 4.1 以上。PATH、`ALLAGANEYE_FFMPEG` 環境変数、または OS 別既知パスから自動検索（`allaganeye/ffmpeg_path.py`）。配布版・開発環境ともに LGPLv3 版 (BtbN FFmpeg-Builds `win64-lgpl-shared`、libdav1d 入り) の使用を推奨 (#508)
   - Windows: `ALLAGANEYE_FFMPEG` で BtbN LGPL ビルドを指定する運用を推奨。既存 winget (`Gyan.FFmpeg`, GPL) のインストール先も後方互換で自動検索される
   - macOS: Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`) を自動検索
 - **Python パッケージ**: numpy, typer, scipy, opencv-python-headless（scorebar V2 検出で使用 #307）

--- a/allaganeye/ffmpeg_path.py
+++ b/allaganeye/ffmpeg_path.py
@@ -115,7 +115,7 @@ def _error_message(name: str) -> str:
         lines.append(
             "  3. Download BtbN LGPL build from "
             "https://github.com/BtbN/FFmpeg-Builds/releases "
-            "(ffmpeg-nX.Y-...-win64-lgpl-X.Y.zip, recommended to match the Portable ZIP)"
+            "(ffmpeg-nX.Y-...-win64-lgpl-shared-X.Y.zip, recommended to match the Portable ZIP)"
         )
         lines.append(
             "  4. Existing winget Gyan.FFmpeg (GPL) installs are still auto-discovered "

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -8,7 +8,7 @@ CLI コマンド・引数・オプションの**構文**をまとめる。各オ
 
 | 要件 | 説明 |
 |---|---|
-| ffmpeg / ffprobe 4.1+ | 以下の順序で自動検索: (1) PATH (`shutil.which`) (2) `ALLAGANEYE_FFMPEG` 環境変数で指定したディレクトリ (3) OS 別既知パス（Windows: winget `Gyan.FFmpeg`、macOS: Homebrew）。配布版・dev 環境ともに LGPLv3 版 (BtbN FFmpeg-Builds `win64-lgpl` static) の使用を推奨 (#508)。winget `Gyan.FFmpeg` は GPL 版で、後方互換 fallback として自動検索される |
+| ffmpeg / ffprobe 4.1+ | 以下の順序で自動検索: (1) PATH (`shutil.which`) (2) `ALLAGANEYE_FFMPEG` 環境変数で指定したディレクトリ (3) OS 別既知パス（Windows: winget `Gyan.FFmpeg`、macOS: Homebrew）。配布版・dev 環境ともに LGPLv3 版 (BtbN FFmpeg-Builds `win64-lgpl-shared`) の使用を推奨 (#508)。winget `Gyan.FFmpeg` は GPL 版で、後方互換 fallback として自動検索される |
 
 ## グローバルオプション
 

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -162,7 +162,7 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
 
 | 優先度 | OS | 状態 | ffmpeg 自動検索 |
 |---|---|---|---|
-| 1 | Windows | 対応済み | `ALLAGANEYE_FFMPEG` で BtbN LGPLv3 static (#508 推奨) または winget (`Gyan.FFmpeg`, GPL、後方互換 fallback) |
+| 1 | Windows | 対応済み | `ALLAGANEYE_FFMPEG` で BtbN LGPLv3 shared (#508 推奨) または winget (`Gyan.FFmpeg`, GPL、後方互換 fallback) |
 | 2 | Linux | 未検証 | パッケージマネージャで PATH に入る（CI は lint/型チェックのみ） |
 | 3 | macOS | 未検証 | Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`) |
 

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -10,7 +10,7 @@
 
 - **Git**: ソースコードの取得・更新に使います
 - **Python 3.11 (3.11.9 推奨)**: 実行環境です（Portable ZIP 同梱の Python とは別に必要です）。CI と Portable ZIP は 3.11.9 で固定しているため、ローカルも同じ patch に揃えると挙動差を避けられます
-- **ffmpeg / ffprobe 8.1 LGPLv3 推奨**: 動画の解析・分割エンジンです。最低 4.1 で動作しますが、CI / Portable ZIP は BtbN の LGPLv3 8.1 static に固定しているので同系列を推奨します
+- **ffmpeg / ffprobe 8.1 LGPLv3 推奨**: 動画の解析・分割エンジンです。最低 4.1 で動作しますが、CI / Portable ZIP は BtbN の LGPLv3 8.1 shared に固定しているので同系列を推奨します
 
 ### Git
 
@@ -331,24 +331,25 @@ CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージ�
 | `scripts/build-portable-zip.ps1` | `$PythonVersion = '3.11.9'` + `$PythonEmbedSha256` |
 | `docs/developer-setup.md` §1 | 「Python 3.11 (3.11.9 推奨)」の記載 |
 
-### FFmpeg (現在 BtbN LGPLv3 n8.1 / `autobuild-2026-04-22-13-15` に固定)
+### FFmpeg (現在 BtbN LGPLv3 n8.1 shared / `autobuild-2026-04-22-13-15` に固定)
 
 更新手順:
 
 1. [BtbN/FFmpeg-Builds/releases](https://github.com/BtbN/FFmpeg-Builds/releases) で新しい `autobuild-YYYY-MM-DD-HH-MM` タグを選ぶ
-1. 必要な 2 資産 (win64-lgpl-8.1.zip / linux64-lgpl-8.1.tar.xz) の SHA256 を取得:
+1. 必要な 2 資産 (win64-lgpl-shared-8.1.zip / linux64-lgpl-shared-8.1.tar.xz) の SHA256 を取得:
 
    ```bash
    gh api repos/BtbN/FFmpeg-Builds/releases/tags/<タグ名> \
-     --jq '.assets[] | select(.name | test("n8[.]1.*(win64-lgpl-8[.]1[.]zip|linux64-lgpl-8[.]1[.]tar[.]xz)$")) | {name, digest}'
+     --jq '.assets[] | select(.name | test("n8[.]1.*(win64-lgpl-shared-8[.]1[.]zip|linux64-lgpl-shared-8[.]1[.]tar[.]xz)$")) | {name, digest}'
    ```
 
-1. 以下を**同一タグ・同一 autobuild 系列で**更新 (下表参照)。major version 系列変更 (例: 8.x → 9.x) 時は docs の major version 記述も揃える
+1. 以下を**同一タグ・同一 autobuild 系列で**更新 (下表参照)。major version 系列変更 (例: 8.x → 9.x) 時は docs の major version 記述も揃える。cache key に SHA256 が埋め込まれているので、SHA256 を変更すれば CI / release 両方のキャッシュが自動で invalidate される
 1. ローカルで Portable ZIP ビルドが緑になることを確認 (`pwsh ./scripts/build-portable-zip.ps1 -Version <version>`) し、PR で CI の `build-windows` と `python` ジョブ両方が通ることを確認する
 
 | 場所 | キー |
 |---|---|
 | `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` (`$FFmpegSourceCommit` は asset 名から自動抽出) |
-| `.github/workflows/ci.yml` (`Install ffmpeg` ステップ) | `FFMPEG_URL` / `FFMPEG_SHA256` (linux64-lgpl 版) |
+| `.github/workflows/ci.yml` (`Cache FFmpeg archive` / `Download FFmpeg archive (cache miss)` / `Install ffmpeg` の 3 ステップ) | cache `key` 内 SHA256 + DL step の URL + install step の `FFMPEG_SHA256` (linux64-lgpl-shared 版) |
+| `.github/workflows/release.yml` (`Cache FFmpeg archive` ステップ) | cache `key` 内 SHA256 (win64-lgpl-shared 版、build-portable-zip.ps1 の SHA256 と同じ値) |
 | `docs/developer-setup.md` §1 | 「ffmpeg / ffprobe 8.1 LGPLv3 推奨」「推奨: ffmpeg 8.1 LGPLv3」の major version 記述 (系列変更時のみ) |
 | `docs/quickstart.md` §10 | 対応 FFmpeg コミット (例: `7f5c90f77e`) の記述 (upstream commit 変更時) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -147,7 +147,7 @@ Portable ZIP には以下のソフトウェアが同梱されています。詳�
 - **allaganeye 本体**: MIT License (リポジトリの `LICENSE` ファイル)
 - **Python**: PSF License (`python\LICENSE.txt`)
 - **FFmpeg**: LGPLv3 (`ffmpeg\LICENSE.txt` に全文)
-  - ビルド: [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) の win64-lgpl static build
+  - ビルド: [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) の win64-lgpl-shared build
   - 対応 FFmpeg コミット: [git.ffmpeg.org](https://git.ffmpeg.org/ffmpeg.git) の commit `7f5c90f77e` (v8.1 系列)
 
-allaganeye 本体 (MIT) は FFmpeg バイナリをサブプロセスとしてのみ呼び出しているため、LGPLv3 の static linking 制約は allaganeye 本体には及びません。
+allaganeye 本体 (MIT) は FFmpeg バイナリをサブプロセスとしてのみ呼び出しているため、LGPLv3 の linking 制約は allaganeye 本体には及びません。同梱している shared-build DLL は FFmpeg 実行ファイルが動的にロードし、LGPLv3 の配布条件は同梱ライセンステキストで充足しています。

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -69,7 +69,7 @@ claude/<scope>-* → PR → /review-pr (受け入れ条件チェック) → /tes
 - タグ形式: `v<major>.<minor>.<patch>`
 - コマンド: `git tag -a v0.x.0 -m "Release v0.x.0: <レイヤー名>"`
 - `git push origin v0.x.0` すると [`.github/workflows/release.yml`](../.github/workflows/release.yml) が発火し、Windows Portable ZIP (`allaganeye-v<version>-windows.zip`) のビルドと GitHub Release への成果物自動添付を実行する (#461)
-  - ビルドは [`scripts/build-portable-zip.ps1`](../scripts/build-portable-zip.ps1) で Python 3.11 embeddable + FFmpeg LGPLv3 static (BtbN FFmpeg-Builds win64-lgpl、libdav1d 入り) を同梱する
+  - ビルドは [`scripts/build-portable-zip.ps1`](../scripts/build-portable-zip.ps1) で Python 3.11 embeddable + FFmpeg LGPLv3 shared (BtbN FFmpeg-Builds win64-lgpl-shared、libdav1d 入り) を同梱する
     - ダウンロードする外部バイナリ (Python embed / get-pip.py / FFmpeg) はスクリプト内に **SHA256 ダイジェストをハードコードして検証** する。ダイジェスト不一致時はビルドを fail。FFmpeg は BtbN の `autobuild-YYYY-MM-DD-HH-MM` タグと特定アセット名を URL にピン留めして再現性を確保する (`latest` タグは日次更新の可動ポインタなので不可)
     - 外部バイナリを更新する場合はスクリプト先頭の `$FFmpegBuildTag` / `$FFmpegAssetName` / `$*Sha256` 定数を更新する
   - Release 本文は [`scripts/extract_release_notes.py`](../scripts/extract_release_notes.py) が CHANGELOG.md から該当バージョンのセクションを抽出する

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -120,7 +120,7 @@ def _ffmpeg_interval(request: pytest.FixtureRequest) -> None:
 
 ### Windows
 
-- ffmpeg のパス自動検索: `ALLAGANEYE_FFMPEG` 環境変数で BtbN LGPLv3 static (配布物と同一、libdav1d 入り) を指定する運用を推奨 (#508)。既存 winget (`Gyan.FFmpeg`, GPL) のインストール先も後方互換で自動検索される
+- ffmpeg のパス自動検索: `ALLAGANEYE_FFMPEG` 環境変数で BtbN LGPLv3 shared (配布物と同一、libdav1d 入り) を指定する運用を推奨 (#508)。既存 winget (`Gyan.FFmpeg`, GPL) のインストール先も後方互換で自動検索される
 - GPU テスト: NVIDIA GPU + 最新ドライバが必要。GPU がない環境では自動的に CPU モードにフォールバックする
 
 ### Linux（未検証）

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -3,12 +3,16 @@
 Build the allaganeye Portable ZIP for Windows.
 
 .DESCRIPTION
-Downloads Python 3.11 embeddable and FFmpeg LGPLv3 static (BtbN), installs
+Downloads Python 3.11 embeddable and FFmpeg LGPLv3 shared (BtbN), installs
 allaganeye and its runtime dependencies into the payload, adds a .bat
 launcher, and compresses everything into dist/allaganeye-v<version>-windows.zip.
 
 Downloaded artefacts (Python embed, get-pip.py, FFmpeg zip) are pinned by URL
 and verified against hard-coded SHA256 digests. A mismatch aborts the build.
+
+The FFmpeg zip is cached in $env:ALLAGANEYE_BUILD_CACHE_DIR when that variable
+is set. CI populates that directory with actions/cache so the ~85MB BtbN zip
+is downloaded only on cache miss.
 
 The script is idempotent: build/portable and dist are cleaned at the start.
 
@@ -23,10 +27,18 @@ Pass -Version to actually run the build.
 Semantic version string (e.g. "0.2.0") used in the output ZIP filename. When
 omitted, the script loads its functions for dot-sourcing and returns without
 building anything.
+
+.PARAMETER SkipArchive
+If specified, leave the expanded payload under build/portable/allaganeye-v<version>/
+and do not create the final zip. CI passes this so actions/upload-artifact can
+zip the payload folder once, avoiding a "zip inside a zip" artifact. Local
+dry-run invocations omit this switch and still get dist/allaganeye-v*-windows.zip.
+Ignored when -Version is omitted (dot-sourcing path).
 #>
 [CmdletBinding()]
 param(
-  [string]$Version = ''
+  [string]$Version = '',
+  [switch]$SkipArchive
 )
 
 $ErrorActionPreference = 'Stop'
@@ -43,14 +55,16 @@ $GetPipSha256 = 'FEBA1C697DF45BE1B539B40D93C102C9EE9DDE1D966303323B830B06F3FBCA3
 
 # FFmpeg is pinned to a specific BtbN autobuild so the same allaganeye tag ships
 # the same binary and the LGPLv3 license applies uniformly across CI and Portable ZIP.
+# We use the shared variant (wrapper exe + individual avcodec/avfilter/... DLLs)
+# rather than the static build to keep Portable ZIP size down (~200 MB vs ~330 MB).
 # To update: bump $FFmpegBuildTag / $FFmpegAsset / $FFmpegSha256 together.
 # CI workflows (`.github/workflows/ci.yml`) must be updated with the matching
-# linux64-lgpl asset at the same build tag; see docs/developer-setup.md § 9.
+# linux64-lgpl-shared asset at the same build tag; see docs/developer-setup.md § 9.
 $FFmpegVersion = '8.1'
 $FFmpegBuildTag = 'autobuild-2026-04-22-13-15'
-$FFmpegAsset = 'ffmpeg-n8.1-10-g7f5c90f77e-win64-lgpl-8.1'
+$FFmpegAsset = 'ffmpeg-n8.1-10-g7f5c90f77e-win64-lgpl-shared-8.1'
 $FFmpegUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$FFmpegBuildTag/$FFmpegAsset.zip"
-$FFmpegSha256 = '230B29CD76AA194F76FB48BBF5D81CBAB8EFD7CD4FD1D7DE6500A040A8587A1C'
+$FFmpegSha256 = 'FEF865CAB8A097F07F1DCBA66D73BE94742B79D952CF6FD8643BD42C18995034'
 
 function Invoke-Download {
   param(
@@ -155,13 +169,15 @@ See https://github.com/Idios/kobutachan-allaganeye for full documentation.
 - allaganeye: MIT (see the repository LICENSE file)
 - Python: PSF License (python\LICENSE.txt)
 - FFmpeg: LGPLv3 (full text in ffmpeg\LICENSE.txt)
-    Build:         ffmpeg n$FFmpegVersion win64-lgpl static build (BtbN/FFmpeg-Builds)
+    Build:         ffmpeg n$FFmpegVersion win64-lgpl-shared build (BtbN/FFmpeg-Builds)
     Build tag:     $FFmpegBuildTag
     Source:        https://git.ffmpeg.org/ffmpeg.git (commit $FFmpegSourceCommit)
     Build scripts: https://github.com/BtbN/FFmpeg-Builds
 
 allaganeye (MIT) invokes the FFmpeg binary as a separate subprocess only.
-Static linking restrictions of LGPLv3 therefore do not apply to allaganeye itself.
+The shared-build DLLs are loaded dynamically by the FFmpeg executables and are
+redistributed under LGPLv3 alongside the license text; LGPLv3 therefore does
+not apply to allaganeye itself.
 "@
 }
 
@@ -214,20 +230,47 @@ New-Item -ItemType Directory -Force -Path $LibDir | Out-Null
     --no-cache-dir `
     $RepoRoot
 
-# 4. FFmpeg LGPLv3 static, BtbN/FFmpeg-Builds (version-pinned)
+# 4. FFmpeg LGPLv3 shared, BtbN/FFmpeg-Builds (version-pinned)
 # LGPLv3 redistribution requires shipping the license text alongside the binary
 # and making the corresponding source available. We copy LICENSE.txt into the
 # payload and point README at the upstream source repo.
 $FFmpegZip = Join-Path $BuildDir 'ffmpeg.zip'
-Invoke-Download -Uri $FFmpegUrl -OutPath $FFmpegZip -ExpectedSha256 $FFmpegSha256
+# Optional download cache: CI sets $env:ALLAGANEYE_BUILD_CACHE_DIR and uses
+# actions/cache to persist the BtbN zip across runs. Local builds leave the
+# variable unset and always download. Cache is keyed by asset name so a pinned
+# bump invalidates automatically; the SHA256 is re-verified on every reuse.
+$FFmpegCacheDir = $env:ALLAGANEYE_BUILD_CACHE_DIR
+if ($FFmpegCacheDir) {
+  $FFmpegCached = Join-Path $FFmpegCacheDir "$FFmpegAsset.zip"
+  if (Test-Path $FFmpegCached) {
+    $cachedHash = (Get-FileHash -Algorithm SHA256 -Path $FFmpegCached).Hash
+    if ($cachedHash -eq $FFmpegSha256.ToUpperInvariant()) {
+      Copy-Item -Path $FFmpegCached -Destination $FFmpegZip
+      Write-Host "Using cached FFmpeg zip: $FFmpegCached"
+    } else {
+      Write-Host "  Cached FFmpeg zip SHA256 mismatch, re-downloading"
+    }
+  }
+}
+if (-not (Test-Path $FFmpegZip)) {
+  Invoke-Download -Uri $FFmpegUrl -OutPath $FFmpegZip -ExpectedSha256 $FFmpegSha256
+  if ($FFmpegCacheDir) {
+    New-Item -ItemType Directory -Force -Path $FFmpegCacheDir | Out-Null
+    Copy-Item -Path $FFmpegZip -Destination (Join-Path $FFmpegCacheDir "$FFmpegAsset.zip") -Force
+    Write-Host "Saved FFmpeg zip to cache: $FFmpegCacheDir"
+  }
+}
 $FFmpegExtract = Join-Path $BuildDir 'ffmpeg-extracted'
 Expand-Archive -Path $FFmpegZip -DestinationPath $FFmpegExtract -Force
 $FFmpegLayout = Assert-FFmpegLayout -ExtractDir $FFmpegExtract
 $FFmpegSourceCommit = Get-FFmpegSourceCommit -AssetName $FFmpegAsset
 $FFmpegDest = Join-Path $PayloadDir 'ffmpeg'
 New-Item -ItemType Directory -Force -Path $FFmpegDest | Out-Null
+# Shared build: copy ffmpeg.exe, ffprobe.exe, and all DLLs. ffplay.exe is excluded
+# because allaganeye never invokes it and keeping it would cost ~17 MB.
 Copy-Item -Path (Join-Path $FFmpegLayout.Bin 'ffmpeg.exe') -Destination $FFmpegDest
 Copy-Item -Path (Join-Path $FFmpegLayout.Bin 'ffprobe.exe') -Destination $FFmpegDest
+Get-ChildItem -Path $FFmpegLayout.Bin -Filter '*.dll' | Copy-Item -Destination $FFmpegDest
 Copy-Item -Path $FFmpegLayout.License -Destination (Join-Path $FFmpegDest 'LICENSE.txt')
 
 # 5. Launcher
@@ -288,6 +331,12 @@ $Readme = Format-ReadmeContent `
   -FFmpegSourceCommit $FFmpegSourceCommit
 Set-Content -Path (Join-Path $PayloadDir 'README.txt') -Value $Readme -Encoding UTF8
 
-# 7. Compress
-Compress-Archive -Path $PayloadDir -DestinationPath $ZipPath -CompressionLevel Optimal
-Write-Host "Built $ZipPath"
+# 7. Compress (skipped with -SkipArchive so CI can hand the payload folder
+# directly to actions/upload-artifact; upload-artifact zips it once instead of
+# producing a nested zip).
+if ($SkipArchive) {
+  Write-Host "Skipping archive creation (-SkipArchive). Payload at: $PayloadDir"
+} else {
+  Compress-Archive -Path $PayloadDir -DestinationPath $ZipPath -CompressionLevel Optimal
+  Write-Host "Built $ZipPath"
+}

--- a/scripts/tests/build-portable-zip.Tests.ps1
+++ b/scripts/tests/build-portable-zip.Tests.ps1
@@ -113,7 +113,7 @@ Describe 'Get-FFmpegSourceCommit' {
 }
 
 Describe 'Format-ReadmeContent' {
-  It 'includes the LGPLv3 BtbN win64-lgpl attribution and the source commit' {
+  It 'includes the LGPLv3 BtbN win64-lgpl-shared attribution and the source commit' {
     $readme = Format-ReadmeContent `
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
@@ -122,8 +122,32 @@ Describe 'Format-ReadmeContent' {
 
     $readme | Should -Match 'LGPLv3'
     $readme | Should -Match 'BtbN/FFmpeg-Builds'
-    $readme | Should -Match 'win64-lgpl'
+    # The Portable ZIP ships the shared variant (#551), so README must point
+    # to the matching BtbN asset name to satisfy LGPLv3 source-availability.
+    $readme | Should -Match 'win64-lgpl-shared'
     $readme | Should -Match '7f5c90f77e'
     $readme | Should -Match 'autobuild-2026-04-22-13-15'
+    # Shared-build wording supersedes the old "Static linking restrictions"
+    # paragraph; assert the new dynamic-linking explanation is present.
+    $readme | Should -Match 'shared-build DLLs'
+  }
+}
+
+Describe 'Script parameters' {
+  It 'exposes -SkipArchive as a switch parameter' {
+    # CI sets -SkipArchive so actions/upload-artifact can zip the payload
+    # folder once (#551). Regression-test: keep the switch on the param block.
+    $cmd = Get-Command $script:BuildScript
+    $cmd.Parameters.ContainsKey('SkipArchive') | Should -BeTrue
+    $cmd.Parameters['SkipArchive'].SwitchParameter | Should -BeTrue
+  }
+
+  It 'keeps -Version optional so dot-sourcing loads functions without building' {
+    # The Pester suite dot-sources the script with no arguments to load helper
+    # functions; making -Version mandatory again would break this contract.
+    $cmd = Get-Command $script:BuildScript
+    $cmd.Parameters['Version'].Attributes |
+      Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+      ForEach-Object { $_.Mandatory | Should -BeFalse }
   }
 }

--- a/tests/test_ffmpeg_path.py
+++ b/tests/test_ffmpeg_path.py
@@ -108,7 +108,7 @@ class TestErrorMessage:
         """
         msg = _error_message("ffmpeg")
         assert "BtbN" in msg
-        assert "win64-lgpl" in msg
+        assert "win64-lgpl-shared" in msg
         assert "Gyan.FFmpeg" in msg
 
     @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific guidance")


### PR DESCRIPTION
## Summary

- issue #551 対応: Portable ZIP / CI の軽量化 3 点を 1 PR にまとめて実施
- artifact 二重 zip を `-SkipArchive` スイッチ新設で根本解消 (CI では payload フォルダを `upload-artifact@v4` に直接渡し、zip 化を 1 回だけに)
- FFmpeg を BtbN `win64-lgpl` (static) → `win64-lgpl-shared` (wrapper exe + 共通 DLL) に切替、`ffmpeg/` が 328MB → 193MB (135MB 削減、41%)
- BtbN FFmpeg zip を `actions/cache` でキャッシュ (cache key に SHA256 埋込、新版で自動 invalidate)

## 受け入れ条件 (#551) 対応

### A. Portable ZIP 二重圧縮の根本解消

- [x] `-SkipArchive` スイッチを新設し、指定時は `Compress-Archive` をスキップ ([scripts/build-portable-zip.ps1:31-36, 277-285](scripts/build-portable-zip.ps1))
- [x] `release.yml` の `build-windows` で `-SkipArchive` を渡し、upload-artifact には `build/portable/allaganeye-v*/` フォルダを渡す ([.github/workflows/release.yml:77, 87](.github/workflows/release.yml))
- [x] `release` ジョブで gh-release に渡す前に 1 回だけ `Compress-Archive` ([.github/workflows/release.yml:103-116](.github/workflows/release.yml))
- [x] `release.yml` を `workflow_dispatch` で dry-run ([run 24817513520](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817513520)) し、artifact ダウンロード時に `.zip` 単独 (中にさらに zip がない) であることを実測
  - artifact zip サイズ: **190,496,814 bytes (181.7 MB)**
  - 展開後 top-level: `README.txt`, `allaganeye.bat`, `ffmpeg/`, `lib/`, `python/` の 5 項目 (= payload 直置き、`allaganeye-v*.zip` のネストなし)
  - `find . -name '*.zip'` → `python/python311.zip` のみ (embeddable Python stdlib、想定内)

### B. FFmpeg static → shared build 切替

- [x] `$FFmpegAsset` を `ffmpeg-n8.1-10-g7f5c90f77e-win64-lgpl-shared-8.1` / `$FFmpegSha256` を `FEF865CA...` に更新 ([scripts/build-portable-zip.ps1:71-75](scripts/build-portable-zip.ps1))
- [x] FFmpeg 配置ロジックを `bin/` 以下全体コピーに変更 (ffplay.exe 除外)。`Assert-FFmpegLayout` の戻り値 `$FFmpegLayout.Bin` 経由 ([scripts/build-portable-zip.ps1:276-283](scripts/build-portable-zip.ps1))
  - 実 payload `ffmpeg/` 内訳: `ffmpeg.exe` + `ffprobe.exe` + `avcodec-62.dll` / `avdevice-62.dll` / `avfilter-11.dll` / `avformat-62.dll` / `avutil-60.dll` / `swresample-6.dll` / `swscale-9.dll` の 7 DLL + `LICENSE.txt`
- [x] `ci.yml` の FFmpeg install を `linux64-lgpl-shared` に揃え + `LD_LIBRARY_PATH` 設定 + 3 step (cache/download/install) に分割 ([.github/workflows/ci.yml:17-43](.github/workflows/ci.yml))
- [x] `Format-ReadmeContent` 関数内の build 表記を `win64-lgpl-shared build` に更新、static linking 文言を「shared-build DLLs are loaded dynamically...」に差し替え ([scripts/build-portable-zip.ps1:180-186](scripts/build-portable-zip.ps1))
- [x] Portable ZIP から `allaganeye split` を CPU/GPU × 音声昇格/--no-audio の **4 組合せ**で実機確認、segment info が CPU 基準版と一致

  | 組合せ | 実行時間 | segments | `match_001.mp4` サイズ | metadata segment-info diff |
  |---|---|---|---|---|
  | CPU × 音声昇格 (基準) | 48 s | 1 | 2,365,638,203 bytes | - |
  | CPU × `--no-audio` | 43 s | 1 | 2,365,638,203 bytes | 一致 |
  | GPU × 音声昇格 | 25 s | 1 | 2,365,638,203 bytes | 一致 |
  | GPU × `--no-audio` | 23 s | 1 | 2,365,638,203 bytes | 一致 |

  検証動画: `E:/royalstraightflesh/videos/20260116/20260116_1.mp4` (2.3 GB, 単一試合)。

- [x] Portable ZIP 合計サイズが static 版比で **100 MB 以上削減** ✓
  - Static 版 `ffmpeg/` (実測): ffmpeg.exe 164 MB + ffprobe.exe 164 MB = **328 MB** (BtbN `win64-lgpl` ダウンロード実測)
  - Shared 版 `ffmpeg/` (実測): 193 MB (7 DLL + 2 exe + LICENSE.txt、ffplay.exe 除外)
  - **削減 135 MB (41%)**

### C. BtbN FFmpeg zip ダウンロードキャッシュ

- [x] `.github/workflows/ci.yml` の FFmpeg install を `actions/cache@v4` で包む。cache key は `btbn-ffmpeg-linux64-lgpl-shared-8.1-<sha256>` で SHA256 ベース (URL 変更で自動 cache miss) ([.github/workflows/ci.yml:17-22](.github/workflows/ci.yml))
- [x] `.github/workflows/release.yml` の `build-windows` で `ALLAGANEYE_BUILD_CACHE_DIR` 環境変数 + `actions/cache@v4` を組み合わせ。`build-portable-zip.ps1` が既存 zip の SHA256 一致時にダウンロードをスキップし、未ヒット時は DL 後に cache dir に保存 ([.github/workflows/release.yml:57-75](.github/workflows/release.yml), [scripts/build-portable-zip.ps1:125-146](scripts/build-portable-zip.ps1))
- [x] ci.yml / release.yml 共に 2 回目以降 cache ヒットを CI ログで確認
  - **CI python (ubuntu)**: 1st [run 24817506083](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817506083) cache miss / 2nd [run 24867693227](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24867693227) `Cache hit for: btbn-ffmpeg-linux64-lgpl-shared-8.1-d3b4...` + `Cache restored from key: ...` + `Cache hit occurred on the primary key ..., not saving cache.`
  - **release.yml build-windows**: 1st [run 24817506084](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817506084) cache miss (Saved FFmpeg zip to cache) / 2nd [run 24867693214](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24867693214) `Cache hit for: btbn-ffmpeg-win64-lgpl-shared-8.1-fef8...` + ps1 log `Using cached FFmpeg zip: D:\a\...\build-cache\ffmpeg-...shared-8.1.zip`

### D. 共通

- [x] `ruff check .` / `ruff format --check .` / `pyright` / `pytest` 通過
  - Local: `All checks passed!` / `64 files already formatted` / `0 errors, 0 warnings` / `741 passed, 1 skipped, 37 deselected`
  - CI python job 2 連続 green ([run 24817506083](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817506083), [run 24867693227](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24867693227))
- [x] Pester v5 テスト通過 (shared 文言 + `-SkipArchive` switch 新規追加分含む)
  - Local: 9/9 passed (前 7 件 + 新規 `Format-ReadmeContent` の `win64-lgpl-shared` / `shared-build DLLs` assertion, `Script parameters` の `-SkipArchive` switch / `-Version` optional dot-sourcing 担保の 2 件)
  - CI installer-pester 2 連続 green
- [x] PR 本文に変更前後の Portable ZIP サイズ・artifact サイズ・CI 所要時間の実測値を記載

  | 測定項目 | 値 | 備考 |
  |---|---|---|
  | Portable ZIP 展開後サイズ (shared) | ~500 MB | ffmpeg/ 193 MB + lib/ 266 MB + python/ 42 MB |
  | `ffmpeg/` 削減 | 328 MB → 193 MB (-135 MB, -41%) | static→shared |
  | upload-artifact zip サイズ (dry-run) | 190,496,814 bytes (181.7 MB) | [run 24817513520](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817513520) |
  | `build-windows` 所要時間 (cache miss→hit) | 84 s → 64 s (-20 s, -24%) | [1st](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817506084) / [2nd](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24867693214) |
  | `ci.yml` python 所要時間 (cache miss→hit) | 57 s → 52 s (-5 s, -9%) | ubuntu 側は DL 元々速く差分小 |

## 変更ファイル

- `scripts/build-portable-zip.ps1`: `-SkipArchive` switch 追加、shared build 切替 (`$FFmpegAsset` / `$FFmpegSha256`)、DLL 全コピー (ffplay.exe 除外) を既存 `Assert-FFmpegLayout` の戻り値 `$FFmpegLayout.Bin` 経由で実装、`ALLAGANEYE_BUILD_CACHE_DIR` 経由のキャッシュロジック、`Format-ReadmeContent` 関数内の shared 文言更新
- `scripts/tests/build-portable-zip.Tests.ps1`: `Format-ReadmeContent` の `win64-lgpl-shared` / `shared-build DLLs` assertion 更新 + `Script parameters` describe 追加 (`-SkipArchive` switch / `-Version` optional 回帰テスト)
- `.github/workflows/release.yml`: `build-windows` で `-SkipArchive` + `actions/cache@v4` + upload-artifact に payload フォルダ / `release` ジョブで zip 再生成
- `.github/workflows/ci.yml`: FFmpeg install を 3 step (cache / download-on-miss / install) に分割、linux64-lgpl-shared + `LD_LIBRARY_PATH` 設定
- `allaganeye/ffmpeg_path.py`, `tests/test_ffmpeg_path.py`: エラーメッセージと assertion を shared 整合に
- docs 7 件 (`quickstart.md`, `release-process.md`, `testing-guide.md`, `cli-spec.md`, `design-overview.md`, `developer-setup.md` ×複数箇所): static → shared の文言整合、`developer-setup.md` §FFmpeg 更新手順に「cache key に SHA256 埋込で自動 invalidate」「ci.yml 3 ステップ化」「release.yml Cache FFmpeg archive step」を追記
- `.gitignore`: `build-cache/` を追加

## 非スコープ (別 issue で対応予定)

#551 の非スコープ節の通り、以下は本 PR では扱わない:

- lib/ の tests/ / cv2/data/ 削除
- .py → .pyc 化
- Python embeddable からの tkinter / ssl / sqlite 削除

## Test plan

- [x] ローカル Windows build (SkipArchive モード / 通常モード両方) が成功し、想定の出力を得る
- [x] Portable ZIP から CPU/GPU × 音声昇格/--no-audio の 4 組合せで実動画動作確認
- [x] ruff / pyright / pytest 通過 (ローカル)
- [x] Pester v5 通過 (ローカル 9/9)
- [x] CI (PR) で `python` / `gui-frontend` / `gui-rust` / `installer-pester` 全緑 ([1st](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817506083), [2nd](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24867693227))
- [x] release.yml (PR-trigger) `build-windows` 緑 + artifact 構造確認 ([1st](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817506084), [2nd](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24867693214))
- [x] release.yml `workflow_dispatch` dry-run で artifact 二重 zip 解消を実証 ([run 24817513520](https://github.com/Idios/kobutachan-allaganeye/actions/runs/24817513520))
- [x] 2 回目 CI run で cache hit をログ確認 (python / build-windows 両方)

## レビュー対応履歴 (goofy-wiles-db1319 への対応)

- **R1 (リベース + #548 競合解消)**: `f0fe43f` で `origin/develop-0.2.0` にリベースし、`scripts/build-portable-zip.ps1` の conflict (param / FFmpeg コピー / README 生成) を base の関数化 (`Assert-FFmpegLayout` / `Format-ReadmeContent`) + `-Version = ''` (dot-sourcing 対応) + `-SkipArchive` switch を維持する形で解消。関数内の "win64-lgpl static build" / "Static linking restrictions" 文言を shared 用に更新
- **R1-c (Pester 更新)**: `Format-ReadmeContent` の assertion を `win64-lgpl-shared` / `shared-build DLLs` に具体化。`Script parameters` describe を新設し、`-SkipArchive` switch と `-Version` optional (dot-sourcing 担保) の回帰テストを追加。ローカル 9/9 / CI installer-pester 2 連続 green
- **R2 (--no-audio 4 組合せ実機)**: 上表の通り、4 組合せ全てで 1 segment / サイズ一致 / metadata segment-info 一致を確認
- **R3 (workflow_dispatch dry-run)**: 上記 A セクションの通り、artifact が `.zip` 単独で展開すると payload 直置きを実測
- **R4 (2 回目 cache hit)**: `1d0592c` (empty commit) で 2 回目発火。python / build-windows 両方で `Cache hit` + `Cache restored` を実ログで確認
- **R5 (artifact / CI 時間実測)**: 上記 D セクションの表に記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)
