### PR TITLE
refactor(hooks): preuse gate を exit 2 block → permissionDecision=ask へ (Refs #559)

### DIFF
--- a/.claude/hooks/preuse.py
+++ b/.claude/hooks/preuse.py
@@ -1,22 +1,26 @@
-"""PreToolUse gate for risky / bulk operations (#401).
+"""PreToolUse gate for risky / bulk operations (#401, #559).
 
-Intercepts a small set of ``gh`` / bulk operations and forces Claude to
-escalate to the user before proceeding.  Designed to backstop the docs
-rules (#399 / #400) when Claude would otherwise independently run:
+Intercepts a small set of ``gh`` / bulk operations and forces the user
+to approve before proceeding.  Designed to backstop the docs rules
+(#399 / #400) when Claude would otherwise independently run:
 
 - ``gh issue create`` 3+ times within 60 seconds (bulk Issue 起票)
 - ``gh pr merge`` (PR マージ)
 - ``gh issue close`` 3+ times within 60 seconds (bulk Issue クローズ, #485)
 - ``gh issue edit ... --add-label deferred`` 2+ times within 60 seconds
 
-Exit code 2 asks Claude Code to show the stderr message to the user and
-pause; Claude then asks for confirmation before proceeding.
+On match, the hook emits a Claude Code PreToolUse JSON output with
+``hookSpecificOutput.permissionDecision = "ask"``, which triggers the
+standard permission prompt.  The user answers allow / deny in the UI
+and the command runs (or is cancelled) in the same tool invocation --
+no retry with a prefix is needed (#559 migration from exit-code 2).
 
 ## Bypass after explicit approval (#485 / PR #491 review)
 
-Once the user has approved a command that was just blocked, Claude can
-re-issue it with the ``ALLAGANEYE_PREUSE_BYPASS=1`` prefix to skip the
-gate for that single invocation:
+Retained as an escape hatch for environments where the permission
+prompt is unavailable (non-interactive runs, older Claude Code builds).
+Claude can prefix the command with ``ALLAGANEYE_PREUSE_BYPASS=1`` to
+skip the gate entirely for that single invocation:
 
     ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 123
 
@@ -28,6 +32,11 @@ command.  Every bypass is logged to stderr for audit.
 
 - Reads a Claude Code PreToolUse JSON event from stdin.  Only Bash tool
   calls are gated; every other tool is allowed unconditionally (exit 0).
+- Gate activation: exit 0 + stdout JSON with ``permissionDecision: "ask"``
+  so Claude Code surfaces an allow / deny prompt to the user.  The matched
+  command is NOT written to ``recent_ops.json`` because the hook cannot
+  observe the user's answer (#513 hygiene preserved: ghost entries would
+  inflate bulk counters).
 - State: ``.claude/state/recent_ops.json`` records ``[{"cmd", "ts"}]``
   for bulk-pattern timing.  Entries older than ``_BULK_WINDOW_SEC`` are
   discarded on every read.
@@ -227,6 +236,43 @@ def _gate_enabled() -> bool:
 
 
 # ---------------------------------------------------------------
+# Permission prompt output (#559)
+# ---------------------------------------------------------------
+
+
+def _emit_ask(key: str, message: str, command: str) -> None:
+    """Emit a PreToolUse ``permissionDecision: "ask"`` payload on stdout.
+
+    Claude Code reads this JSON (while exit code stays 0) and surfaces
+    the standard allow / deny permission prompt to the user with
+    ``permissionDecisionReason`` as the body text.
+
+    The reason string is intentionally verbose (Iron Law context +
+    command preview) so the prompt is self-contained for the user --
+    they should not need to scroll the transcript to understand why
+    they're being asked.
+    """
+    reason = (
+        f"[{key}] {message}\n"
+        "Claude Code permission prompt で allow / deny を選んでください。\n"
+        "allow 時のみコマンドが 1 回だけ実行されます (state は allow 後の"
+        " PostToolUse 経路でなく、次回 PreToolUse の pass 時に記録されます)。\n"
+        f"Detected command: {command.strip()[:400]}"
+    )
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": reason,
+        }
+    }
+    # Advanced JSON output must be on stdout (Claude Code hooks spec).
+    # A single line keeps the payload obvious in hook logs.
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+    sys.stdout.write("\n")
+
+
+# ---------------------------------------------------------------
 # Classification
 # ---------------------------------------------------------------
 
@@ -310,25 +356,24 @@ def main() -> int:
     key, message = _classify(command, recent)
 
     if key is not None:
-        # block された時点では state に記録しない (#513).
-        # 実行されないコマンドを bulk counter に入れると、prefix 付け忘れ
-        # による再試行で counter が累積的に膨張し、閾値を永続的に超えて
-        # 再ブロックが続く不具合になる。bypass 経由で実行された場合のみ
-        # bypass ルート側で記録されるので、実測の実行回数と state が一致する。
+        # ask された時点では state に記録しない (#513 + #559).
+        # 実行されるかはユーザーの allow / deny 回答次第で、hook からは
+        # 観測できない。deny された ghost 実行を bulk counter に入れると、
+        # 閾値を永続的に超えて ask が連発する不具合になるので、state に
+        # 載せるのは bypass / pass ルートに限定する (実測主義、#513 維持)。
+        #
+        # stderr には audit 用の log を残し、stdout には Claude Code の
+        # permission prompt 用 JSON を出力して exit 0 で終了する。
+        assert message is not None  # _classify 契約: key != None のとき message も非 None
         print(
-            f"[preuse:{key}] {message}\n"
-            "このコマンドは未実行で state にも記録されていません。\n"
-            "ユーザー承認済みの場合は必ず `ALLAGANEYE_PREUSE_BYPASS=1 <command>` "
-            "prefix を付けて再実行してください (1 回分のみ bypass)。\n"
-            "prefix なしで同じコマンドを再送しても同じ理由でブロックされます。\n"
-            f"Detected command: {command.strip()[:400]}",
+            f"[preuse:{key}] ask -> user permission prompt\n"
+            f"Command: {command.strip()[:400]}",
             file=sys.stderr,
         )
-        # Exit code 2 = block with error surfaced to Claude (PreToolUse
-        # hook convention).  Claude will pause and escalate to the user.
-        return 2
+        _emit_ask(key, message, command)
+        return 0
 
-    # Block 通過時のみ state に記録 (bulk カウント用).
+    # Block / ask 通過時のみ state に記録 (bulk カウント用).
     _append_op(state_path, command.strip(), now)
     return 0
 

--- a/.claude/hooks/preuse.py
+++ b/.claude/hooks/preuse.py
@@ -364,7 +364,9 @@ def main() -> int:
         #
         # stderr には audit 用の log を残し、stdout には Claude Code の
         # permission prompt 用 JSON を出力して exit 0 で終了する。
-        assert message is not None  # _classify 契約: key != None のとき message も非 None
+        assert (
+            message is not None
+        )  # _classify 契約: key != None のとき message も非 None
         print(
             f"[preuse:{key}] ask -> user permission prompt\n"
             f"Command: {command.strip()[:400]}",

--- a/.claude/hooks/preuse.py
+++ b/.claude/hooks/preuse.py
@@ -364,9 +364,8 @@ def main() -> int:
         #
         # stderr には audit 用の log を残し、stdout には Claude Code の
         # permission prompt 用 JSON を出力して exit 0 で終了する。
-        assert (
-            message is not None
-        )  # _classify 契約: key != None のとき message も非 None
+        # _classify 契約: key != None のとき message も非 None
+        assert message is not None
         print(
             f"[preuse:{key}] ask -> user permission prompt\n"
             f"Command: {command.strip()[:400]}",

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -171,28 +171,32 @@ PR #343 のような「複数 Issue が不完全修正のままクローズさ�
 | 6 | PR テンプレート (`.github/pull_request_template.md`) | Iron Law 1/3/4 の逐条チェックリスト |
 | 7 | ユーザー最終承認 | マージは全て Idios が実行、未達 PR は差し戻し |
 
-**真のハードゲート候補 (未実装)**: `PreToolUse` で `gh` bulk 操作の exit 2 ブロック、GitHub Action でマージブロック。L2 実装中に必要性が顕在化したら別 issue で対応。
+**ハードゲートの実装**: `.claude/hooks/preuse.py` が `PreToolUse` で `gh` bulk 操作・PR マージ等をインターセプトし、#559 以降は `permissionDecision=ask` を返して Claude Code の permission prompt を出す (旧: #401 の exit 2 block + bypass prefix 運用)。GitHub Action でのマージブロックは将来候補。
 
-#### PreToolUse hook の bypass 運用 (#485 / #513)
+#### PreToolUse hook の gate 運用 (#485 / #513 / #559)
 
-`preuse.py` が exit 2 でブロックした `gh` コマンドは、ユーザー承認後に `ALLAGANEYE_PREUSE_BYPASS=1 <command>` prefix を付けて再実行することで 1 回分だけ通過できる (`_BYPASS_PREFIX` 正規表現)。
+`preuse.py` は gate 発動時に **exit 0 + stdout JSON (`permissionDecision: "ask"`)** を出力し、Claude Code 本体の permission prompt でユーザーが allow / deny を選ぶ (#559)。allow なら同一 tool invocation でそのまま実行、deny ならキャンセルされる。旧来の `ALLAGANEYE_PREUSE_BYPASS=1 <command>` prefix は **非対話環境向けの escape hatch** として維持 (自動化スクリプト等で permission prompt が出せない場合 / 旧 exit 2 方式の hook と互換したい場合)。
 
-運用手順:
+運用手順 (主フロー, #559 以降):
 
-1. Claude が `gh` コマンドを発行 → hook が bulk 閾値 (3 件 / 60s) または always gate (PR マージ等) でブロック (exit 2)
-2. Claude は `AskUserQuestion` でサンプル 1 件を提示し、**「全件 OK / 個別調整 / やめる」** の 3 択を問う (Iron Law 2)
-3. ユーザーが承認したら、該当コマンドに `ALLAGANEYE_PREUSE_BYPASS=1` prefix (末尾スペース込み) を付けて再実行する
+1. Claude が `gh` コマンドを発行 → hook が bulk 閾値 (3 件 / 60s) または always gate (PR マージ等) を判定
+2. gate 発動時、hook は `{"hookSpecificOutput": {"permissionDecision": "ask", "permissionDecisionReason": ...}}` を stdout に出力して exit 0
+3. Claude Code 本体が permission prompt を表示 (reason にコマンド先頭数百文字と Iron Law 解説が含まれる)
+4. ユーザーが allow すればそのまま実行、deny すればツール呼び出しがキャンセルされる
 
-   ```bash
-   ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 123
-   ```
+escape hatch (非対話環境等):
 
-4. prefix は strip されて `gh issue close 123` が実行される。`[preuse:bypass]` 監査ログが stderr に出力され、実行コマンド本体のみが state (`.claude/state/recent_ops.json`) に記録され、以降の bulk 判定に正しく参入する
+```bash
+ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 123
+```
+
+prefix は strip されて `gh issue close 123` が実行される。`[preuse:bypass]` 監査ログが stderr に出力される。
 
 重要ポイント:
 
-- prefix は **1 コマンドごとに都度付与** する。bulk 承認を得た場合でも各コマンドに個別に付ける (1 回分のみ bypass の仕様)
-- **ブロックされたコマンドは state に記録されない** (#513)。prefix を付け忘れて素の再送をしても、counter が累積膨張することはなく同じ理由で再ブロックされるだけ
+- **主フローは Claude Code の permission prompt**。Claude が `AskUserQuestion` で別途確認する必要はない (permission prompt 自体が確認動作を兼ねる)
+- bypass prefix は escape hatch のみ。非対話環境では 1 コマンドごとに個別付与する (1 回分のみ bypass の仕様)
+- **ask / bypass されたコマンドは state に記録されない** (#513 挙動を #559 以降も維持)。permission prompt で deny された場合や prefix 付き実行 (`[preuse:bypass]`) では counter が累積膨張せず、以降の bulk 判定に影響を与えない
 - `ALLAGANEYE_PREUSE_BYPASS=0` 等は認識されない (prefix 正規表現は `=1` 固定)
 - `.claude/settings.local.json` で `"pretooluse_gate": false` を設定すると gate 全体を無効化できる (緊急避難用、通常は true = デフォルト)
 

--- a/tests/test_preuse_hook.py
+++ b/tests/test_preuse_hook.py
@@ -1,9 +1,16 @@
-"""Tests for the PreToolUse gate (.claude/hooks/preuse.py, #401).
+"""Tests for the PreToolUse gate (.claude/hooks/preuse.py, #401 / #559).
 
 The hook is a standalone script invoked by Claude Code with a JSON
 payload on stdin.  We import it as a module and drive the entry point
 directly so the tests never spawn a subprocess, which keeps them fast
 and deterministic on Windows.
+
+Gate activation contract (#559):
+- Exit code is always 0 from ``main()``.
+- On match, stdout contains a JSON payload with
+  ``hookSpecificOutput.permissionDecision == "ask"`` so Claude Code
+  surfaces the permission prompt to the user.
+- Non-match / bypass / disabled paths leave stdout empty.
 """
 
 from __future__ import annotations
@@ -57,19 +64,45 @@ def _isolated_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     return {"state": state_path, "settings": settings_path}
 
 
-def _invoke(event: dict, monkeypatch: pytest.MonkeyPatch) -> tuple[int, str]:
-    """Drive ``preuse.main()`` with a fake stdin payload.  Return (rc, stderr)."""
+def _invoke(event: dict, monkeypatch: pytest.MonkeyPatch) -> tuple[int, str, str]:
+    """Drive ``preuse.main()`` with a fake stdin payload.
+
+    Returns ``(rc, stderr, stdout)``.  stdout is where the permission
+    prompt payload lands under the #559 ask protocol; stderr is the
+    audit log line.
+    """
     monkeypatch.setattr(
         sys, "stdin", io.StringIO(json.dumps(event) if event is not None else "")
     )
+    out_buf = io.StringIO()
     err_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out_buf)
     monkeypatch.setattr(sys, "stderr", err_buf)
     rc = preuse.main()
-    return rc, err_buf.getvalue()
+    return rc, err_buf.getvalue(), out_buf.getvalue()
 
 
 def _bash_event(command: str) -> dict:
     return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _assert_ask(rc: int, stdout: str) -> str:
+    """Validate a ``permissionDecision: "ask"`` hookSpecificOutput payload.
+
+    Returns the ``permissionDecisionReason`` body so callers can spot-check
+    that pattern-specific messaging (e.g. "PR マージ", "Issue クローズ")
+    reached the prompt text shown to the user.
+    """
+    assert rc == 0, f"ask path must exit 0; got {rc}"
+    assert stdout.strip(), "ask path must emit stdout JSON"
+    payload = json.loads(stdout)
+    hook_out = payload.get("hookSpecificOutput")
+    assert isinstance(hook_out, dict), f"missing hookSpecificOutput: {payload!r}"
+    assert hook_out.get("hookEventName") == "PreToolUse"
+    assert hook_out.get("permissionDecision") == "ask"
+    reason = hook_out.get("permissionDecisionReason")
+    assert isinstance(reason, str) and reason, "reason must be non-empty string"
+    return reason
 
 
 # ---------------------------------------------------------------
@@ -77,11 +110,12 @@ def _bash_event(command: str) -> dict:
 # ---------------------------------------------------------------
 
 
-def test_pr_merge_always_gated(_isolated_paths, monkeypatch):
-    """``gh pr merge`` is gated on the very first invocation (#401 G-2)."""
-    rc, err = _invoke(_bash_event("gh pr merge 123 --squash"), monkeypatch)
-    assert rc == 2
-    assert "PR マージ" in err
+def test_pr_merge_triggers_ask(_isolated_paths, monkeypatch):
+    """``gh pr merge`` requests a permission prompt on every invocation (#559)."""
+    rc, _err, out = _invoke(_bash_event("gh pr merge 123 --squash"), monkeypatch)
+    reason = _assert_ask(rc, out)
+    assert "PR マージ" in reason
+    assert "gh pr merge 123 --squash" in reason
 
 
 def test_issue_close_single_allowed(_isolated_paths, monkeypatch):
@@ -91,26 +125,29 @@ def test_issue_close_single_allowed(_isolated_paths, monkeypatch):
     AskUserQuestion before each close; the hook only catches genuine
     bulk shortcuts (3+ / 60s).
     """
-    rc, err = _invoke(_bash_event("gh issue close 42"), monkeypatch)
+    rc, err, out = _invoke(_bash_event("gh issue close 42"), monkeypatch)
     assert rc == 0
     assert err == ""
+    assert out == ""
 
 
 def test_issue_close_second_allowed(_isolated_paths, monkeypatch):
     """2 ``gh issue close`` calls in 60s are still allowed (below threshold=3)."""
-    rc1, _ = _invoke(_bash_event("gh issue close 1"), monkeypatch)
-    rc2, _ = _invoke(_bash_event("gh issue close 2"), monkeypatch)
+    rc1, _, out1 = _invoke(_bash_event("gh issue close 1"), monkeypatch)
+    rc2, _, out2 = _invoke(_bash_event("gh issue close 2"), monkeypatch)
     assert rc1 == 0
     assert rc2 == 0
+    assert out1 == ""
+    assert out2 == ""
 
 
-def test_issue_close_third_in_window_triggers_gate(_isolated_paths, monkeypatch):
-    """3rd ``gh issue close`` within 60s trips the bulk gate (#485)."""
+def test_issue_close_third_in_window_triggers_ask(_isolated_paths, monkeypatch):
+    """3rd ``gh issue close`` within 60s trips the bulk gate (#485 / #559)."""
     _invoke(_bash_event("gh issue close 1"), monkeypatch)
     _invoke(_bash_event("gh issue close 2"), monkeypatch)
-    rc, err = _invoke(_bash_event("gh issue close 3"), monkeypatch)
-    assert rc == 2
-    assert "Issue クローズ" in err or "60 秒" in err
+    rc, _, out = _invoke(_bash_event("gh issue close 3"), monkeypatch)
+    reason = _assert_ask(rc, out)
+    assert "Issue クローズ" in reason or "60 秒" in reason
 
 
 def test_issue_close_outside_window_resets(_isolated_paths, monkeypatch):
@@ -119,38 +156,78 @@ def test_issue_close_outside_window_resets(_isolated_paths, monkeypatch):
     preuse._append_op(_isolated_paths["state"], "gh issue close 1", stale)
     preuse._append_op(_isolated_paths["state"], "gh issue close 2", stale)
     # Fresh 3rd call is NOT gated because stale entries are discarded.
-    rc, _ = _invoke(_bash_event("gh issue close 3"), monkeypatch)
+    rc, _, out = _invoke(_bash_event("gh issue close 3"), monkeypatch)
     assert rc == 0
+    assert out == ""
 
 
 # ---------------------------------------------------------------
-# ALLAGANEYE_PREUSE_BYPASS=1 (user-approved one-shot bypass, PR #491 review)
+# Ask payload structural checks (#559)
+# ---------------------------------------------------------------
+
+
+def test_ask_payload_is_single_line_json(_isolated_paths, monkeypatch):
+    """The ask payload is a single JSON object on stdout (hooks wire format)."""
+    rc, _, out = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
+    assert rc == 0
+    # Exactly one JSON object followed by an optional newline.
+    stripped = out.strip()
+    payload = json.loads(stripped)
+    # Top-level must contain hookSpecificOutput per Claude Code PreToolUse spec.
+    assert set(payload.keys()) == {"hookSpecificOutput"}
+    hook_out = payload["hookSpecificOutput"]
+    assert hook_out["hookEventName"] == "PreToolUse"
+    assert hook_out["permissionDecision"] == "ask"
+    assert "permissionDecisionReason" in hook_out
+
+
+def test_ask_reason_has_command_preview_and_pattern_key(_isolated_paths, monkeypatch):
+    """Prompt body includes pattern key tag and a command preview for the user."""
+    cmd = "gh pr merge 456 --squash --delete-branch"
+    rc, _, out = _invoke(_bash_event(cmd), monkeypatch)
+    reason = _assert_ask(rc, out)
+    assert "[pr_merge]" in reason
+    assert cmd in reason
+
+
+def test_ask_stderr_audit_log_present(_isolated_paths, monkeypatch):
+    """stderr still carries an audit log for offline review (#559)."""
+    rc, err, out = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
+    _assert_ask(rc, out)
+    assert "[preuse:pr_merge]" in err
+    assert "ask -> user permission prompt" in err
+
+
+# ---------------------------------------------------------------
+# ALLAGANEYE_PREUSE_BYPASS=1 (escape hatch, #485 / PR #491 review / #559 retained)
 # ---------------------------------------------------------------
 
 
 def test_bypass_allows_blocked_bulk_retry(_isolated_paths, monkeypatch):
-    """After the 3rd close is blocked, prefix-bypass re-execution is allowed."""
+    """After the 3rd close triggers ask, prefix-bypass re-execution is allowed."""
     _invoke(_bash_event("gh issue close 1"), monkeypatch)
     _invoke(_bash_event("gh issue close 2"), monkeypatch)
-    rc_block, _ = _invoke(_bash_event("gh issue close 3"), monkeypatch)
-    assert rc_block == 2
+    rc_ask, _, out_ask = _invoke(_bash_event("gh issue close 3"), monkeypatch)
+    _assert_ask(rc_ask, out_ask)
     # User approves, Claude retries with bypass prefix.
-    rc_bypass, err = _invoke(
+    rc_bypass, err, out = _invoke(
         _bash_event("ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 3"), monkeypatch
     )
     assert rc_bypass == 0
+    assert out == ""
     assert "[preuse:bypass]" in err
     assert "gh issue close 3" in err
 
 
 def test_bypass_allows_always_gated_pr_merge(_isolated_paths, monkeypatch):
     """Bypass also releases pr_merge (always mode) after user approval."""
-    rc_block, _ = _invoke(_bash_event("gh pr merge 42 --squash"), monkeypatch)
-    assert rc_block == 2
-    rc_bypass, err = _invoke(
+    rc_ask, _, out_ask = _invoke(_bash_event("gh pr merge 42 --squash"), monkeypatch)
+    _assert_ask(rc_ask, out_ask)
+    rc_bypass, err, out = _invoke(
         _bash_event("ALLAGANEYE_PREUSE_BYPASS=1 gh pr merge 42 --squash"), monkeypatch
     )
     assert rc_bypass == 0
+    assert out == ""
     assert "[preuse:bypass]" in err
 
 
@@ -167,35 +244,26 @@ def test_bypass_counts_toward_subsequent_bulk(_isolated_paths, monkeypatch):
     """Bypassed close still adds to the 60s window for non-bypassed retries."""
     _invoke(_bash_event("gh issue close 1"), monkeypatch)
     _invoke(_bash_event("gh issue close 2"), monkeypatch)
-    _invoke(
-        _bash_event("gh issue close 3"), monkeypatch
-    )  # blocked (NOT recorded, #513)
+    _invoke(_bash_event("gh issue close 3"), monkeypatch)  # ask (NOT recorded, #513)
     _invoke(_bash_event("ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 3"), monkeypatch)
-    # Next un-prefixed close is still blocked -- bypass entry (3 in window)
-    # plus current (4) exceed threshold=3.
-    rc, _ = _invoke(_bash_event("gh issue close 4"), monkeypatch)
-    assert rc == 2
+    # Next un-prefixed close triggers ask -- bypass entry (3 in window) plus
+    # current (4) exceed threshold=3.
+    rc, _, out = _invoke(_bash_event("gh issue close 4"), monkeypatch)
+    _assert_ask(rc, out)
 
 
-def test_bypass_wrong_value_still_blocked(_isolated_paths, monkeypatch):
+def test_bypass_wrong_value_still_passes_through(_isolated_paths, monkeypatch):
     """Only exactly ``ALLAGANEYE_PREUSE_BYPASS=1`` honors; ``=0`` is not magic."""
     _invoke(_bash_event("gh issue close 1"), monkeypatch)
     _invoke(_bash_event("gh issue close 2"), monkeypatch)
-    rc, _ = _invoke(
+    rc, _, out = _invoke(
         _bash_event("ALLAGANEYE_PREUSE_BYPASS=0 gh issue close 3"), monkeypatch
     )
     # The prefix is not recognized, so the command is evaluated as-is.  Because
     # `^gh ...` anchor requires the string to start with `gh`, no pattern
     # matches -- the command is allowed but NOT via bypass path.
     assert rc == 0
-
-
-def test_bypass_block_message_mentions_bypass_option(_isolated_paths, monkeypatch):
-    """Block stderr instructs Claude to retry with the bypass prefix."""
-    _invoke(_bash_event("gh issue close 1"), monkeypatch)
-    _invoke(_bash_event("gh issue close 2"), monkeypatch)
-    _, err = _invoke(_bash_event("gh issue close 3"), monkeypatch)
-    assert "ALLAGANEYE_PREUSE_BYPASS=1" in err
+    assert out == ""
 
 
 # ---------------------------------------------------------------
@@ -205,19 +273,21 @@ def test_bypass_block_message_mentions_bypass_option(_isolated_paths, monkeypatc
 
 def test_issue_create_under_threshold_allowed(_isolated_paths, monkeypatch):
     """2 ``gh issue create`` calls in 60s are allowed (below threshold=3)."""
-    rc1, _ = _invoke(_bash_event("gh issue create --title a"), monkeypatch)
-    rc2, _ = _invoke(_bash_event("gh issue create --title b"), monkeypatch)
+    rc1, _, out1 = _invoke(_bash_event("gh issue create --title a"), monkeypatch)
+    rc2, _, out2 = _invoke(_bash_event("gh issue create --title b"), monkeypatch)
     assert rc1 == 0
     assert rc2 == 0
+    assert out1 == ""
+    assert out2 == ""
 
 
-def test_issue_create_third_in_window_triggers_gate(_isolated_paths, monkeypatch):
-    """3rd ``gh issue create`` within 60s trips the bulk gate (#401 G-1)."""
+def test_issue_create_third_in_window_triggers_ask(_isolated_paths, monkeypatch):
+    """3rd ``gh issue create`` within 60s trips the bulk gate (#401 G-1 / #559)."""
     _invoke(_bash_event("gh issue create --title a"), monkeypatch)
     _invoke(_bash_event("gh issue create --title b"), monkeypatch)
-    rc, err = _invoke(_bash_event("gh issue create --title c"), monkeypatch)
-    assert rc == 2
-    assert "Issue 起票" in err or "60 秒" in err
+    rc, _, out = _invoke(_bash_event("gh issue create --title c"), monkeypatch)
+    reason = _assert_ask(rc, out)
+    assert "Issue 起票" in reason or "60 秒" in reason
 
 
 def test_issue_create_outside_window_resets(_isolated_paths, monkeypatch):
@@ -229,19 +299,23 @@ def test_issue_create_outside_window_resets(_isolated_paths, monkeypatch):
 
     # Fresh 3rd call should *not* be gated because stale entries are
     # discarded at read time.
-    rc, _ = _invoke(_bash_event("gh issue create --title fresh"), monkeypatch)
+    rc, _, out = _invoke(_bash_event("gh issue create --title fresh"), monkeypatch)
     assert rc == 0
+    assert out == ""
 
 
-def test_deferred_label_second_in_window_triggers_gate(_isolated_paths, monkeypatch):
+def test_deferred_label_second_in_window_triggers_ask(_isolated_paths, monkeypatch):
     """2 consecutive ``deferred`` label assignments in 60s are gated (#401 G-4)."""
-    rc1, _ = _invoke(_bash_event('gh issue edit 1 --add-label "deferred"'), monkeypatch)
-    rc2, err2 = _invoke(
-        _bash_event('gh issue edit 2 --add-label "deferred"'), monkeypatch
+    rc1, _, out1 = _invoke(
+        _bash_event('gh issue edit 1 --add-label "deferred"'), monkeypatch
     )
     assert rc1 == 0
-    assert rc2 == 2
-    assert "deferred" in err2
+    assert out1 == ""
+    rc2, _, out2 = _invoke(
+        _bash_event('gh issue edit 2 --add-label "deferred"'), monkeypatch
+    )
+    reason2 = _assert_ask(rc2, out2)
+    assert "deferred" in reason2
 
 
 def test_non_deferred_label_not_gated(_isolated_paths, monkeypatch):
@@ -249,10 +323,11 @@ def test_non_deferred_label_not_gated(_isolated_paths, monkeypatch):
     # Even 3 P1-high assignments should stay allowed -- not on the
     # gated list.
     for i in range(3):
-        rc, _ = _invoke(
+        rc, _, out = _invoke(
             _bash_event(f'gh issue edit {i} --add-label "P1-high"'), monkeypatch
         )
         assert rc == 0
+        assert out == ""
 
 
 # ---------------------------------------------------------------
@@ -263,21 +338,24 @@ def test_non_deferred_label_not_gated(_isolated_paths, monkeypatch):
 def test_non_bash_tool_untouched(_isolated_paths, monkeypatch):
     """Other tools (Read / Edit / Write) are never gated."""
     event = {"tool_name": "Edit", "tool_input": {"file_path": "foo", "old_string": "a"}}
-    rc, err = _invoke(event, monkeypatch)
+    rc, err, out = _invoke(event, monkeypatch)
     assert rc == 0
     assert err == ""
+    assert out == ""
 
 
 def test_arbitrary_bash_untouched(_isolated_paths, monkeypatch):
     """Bash commands outside the gated list run freely."""
-    rc, _ = _invoke(_bash_event("pytest -q"), monkeypatch)
+    rc, _, out = _invoke(_bash_event("pytest -q"), monkeypatch)
     assert rc == 0
+    assert out == ""
 
 
 def test_empty_command_untouched(_isolated_paths, monkeypatch):
     """Whitespace-only command is treated as no-op."""
-    rc, _ = _invoke(_bash_event("   "), monkeypatch)
+    rc, _, out = _invoke(_bash_event("   "), monkeypatch)
     assert rc == 0
+    assert out == ""
 
 
 def test_gate_can_be_disabled_globally(_isolated_paths, monkeypatch):
@@ -287,22 +365,23 @@ def test_gate_can_be_disabled_globally(_isolated_paths, monkeypatch):
         json.dumps({"pretooluse_gate": False}), encoding="utf-8"
     )
 
-    rc, _ = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
+    rc, _, out = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
     assert rc == 0
+    assert out == ""
 
 
 def test_gate_defaults_on_when_settings_missing(_isolated_paths, monkeypatch):
     """Absent / malformed settings file defaults to enabled (fail-safe)."""
     # No settings file at all.
-    rc, _ = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
-    assert rc == 2
+    rc, _, out = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
+    _assert_ask(rc, out)
 
 
 def test_malformed_settings_keeps_gate_on(_isolated_paths, monkeypatch):
     _isolated_paths["settings"].parent.mkdir(parents=True, exist_ok=True)
     _isolated_paths["settings"].write_text("not json", encoding="utf-8")
-    rc, _ = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
-    assert rc == 2
+    rc, _, out = _invoke(_bash_event("gh pr merge 1"), monkeypatch)
+    _assert_ask(rc, out)
 
 
 # ---------------------------------------------------------------
@@ -324,8 +403,9 @@ def test_corrupt_state_fails_open(_isolated_paths, monkeypatch):
     """Garbage state file is tolerated (read returns [], write overwrites)."""
     _isolated_paths["state"].write_text("not json", encoding="utf-8")
     # Should not raise, nor falsely trip the bulk gate.
-    rc, _ = _invoke(_bash_event("gh issue create --title a"), monkeypatch)
+    rc, _, out = _invoke(_bash_event("gh issue create --title a"), monkeypatch)
     assert rc == 0
+    assert out == ""
 
 
 # ---------------------------------------------------------------
@@ -336,88 +416,103 @@ def test_corrupt_state_fails_open(_isolated_paths, monkeypatch):
 def test_empty_stdin(_isolated_paths, monkeypatch):
     """Empty payload is a no-op pass (rc=0)."""
     monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    out_buf = io.StringIO()
     err_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out_buf)
     monkeypatch.setattr(sys, "stderr", err_buf)
     rc = preuse.main()
     assert rc == 0
+    assert out_buf.getvalue() == ""
 
 
 def test_invalid_json_stdin(_isolated_paths, monkeypatch):
     monkeypatch.setattr(sys, "stdin", io.StringIO("<not-json>"))
+    out_buf = io.StringIO()
     err_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out_buf)
     monkeypatch.setattr(sys, "stderr", err_buf)
     rc = preuse.main()
     assert rc == 0
+    assert out_buf.getvalue() == ""
 
 
 def test_missing_tool_input(_isolated_paths, monkeypatch):
     event = {"tool_name": "Bash"}
-    rc, _ = _invoke(event, monkeypatch)
+    rc, _, out = _invoke(event, monkeypatch)
     assert rc == 0
+    assert out == ""
 
 
 # ---------------------------------------------------------------
-# State hygiene: blocked commands must NOT inflate bulk counters (#513)
+# State hygiene: asked commands must NOT inflate bulk counters (#513 / #559)
 # ---------------------------------------------------------------
 
 
-def test_blocked_bulk_command_not_recorded(_isolated_paths, monkeypatch):
-    """Blocked bulk command must not be recorded to state (#513 A).
+def test_asked_bulk_command_not_recorded(_isolated_paths, monkeypatch):
+    """Ask'd bulk command must not be recorded to state (#513 A retained in #559).
 
     Previously every blocked invocation was appended to state, so the
     bulk counter included ghost entries for commands that never ran.
+    Under the ask protocol the hook also cannot observe whether the
+    user ultimately approved, so the same hygiene rule applies.
     """
     _invoke(_bash_event("gh issue close 1"), monkeypatch)
     _invoke(_bash_event("gh issue close 2"), monkeypatch)
-    rc, _ = _invoke(_bash_event("gh issue close 3"), monkeypatch)
-    assert rc == 2
+    rc, _, out = _invoke(_bash_event("gh issue close 3"), monkeypatch)
+    _assert_ask(rc, out)
     data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
-    # Only the two allowed closes are recorded; the blocked 3rd is dropped.
+    # Only the two allowed closes are recorded; the ask'd 3rd is dropped.
     assert len(data) == 2
     assert all("close 3" not in entry.get("cmd", "") for entry in data)
 
 
-def test_blocked_always_gated_command_not_recorded(_isolated_paths, monkeypatch):
-    """Blocked always-mode pr_merge must not create any state entry (#513)."""
-    rc, _ = _invoke(_bash_event("gh pr merge 42 --squash"), monkeypatch)
-    assert rc == 2
+def test_asked_always_gated_command_not_recorded(_isolated_paths, monkeypatch):
+    """Ask'd always-mode pr_merge must not create any state entry (#513 / #559)."""
+    rc, _, out = _invoke(_bash_event("gh pr merge 42 --squash"), monkeypatch)
+    _assert_ask(rc, out)
     if _isolated_paths["state"].exists():
         data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
         assert data == []
 
 
 def test_forgotten_bypass_retry_does_not_inflate_counter(_isolated_paths, monkeypatch):
-    """Un-prefixed retries of a blocked command must not grow state (#513).
+    """Un-prefixed retries of an ask'd command must not grow state (#513 / #559).
 
-    Regression guard for the scenario: Claude forgets the bypass prefix
-    and retries the same command multiple times.  Previously every attempt
-    was appended to state, so bulk counters would grow indefinitely even
-    though no command actually ran.  With the fix, state is unchanged
-    after any number of un-prefixed retries, and the subsequent
-    user-approved bypass adds exactly one entry.
+    Regression guard for the scenario: the permission prompt is surfaced
+    repeatedly (user keeps cancelling / Claude retries) and must not
+    grow ``recent_ops.json``.  Only the eventual bypass-prefixed call
+    (or a real un-gated execution) writes state.
     """
     _invoke(_bash_event("gh issue close 1"), monkeypatch)
     _invoke(_bash_event("gh issue close 2"), monkeypatch)
     for _ in range(5):
-        rc, _ = _invoke(_bash_event("gh issue close 3"), monkeypatch)
-        assert rc == 2
+        rc, _, out = _invoke(_bash_event("gh issue close 3"), monkeypatch)
+        _assert_ask(rc, out)
     data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
     assert len(data) == 2
-    rc, _ = _invoke(
+    rc, _, out = _invoke(
         _bash_event("ALLAGANEYE_PREUSE_BYPASS=1 gh issue close 3"), monkeypatch
     )
     assert rc == 0
+    assert out == ""
     data = json.loads(_isolated_paths["state"].read_text(encoding="utf-8"))
     assert len(data) == 3
 
 
-def test_block_message_mentions_state_not_recorded(_isolated_paths, monkeypatch):
-    """Block stderr explains both bypass prefix and state hygiene (#513 B)."""
+def test_ask_reason_mentions_prompt_flow(_isolated_paths, monkeypatch):
+    """Reason body tells the user this came from the permission prompt path.
+
+    Replaces the previous assertion that stderr mentioned the bypass
+    prefix: under #559 the primary UX is the Claude Code prompt, and
+    the reason text is what the user actually reads.
+    """
     _invoke(_bash_event("gh issue create --title a"), monkeypatch)
     _invoke(_bash_event("gh issue create --title b"), monkeypatch)
-    _, err = _invoke(_bash_event("gh issue create --title c"), monkeypatch)
-    assert "ALLAGANEYE_PREUSE_BYPASS=1" in err
-    assert "記録" in err
+    rc, _, out = _invoke(_bash_event("gh issue create --title c"), monkeypatch)
+    reason = _assert_ask(rc, out)
+    assert "permission prompt" in reason
+    assert "allow" in reason
+    assert "deny" in reason
 
 
 # ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `.claude/hooks/preuse.py` の gate 発動を `exit 2` → `exit 0 + stdout JSON (permissionDecision: "ask")` に統一
- Claude Code 本体の permission prompt でユーザーが allow / deny を選べるため、従来の "block → bypass prefix で再実行" の 2 回 tool invocation が 1 回に
- `ALLAGANEYE_PREUSE_BYPASS=1` prefix は非対話環境向け escape hatch として維持
- `#513` の state 非記録 (asked コマンドは `recent_ops.json` に載せない) 挙動も維持

Refs #559

## 受け入れ条件 (issue #559 から逐条引用)

- [x] **`gh pr merge ...` 実行時、Claude Code の permission prompt が表示され allow/deny を選べる (hook が exit 2 で落ちず JSON を返す)**
  - `.claude/hooks/preuse.py:243-272` で `_emit_ask` が `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": ...}}` を stdout に出力
  - `.claude/hooks/preuse.py:358-373` で gate 発動時は `_emit_ask()` を呼び `return 0`
  - テスト: `tests/test_preuse_hook.py::test_pr_merge_triggers_ask` (rc=0 + JSON 検証)

- [x] **60秒以内に 3 件目の `gh issue create` で prompt が出る (allowしてもそのコマンド 1 件のみ実行)**
  - `.claude/hooks/preuse.py:93-103` (`issue_create_bulk` 定義) + `_emit_ask` 共通経路
  - テスト: `tests/test_preuse_hook.py::test_issue_create_third_in_window_triggers_ask`

- [x] **60秒以内に 3 件目の `gh issue close` で prompt が出る**
  - テスト: `tests/test_preuse_hook.py::test_issue_close_third_in_window_triggers_ask`

- [x] **60秒以内に 2 件目の `deferred` ラベル付与で prompt が出る**
  - テスト: `tests/test_preuse_hook.py::test_deferred_label_second_in_window_triggers_ask`

- [x] **`permissionDecisionReason` に既存の Iron Law 解説文言 (例: "PR マージは常に確認必須") とコマンドの先頭数百文字が含まれる**
  - `.claude/hooks/preuse.py:255-261` で `[{key}] {message}` + 案内文 + `Detected command: {command[:400]}`
  - テスト: `tests/test_preuse_hook.py::test_ask_reason_has_command_preview_and_pattern_key`, `test_pr_merge_triggers_ask` (reason に "PR マージ" を含む検証)

- [x] **`ALLAGANEYE_PREUSE_BYPASS=1 <cmd>` は引き続き prompt なしで実行され、stderr に bypass log が残る**
  - `.claude/hooks/preuse.py:341-353` の bypass 経路は未変更
  - テスト: `tests/test_preuse_hook.py::test_bypass_allows_blocked_bulk_retry`, `test_bypass_allows_always_gated_pr_merge`

- [x] **`pretooluse_gate: false` で gate 全部 off (どの gate コマンドもそのまま exit 0 で通る, JSON なし)**
  - `.claude/hooks/preuse.py:210-235` の `_gate_enabled` は未変更。無効時は早期 `return 0` (stdout 空)
  - テスト: `tests/test_preuse_hook.py::test_gate_can_be_disabled_globally` (rc=0 + out=="")

- [x] **#513 挙動 (block/ask されたコマンドは `recent_ops.json` に記録されない) が回帰**
  - `.claude/hooks/preuse.py:358-377` で `_emit_ask()` 後は即 `return 0` し `_append_op` を呼ばない
  - テスト: `tests/test_preuse_hook.py::test_asked_bulk_command_not_recorded`, `test_asked_always_gated_command_not_recorded`, `test_forgotten_bypass_retry_does_not_inflate_counter`

- [x] **`tests/test_preuse_hook.py` の全テストがグリーン**
  - `python -m pytest tests/test_preuse_hook.py -q` → 35 passed

- [x] **`ruff check .` / `ruff format --check .` / `pyright` はエラーなし**
  - 実行済み: ruff check pass / ruff format pass (ruff 0.15.11) / pyright 0 errors

## Test plan

- [x] `python -m pytest tests/test_preuse_hook.py -q` (35 passed)
- [x] `python -m pytest -q` (759 passed, 1 skipped = sample video fixture)
- [x] `python -m ruff check .claude/hooks/preuse.py tests/test_preuse_hook.py`
- [x] `python -m ruff format --check .claude/hooks/preuse.py tests/test_preuse_hook.py` (ruff 0.15.11 で整形済み)
- [x] `python -m pyright .claude/hooks/preuse.py tests/test_preuse_hook.py` (0 errors)

**マージ前の実機確認 (Idios 側 / レビュー時タスク)**: 実 Claude Code 上で `gh pr merge ...` を呼び出し permission prompt が表示されるか確認してからマージ。prompt が出ずに hook が落ちる場合は merge せず本 PR に差し戻し。

## 挙動変更の影響

- `main()` は gate 発動時でも exit 0 を返すようになった。shell 越しに hook を直接呼ぶ外部スクリプトがあれば要確認だが、本リポジトリには該当なし
- 非対話環境 (自動化スクリプト等) で permission prompt が出せない場合は bypass prefix を引き続き利用可能
- block 時の stderr 案内文からは "ALLAGANEYE_PREUSE_BYPASS=1 prefix を付けて再実行" の文言を削除 (新方式では UI prompt が基本)。audit log としての `[preuse:{key}] ask -> user permission prompt` は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)
