### PR TITLE
docs(developer-setup): venv Permission denied トラブルシュートを追記 (Refs #431)

### DIFF
--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -208,6 +208,64 @@ pip install -e ".[dev]"
 deactivate
 ```
 
+### venv 作成が `Permission denied` で失敗するとき (Windows)
+
+`python -m venv .venv` 実行時に以下のようなエラーが出ることがあります。
+
+```text
+Error: [Errno 13] Permission denied: 'E:\tmp\...\.venv\Scripts\python.exe'
+```
+
+Windows は使用中ファイルのロックで上書き・削除を拒否するため、既存 `.venv` 内の `python.exe` を別プロセスが掴んでいると再作成が失敗します。
+
+**典型的な原因**:
+
+- 別ターミナルで同じ `.venv` を activate したまま残っている
+- VSCode / PyCharm 等の IDE が Python extension 経由で `.venv` を参照している
+- Antivirus / Windows Defender が一時的にファイルをスキャン中
+
+**解決手順** (上から順に試す):
+
+1. Python プロセスの確認と終了
+
+    ```powershell
+    Get-Process python -ErrorAction SilentlyContinue
+    ```
+
+    該当プロセスが見つかったら、他のターミナル / IDE を閉じるか `Stop-Process` で終了させる。
+
+1. VSCode / 他 IDE を完全に閉じてから再実行
+
+    IDE の Python extension が裏で `.venv\Scripts\python.exe` を開いていることがある。ウィンドウを閉じるだけでは解消しない場合、タスクマネージャで該当プロセスが残っていないか確認する。
+
+1. 既存 `.venv` を完全削除して再作成
+
+    ```powershell
+    # PowerShell
+    Remove-Item -Recurse -Force .venv
+    python -m venv .venv
+    ```
+
+    ```cmd
+    rem コマンドプロンプト
+    rmdir /s /q .venv
+    python -m venv .venv
+    ```
+
+    ```bash
+    # Git Bash / MSYS2
+    rm -rf .venv
+    python -m venv .venv
+    ```
+
+1. 別パスで切り分け
+
+    ```bash
+    python -m venv C:\temp\test_venv
+    ```
+
+    これが成功するなら原因はリポジトリ配下の `.venv` ロックに特定される。失敗するなら Antivirus / 権限周り (書き込み禁止フォルダ等) を疑う。
+
 ## 3. 更新
 
 ```bash


### PR DESCRIPTION
## 概要

`docs/developer-setup.md` §2 末尾に venv 作成が `Permission denied` で失敗するときのトラブルシュート節を追加。Windows で既存 `.venv\Scripts\python.exe` が別プロセス (別ターミナル / VSCode 等) にロックされて `python -m venv .venv` が落ちるケースを想定。

## 配置先変更の経緯

issue #431 本文では `docs/quickstart.md` 追記が指示されていたが、現行の `quickstart.md` は Portable ZIP 端末ユーザー向けで venv 手順を一切含まない。発生シナリオ (`E:\tmp\allaganeye-usertest\kobutachan-allaganeye` で `python -m venv .venv`) もソース開発者向けで、venv 手順のある `developer-setup.md` §2 の方が内容整合する。セッション冒頭で Iron Law 5 に基づきユーザー確認し、`developer-setup.md` のみ追記の方針で合意 (本 PR では quickstart.md は変更しない)。

## 追記内容

- 症状例 (エラーメッセージ形式)
- 典型的原因 3 点 (別ターミナルの activate 残 / IDE Python extension / Antivirus)
- 解決手順 4 段階:
  1. `Get-Process python` でロック中プロセス確認
  2. VSCode / 他 IDE を完全に閉じてから再実行
  3. 既存 `.venv` 完全削除 (PowerShell / cmd / Git Bash の 3 形式)
  4. 別パス (`C:\temp\test_venv`) で切り分け

## 受け入れ条件 (issue #431 から引用)

- [x] 症状例 `Permission denied: ...\.venv\Scripts\python.exe` → 追記節の最初のコードブロックで引用
- [x] 典型的原因 (別プロセス使用中 / Antivirus / Defender) → 「典型的な原因」3 項目で記載
- [x] 解決手順 `Get-Process python` / 既存 `.venv` 削除 (PS / cmd / bash) / VSCode 等を閉じる / 別パスで切り分け → 「解決手順」1-4 で全項目網羅

## Test plan

- [x] 自分の追加分 (line 211-266) に markdownlint エラーがないことを `npx markdownlint-cli2 docs/developer-setup.md` で確認
- [x] 既存の MD060 エラーは CI で使っている `DavidAnson/markdownlint-cli2-action@v20` 同梱の markdownlint-cli2 では enable されておらず、develop-0.2.0 上の他 doc でも同じ状態のため本 PR の責務外
- [x] CI の Markdownlint job が通ること (push 後に pass 確認済み)

## 備考

- ドキュメント単独変更 (Python コード / GUI なし) のため `ruff` / `pytest` / `npm test` / `cargo check` は不要
- Iron Law 4 遵守: `Closes` / `Fixes` / `Resolves` キーワードは使用していない。マージ後に手動で issue #431 を clo-se する運用