### PR TITLE
feat(video): AMD GPU decode を d3d11va + hwdownload で実装 (Refs #553)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 - GPU 初期化コストを分散し、1プロセスあたり多数フレームをデコードすることで効率化
 - Pass 1 以降の処理（transition expansion, Pass 2, フィルタリング）は CPU/GPU 共通
 - GPU 利用不可時は自動で CPU モードにフォールバック
-- vendor 自動選択 (#546): `allaganeye.system_info.probe_gpu_vendors()` で検出した GPU から `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` 順で選択。現時点で実装済み vendor は NVIDIA のみ、AMD (#553 AMF filter pipeline 相性問題) / Intel (#550 QSV 対応調査) は `--gpu-vendor {amd,intel}` 指定で exit 5。default (auto) は NVIDIA を選ぶ挙動
+- vendor 自動選択 (#546 / #553): `allaganeye.system_info.probe_gpu_vendors()` で検出した GPU から `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` 順で選択。実装済み vendor は NVIDIA (cuvid, #546) と AMD (d3d11va + hwdownload, #553) の 2 つ。Intel (#550 QSV 対応調査) は `--gpu-vendor intel` 指定で exit 5。default (auto) は NVIDIA > AMD > Intel の preference 順で実装済み vendor を選ぶ
 
 ### Exit Codes
 

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -552,8 +552,8 @@ def _resolve_gpu_mode(
         if gpu_vendor_option not in _VENDOR_HWACCEL_MAP:
             raise ConfigValidationError(
                 f"--gpu-vendor {gpu_vendor_option}: 現在未実装です "
-                "(AMD AMF は #553, Intel QSV は #550 で追跡予定)。"
-                " --gpu-vendor auto / nvidia のいずれかを使用してください。"
+                "(Intel QSV は #550 で追跡予定)。"
+                " --gpu-vendor auto / nvidia / amd のいずれかを使用してください。"
             )
         if gpu_vendor_option not in available:
             raise ConfigValidationError(

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -48,20 +48,38 @@ _GPU_DECODER_MAP: dict[str, dict[str, str]] = {
         "mpeg2video": "mpeg2_cuvid",
         "mpeg4": "mpeg4_cuvid",
     },
-    # "amd": {} は #553 (AMD AMF decoder + allaganeye filter pipeline
-    # 相性問題) で追跡中。AMF decoder 出力 pix_fmt `amf` が swscaler
-    # と不整合で `fps -> scale -> format=gray` が失敗するため、
-    # `--gpu-vendor amd` は #546 実装時点では option を受けるが
-    # _VENDOR_HWACCEL_MAP にも未登録 -> ConfigValidationError で exit 5。
-    # #553 で filter pipeline workaround が確定した時点で復活。
+    "amd": {
+        # AMD は AMF decoder ではなく d3d11va 経由で native decoder を
+        # ハードウェア化する (#553 結論)。AMF decoder の出力 pix_fmt
+        # `amf` は swscaler と不整合で `fps -> scale -> format=gray` が
+        # EOPNOTSUPP で fail するが、d3d11va は GPU 上 D3D11 surface に
+        # decode したあと filter graph 先頭の `hwdownload,format=nv12,...`
+        # で system memory に降ろせるので allaganeye の filter pipeline と
+        # 相性が取れる。
+        "h264": "h264",
+        "hevc": "hevc",
+        "av1": "av1",
+        # vp9 / mpeg* も d3d11va で動作可能だが OBS 録画では稀なので
+        # 現状未登録。必要になったら追加。
+    },
     # "intel": {} は #550 (Intel QSV 対応調査) で追加予定。
 }
 
 _VENDOR_HWACCEL_MAP: dict[str, str] = {
     "nvidia": "cuda",
-    # "amd": "amf" は #553 で filter pipeline 相性確定後に追加。
+    "amd": "d3d11va",  # #553 generic D3D11 hwaccel + native decoder
     # "intel": "qsv" は #550 で追加予定。
 }
+
+_HWACCELS_NEED_HWDOWNLOAD: frozenset[str] = frozenset({"d3d11va"})
+"""GPU memory に decode する hwaccel 一覧 (#553).
+
+これらの hwaccel は decoded frame を GPU surface のまま filter graph
+に送り込むため、CPU 側で動く ``fps``/``scale``/``format=gray`` filter に
+渡す前に ``hwdownload,format=nv12,`` を filter chain 先頭に挿入する
+必要がある。NVIDIA CUVID decoder (e.g. ``av1_cuvid``) は decode 結果を
+nv12 system memory に直接出力するため不要。
+"""
 
 _VENDOR_PREFERENCE: tuple[str, ...] = ("nvidia", "amd", "intel")
 """Auto-select 時の vendor 優先順 (#546). dGPU (NVIDIA) を最優先、
@@ -266,9 +284,12 @@ def _check_gpu_usage(
     stderr_text: str, codec: str | None, cuvid_decoder: str | None
 ) -> None:
     """Log GPU decode status based on ffmpeg stderr output."""
+    lowered = stderr_text.lower()
     if cuvid_decoder and cuvid_decoder in stderr_text:
         logger.info("GPU decode active: %s", cuvid_decoder)
-    elif "hwaccel" in stderr_text.lower() or "cuda" in stderr_text.lower():
+    elif "d3d11va" in lowered:
+        logger.info("GPU decode active (d3d11va)")
+    elif "hwaccel" in lowered or "cuda" in lowered:
         logger.info("GPU decode active (hwaccel auto)")
     else:
         logger.warning(
@@ -319,10 +340,22 @@ def _decode_chunk(
         if decoder:
             hwaccel_name = "cuda"
 
+    needs_hwdownload = (
+        hwaccel_name is not None and hwaccel_name in _HWACCELS_NEED_HWDOWNLOAD
+    )
     if decoder and hwaccel_name:
-        hwaccel_args = ["-hwaccel", hwaccel_name, "-c:v", decoder]
+        hwaccel_args = ["-hwaccel", hwaccel_name]
+        if needs_hwdownload:
+            # d3d11va は decode 結果を D3D11 surface に置くので、filter
+            # graph に渡す前に system memory への download が必要 (#553)。
+            # `-hwaccel_output_format d3d11` で surface format を明示し
+            # 後段の hwdownload と整合させる。
+            hwaccel_args += ["-hwaccel_output_format", "d3d11"]
+        hwaccel_args += ["-c:v", decoder]
     else:
         hwaccel_args = ["-hwaccel", "auto"]
+
+    vf_prefix = "hwdownload,format=nv12," if needs_hwdownload else ""
 
     cmd = [
         find_ffmpeg(),
@@ -334,7 +367,7 @@ def _decode_chunk(
         "-i",
         str(video_path),
         "-vf",
-        f"fps={fps_value},scale={_SAMPLE_WIDTH}:{_SAMPLE_HEIGHT},format=gray",
+        f"{vf_prefix}fps={fps_value},scale={_SAMPLE_WIDTH}:{_SAMPLE_HEIGHT},format=gray",
         "-f",
         "rawvideo",
         "-pix_fmt",

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -53,7 +53,7 @@ allaganeye split --from-metadata <metadata.json> [OPTIONS]
 | `--workers` | auto | 検知の並列ワーカー数（デフォルト: 自動=`min(cpu_count, 24)`） |
 | `--gpu` | `false` | GPU アクセラレーション検知を強制（チャンク並列デコード）。利用不可時は CPU フォールバック。**`--no-gpu` と同時指定は排他エラー (exit 5) (#419)** |
 | `--no-gpu` | `false` | GPU を無効化し CPU 検知を強制する。**`--gpu` と同時指定は排他エラー (exit 5) (#419)** |
-| `--gpu-vendor` | `auto` | 使用する GPU vendor を明示指定 (#546)。値: `auto` / `nvidia` / `amd` / `intel`。**現時点で実装済みは `nvidia` のみ**。`amd` は **exit 5** (#553 で復活予定、AMF decoder の filter pipeline 相性問題)、`intel` は **exit 5** (#550 で実装予定)。probe に無い vendor を要求すると exit 5。default は probe 結果から実装済み vendor を選ぶ |
+| `--gpu-vendor` | `auto` | 使用する GPU vendor を明示指定 (#546 / #553)。値: `auto` / `nvidia` / `amd` / `intel`。**実装済みは `nvidia` (cuvid, #546) と `amd` (d3d11va + hwdownload, #553)**。`intel` は **exit 5** (#550 で実装予定)。probe に無い vendor を要求すると exit 5。default は probe 結果から `_VENDOR_PREFERENCE` (nvidia > amd > intel) 順で実装済み vendor を選ぶ |
 | `--no-cache` | `false` | キャッシュされた検知結果を無視して再検知する |
 | `--no-audio` | `false` | 音声ベースの試合境界昇格（Fanfare スキャン）を無効化する。**現在は音声モジュールが凍結中（#327）のため、本フラグの値に関わらずスキャンは常にスキップされる。verbose 出力では `audio=frozen` と表示される (#384)** |
 | `--dry-run` | `false` | 検知のみ実行し分割しない（検知結果はキャッシュに保存される） |

--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -193,13 +193,16 @@ GPU 対応環境（NVIDIA CUDA, Intel QSV 等）では、暗転検知の処理�
 
 低コア数 CPU（4-8 コア）では、GPU モードが有利になりやすい傾向があります。
 
-#### GPU vendor の選択 (`--gpu-vendor`, #546)
+#### GPU vendor の選択 (`--gpu-vendor`, #546 / #553)
 
-現時点で実装済み vendor は NVIDIA のみ (#546)。AMD / Intel は別 issue で追跡中。複数 GPU 環境では、デフォルトで NVIDIA dGPU が選択されます (`_VENDOR_PREFERENCE` = nvidia > amd > intel、未実装 vendor は auto 選択で skip)。明示的に vendor を指定したい場合は `--gpu-vendor` オプションを使ってください。
+実装済み vendor は NVIDIA (#546) と AMD (#553) の 2 つ。Intel (#550) は別 issue で追跡中。複数 GPU 環境では、デフォルトで NVIDIA dGPU が選択されます (`_VENDOR_PREFERENCE` = nvidia > amd > intel、未実装 vendor は auto 選択で skip)。明示的に vendor を指定したい場合は `--gpu-vendor` オプションを使ってください。
 
 ```bash
 # NVIDIA GPU を明示使用 (dual GPU 環境で dGPU を強制)
 allaganeye split your_recording.mkv --gpu --gpu-vendor nvidia
+
+# AMD iGPU / dGPU を明示使用 (NVIDIA 不在 or AMD-only 環境)
+allaganeye split your_recording.mkv --gpu --gpu-vendor amd
 
 # 自動選択 (既定値、--gpu-vendor 省略時と同じ)
 allaganeye split your_recording.mkv --gpu --gpu-vendor auto
@@ -207,10 +210,10 @@ allaganeye split your_recording.mkv --gpu --gpu-vendor auto
 
 | Vendor | 対応状況 | 備考 |
 |---|---|---|
-| `nvidia` | 実装済み | NVDEC cuvid 経由、h264 / hevc / av1 対応 |
-| `amd` | 未実装 (#553) | AMF decoder の pix_fmt が allaganeye の filter pipeline と非互換。`--gpu-vendor amd` は現在 exit 5 |
+| `nvidia` | 実装済み (#546) | NVDEC cuvid 経由、h264 / hevc / av1 対応 |
+| `amd` | 実装済み (#553) | d3d11va + native decoder + `hwdownload,format=nv12` 経由、h264 / hevc / av1 対応。RDNA2+ iGPU (Granite Ridge) で SW 比 3x 高速 |
 | `intel` | 未実装 (#550) | `--gpu-vendor intel` は現在 exit 5 |
-| `auto` | 自動選択 | probe 結果から NVIDIA を優先 (AMD / Intel 実装完了までは nvidia が事実上の唯一の選択肢) |
+| `auto` | 自動選択 | probe 結果から `_VENDOR_PREFERENCE` 順に選択 (NVIDIA > AMD > Intel) |
 
 #### ベンチマークで判断する
 

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -137,22 +137,22 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 | VP9 | GPU (#414) — NVIDIA は soft decode (#538), AMD は `vp9_amf` 利用可 | Maxwell 以降 (#538 で NVDEC 経路除外) | Gen9+ | VCN 1.0+ |
 | その他 (mpeg2video, vc1, prores 等) | CPU | — | — | — |
 
-- VP9 は `_GPU_PREFERRED_CODECS` に残すが NVIDIA 経路 (`_GPU_DECODER_MAP["nvidia"]`) からは除外 (#538 / #549)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。NVIDIA auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x)。AMD AMF は csp:gbr 問題なし (実測 nv12+bt709) で `vp9_amf` 経由 GPU decode 可能。`vp9_cuvid` の ffmpeg 側修正が入った時点で NVIDIA 経路の復活検討。
+- VP9 は `_GPU_PREFERRED_CODECS` に残すが NVIDIA 経路 (`_GPU_DECODER_MAP["nvidia"]`) からは除外 (#538 / #549)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。NVIDIA auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x)。`vp9_cuvid` の ffmpeg 側修正が入った時点で NVIDIA 経路の復活検討。AMD は #553 で d3d11va 経路に統一しているため csp:gbr 問題なし (filter 先頭で `hwdownload,format=nv12` 経由で system memory に降ろす)。
 
-**vendor × codec 実装状況 (#546)**
+**vendor × codec 実装状況 (#546 / #553)**
 
 | Vendor | hwaccel | h264 | hevc | av1 | vp9 | 備考 |
 |---|---|---|---|---|---|---|
 | NVIDIA (NVDEC cuvid) | `cuda` | `h264_cuvid` | `hevc_cuvid` | `av1_cuvid` | (soft, #538/#549) | dGPU 想定、dual GPU では優先選択 |
-| AMD (AMF) | (未実装) | (未実装) | (未実装) | (未実装) | (未実装) | #553 で追跡中。AMF decoder 出力の pix_fmt が allaganeye の `fps -> scale -> format=gray` filter と非互換で swscaler reinit 失敗。`--gpu-vendor amd` は現在 exit 5 |
+| AMD (d3d11va) | `d3d11va` | `h264` | `hevc` | `av1` | (未登録) | #553 で実装。AMF decoder ではなく d3d11va + native decoder + filter 先頭 `hwdownload,format=nv12` で allaganeye filter pipeline と整合させる。RDNA2+ iGPU (Granite Ridge) で実測 speed 23x (SW 7.6x 比 3x 高速) |
 | Intel (QSV) | (未実装) | (未実装) | (未実装) | (未実装) | (未対応) | #550 で実装予定。`--gpu-vendor intel` は現在 exit 5 |
 | Apple (VideoToolbox) | — | — | — | — | — | Windows ffmpeg 未同梱、別 issue 追跡 |
 
 **vendor 自動選択ロジック (`_resolve_gpu_mode` + `_select_gpu_vendor`)**
 
 1. `allaganeye.system_info.probe_gpu_vendors()` が platform 別 probe (nvidia-smi / wmic / lspci / system_profiler) で検出した vendor list を取得
-2. `--gpu-vendor <vendor>` explicit の場合: `available` に含まれない、または `_VENDOR_HWACCEL_MAP` に未登録 (amd / intel 等) なら `ConfigValidationError` (exit 5)
-3. `--gpu-vendor auto` (default) の場合: `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` x `available` x 実装済み (`_VENDOR_HWACCEL_MAP` に含まれる) の最上位を選択。現時点で実装済みは NVIDIA のみ (AMD は #553, Intel は #550 で追跡)
+2. `--gpu-vendor <vendor>` explicit の場合: `available` に含まれない、または `_VENDOR_HWACCEL_MAP` に未登録 (intel) なら `ConfigValidationError` (exit 5)
+3. `--gpu-vendor auto` (default) の場合: `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` x `available` x 実装済み (`_VENDOR_HWACCEL_MAP` に含まれる) の最上位を選択。現時点で実装済みは NVIDIA + AMD (d3d11va, #553)。Intel は #550 で追跡
 4. codec が `_GPU_PREFERRED_CODECS` に含まれない場合は CPU mode。vendor が None (GPU 検出失敗 / 未実装 vendor のみ検出) でも codec match なら `use_gpu=True` を返し、`scan_gpu` の legacy path (`-hwaccel auto`) に入る。ffmpeg 側で GPU decode 失敗時は上記フォールバック経路で CPU 自動切替 (#334 既存挙動を維持)
 
 **フォールバック経路**

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -91,50 +91,113 @@ class TestDecodeChunk:
         assert cmd[cv_idx + 1] == "av1_cuvid"
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
-    def test_unimplemented_vendor_falls_back_to_hwaccel_auto(self, mock_run):
-        """vendor=amd / intel は _VENDOR_HWACCEL_MAP 未定義で
-        `-hwaccel auto` に fallback する (#546 / #550 / #553).
+    def test_hwaccel_d3d11va_for_amd_av1(self, mock_run):
+        """vendor=amd で AV1 は d3d11va + native av1 decoder + hwdownload (#553)."""
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="av1", vendor="amd")
 
-        explicit `--gpu-vendor amd` の場合、CLI 層 (_resolve_gpu_mode)
-        が ConfigValidationError で先に拒否するので実際にはこの経路に
-        は入らない。ただし probe 結果から自動選択されたケース (今は
-        preference で skip される) や将来 _VENDOR_HWACCEL_MAP に
-        vendor を追加し忘れた際のガードとしてこの挙動を維持する。
+        cmd = mock_run.call_args[0][0]
+        hw_idx = cmd.index("-hwaccel")
+        assert cmd[hw_idx + 1] == "d3d11va"
+        # AMD は AMF decoder ではなく native decoder + d3d11va wrapping
+        cv_idx = cmd.index("-c:v")
+        assert cmd[cv_idx + 1] == "av1"
+        assert "av1_amf" not in cmd
+        # surface format を明示して hwdownload と整合
+        of_idx = cmd.index("-hwaccel_output_format")
+        assert cmd[of_idx + 1] == "d3d11"
+        # filter graph 先頭で system memory に降ろす
+        vf_idx = cmd.index("-vf")
+        assert cmd[vf_idx + 1].startswith("hwdownload,format=nv12,")
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_hwaccel_d3d11va_for_amd_h264(self, mock_run):
+        """vendor=amd / codec=h264 でも d3d11va 経路 (#553)."""
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="h264", vendor="amd")
+
+        cmd = mock_run.call_args[0][0]
+        hw_idx = cmd.index("-hwaccel")
+        assert cmd[hw_idx + 1] == "d3d11va"
+        cv_idx = cmd.index("-c:v")
+        assert cmd[cv_idx + 1] == "h264"
+        assert "h264_amf" not in cmd
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_hwaccel_d3d11va_for_amd_hevc(self, mock_run):
+        """vendor=amd / codec=hevc でも d3d11va 経路 (#553)."""
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="hevc", vendor="amd")
+
+        cmd = mock_run.call_args[0][0]
+        hw_idx = cmd.index("-hwaccel")
+        assert cmd[hw_idx + 1] == "d3d11va"
+        cv_idx = cmd.index("-c:v")
+        assert cmd[cv_idx + 1] == "hevc"
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_nvidia_path_skips_hwdownload(self, mock_run):
+        """NVIDIA cuvid 経路は hwdownload prefix を付けない (#553 回帰防止).
+
+        cuvid decoder は decode 結果を nv12 system memory に直接出力する
+        ため、d3d11va のような hwdownload は不要。filter chain 先頭が
+        ``fps=...`` で始まることを確認。
         """
         mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
-        for vendor in ("amd", "intel"):
-            mock_run.reset_mock()
-            _decode_chunk(
-                Path("test.mp4"),
-                0.0,
-                10.0,
-                1.0,
-                codec="av1",
-                vendor=vendor,
-            )
-            cmd = mock_run.call_args[0][0]
-            hw_idx = cmd.index("-hwaccel")
-            assert cmd[hw_idx + 1] == "auto", (
-                f"vendor={vendor} should fall back to -hwaccel auto, "
-                f"got -hwaccel {cmd[hw_idx + 1]}"
-            )
-            assert "av1_qsv" not in cmd
-            assert "av1_amf" not in cmd
-            assert "av1_cuvid" not in cmd
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="av1", vendor="nvidia")
 
-    def test_select_gpu_vendor_auto_returns_nvidia_only_when_implemented(self):
-        """auto 選択は _VENDOR_HWACCEL_MAP 登録済みの vendor のみ返す (#546).
+        cmd = mock_run.call_args[0][0]
+        assert "-hwaccel_output_format" not in cmd
+        vf_idx = cmd.index("-vf")
+        assert cmd[vf_idx + 1].startswith("fps="), (
+            "NVIDIA cuvid path must not include hwdownload prefix"
+        )
 
-        現在 NVIDIA のみ実装。AMD (#553) / Intel (#550) は preference
-        内でも skip されて None または後続 vendor にフォールバックする。
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_unimplemented_vendor_falls_back_to_hwaccel_auto(self, mock_run):
+        """vendor=intel は _VENDOR_HWACCEL_MAP 未定義で
+        `-hwaccel auto` に fallback する (#550 で QSV 実装予定).
+
+        explicit `--gpu-vendor intel` の場合、CLI 層 (_resolve_gpu_mode)
+        が ConfigValidationError で先に拒否するので実際にはこの経路に
+        は入らない。ただし将来 _VENDOR_HWACCEL_MAP に vendor を追加
+        し忘れた際のガードとしてこの挙動を維持する。
+        AMD は #553 で d3d11va として実装済み。
+        """
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(
+            Path("test.mp4"),
+            0.0,
+            10.0,
+            1.0,
+            codec="av1",
+            vendor="intel",
+        )
+        cmd = mock_run.call_args[0][0]
+        hw_idx = cmd.index("-hwaccel")
+        assert cmd[hw_idx + 1] == "auto", (
+            f"vendor=intel should fall back to -hwaccel auto, "
+            f"got -hwaccel {cmd[hw_idx + 1]}"
+        )
+        assert "av1_qsv" not in cmd
+        assert "av1_cuvid" not in cmd
+
+    def test_select_gpu_vendor_auto_returns_nvidia_first(self):
+        """auto 選択は preference 順に _VENDOR_HWACCEL_MAP 登録済みを返す (#546 / #553).
+
+        NVIDIA dGPU 優先、AMD (#553 で d3d11va 実装済み) がフォールバック、
+        Intel (#550) は preference にあっても _VENDOR_HWACCEL_MAP 未登録
+        で skip される。
         """
         from allaganeye.video.gpu_detector import _select_gpu_vendor
 
+        # NVIDIA が available にあれば最優先
         assert _select_gpu_vendor(None, ["nvidia", "amd"]) == "nvidia"
         assert _select_gpu_vendor("auto", ["nvidia", "amd"]) == "nvidia"
-        # AMD / Intel only -> None (not implemented yet)
-        assert _select_gpu_vendor(None, ["amd", "intel"]) is None
-        assert _select_gpu_vendor(None, ["amd"]) is None
+        # NVIDIA 不在で AMD があれば AMD (#553)
+        assert _select_gpu_vendor(None, ["amd", "intel"]) == "amd"
+        assert _select_gpu_vendor(None, ["amd"]) == "amd"
+        # Intel のみ -> None (#550 まだ未実装)
         assert _select_gpu_vendor(None, ["intel"]) is None
         assert _select_gpu_vendor(None, []) is None
 
@@ -148,18 +211,17 @@ class TestDecodeChunk:
     def test_select_gpu_vendor_explicit_unavailable_returns_none(self):
         """explicit vendor が available に無い場合は None (#546).
 
-        実装済み vendor の「未検出」と未実装 vendor の両方カバー。
-        実行時は _resolve_gpu_mode が ConfigValidationError で
-        落とす仕組み。
+        実装済み vendor (NVIDIA #546, AMD #553) の「未検出」と未実装
+        vendor (Intel #550) の両方カバー。実行時は _resolve_gpu_mode が
+        ConfigValidationError で落とす仕組み。
         """
         from allaganeye.video.gpu_detector import _select_gpu_vendor
 
         assert _select_gpu_vendor("nvidia", ["amd"]) is None
-        # AMD / Intel は explicit request でもサポート外 (available に
-        # 含まれても _VENDOR_HWACCEL_MAP でないので scan_gpu 側で
-        # fallback、ここでは vendor 名を返すだけ)
+        # AMD は #553 で _VENDOR_HWACCEL_MAP=d3d11va で実装済み
         assert _select_gpu_vendor("amd", ["amd", "nvidia"]) == "amd"
         assert _select_gpu_vendor("amd", ["nvidia"]) is None
+        # Intel は #550 で QSV 実装予定 (現状は未実装 vendor)
         assert _select_gpu_vendor("intel", ["nvidia"]) is None
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1890,15 +1890,13 @@ class TestResolveGpuMode:
         _, vendor = _resolve_gpu_mode(None, None, "av1", show=False, verbose=False)
         assert vendor == "nvidia"
 
-    def test_vendor_auto_no_vendor_when_only_amd(self, monkeypatch):
-        """AMD iGPU のみ環境では vendor=None だが codec match で use_gpu=True.
+    def test_vendor_auto_selects_amd_when_only_amd(self, monkeypatch):
+        """AMD iGPU のみ環境では vendor=amd を返し d3d11va 経路で動作する (#553).
 
-        AMD AMF decoder は #546 実装時点では _VENDOR_HWACCEL_MAP 未登録
-        (#553 で filter pipeline workaround 確定時に復活予定)。auto
-        選択で AMD は skip されるが、codec=av1 が `_GPU_PREFERRED_CODECS`
-        に含まれるため use_gpu=True を返し、scan_gpu の legacy path
-        (-hwaccel auto) で動作する (GPU decode 失敗時は ffmpeg が
-        CPU fallback)。
+        #546 時点では AMD は AMF decoder の filter pipeline 不整合で skip
+        されていたが、#553 で d3d11va + hwdownload 経路を実装したことで
+        auto 選択でも AMD が選ばれる。codec=av1 は ``_GPU_PREFERRED_CODECS``
+        に含まれるため use_gpu=True。
         """
         monkeypatch.setattr(
             "allaganeye.system_info.probe_gpu_vendors",
@@ -1910,19 +1908,21 @@ class TestResolveGpuMode:
             None, None, "av1", show=False, verbose=False
         )
         assert use_gpu is True
-        assert vendor is None
+        assert vendor == "amd"
 
-    def test_vendor_explicit_amd_unimplemented_raises(self, monkeypatch):
-        """AMD は #553 で復活予定、explicit 要求は exit 5 (#546)."""
+    def test_vendor_explicit_amd_resolves(self, monkeypatch):
+        """AMD は #553 で d3d11va 経路として実装済み、explicit 要求も通る."""
         monkeypatch.setattr(
             "allaganeye.system_info.probe_gpu_vendors",
             lambda: ["nvidia", "amd"],
         )
         from allaganeye.commands.split_matches import _resolve_gpu_mode
-        from allaganeye.exceptions import ConfigValidationError
 
-        with pytest.raises(ConfigValidationError, match="--gpu-vendor amd"):
-            _resolve_gpu_mode(None, "amd", "av1", show=False, verbose=False)
+        use_gpu, vendor = _resolve_gpu_mode(
+            None, "amd", "av1", show=False, verbose=False
+        )
+        assert use_gpu is True
+        assert vendor == "amd"
 
     def test_vendor_explicit_unavailable_raises_config_error(self, monkeypatch):
         """--gpu-vendor で probe に無い vendor を要求すると exit 5 (#546).
@@ -1952,7 +1952,12 @@ class TestResolveGpuMode:
             _resolve_gpu_mode(None, "intel", "av1", show=False, verbose=False)
 
     def test_vendor_auto_skips_unimplemented(self, monkeypatch):
-        """auto 選択では AMD / Intel (未実装) が available でも skip して NVIDIA を選ぶ (#546)."""
+        """auto 選択は preference 順 (#546 / #553).
+
+        Intel (#550 未実装) は available でも skip。AMD (#553 で d3d11va
+        として実装済み) は preference で NVIDIA の次に位置するため、
+        NVIDIA が available なら NVIDIA が優先される。
+        """
         monkeypatch.setattr(
             "allaganeye.system_info.probe_gpu_vendors",
             lambda: ["intel", "amd", "nvidia"],


### PR DESCRIPTION
## Summary

- AMD GPU decode を **d3d11va + hwdownload** 経路で実装。AMF decoder ではなく ffmpeg の generic D3D11 hwaccel を使うことで allaganeye の `fps → scale → format=gray` filter pipeline と整合させる
- ローカル AMD iGPU (Ryzen 9 9950X3D Granite Ridge RDNA2 2CU, ffmpeg 8.1) 実機で `allaganeye split --gpu-vendor amd` が **`stats.mode: GPU`** で完走することを確認
- AV1 / H.264 / HEVC で動作、AV1 で SW 7.6x → HW 23.2x (3x 高速化)

## Root cause と方針

### 問題
issue #553 では `_GPU_DECODER_MAP["amd"]` に `av1_amf` 等の AMF decoder を登録すると、AMF decoder の出力 pix_fmt `amf` が後段の swscaler と不整合を起こし、`fps → scale → format=gray` filter chain で:

```
[vf#0:0] Error reinitializing filters!
[vf#0:0] Task finished with error code: -40 (Function not implemented)
```

の error が発生。issue で試した workaround A/B/C (AMF + filter graph 調整) は全て失敗。

### 解決: d3d11va 経路

**AMF decoder ではなく `-hwaccel d3d11va`** を使う。d3d11va は ffmpeg の generic D3D11 ハードウェア acceleration で、native decoder (`av1` / `h264` / `hevc`) を D3D11 surface 上で hardware decode する。

filter chain 先頭に `hwdownload,format=nv12,` を挿入することで、GPU 上 D3D11 surface から system memory (nv12) に降ろし、その後 CPU 上で `fps → scale → format=gray` を実行できる。

### 実機ベンチマーク (single thread, AV1 30s sample)

| 経路 | ffmpeg コマンド | speed |
|---|---|---|
| SW (native AV1) | `-c:v av1` | 7.6x |
| d3d11va (no output_format) | `-hwaccel d3d11va -c:v av1` | 13.5x |
| d3d11va + hwdownload (採用) | `-hwaccel d3d11va -hwaccel_output_format d3d11 -c:v av1 -vf "hwdownload,format=nv12,..."` | **23.2x** |

採用方式が SW 比 **3x 高速**、`-hwaccel_output_format` 明示で auto download より更に高速。

### NVIDIA cuvid 経路への影響なし

NVIDIA cuvid decoder (e.g. `av1_cuvid`) は decode 結果を nv12 system memory に直接出力するため hwdownload 不要。`_HWACCELS_NEED_HWDOWNLOAD = {d3d11va}` の集合判定で d3d11va のみに hwdownload prefix を付与し、cuvid 経路は filter chain 先頭が `fps=...` のままを保証 (test_nvidia_path_skips_hwdownload で回帰防止)。

## 変更内容

### `allaganeye/video/gpu_detector.py`

```python
_GPU_DECODER_MAP["amd"] = {
    "h264": "h264",  # native + d3d11va wrapping
    "hevc": "hevc",
    "av1": "av1",
    # vp9 / mpeg* は OBS 録画で稀なので未登録
}
_VENDOR_HWACCEL_MAP["amd"] = "d3d11va"
_HWACCELS_NEED_HWDOWNLOAD = frozenset({"d3d11va"})
```

`_decode_chunk` で `hwaccel_name in _HWACCELS_NEED_HWDOWNLOAD` のとき:
- `-hwaccel_output_format d3d11` を hwaccel_args に追加
- filter graph 先頭に `hwdownload,format=nv12,` を挿入

`_check_gpu_usage` で stderr に `d3d11va` を含む場合の info ログを追加。

### `allaganeye/commands/split_matches.py`

`_resolve_gpu_mode` のエラーメッセージから AMD を除外 (実装済みのため):

```python
# Before
"(AMD AMF は #553, Intel QSV は #550 で追跡予定)。"
" --gpu-vendor auto / nvidia のいずれかを使用してください。"
# After
"(Intel QSV は #550 で追跡予定)。"
" --gpu-vendor auto / nvidia / amd のいずれかを使用してください。"
```

### Tests (`tests/test_gpu_detector.py`)

新規:
- `test_hwaccel_d3d11va_for_amd_av1`: AMD/AV1 で d3d11va + native av1 + hwdownload を assert
- `test_hwaccel_d3d11va_for_amd_h264`: H.264 でも同様
- `test_hwaccel_d3d11va_for_amd_hevc`: HEVC でも同様
- `test_nvidia_path_skips_hwdownload`: NVIDIA cuvid 経路に hwdownload が混入しないことを保証

調整:
- `test_unimplemented_vendor_falls_back_to_hwaccel_auto`: vendor リストから `amd` を削除し `intel` のみ対象
- `test_select_gpu_vendor_auto_returns_nvidia_first` (旧 `..._only_when_implemented`): AMD-only 環境で `amd` 返すよう更新

### Tests (`tests/test_split_matches.py`)

調整:
- `test_vendor_auto_selects_amd_when_only_amd` (旧 `..._no_vendor_when_only_amd`): AMD-only で `vendor="amd"` 返すよう更新
- `test_vendor_explicit_amd_resolves` (旧 `..._unimplemented_raises`): explicit `--gpu-vendor amd` が成功することを assert

### Docs

- `docs/video-processing.md` の vendor × codec 実装状況テーブルを「AMD (AMF) 未実装」→「AMD (d3d11va) 実装済み」に更新
- `docs/tuning-guide.md` の `--gpu-vendor` 説明にも AMD 実装済みを反映 + AMD コマンド例追加

## 受け入れ条件達成状況 (#553)

- [x] **AMF decoder + allaganeye filter pipeline の動作する組み合わせを 1 つ以上特定**
  - AMF を使わず d3d11va + hwdownload で解決。issue 想定とは別解決だが、ユーザー視点 (AMD GPU acceleration が allaganeye で動く) は満たされる
- [x] **`_GPU_DECODER_MAP["amd"]` / `_VENDOR_HWACCEL_MAP["amd"]` を再度有効化**
  - 値は AMF ではなく d3d11va に変更
- [x] **AMD iGPU 実機で `allaganeye split --gpu-vendor amd` が `stats.mode: GPU` で完走する**
  - Ryzen 9 9950X3D Granite Ridge iGPU で確認 (Pass 1 = 3.05s / 16 chunks / mode=GPU)

## E2E 実行ログ (Ryzen 9 9950X3D iGPU)

### 30s sample (基本動作確認)

```
$ python -m allaganeye split tmp/av1_30s.mkv -o tmp/amd_e2e --gpu --gpu-vendor amd -v --no-cache

Detecting [dispatching 16 chunks, first result pending...]
Detecting [chunk 1/16, ETA ~34s]
...
Detecting [chunk 16/16]
  stats.mode: GPU
  stats.pass1_samples: 32
  stats.pass1_blackout_frames: 0
  stats.pass1_elapsed_s: 3.0469999999913853
  ...
```

(短い 30s sample なので "No match boundaries detected" は期待動作)

### 実動画フルパイプライン E2E (2h17m AV1 1080p)

`ALLAGANEYE_SAMPLE_VIDEO_DIR/2026-01-18 22-15-18.mkv` (2h17m, AV1, 1920x1080) で AMD GPU と CPU の比較 E2E を実施。

| mode | Pass 1 | Pass 2 | Scorebar | Splitting | Total |
|---|---|---|---|---|---|
| AMD GPU (`--gpu-vendor amd`) | 4m06s | 1m44s | 1m07s | 0m24s | **7m23s** |
| CPU (`--no-gpu`) | 5m38s | 1m41s | 1m08s | 0m27s | 8m55s |

AMD iGPU (Granite Ridge RDNA2 2CU) は CPU 比 17% 高速 (Pass 1 単独 27% 高速)。

**boundary 完全一致 (AMD ↔ CPU)**: 5 matches すべて start/end が **Δ=0.00** で一致。

| idx | AMD start | AMD end | CPU start | CPU end | Δstart | Δend |
|---|---|---|---|---|---|---|
| 1 | 177.25 | 2610.75 | 177.25 | 2610.75 | 0.00 | 0.00 |
| 2 | 2976.25 | 4195.75 | 2976.25 | 4195.75 | 0.00 | 0.00 |
| 3 | 4200.25 | 5255.50 | 4200.25 | 5255.50 | 0.00 | 0.00 |
| 4 | 5499.00 | 6465.25 | 5499.00 | 6465.25 | 0.00 | 0.00 |
| 5 | 7231.25 | 8114.62 | 7231.25 | 8114.62 | 0.00 | 0.00 |

AMD d3d11va decode と CPU decode が同じ filter pipeline (`fps → scale → format=gray`) を経由するため、brightness 値 → blackout 判定 → match boundary が完全一致する設計。

確認点:
- ✅ `stats.mode: GPU` 維持
- ✅ 試合境界検出 5 件 (manual splits 6 件と scorebar +/-2 tolerance 内)
- ✅ scorebar フィルタリング (10 match_boundary, 7 in_match, 3 non_fl)
- ✅ Pass 2 完走 (20 regions refined)
- ✅ 試合ごと MP4 + metadata.json 生成成功
- ✅ chunk dispatch 動作 (32 chunks / `max_parallel=16` で 2 wave 実行)

## Test plan

- [x] `python -m pytest tests/test_gpu_detector.py tests/test_split_matches.py tests/test_gpu_probe.py -v` 200 passed
- [x] `python -m pytest` (default deselect) 794 passed
- [x] `python -m ruff check .` PASS
- [x] `python -m ruff format --check .` PASS
- [x] `python -m pyright` 0 errors
- [x] AMD iGPU 実機 30s sample E2E (`stats.mode: GPU` 確認)
- [x] AMD iGPU 実機 2h17m 実動画フルパイプライン E2E (5 matches, scorebar/Pass2/splitter 全動作)
- [x] CPU mode (`--no-gpu`) 比較で boundary 完全一致 (Δ=0.00)

