### PR TITLE
feat(gpu): Intel QSV decode 対応 (h264 / hevc / av1) (Refs #550)

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -116,8 +116,9 @@ def split(
         typer.Option(
             "--gpu-vendor",
             help="GPU vendor for hardware decode. Choices: auto / nvidia / amd / intel. "
-            "'intel' is currently not implemented (tracked in #550) and returns exit 5. "
-            "Default: auto (probe-based, NVIDIA dGPU preferred). #546",
+            "All three vendors are implemented (nvidia=cuvid, amd=d3d11va, intel=qsv). "
+            "Default: auto (probe-based, _VENDOR_PREFERENCE = nvidia > amd > intel). "
+            "#546 / #553 / #550",
         ),
     ] = None,
     no_cache: Annotated[
@@ -285,8 +286,9 @@ def detect(
         typer.Option(
             "--gpu-vendor",
             help="GPU vendor for hardware decode. Choices: auto / nvidia / amd / intel. "
-            "'intel' is currently not implemented (tracked in #550) and returns exit 5. "
-            "Default: auto (probe-based, NVIDIA dGPU preferred). #546",
+            "All three vendors are implemented (nvidia=cuvid, amd=d3d11va, intel=qsv). "
+            "Default: auto (probe-based, _VENDOR_PREFERENCE = nvidia > amd > intel). "
+            "#546 / #553 / #550",
         ),
     ] = None,
     no_cache: Annotated[

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -528,12 +528,13 @@ def _resolve_gpu_mode(
     show: bool,
     verbose: bool,
 ) -> tuple[bool, str | None]:
-    """Resolve GPU/CPU mode and vendor from user flags + probe (#334, #546).
+    """Resolve GPU/CPU mode and vendor from user flags + probe (#334, #546, #553, #550).
 
     - *use_gpu*: None で自動 codec 判定、True/False で明示指示。
     - *gpu_vendor_option*: None / "auto" で自動選択、"nvidia" / "amd" /
-      "intel" で明示指定。未実装 vendor (intel) や probe に見つからない
-      vendor を要求すると ``ConfigValidationError`` (exit 5)。
+      "intel" で明示指定。``_VENDOR_HWACCEL_MAP`` に未登録の vendor や
+      probe に見つからない vendor を要求すると ``ConfigValidationError``
+      (exit 5)。現時点で nvidia / amd / intel すべて実装済み。
 
     Returns ``(use_gpu_concrete, selected_vendor)`` tuple.  vendor が
     ``None`` の場合は GPU 経路で ``-hwaccel auto`` が使われる。
@@ -547,13 +548,15 @@ def _resolve_gpu_mode(
 
     available = probe_gpu_vendors()
 
-    # Explicit vendor request validation (#546): 未実装 or 未検出は exit 5
+    # Explicit vendor request validation (#546 / #553 / #550): 未実装 or 未検出は exit 5。
+    # 現時点で _VENDOR_HWACCEL_MAP は nvidia / amd / intel すべて含むので
+    # この分岐は config 側 (auto/nvidia/amd/intel) の validation を抜ける
+    # 将来の vendor 追加忘れに対する defensive guard。
     if gpu_vendor_option and gpu_vendor_option != "auto":
         if gpu_vendor_option not in _VENDOR_HWACCEL_MAP:
             raise ConfigValidationError(
-                f"--gpu-vendor {gpu_vendor_option}: 現在未実装です "
-                "(Intel QSV は #550 で追跡予定)。"
-                " --gpu-vendor auto / nvidia / amd のいずれかを使用してください。"
+                f"--gpu-vendor {gpu_vendor_option}: 現在未実装です。"
+                " --gpu-vendor auto / nvidia / amd / intel のいずれかを使用してください。"
             )
         if gpu_vendor_option not in available:
             raise ConfigValidationError(

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -105,11 +105,11 @@ nv12 system memory に直接出力するため不要。
 """
 
 _VENDOR_PREFERENCE: tuple[str, ...] = ("nvidia", "amd", "intel")
-"""Auto-select 時の vendor 優先順 (#546 / #550). dGPU (NVIDIA) を最優先、
-次に AMD (#553 で復活予定), 最後に Intel (#550 で実装済み)。AMD は現時点
-で未実装だが future-proof で preference に含める (_VENDOR_HWACCEL_MAP
-に無いので auto-select では skip される)。Intel は実装済みだが NVIDIA
-dGPU 環境では NVDEC を優先する想定。"""
+"""Auto-select 時の vendor 優先順 (#546 / #553 / #550). dGPU (NVIDIA) を最優先、
+次に AMD (#553 / #578 で d3d11va 経由実装済み), 最後に Intel
+(#550 で QSV 経由実装済み)。3 vendor すべて _VENDOR_HWACCEL_MAP に登録済みで
+auto-select の対象。NVIDIA dGPU + Intel iGPU / AMD APU + Intel iGPU のような
+組み合わせでは preference 順で上位 vendor が選ばれる。"""
 
 _HWACCEL_OUTPUT_FORMAT_MAP: dict[str, str] = {
     # `-hwaccel_output_format` の値マップ (#553 / #550)。

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -62,30 +62,63 @@ _GPU_DECODER_MAP: dict[str, dict[str, str]] = {
         # vp9 / mpeg* も d3d11va で動作可能だが OBS 録画では稀なので
         # 現状未登録。必要になったら追加。
     },
-    # "intel": {} は #550 (Intel QSV 対応調査) で追加予定。
+    "intel": {
+        # #550 で追加。Tiger Lake (11th gen Iris Xe) 以降は
+        # h264 / hevc / av1 を QSV decode 可能。`_HWACCELS_NEED_HWDOWNLOAD`
+        # に "qsv" を追加してあるので _decode_chunk が
+        # `-hwaccel_output_format qsv` + filter chain 先頭の
+        # `hwdownload,format=nv12,` を自動付与し、QSV surface を system
+        # memory に降ろしてから fps -> scale -> format=gray に渡す。
+        # VP9 は QSV decoder 自体は ffmpeg 8.1 に存在 (`vp9_qsv`) するが
+        # 本 issue ではスコープ外で除外 (将来別 issue で追加検討)。
+        # 古い世代 (Skylake 等) で av1_qsv が「unsupported (-3)」で
+        # 失敗するケースは _decode_chunk が VideoProcessingError を上げ、
+        # detect_match_boundaries が CPU fallback する (実機検証:
+        # i7-1185G7 / Iris Xe では av1_qsv 非対応で CPU fallback 動作確認済み)。
+        "h264": "h264_qsv",
+        "hevc": "hevc_qsv",
+        "av1": "av1_qsv",
+    },
 }
 
 _VENDOR_HWACCEL_MAP: dict[str, str] = {
     "nvidia": "cuda",
     "amd": "d3d11va",  # #553 generic D3D11 hwaccel + native decoder
-    # "intel": "qsv" は #550 で追加予定。
+    "intel": "qsv",  # #550 Intel Quick Sync Video
 }
 
-_HWACCELS_NEED_HWDOWNLOAD: frozenset[str] = frozenset({"d3d11va"})
-"""GPU memory に decode する hwaccel 一覧 (#553).
+_HWACCELS_NEED_HWDOWNLOAD: frozenset[str] = frozenset({"d3d11va", "qsv"})
+"""GPU memory に decode する hwaccel 一覧 (#553 / #550).
 
 これらの hwaccel は decoded frame を GPU surface のまま filter graph
 に送り込むため、CPU 側で動く ``fps``/``scale``/``format=gray`` filter に
 渡す前に ``hwdownload,format=nv12,`` を filter chain 先頭に挿入する
 必要がある。NVIDIA CUVID decoder (e.g. ``av1_cuvid``) は decode 結果を
 nv12 system memory に直接出力するため不要。
+
+`-hwaccel_output_format` の値は hwaccel 名と一致させる:
+- d3d11va -> ``d3d11`` (#553)
+- qsv -> ``qsv`` (#550)。実機検証 (i7-1185G7 / Iris Xe) で h264_qsv 13.7x speed。
+  ``-hwaccel_output_format nv12`` 直指定でも動くが、d3d11va と同じ
+  パターンに揃え hwdownload filter で system memory に降ろす方が
+  vendor 間の挙動を一本化できる
 """
 
 _VENDOR_PREFERENCE: tuple[str, ...] = ("nvidia", "amd", "intel")
-"""Auto-select 時の vendor 優先順 (#546). dGPU (NVIDIA) を最優先、
-次に AMD (#553 で復活予定), 最後に Intel (#550)。AMD / Intel は現時点
-で実装未完だが future-proof で preference に含める (_VENDOR_HWACCEL_MAP
-に無いので auto-select では skip される)."""
+"""Auto-select 時の vendor 優先順 (#546 / #550). dGPU (NVIDIA) を最優先、
+次に AMD (#553 で復活予定), 最後に Intel (#550 で実装済み)。AMD は現時点
+で未実装だが future-proof で preference に含める (_VENDOR_HWACCEL_MAP
+に無いので auto-select では skip される)。Intel は実装済みだが NVIDIA
+dGPU 環境では NVDEC を優先する想定。"""
+
+_HWACCEL_OUTPUT_FORMAT_MAP: dict[str, str] = {
+    # `-hwaccel_output_format` の値マップ (#553 / #550)。
+    # `_HWACCELS_NEED_HWDOWNLOAD` の各 hwaccel に対応する surface format。
+    # ffmpeg は `-hwaccel <X> -hwaccel_output_format <Y>` の <Y> として
+    # hwaccel 自身の surface format 名 (d3d11 / qsv 等) を要求する。
+    "d3d11va": "d3d11",
+    "qsv": "qsv",
+}
 
 # Backward-compat alias: 既存の `_CUVID_CODEC_MAP` 参照 (テスト等) を
 # 壊さないため NVIDIA 用 dict を指す。新規コードは `_GPU_DECODER_MAP`
@@ -289,6 +322,8 @@ def _check_gpu_usage(
         logger.info("GPU decode active: %s", cuvid_decoder)
     elif "d3d11va" in lowered:
         logger.info("GPU decode active (d3d11va)")
+    elif "qsv" in lowered:
+        logger.info("GPU decode active (qsv)")
     elif "hwaccel" in lowered or "cuda" in lowered:
         logger.info("GPU decode active (hwaccel auto)")
     else:
@@ -321,9 +356,17 @@ def _decode_chunk(
     compatibility with the unit tests that invoke the function directly.
 
     When *vendor* is provided (#546), the ffmpeg command uses the
-    vendor-specific decoder (e.g. ``-hwaccel amf -c:v av1_amf``).  When
+    vendor-specific decoder (e.g. ``-hwaccel qsv -c:v av1_qsv``).  When
     vendor is None, falls back to the legacy NVIDIA CUVID path to keep
     existing unit tests working.
+
+    For hwaccels in ``_HWACCELS_NEED_HWDOWNLOAD`` (currently d3d11va #553
+    and qsv #550), ffmpeg outputs frames to a GPU surface rather than
+    system memory.  The wrapper then adds
+    ``-hwaccel_output_format <surface_fmt>`` (mapped via
+    ``_HWACCEL_OUTPUT_FORMAT_MAP``) and prepends ``hwdownload,format=nv12,``
+    to the ``-vf`` chain so the subsequent fps/scale/format=gray filters
+    receive system-memory nv12 frames.
     """
     chunk_duration = chunk_end - chunk_start
     fps_value = 1.0 / sample_interval
@@ -346,11 +389,13 @@ def _decode_chunk(
     if decoder and hwaccel_name:
         hwaccel_args = ["-hwaccel", hwaccel_name]
         if needs_hwdownload:
-            # d3d11va は decode 結果を D3D11 surface に置くので、filter
-            # graph に渡す前に system memory への download が必要 (#553)。
-            # `-hwaccel_output_format d3d11` で surface format を明示し
-            # 後段の hwdownload と整合させる。
-            hwaccel_args += ["-hwaccel_output_format", "d3d11"]
+            # d3d11va / qsv は decode 結果を GPU surface に置くため、
+            # filter graph に渡す前に system memory への download が
+            # 必要 (#553 / #550)。`-hwaccel_output_format` で surface
+            # format を明示 (d3d11va -> d3d11, qsv -> qsv) し、後段の
+            # hwdownload filter と整合させる。
+            surface_fmt = _HWACCEL_OUTPUT_FORMAT_MAP.get(hwaccel_name, hwaccel_name)
+            hwaccel_args += ["-hwaccel_output_format", surface_fmt]
         hwaccel_args += ["-c:v", decoder]
     else:
         hwaccel_args = ["-hwaccel", "auto"]

--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -193,9 +193,9 @@ GPU 対応環境（NVIDIA CUDA, Intel QSV 等）では、暗転検知の処理�
 
 低コア数 CPU（4-8 コア）では、GPU モードが有利になりやすい傾向があります。
 
-#### GPU vendor の選択 (`--gpu-vendor`, #546 / #553)
+#### GPU vendor の選択 (`--gpu-vendor`, #546 / #553 / #550)
 
-実装済み vendor は NVIDIA (#546) と AMD (#553) の 2 つ。Intel (#550) は別 issue で追跡中。複数 GPU 環境では、デフォルトで NVIDIA dGPU が選択されます (`_VENDOR_PREFERENCE` = nvidia > amd > intel、未実装 vendor は auto 選択で skip)。明示的に vendor を指定したい場合は `--gpu-vendor` オプションを使ってください。
+実装済み vendor は NVIDIA (#546) / AMD (#553) / Intel (#550) の 3 つ。複数 GPU 環境では、デフォルトで NVIDIA dGPU が選択されます (`_VENDOR_PREFERENCE` = nvidia > amd > intel)。明示的に vendor を指定したい場合は `--gpu-vendor` オプションを使ってください。
 
 ```bash
 # NVIDIA GPU を明示使用 (dual GPU 環境で dGPU を強制)
@@ -203,6 +203,9 @@ allaganeye split your_recording.mkv --gpu --gpu-vendor nvidia
 
 # AMD iGPU / dGPU を明示使用 (NVIDIA 不在 or AMD-only 環境)
 allaganeye split your_recording.mkv --gpu --gpu-vendor amd
+
+# Intel iGPU を明示使用 (NVIDIA / AMD 不在 or Intel 単独環境)
+allaganeye split your_recording.mkv --gpu --gpu-vendor intel
 
 # 自動選択 (既定値、--gpu-vendor 省略時と同じ)
 allaganeye split your_recording.mkv --gpu --gpu-vendor auto
@@ -212,8 +215,10 @@ allaganeye split your_recording.mkv --gpu --gpu-vendor auto
 |---|---|---|
 | `nvidia` | 実装済み (#546) | NVDEC cuvid 経由、h264 / hevc / av1 対応 |
 | `amd` | 実装済み (#553) | d3d11va + native decoder + `hwdownload,format=nv12` 経由、h264 / hevc / av1 対応。RDNA2+ iGPU (Granite Ridge) で SW 比 3x 高速 |
-| `intel` | 未実装 (#550) | `--gpu-vendor intel` は現在 exit 5 |
-| `auto` | 自動選択 | probe 結果から `_VENDOR_PREFERENCE` 順に選択 (NVIDIA > AMD > Intel) |
+| `intel` | 実装済み (#550) | QSV 経由 (`-hwaccel qsv -hwaccel_output_format qsv` + `hwdownload,format=nv12`)、h264 / hevc / av1 対応。AV1 は Alder Lake (12th gen) / Arc 以降のハードウェアで decode 可能。Tiger Lake (11th gen Iris Xe) は av1_qsv 非対応のため AV1 入力時は自動で CPU fallback (h264/hevc は QSV decode 動作確認済み)。VP9 は本 issue ではスコープ外で除外 |
+| `auto` | 自動選択 | probe 結果から `_VENDOR_PREFERENCE` 順に実装済み vendor を選択 (NVIDIA > AMD > Intel) |
+
+**Intel QSV の追加引数 (実装メモ)**: Intel QSV は default で GPU surface (`pix_fmt=qsv`) を出力し、後段の swscaler が gray 変換時に `Function not implemented (-40)` で失敗します。`_decode_chunk` は AMD d3d11va と同じ `_HWACCELS_NEED_HWDOWNLOAD` 機構を再利用し、vendor=intel のとき自動で `-hwaccel_output_format qsv` を付与しつつ filter chain 先頭に `hwdownload,format=nv12,` を挿入します。実機ベンチでは i7-1185G7 / Iris Xe で h264_qsv 13.7x speed、hevc_qsv (720p) 3.76x speed を確認 (#550)。
 
 #### ベンチマークで判断する
 

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -123,7 +123,7 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 
 **フォールバック**: GPU デコードに失敗した場合は `VideoProcessingError` を送出し、呼び出し元（`detector.py`）が自動で CPU モードにフォールバックする。
 
-### コーデック + vendor 自動選択（#334, #414, #546）
+### コーデック + vendor 自動選択（#334, #414, #546, #550）
 
 `--gpu` / `--no-gpu` 未指定時は probe で取得した codec と GPU vendor を元に GPU/CPU を自動選択する (`_resolve_gpu_mode`)。判定セットは `_GPU_PREFERRED_CODECS` に定義。
 
@@ -139,20 +139,28 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 
 - VP9 は `_GPU_PREFERRED_CODECS` に残すが NVIDIA 経路 (`_GPU_DECODER_MAP["nvidia"]`) からは除外 (#538 / #549)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。NVIDIA auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x)。`vp9_cuvid` の ffmpeg 側修正が入った時点で NVIDIA 経路の復活検討。AMD は #553 で d3d11va 経路に統一しているため csp:gbr 問題なし (filter 先頭で `hwdownload,format=nv12` 経由で system memory に降ろす)。
 
-**vendor × codec 実装状況 (#546 / #553)**
+**vendor × codec 実装状況 (#546 / #553 / #550)**
 
 | Vendor | hwaccel | h264 | hevc | av1 | vp9 | 備考 |
 |---|---|---|---|---|---|---|
 | NVIDIA (NVDEC cuvid) | `cuda` | `h264_cuvid` | `hevc_cuvid` | `av1_cuvid` | (soft, #538/#549) | dGPU 想定、dual GPU では優先選択 |
 | AMD (d3d11va) | `d3d11va` | `h264` | `hevc` | `av1` | (未登録) | #553 で実装。AMF decoder ではなく d3d11va + native decoder + filter 先頭 `hwdownload,format=nv12` で allaganeye filter pipeline と整合させる。RDNA2+ iGPU (Granite Ridge) で実測 speed 23x (SW 7.6x 比 3x 高速) |
-| Intel (QSV) | (未実装) | (未実装) | (未実装) | (未実装) | (未対応) | #550 で実装予定。`--gpu-vendor intel` は現在 exit 5 |
+| Intel (QSV) | `qsv` | `h264_qsv` | `hevc_qsv` | `av1_qsv` | (本 issue 範囲外) | #550 で実装。Tiger Lake (11th gen Iris Xe) 以降で QSV decode 対応。AV1 は **Alder Lake / Arc 以降**でハードウェア decode、Tiger Lake では `Error initializing the MFX video decoder: unsupported (-3)` で `_decode_chunk` が `VideoProcessingError` を上げ CPU fallback。AMD と同じく `_HWACCELS_NEED_HWDOWNLOAD` 経路を使用 (`-hwaccel_output_format qsv` + filter 先頭 `hwdownload,format=nv12`)。VP9 は QSV decoder 自体は存在 (`vp9_qsv`) するが本 issue ではスコープ外で除外 (将来別 issue) |
 | Apple (VideoToolbox) | — | — | — | — | — | Windows ffmpeg 未同梱、別 issue 追跡 |
+
+**`-hwaccel_output_format` + `hwdownload` filter の vendor 別差分 (#553 / #550)**
+
+- NVIDIA cuvid は default で nv12 (system memory) 出力するため追加引数不要
+- AMD d3d11va / Intel QSV は default で GPU surface (`pix_fmt=d3d11` / `pix_fmt=qsv`) 出力。後段の swscaler (`fps -> scale -> format=gray`) が surface format を変換できず filter init が `-40 (Function not implemented)` で失敗するため、`_HWACCELS_NEED_HWDOWNLOAD = frozenset({"d3d11va", "qsv"})` に該当する hwaccel では `_decode_chunk` が以下を自動付与する:
+  - 入力側に `-hwaccel_output_format <surface_fmt>` (`_HWACCEL_OUTPUT_FORMAT_MAP`: d3d11va→`d3d11`, qsv→`qsv`)
+  - filter chain 先頭に `hwdownload,format=nv12,` を挿入し system memory に降ろしてから fps/scale/format=gray に渡す
+- 引数順序は `-hwaccel <hwaccel> [-hwaccel_output_format <fmt>] -c:v <decoder> -ss ... -i ...`。ffmpeg は input option を `-i` より前に置く必要があるため厳守
 
 **vendor 自動選択ロジック (`_resolve_gpu_mode` + `_select_gpu_vendor`)**
 
 1. `allaganeye.system_info.probe_gpu_vendors()` が platform 別 probe (nvidia-smi / wmic / lspci / system_profiler) で検出した vendor list を取得
-2. `--gpu-vendor <vendor>` explicit の場合: `available` に含まれない、または `_VENDOR_HWACCEL_MAP` に未登録 (intel) なら `ConfigValidationError` (exit 5)
-3. `--gpu-vendor auto` (default) の場合: `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` x `available` x 実装済み (`_VENDOR_HWACCEL_MAP` に含まれる) の最上位を選択。現時点で実装済みは NVIDIA + AMD (d3d11va, #553)。Intel は #550 で追跡
+2. `--gpu-vendor <vendor>` explicit の場合: `available` に含まれない、または `_VENDOR_HWACCEL_MAP` に未登録なら `ConfigValidationError` (exit 5)。現時点で nvidia / amd / intel すべて実装済みなので未登録分岐は将来の vendor 追加忘れガード
+3. `--gpu-vendor auto` (default) の場合: `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` x `available` x 実装済み (`_VENDOR_HWACCEL_MAP` に含まれる) の最上位を選択。NVIDIA dGPU + Intel iGPU 環境では NVDEC が優先、AMD APU + Intel iGPU では AMD d3d11va が優先される
 4. codec が `_GPU_PREFERRED_CODECS` に含まれない場合は CPU mode。vendor が None (GPU 検出失敗 / 未実装 vendor のみ検出) でも codec match なら `use_gpu=True` を返し、`scan_gpu` の legacy path (`-hwaccel auto`) に入る。ffmpeg 側で GPU decode 失敗時は上記フォールバック経路で CPU 自動切替 (#334 既存挙動を維持)
 
 **フォールバック経路**
@@ -160,6 +168,7 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 - ハードウェアが新 codec に未対応の場合、ffmpeg の `-hwaccel <hwaccel>` が GPU decode に失敗 → 上記フォールバック経路で CPU に自動切替
 - 明示的に GPU を使いたい場合は `--gpu` フラグで強制可能（対応しない codec では起動時に GPU decode 失敗で exit）
 - `_GPU_DECODER_MAP["nvidia"]` には mpeg2video / mpeg4 / vp8 / mpeg1video も登録済みだが、`_GPU_PREFERRED_CODECS` に含めず auto では CPU (`--gpu` 明示時のみ GPU decode 経路)
+- Intel QSV では Tiger Lake (11th gen) で `av1_qsv` が `unsupported (-3)` を返すなど世代別非対応がある。chunk decode が `VideoProcessingError` を投げると `detect_match_boundaries` が CPU mode (`_scan_cpu`) に自動切替するため動作は継続する (#550 実機検証済み: i7-1185G7 / Iris Xe)
 
 ### スコアバーフィルタリング（Phase 3, #111）
 

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -89,6 +89,80 @@ class TestDecodeChunk:
         assert cmd[hw_idx + 1] == "cuda"
         cv_idx = cmd.index("-c:v")
         assert cmd[cv_idx + 1] == "av1_cuvid"
+        # NVIDIA は -hwaccel_output_format を指定しない (cuvid が default
+        # で nv12 system memory 出力するため不要)。Intel との挙動差
+        # を回帰防止する (#550)。
+        assert "-hwaccel_output_format" not in cmd
+
+    @pytest.mark.parametrize(
+        ("codec", "expected_decoder"),
+        [
+            ("av1", "av1_qsv"),
+            ("hevc", "hevc_qsv"),
+            ("h264", "h264_qsv"),
+        ],
+    )
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_hwaccel_qsv_for_intel_codecs(self, mock_run, codec, expected_decoder):
+        """vendor=intel + codec で `-hwaccel qsv -hwaccel_output_format qsv
+        -c:v {codec}_qsv` + `hwdownload,format=nv12,` filter prefix を
+        組み立てる (#550, #553 と同じ汎用機構を再利用).
+
+        QSV decoder は default で `pix_fmt=qsv` の GPU surface を出力し、
+        後段の swscaler (`fps -> scale -> format=gray`) が `Function not
+        implemented (-40)` で失敗する。`_HWACCELS_NEED_HWDOWNLOAD` に
+        "qsv" を加え、`-hwaccel_output_format qsv` で surface format を
+        明示しつつ filter chain 先頭の `hwdownload,format=nv12,` で
+        system memory に降ろすのが #550 実装の核心 (#553 の AMD d3d11va
+        と同じパターン)。
+
+        実機検証 (i7-1185G7 / Iris Xe Graphics, ffmpeg 8.1):
+        - h264_qsv: 13.7x speed (`-hwaccel_output_format qsv` + hwdownload)
+        - hevc_qsv: 3.76x speed @ 720p
+        - av1_qsv: Tiger Lake 非対応 -> VideoProcessingError -> CPU fallback
+        """
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec=codec, vendor="intel")
+
+        cmd = mock_run.call_args[0][0]
+        hw_idx = cmd.index("-hwaccel")
+        assert cmd[hw_idx + 1] == "qsv"
+        out_idx = cmd.index("-hwaccel_output_format")
+        assert cmd[out_idx + 1] == "qsv", (
+            "-hwaccel_output_format qsv で surface format を hwaccel に揃え、"
+            "hwdownload filter で system memory へ降ろす (#550)"
+        )
+        cv_idx = cmd.index("-c:v")
+        assert cmd[cv_idx + 1] == expected_decoder
+        # 引数順序: -hwaccel qsv -hwaccel_output_format qsv -c:v ...
+        # ffmpeg の input option は -i より前に並ぶ必要がある。
+        assert hw_idx < out_idx < cv_idx
+        i_idx = cmd.index("-i")
+        assert cv_idx < i_idx
+        # filter graph 先頭で system memory に降ろす (#553 と同じパターン)
+        vf_idx = cmd.index("-vf")
+        assert cmd[vf_idx + 1].startswith("hwdownload,format=nv12,"), (
+            "qsv decode 出力 (GPU surface) を hwdownload で system memory に "
+            "降ろさないと swscaler が pix_fmt=qsv を扱えず失敗する (#550)"
+        )
+
+    @patch("allaganeye.video.gpu_detector.subprocess.run")
+    def test_hwaccel_auto_for_intel_unsupported_codec(self, mock_run):
+        """vendor=intel + 非対応 codec (vp9/mpeg2 等) は legacy
+        `-hwaccel auto` に fallback (#550).
+
+        Intel QSV は VP9 decode 自体は対応しているが、本 issue では
+        スコープ外として `_GPU_DECODER_MAP["intel"]` から除外している。
+        将来別 issue で追加検討。
+        """
+        mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
+        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="vp9", vendor="intel")
+
+        cmd = mock_run.call_args[0][0]
+        hw_idx = cmd.index("-hwaccel")
+        assert cmd[hw_idx + 1] == "auto"
+        assert "vp9_qsv" not in cmd
+        assert "-hwaccel_output_format" not in cmd
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_hwaccel_d3d11va_for_amd_av1(self, mock_run):
@@ -137,10 +211,10 @@ class TestDecodeChunk:
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_nvidia_path_skips_hwdownload(self, mock_run):
-        """NVIDIA cuvid 経路は hwdownload prefix を付けない (#553 回帰防止).
+        """NVIDIA cuvid 経路は hwdownload prefix を付けない (#553 / #550 回帰防止).
 
         cuvid decoder は decode 結果を nv12 system memory に直接出力する
-        ため、d3d11va のような hwdownload は不要。filter chain 先頭が
+        ため、d3d11va / qsv のような hwdownload は不要。filter chain 先頭が
         ``fps=...`` で始まることを確認。
         """
         mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
@@ -154,15 +228,13 @@ class TestDecodeChunk:
         )
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
-    def test_unimplemented_vendor_falls_back_to_hwaccel_auto(self, mock_run):
-        """vendor=intel は _VENDOR_HWACCEL_MAP 未定義で
-        `-hwaccel auto` に fallback する (#550 で QSV 実装予定).
+    def test_unknown_vendor_falls_back_to_hwaccel_auto(self, mock_run):
+        """`_VENDOR_HWACCEL_MAP` 未定義の vendor 名は `-hwaccel auto` に
+        fallback する (#546 / #553 / #550 回帰防止 + 将来追加忘れガード).
 
-        explicit `--gpu-vendor intel` の場合、CLI 層 (_resolve_gpu_mode)
-        が ConfigValidationError で先に拒否するので実際にはこの経路に
-        は入らない。ただし将来 _VENDOR_HWACCEL_MAP に vendor を追加
-        し忘れた際のガードとしてこの挙動を維持する。
-        AMD は #553 で d3d11va として実装済み。
+        現在 nvidia / amd / intel は全て実装済みなので config 層で先に
+        validation される。本テストは将来新 vendor を `_VENDOR_HWACCEL_MAP`
+        に登録し忘れたケースに備えた防御。
         """
         mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
         _decode_chunk(
@@ -171,34 +243,41 @@ class TestDecodeChunk:
             10.0,
             1.0,
             codec="av1",
-            vendor="intel",
+            vendor="apple",  # not in _VENDOR_HWACCEL_MAP
         )
         cmd = mock_run.call_args[0][0]
         hw_idx = cmd.index("-hwaccel")
         assert cmd[hw_idx + 1] == "auto", (
-            f"vendor=intel should fall back to -hwaccel auto, "
+            f"unknown vendor should fall back to -hwaccel auto, "
             f"got -hwaccel {cmd[hw_idx + 1]}"
         )
         assert "av1_qsv" not in cmd
+        assert "av1_amf" not in cmd
         assert "av1_cuvid" not in cmd
+        assert "-hwaccel_output_format" not in cmd
 
-    def test_select_gpu_vendor_auto_returns_nvidia_first(self):
-        """auto 選択は preference 順に _VENDOR_HWACCEL_MAP 登録済みを返す (#546 / #553).
+    def test_select_gpu_vendor_auto_returns_implemented_vendor(self):
+        """auto 選択は preference 順に _VENDOR_HWACCEL_MAP 登録済みの
+        vendor を返す (#546 / #553 / #550).
 
-        NVIDIA dGPU 優先、AMD (#553 で d3d11va 実装済み) がフォールバック、
-        Intel (#550) は preference にあっても _VENDOR_HWACCEL_MAP 未登録
-        で skip される。
+        nvidia / amd / intel すべて実装済み。dual / triple GPU 環境では
+        `_VENDOR_PREFERENCE` (nvidia > amd > intel) に従い、最も優先度の
+        高い vendor が選ばれる。
         """
         from allaganeye.video.gpu_detector import _select_gpu_vendor
 
         # NVIDIA が available にあれば最優先
         assert _select_gpu_vendor(None, ["nvidia", "amd"]) == "nvidia"
         assert _select_gpu_vendor("auto", ["nvidia", "amd"]) == "nvidia"
+        assert _select_gpu_vendor(None, ["nvidia", "intel"]) == "nvidia"
+        assert _select_gpu_vendor(None, ["nvidia", "amd", "intel"]) == "nvidia"
         # NVIDIA 不在で AMD があれば AMD (#553)
         assert _select_gpu_vendor(None, ["amd", "intel"]) == "amd"
         assert _select_gpu_vendor(None, ["amd"]) == "amd"
-        # Intel のみ -> None (#550 まだ未実装)
-        assert _select_gpu_vendor(None, ["intel"]) is None
+        # AMD / NVIDIA 不在で Intel があれば Intel (#550)
+        assert _select_gpu_vendor(None, ["intel"]) == "intel"
+        assert _select_gpu_vendor("auto", ["intel"]) == "intel"
+        # 何も無い -> None
         assert _select_gpu_vendor(None, []) is None
 
     def test_select_gpu_vendor_explicit_nvidia_match(self):
@@ -208,21 +287,27 @@ class TestDecodeChunk:
         assert _select_gpu_vendor("nvidia", ["nvidia"]) == "nvidia"
         assert _select_gpu_vendor("nvidia", ["nvidia", "amd"]) == "nvidia"
 
-    def test_select_gpu_vendor_explicit_unavailable_returns_none(self):
-        """explicit vendor が available に無い場合は None (#546).
+    def test_select_gpu_vendor_explicit_intel_match(self):
+        """explicit intel request が available に含まれれば返す (#550)."""
+        from allaganeye.video.gpu_detector import _select_gpu_vendor
 
-        実装済み vendor (NVIDIA #546, AMD #553) の「未検出」と未実装
-        vendor (Intel #550) の両方カバー。実行時は _resolve_gpu_mode が
+        assert _select_gpu_vendor("intel", ["intel"]) == "intel"
+        assert _select_gpu_vendor("intel", ["nvidia", "intel"]) == "intel"
+
+    def test_select_gpu_vendor_explicit_unavailable_returns_none(self):
+        """explicit vendor が available に無い場合は None (#546 / #553 / #550).
+
+        実装済み (nvidia / amd / intel) のいずれを explicit 指定しても、
+        probe で見つからなければ None を返す。実行時は _resolve_gpu_mode が
         ConfigValidationError で落とす仕組み。
         """
         from allaganeye.video.gpu_detector import _select_gpu_vendor
 
         assert _select_gpu_vendor("nvidia", ["amd"]) is None
-        # AMD は #553 で _VENDOR_HWACCEL_MAP=d3d11va で実装済み
+        assert _select_gpu_vendor("intel", ["nvidia"]) is None
+        # AMD は #553 で _VENDOR_HWACCEL_MAP=d3d11va として実装済み
         assert _select_gpu_vendor("amd", ["amd", "nvidia"]) == "amd"
         assert _select_gpu_vendor("amd", ["nvidia"]) is None
-        # Intel は #550 で QSV 実装予定 (現状は未実装 vendor)
-        assert _select_gpu_vendor("intel", ["nvidia"]) is None
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_nonzero_returncode_raises(self, mock_run):

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1941,11 +1941,25 @@ class TestResolveGpuMode:
         with pytest.raises(ConfigValidationError, match="--gpu-vendor nvidia"):
             _resolve_gpu_mode(None, "nvidia", "av1", show=False, verbose=False)
 
-    def test_vendor_explicit_intel_unimplemented_raises(self, monkeypatch):
-        """Intel は map 未定義なので explicit 要求は exit 5 (#550 で実装予定)."""
+    def test_vendor_explicit_intel_succeeds_when_available(self, monkeypatch):
+        """Intel は #550 で実装済み。explicit 要求 + available なら通る."""
         monkeypatch.setattr(
             "allaganeye.system_info.probe_gpu_vendors",
             lambda: ["intel", "nvidia"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        use_gpu, vendor = _resolve_gpu_mode(
+            None, "intel", "av1", show=False, verbose=False
+        )
+        assert use_gpu is True
+        assert vendor == "intel"
+
+    def test_vendor_explicit_intel_unavailable_raises(self, monkeypatch):
+        """Intel 実装済みでも probe で見つからなければ exit 5 (#550)."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["nvidia"],
         )
         from allaganeye.commands.split_matches import _resolve_gpu_mode
         from allaganeye.exceptions import ConfigValidationError
@@ -1953,12 +1967,13 @@ class TestResolveGpuMode:
         with pytest.raises(ConfigValidationError, match="--gpu-vendor intel"):
             _resolve_gpu_mode(None, "intel", "av1", show=False, verbose=False)
 
-    def test_vendor_auto_skips_unimplemented(self, monkeypatch):
-        """auto 選択は preference 順 (#546 / #553).
+    def test_vendor_auto_picks_preference_order(self, monkeypatch):
+        """auto 選択は `_VENDOR_PREFERENCE` (nvidia > amd > intel) 順で
+        実装済み vendor を選ぶ (#546 / #553 / #550).
 
-        Intel (#550 未実装) は available でも skip。AMD (#553 で d3d11va
-        として実装済み) は preference で NVIDIA の次に位置するため、
-        NVIDIA が available なら NVIDIA が優先される。
+        nvidia / amd / intel の 3 つが available で、いずれも実装済み
+        (nvidia=cuvid #546, amd=d3d11va #553, intel=qsv #550) のとき、
+        preference 順に NVIDIA dGPU が最優先される。
         """
         monkeypatch.setattr(
             "allaganeye.system_info.probe_gpu_vendors",
@@ -1968,6 +1983,39 @@ class TestResolveGpuMode:
 
         _, vendor = _resolve_gpu_mode(None, None, "av1", show=False, verbose=False)
         assert vendor == "nvidia"
+
+    def test_vendor_auto_picks_amd_when_no_nvidia(self, monkeypatch):
+        """NVIDIA 不在 + AMD + Intel 環境で auto は AMD を選ぶ (#553).
+
+        preference = nvidia > amd > intel。NVIDIA が無く AMD と Intel が
+        ある場合、preference 順で AMD が選ばれる (Intel iGPU を持つ AMD
+        dGPU/iGPU 環境を想定)。
+        """
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["amd", "intel"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        use_gpu, vendor = _resolve_gpu_mode(
+            None, None, "av1", show=False, verbose=False
+        )
+        assert use_gpu is True
+        assert vendor == "amd"
+
+    def test_vendor_auto_picks_intel_when_only_intel(self, monkeypatch):
+        """Intel iGPU 単独環境で auto は intel を選ぶ (#550)."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["intel"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        use_gpu, vendor = _resolve_gpu_mode(
+            None, None, "av1", show=False, verbose=False
+        )
+        assert use_gpu is True
+        assert vendor == "intel"
 
     def test_vendor_none_when_no_gpu_available(self, monkeypatch):
         """GPU probe が空でも codec match なら use_gpu=True (legacy path).


### PR DESCRIPTION
## Summary

#550 の対応。#546 で deferred されていた Intel QSV (Quick Sync Video) decode 経路を実装。

- `_GPU_DECODER_MAP["intel"]` / `_VENDOR_HWACCEL_MAP["intel"]` 追加 (h264_qsv / hevc_qsv / av1_qsv)
- `_HWACCELS_NEED_HWDOWNLOAD` に `"qsv"` を追加 + `_HWACCEL_OUTPUT_FORMAT_MAP["qsv"] = "qsv"` で集約 (#578 で導入された AMD d3d11va と同じ汎用機構を再利用)
- `_decode_chunk` は `-hwaccel qsv -hwaccel_output_format qsv -c:v {decoder}` を組み立て、filter chain 先頭に `hwdownload,format=nv12,` を挿入
- `_resolve_gpu_mode` の ConfigError メッセージを 3 vendor 全実装済みに更新
- CLI helptext と docs (`video-processing.md` / `tuning-guide.md`) 反映

> **設計詳細**: 当初 `_VENDOR_HWACCEL_OUTPUT_FORMAT` (vendor 別マップ) を新設したが、#578 (AMD d3d11va) との rebase 時に `_HWACCELS_NEED_HWDOWNLOAD` 汎用機構へ統合。詳細は本 PR の Rebase notes コメント参照。

## 実装上の注意点

QSV decoder は default で `pix_fmt=qsv` (GPU surface) を出力するため、後段の swscaler が `Function not implemented (-40)` で失敗する。`_HWACCELS_NEED_HWDOWNLOAD` 機構で AMD d3d11va と同じく `-hwaccel_output_format qsv` を付与しつつ filter chain 先頭に `hwdownload,format=nv12,` を挿入し system memory に降ろすのが key (NVIDIA cuvid は default で nv12 system memory 出力なので不要、この差分が `_HWACCELS_NEED_HWDOWNLOAD` の存在理由)。

ffmpeg 引数: `-hwaccel qsv -hwaccel_output_format qsv -c:v {decoder} -ss ... -i ... -vf "hwdownload,format=nv12,fps=...,scale=...,format=gray"` (input option は `-i` より前)。

VP9 は QSV decoder 自体は ffmpeg 8.1 に存在 (`vp9_qsv`) するが、本 issue ではスコープ外として除外 (将来別 issue で追加検討)。

## 受け入れ条件 (#550 元 issue より)

- [x] **Intel iGPU での実機 AV1 decode success/fallback を記録** — i7-1185G7 / Iris Xe Graphics (Tiger Lake) で検証。h264_qsv / hevc_qsv は GPU mode 成功 (Pass 1 GPU)、av1_qsv は Tiger Lake が AV1 hardware decode 非対応で `Error initializing the MFX video decoder: unsupported (-3)` を返し `Pass 1 (CPU (GPU fallback))` に自動切替する fallback path を確認
- [x] **`--gpu-vendor intel` で適切な decoder が選ばれ ConfigError が出ないことを確認** — 動作確認済み (`GPU vendor: intel` 表示 + Pass 1 GPU)
- [x] **`_GPU_DECODER_MAP` / `_VENDOR_HWACCEL_MAP` / docs 反映** — 上記参照
- [x] **既存 NVIDIA / AMD 経路の回帰なし** — pytest 802 passed (1 skipped, 37 deselected) + `test_nvidia_path_skips_hwdownload` / `test_hwaccel_d3d11va_for_amd_*` 全 pass

## 実機検証ログ

i7-1185G7 / Iris Xe Graphics / ffmpeg 8.1 (Gyan.FFmpeg via winget):

\`\`\`
$ allaganeye split h264_15s.mp4 --gpu --gpu-vendor intel -v
  GPU: Intel(R) Iris(R) Xe Graphics
  GPU vendor: intel
  Pass 1 (GPU): 15 samples, 0 blackout frames (0.0%), 0m01s   ← rebase 後 hwdownload 経路で 1s

$ allaganeye split av1_test.mp4 --gpu --gpu-vendor intel -v
  GPU vendor: intel
  Pass 1 (CPU (GPU fallback)): 3 samples, 0 blackout frames (0.0%), 0m00s   ← av1_qsv 非対応で fallback

$ allaganeye split hevc_test.mp4 --gpu --gpu-vendor intel -v
  GPU vendor: intel
  Pass 1 (GPU): 0 samples, 0 blackout frames (0.0%), 0m00s   ← 短尺で 0 サンプルだが GPU mode で起動

$ allaganeye split h264_15s.mp4 --gpu -v          # auto vendor (Intel-only 環境)
  GPU vendor: intel                                # auto で intel を選択
  Pass 1 (GPU): 15 samples
\`\`\`

bare ffmpeg pipeline 計測 (`-hwaccel qsv -hwaccel_output_format qsv ... -vf "hwdownload,format=nv12,fps,scale,format=gray"`):
- h264_qsv: **13.7x speed**
- hevc_qsv (720p): **3.76x speed**
- av1_qsv: `unsupported (-3)` で失敗 (期待通り、CPU fallback で救済)

## Test plan

- [x] `pytest` 全件 (802 passed)
- [x] `ruff check` / `ruff format --check` (clean)
- [x] `pyright` (0 errors)
- [x] 実機 H.264 / HEVC で QSV decode 動作確認
- [x] 実機 AV1 で `unsupported -> CPU fallback` パス確認
- [x] auto vendor selection が Intel iGPU を選ぶ
- [x] NVIDIA cuvid 経路は `-hwaccel_output_format` / `hwdownload` を付与しない (回帰防止)

## 関連

- Refs #550 (本 issue)
- Refs #546 (親 issue, vendor 抽象化)
- Refs #553 / #578 (AMD d3d11va、本実装が再利用する `_HWACCELS_NEED_HWDOWNLOAD` 機構の出所)
- Refs #538 (VP9 NVIDIA fallback の前例)