### PR TITLE
test(installer): launcher template の exit code 伝搬 idiom に Pester regression 追加 (Refs #583)

### DIFF
--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -181,6 +181,59 @@ not apply to allaganeye itself.
 "@
 }
 
+function Get-LauncherTemplate {
+  <#
+  .SYNOPSIS
+  Returns the .bat launcher template embedded in the Portable ZIP.
+
+  Exposed as a function so Pester (#583) can verify the exit code propagation
+  idiom (#580: `set EXIT_CODE=%ERRORLEVEL%` + `endlocal & exit /b %EXIT_CODE%`)
+  without dot-sourcing the full build path.
+  #>
+  return @'
+@echo off
+setlocal
+set PAYLOAD=%~dp0
+set ALLAGANEYE_FFMPEG=%PAYLOAD%ffmpeg\ffmpeg.exe
+set PATH=%PAYLOAD%ffmpeg;%PATH%
+
+if "%~1"=="" (
+  echo.
+  echo allaganeye - FF14 Frontline video splitter
+  echo.
+  echo How to use:
+  echo   1. Drag a video file ^(.mkv / .mp4 / .avi / .mov^) onto allaganeye.bat
+  echo      to split it automatically.
+  echo   2. From a Command Prompt:
+  echo      allaganeye.bat split "C:\path\to\video.mkv"
+  echo.
+  echo Docs: https://github.com/Idios/kobutachan-allaganeye
+  echo.
+  pause
+  endlocal
+  exit /b 0
+)
+
+set EXT=%~x1
+set IS_VIDEO=
+if /i "%EXT%"==".mp4" set IS_VIDEO=1
+if /i "%EXT%"==".mkv" set IS_VIDEO=1
+if /i "%EXT%"==".avi" set IS_VIDEO=1
+if /i "%EXT%"==".mov" set IS_VIDEO=1
+
+if defined IS_VIDEO (
+  "%PAYLOAD%python\python.exe" -m allaganeye split %*
+) else (
+  "%PAYLOAD%python\python.exe" -m allaganeye %*
+)
+set EXIT_CODE=%ERRORLEVEL%
+
+echo.
+pause
+endlocal & exit /b %EXIT_CODE%
+'@
+}
+
 # Dot-sourced (no -Version): stop here so callers only get the function
 # definitions. Pester tests rely on this behaviour.
 if ([string]::IsNullOrEmpty($Version)) { return }
@@ -274,54 +327,9 @@ Get-ChildItem -Path $FFmpegLayout.Bin -Filter '*.dll' | Copy-Item -Destination $
 Copy-Item -Path $FFmpegLayout.License -Destination (Join-Path $FFmpegDest 'LICENSE.txt')
 
 # 5. Launcher
-# The launcher is ASCII-only so that it runs on any Windows code page without
-# chcp munging. Keep help text in English for the same reason.
-# Behaviour:
-#   - double-click (no args)       -> print help + pause
-#   - drag & drop of a video file  -> treat as `allaganeye split <file>` + pause
-#   - explicit args via cmd        -> pass through to allaganeye + pause
-$Launcher = @'
-@echo off
-setlocal
-set PAYLOAD=%~dp0
-set ALLAGANEYE_FFMPEG=%PAYLOAD%ffmpeg\ffmpeg.exe
-set PATH=%PAYLOAD%ffmpeg;%PATH%
-
-if "%~1"=="" (
-  echo.
-  echo allaganeye - FF14 Frontline video splitter
-  echo.
-  echo How to use:
-  echo   1. Drag a video file ^(.mkv / .mp4 / .avi / .mov^) onto allaganeye.bat
-  echo      to split it automatically.
-  echo   2. From a Command Prompt:
-  echo      allaganeye.bat split "C:\path\to\video.mkv"
-  echo.
-  echo Docs: https://github.com/Idios/kobutachan-allaganeye
-  echo.
-  pause
-  endlocal
-  exit /b 0
-)
-
-set EXT=%~x1
-set IS_VIDEO=
-if /i "%EXT%"==".mp4" set IS_VIDEO=1
-if /i "%EXT%"==".mkv" set IS_VIDEO=1
-if /i "%EXT%"==".avi" set IS_VIDEO=1
-if /i "%EXT%"==".mov" set IS_VIDEO=1
-
-if defined IS_VIDEO (
-  "%PAYLOAD%python\python.exe" -m allaganeye split %*
-) else (
-  "%PAYLOAD%python\python.exe" -m allaganeye %*
-)
-set EXIT_CODE=%ERRORLEVEL%
-
-echo.
-pause
-endlocal & exit /b %EXIT_CODE%
-'@
+# Template is defined as Get-LauncherTemplate (#583) so Pester can verify the
+# exit code propagation idiom (#580) without dot-sourcing the full build path.
+$Launcher = Get-LauncherTemplate
 Set-Content -Path (Join-Path $PayloadDir 'allaganeye.bat') -Value $Launcher -Encoding ASCII
 
 # 6. README

--- a/scripts/tests/build-portable-zip.Tests.ps1
+++ b/scripts/tests/build-portable-zip.Tests.ps1
@@ -133,6 +133,18 @@ Describe 'Format-ReadmeContent' {
   }
 }
 
+Describe 'Get-LauncherTemplate' {
+  It 'preserves python exit code via EXIT_CODE save and endlocal & exit /b idiom (#580)' {
+    # Launcher must propagate python exit code so callers can chain
+    # `allaganeye.bat detect file.mp4 && next-step` and CI smoke (Level B in
+    # release.yml) can observe non-zero exit codes. CI smoke is the de-facto
+    # regression test; this unit test is the unit-level safety net (#583).
+    $template = Get-LauncherTemplate
+    $template | Should -Match 'set EXIT_CODE=%ERRORLEVEL%'
+    $template | Should -Match 'endlocal & exit /b %EXIT_CODE%'
+  }
+}
+
 Describe 'Script parameters' {
   It 'exposes -SkipArchive as a switch parameter' {
     # CI sets -SkipArchive so actions/upload-artifact can zip the payload

--- a/scripts/tests/build-portable-zip.Tests.ps1
+++ b/scripts/tests/build-portable-zip.Tests.ps1
@@ -6,12 +6,17 @@ Run:
 
 CI: `.github/workflows/ci.yml` `installer-pester` job (windows runner).
 
-Scope (issue #528 / PR #528):
-  1. Invoke-Download verifies matching SHA256 and emits a "verified" message.
-  2. Invoke-Download throws on SHA256 mismatch.
-  3. Assert-FFmpegLayout throws when the extracted archive has no `bin/`.
-  4. Format-ReadmeContent includes the LGPLv3 attribution + BtbN / win64-lgpl
-     pointers required by the Portable ZIP license compliance.
+Scope (#528 / #551 / #583):
+  1. Invoke-Download verifies matching SHA256 / throws on mismatch.
+  2. Assert-FFmpegLayout throws when the extracted archive has no `bin/`,
+     returns Root/Bin/License paths when valid.
+  3. Get-FFmpegSourceCommit extracts the upstream commit from valid BtbN
+     asset names / throws on unexpected names.
+  4. Format-ReadmeContent includes the LGPLv3 attribution + BtbN /
+     win64-lgpl-shared pointers required by Portable ZIP license compliance.
+  5. Get-LauncherTemplate preserves the python exit code propagation idiom
+     (#580: `set EXIT_CODE=%ERRORLEVEL%` + `endlocal & exit /b %EXIT_CODE%`).
+  6. Script parameters: -SkipArchive switch / -Version optional for dot-source.
 
 We dot-source build-portable-zip.ps1 without -Version so it loads the helper
 functions and returns before running the real build.


### PR DESCRIPTION
## 概要

PR [#579](https://github.com/Idios/kobutachan-allaganeye/pull/579) で同梱した [#580](https://github.com/Idios/kobutachan-allaganeye/issues/580) launcher exit code 伝搬修正 (`set EXIT_CODE=%ERRORLEVEL%` + `endlocal & exit /b %EXIT_CODE%`) について、`scripts/tests/build-portable-zip.Tests.ps1` に unit-level の Pester regression test を追加する。

現状は CI smoke-test Level A + Level B (`release.yml build-windows`) が de-facto regression test として機能しているが、将来 smoke step が disable / 大幅変更された場合に launcher template の regression を unit test レベルで検出できなくなる。本 PR で safety net を追加する。

## 変更点

| ファイル | 変更内容 |
|---|---|
| `scripts/build-portable-zip.ps1` | `$Launcher` heredoc を `Get-LauncherTemplate` 関数として抽出 (L186 早期 return より前に配置)、`$Launcher = Get-LauncherTemplate` に置換 |
| `scripts/tests/build-portable-zip.Tests.ps1` | `Describe 'Get-LauncherTemplate'` ブロックを追加 (2 assertion) |

## 設計判断

### 関数化アプローチ (#528 慣習踏襲)

`scripts/build-portable-zip.ps1:186` `if ([string]::IsNullOrEmpty($Version)) { return }` で dot-source 時は早期 return するため、L283 にあった `$Launcher = @'...'@` heredoc は dot-source 時に**未到達**で、Pester から内容を直接検証できなかった。

`Format-ReadmeContent` (L129-182) が L186 より前に定義された関数で here-string を `return` する慣習 (commit d9f705b の #528 で初回採用) を踏襲し、`Get-LauncherTemplate` 関数として抽出。本体側は `$Launcher = Get-LauncherTemplate` に置換し機能等価性を維持。

### Test 設計 (issue 文言厳守、scope creep 回避)

issue 受け入れ条件通り 2 assertion のみ:

```powershell
$template = Get-LauncherTemplate
$template | Should -Match 'set EXIT_CODE=%ERRORLEVEL%'
$template | Should -Match 'endlocal & exit /b %EXIT_CODE%'
```

`@echo off` 等の余計な assertion は追加しない (overspec 回避)。`docs/developer-setup.md` への追記も issue 受け入れ条件未記載のため対象外。

## 受け入れ条件の逐条対応

| 受け入れ条件 | 対応 |
|---|---|
| `scripts/tests/build-portable-zip.Tests.ps1` に launcher template regression test 追加 | ✅ `Describe 'Get-LauncherTemplate'` 追加、2 assertion |
| `set EXIT_CODE=%ERRORLEVEL%` の存在を `Should -Match` で検証 | ✅ `$template \| Should -Match 'set EXIT_CODE=%ERRORLEVEL%'` |
| `endlocal & exit /b %EXIT_CODE%` の存在を `Should -Match` で検証 | ✅ `$template \| Should -Match 'endlocal & exit /b %EXIT_CODE%'` |
| heredoc 抽出ヘルパが必要なら build-portable-zip.ps1 側にも軽微変更 | ✅ `Get-LauncherTemplate` 関数を抽出 (L186 早期 return より前に配置) |
| `installer-pester` CI ジョブで test pass を実測 | ⏳ 本 PR の CI 実行で実証予定 |

## 事前検証 (ローカル実機)

PowerShell 5.1 + Pester 5.7.1 で全テスト走行:

```
Tests Passed: 10, Failed: 0, Skipped: 0
```

新 `Get-LauncherTemplate` test (10ms) pass、既存 9 tests 回帰なし。

加えて `python -m ruff check .` / `ruff format --check .` 緑 (本 PR は Python 影響なし)。

## 関連

- 由来: PR [#579](https://github.com/Idios/kobutachan-allaganeye/pull/579) Round 1 ギャップ分析の派生 issue (`interesting-dewdney-aad742` 承認)
- 親: [#572](https://github.com/Idios/kobutachan-allaganeye/issues/572) (Level B smoke-test)、[#580](https://github.com/Idios/kobutachan-allaganeye/issues/580) (launcher exit code 修正)
- パターン参照: commit d9f705b ([#528](https://github.com/Idios/kobutachan-allaganeye/issues/528)) — 初回 heredoc → 関数化 refactor の先例
- Refs #583

作成: charming-swirles-98b725