### PR TITLE
feat(gpu): Intel QSV VP9 decode 追加 (Refs #582)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 - GPU 初期化コストを分散し、1プロセスあたり多数フレームをデコードすることで効率化
 - Pass 1 以降の処理（transition expansion, Pass 2, フィルタリング）は CPU/GPU 共通
 - GPU 利用不可時は自動で CPU モードにフォールバック
-- vendor 自動選択 (#546 / #553): `allaganeye.system_info.probe_gpu_vendors()` で検出した GPU から `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` 順で選択。実装済み vendor は NVIDIA (cuvid, #546) と AMD (d3d11va + hwdownload, #553) の 2 つ。Intel (#550 QSV 対応調査) は `--gpu-vendor intel` 指定で exit 5。default (auto) は NVIDIA > AMD > Intel の preference 順で実装済み vendor を選ぶ
+- vendor 自動選択 (#546 / #553 / #550 / #582): `allaganeye.system_info.probe_gpu_vendors()` で検出した GPU から `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` 順で選択。実装済み vendor は NVIDIA (cuvid, #546) / AMD (d3d11va + hwdownload, #553) / Intel (QSV + hwdownload, #550 h264/hevc/av1 + #582 vp9) の 3 つ。default (auto) は NVIDIA > AMD > Intel の preference 順で実装済み vendor を選ぶ
 
 ### Exit Codes
 

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -63,20 +63,24 @@ _GPU_DECODER_MAP: dict[str, dict[str, str]] = {
         # 現状未登録。必要になったら追加。
     },
     "intel": {
-        # #550 で追加。Tiger Lake (11th gen Iris Xe) 以降は
-        # h264 / hevc / av1 を QSV decode 可能。`_HWACCELS_NEED_HWDOWNLOAD`
-        # に "qsv" を追加してあるので _decode_chunk が
-        # `-hwaccel_output_format qsv` + filter chain 先頭の
-        # `hwdownload,format=nv12,` を自動付与し、QSV surface を system
-        # memory に降ろしてから fps -> scale -> format=gray に渡す。
-        # VP9 は QSV decoder 自体は ffmpeg 8.1 に存在 (`vp9_qsv`) するが
-        # 本 issue ではスコープ外で除外 (将来別 issue で追加検討)。
-        # 古い世代 (Skylake 等) で av1_qsv が「unsupported (-3)」で
-        # 失敗するケースは _decode_chunk が VideoProcessingError を上げ、
-        # detect_match_boundaries が CPU fallback する (実機検証:
-        # i7-1185G7 / Iris Xe では av1_qsv 非対応で CPU fallback 動作確認済み)。
+        # #550 で追加 (h264/hevc/av1)、#582 で vp9 追加。Tiger Lake
+        # (11th gen Iris Xe) 以降は h264 / hevc / vp9 / av1 を QSV decode
+        # 可能。`_HWACCELS_NEED_HWDOWNLOAD` に "qsv" を追加してあるので
+        # _decode_chunk が `-hwaccel_output_format qsv` + filter chain
+        # 先頭の `hwdownload,format=nv12,` を自動付与し、QSV surface を
+        # system memory に降ろしてから fps -> scale -> format=gray に渡す。
+        # 古い世代で codec 非対応 (例: Tiger Lake で av1_qsv は
+        # 「unsupported (-3)」) のケースは _decode_chunk が
+        # VideoProcessingError を上げ、detect_match_boundaries が
+        # CPU fallback する (実機検証:
+        # - h264_qsv: i7-1185G7 / Iris Xe で 13.7x speed (#550)
+        # - hevc_qsv: 同 720p で 3.76x speed (#550)
+        # - vp9_qsv: 同 720p で 8.29x speed (#582)
+        # - av1_qsv: Tiger Lake 非対応で CPU fallback (#550)
+        # )。
         "h264": "h264_qsv",
         "hevc": "hevc_qsv",
+        "vp9": "vp9_qsv",
         "av1": "av1_qsv",
     },
 }

--- a/docs/tuning-guide.md
+++ b/docs/tuning-guide.md
@@ -189,11 +189,11 @@ GPU 対応環境（NVIDIA CUDA, Intel QSV 等）では、暗転検知の処理�
 | H.264 | GPU (`--gpu`) | GPU デコード支援が最も成熟しており、恩恵が大きい |
 | HEVC (H.265) | GPU (`--gpu`) | GPU 支援あり。AV1 より効率的 |
 | AV1 | GPU (`--gpu`) (NVDEC RTX 30+ / QSV Arc・Gen12+ / VCN 4.0+) | #414 で GPU auto-select 対象に追加。対応 GPU で decode 成功、未対応環境では自動で CPU フォールバック |
-| VP9 | GPU (`--gpu`) — 実 decode は soft (#538) | #414 で GPU auto-select 対象、ただし #538 で `vp9_cuvid` + swscaler gray 変換の非互換が判明したため `_decode_chunk` は `-hwaccel auto` 経路で soft decode を選ぶ。CPU モード相当の速度 (speed 2.64x 実測) だが chunk 並列で十分高速 |
+| VP9 | GPU (`--gpu`) — Intel QSV は HW decode (#582), NVIDIA / AMD は soft (#538) | #414 で GPU auto-select 対象。NVIDIA は #538 で `vp9_cuvid` + swscaler gray 変換の非互換のため `-hwaccel auto` 経路で soft decode (speed 2.64x)。AMD d3d11va 用 dict には vp9 未登録で同様に soft fallback。Intel は #582 で `vp9_qsv` 登録、Tiger Lake で 8.29x speed (HW decode) 動作確認 |
 
 低コア数 CPU（4-8 コア）では、GPU モードが有利になりやすい傾向があります。
 
-#### GPU vendor の選択 (`--gpu-vendor`, #546 / #553 / #550)
+#### GPU vendor の選択 (`--gpu-vendor`, #546 / #553 / #550 / #582)
 
 実装済み vendor は NVIDIA (#546) / AMD (#553) / Intel (#550) の 3 つ。複数 GPU 環境では、デフォルトで NVIDIA dGPU が選択されます (`_VENDOR_PREFERENCE` = nvidia > amd > intel)。明示的に vendor を指定したい場合は `--gpu-vendor` オプションを使ってください。
 
@@ -215,10 +215,10 @@ allaganeye split your_recording.mkv --gpu --gpu-vendor auto
 |---|---|---|
 | `nvidia` | 実装済み (#546) | NVDEC cuvid 経由、h264 / hevc / av1 対応 |
 | `amd` | 実装済み (#553) | d3d11va + native decoder + `hwdownload,format=nv12` 経由、h264 / hevc / av1 対応。RDNA2+ iGPU (Granite Ridge) で SW 比 3x 高速 |
-| `intel` | 実装済み (#550) | QSV 経由 (`-hwaccel qsv -hwaccel_output_format qsv` + `hwdownload,format=nv12`)、h264 / hevc / av1 対応。AV1 は Alder Lake (12th gen) / Arc 以降のハードウェアで decode 可能。Tiger Lake (11th gen Iris Xe) は av1_qsv 非対応のため AV1 入力時は自動で CPU fallback (h264/hevc は QSV decode 動作確認済み)。VP9 は本 issue ではスコープ外で除外 |
+| `intel` | 実装済み (#550 / #582) | QSV 経由 (`-hwaccel qsv -hwaccel_output_format qsv` + `hwdownload,format=nv12`)、h264 / hevc / vp9 / av1 対応。AV1 は Alder Lake (12th gen) / Arc 以降のハードウェアで decode 可能。Tiger Lake (11th gen Iris Xe) は av1_qsv 非対応のため AV1 入力時は自動で CPU fallback (h264 / hevc / vp9 は QSV decode 動作確認済み) |
 | `auto` | 自動選択 | probe 結果から `_VENDOR_PREFERENCE` 順に実装済み vendor を選択 (NVIDIA > AMD > Intel) |
 
-**Intel QSV の追加引数 (実装メモ)**: Intel QSV は default で GPU surface (`pix_fmt=qsv`) を出力し、後段の swscaler が gray 変換時に `Function not implemented (-40)` で失敗します。`_decode_chunk` は AMD d3d11va と同じ `_HWACCELS_NEED_HWDOWNLOAD` 機構を再利用し、vendor=intel のとき自動で `-hwaccel_output_format qsv` を付与しつつ filter chain 先頭に `hwdownload,format=nv12,` を挿入します。実機ベンチでは i7-1185G7 / Iris Xe で h264_qsv 13.7x speed、hevc_qsv (720p) 3.76x speed を確認 (#550)。
+**Intel QSV の追加引数 (実装メモ)**: Intel QSV は default で GPU surface (`pix_fmt=qsv`) を出力し、後段の swscaler が gray 変換時に `Function not implemented (-40)` で失敗します。`_decode_chunk` は AMD d3d11va と同じ `_HWACCELS_NEED_HWDOWNLOAD` 機構を再利用し、vendor=intel のとき自動で `-hwaccel_output_format qsv` を付与しつつ filter chain 先頭に `hwdownload,format=nv12,` を挿入します。実機ベンチ (i7-1185G7 / Iris Xe): h264_qsv 13.7x / hevc_qsv (720p) 3.76x (#550) / vp9_qsv (720p) 8.29x (#582)。
 
 #### ベンチマークで判断する
 

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -137,15 +137,15 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 | VP9 | GPU (#414) — NVIDIA は soft decode (#538), AMD は `vp9_amf` 利用可 | Maxwell 以降 (#538 で NVDEC 経路除外) | Gen9+ | VCN 1.0+ |
 | その他 (mpeg2video, vc1, prores 等) | CPU | — | — | — |
 
-- VP9 は `_GPU_PREFERRED_CODECS` に残すが NVIDIA 経路 (`_GPU_DECODER_MAP["nvidia"]`) からは除外 (#538 / #549)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。NVIDIA auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x)。`vp9_cuvid` の ffmpeg 側修正が入った時点で NVIDIA 経路の復活検討。AMD は #553 で d3d11va 経路に統一しているため csp:gbr 問題なし (filter 先頭で `hwdownload,format=nv12` 経由で system memory に降ろす)。
+- VP9 は `_GPU_PREFERRED_CODECS` に残すが NVIDIA 経路 (`_GPU_DECODER_MAP["nvidia"]`) からは除外 (#538 / #549)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。NVIDIA auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x)。`vp9_cuvid` の ffmpeg 側修正が入った時点で NVIDIA 経路の復活検討。AMD は #553 で d3d11va 経路に統一しているため csp:gbr 問題なし (filter 先頭で `hwdownload,format=nv12` 経由で system memory に降ろす、ただし AMD 用 dict には vp9 未登録)。Intel は #582 で `vp9_qsv` を `_GPU_DECODER_MAP["intel"]` に追加 (QSV は decode 後の `hwdownload` で nv12 に明示 download するため csp:gbr 問題なし、Tiger Lake で 8.29x speed 実機確認)。
 
-**vendor × codec 実装状況 (#546 / #553 / #550)**
+**vendor × codec 実装状況 (#546 / #553 / #550 / #582)**
 
 | Vendor | hwaccel | h264 | hevc | av1 | vp9 | 備考 |
 |---|---|---|---|---|---|---|
 | NVIDIA (NVDEC cuvid) | `cuda` | `h264_cuvid` | `hevc_cuvid` | `av1_cuvid` | (soft, #538/#549) | dGPU 想定、dual GPU では優先選択 |
 | AMD (d3d11va) | `d3d11va` | `h264` | `hevc` | `av1` | (未登録) | #553 で実装。AMF decoder ではなく d3d11va + native decoder + filter 先頭 `hwdownload,format=nv12` で allaganeye filter pipeline と整合させる。RDNA2+ iGPU (Granite Ridge) で実測 speed 23x (SW 7.6x 比 3x 高速) |
-| Intel (QSV) | `qsv` | `h264_qsv` | `hevc_qsv` | `av1_qsv` | (本 issue 範囲外) | #550 で実装。Tiger Lake (11th gen Iris Xe) 以降で QSV decode 対応。AV1 は **Alder Lake / Arc 以降**でハードウェア decode、Tiger Lake では `Error initializing the MFX video decoder: unsupported (-3)` で `_decode_chunk` が `VideoProcessingError` を上げ CPU fallback。AMD と同じく `_HWACCELS_NEED_HWDOWNLOAD` 経路を使用 (`-hwaccel_output_format qsv` + filter 先頭 `hwdownload,format=nv12`)。VP9 は QSV decoder 自体は存在 (`vp9_qsv`) するが本 issue ではスコープ外で除外 (将来別 issue) |
+| Intel (QSV) | `qsv` | `h264_qsv` | `hevc_qsv` | `av1_qsv` | `vp9_qsv` | #550 (h264/hevc/av1) + #582 (vp9) で実装。Tiger Lake (11th gen Iris Xe) 以降で QSV decode 対応。AV1 は **Alder Lake / Arc 以降**でハードウェア decode、Tiger Lake では `Error initializing the MFX video decoder: unsupported (-3)` で `_decode_chunk` が `VideoProcessingError` を上げ CPU fallback。VP9 は Tiger Lake で動作確認済み (実機 8.29x speed @ 720p)。AMD と同じく `_HWACCELS_NEED_HWDOWNLOAD` 経路を使用 (`-hwaccel_output_format qsv` + filter 先頭 `hwdownload,format=nv12`)。NVIDIA `vp9_cuvid` の csp:gbr 不整合 (#538/#549) は QSV decoder では発生しない (decode 後 `hwdownload` で nv12 に明示 download するため) |
 | Apple (VideoToolbox) | — | — | — | — | — | Windows ffmpeg 未同梱、別 issue 追跡 |
 
 **`-hwaccel_output_format` + `hwdownload` filter の vendor 別差分 (#553 / #550)**

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -134,7 +134,7 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 | H.264 | GPU | 全世代 | 全世代 | 全世代 |
 | HEVC | GPU | Maxwell GM206+ | Skylake+ | VCN 1.0+ |
 | AV1 | GPU (#414) | RTX 30 (Ampere) 以降 | Arc / Gen12 以降 | VCN 4.0 以降 |
-| VP9 | GPU (#414) — NVIDIA は soft decode (#538), AMD は `vp9_amf` 利用可 | Maxwell 以降 (#538 で NVDEC 経路除外) | Gen9+ | VCN 1.0+ |
+| VP9 | GPU (#414) — NVIDIA は soft decode (#538), AMD は dict 未登録で soft decode, Intel は `vp9_qsv` HW decode (#582) | Maxwell 以降 (#538 で NVDEC 経路除外) | Gen9+ (`vp9_qsv` は Tiger Lake 11th gen 以降検証済 #582) | VCN 1.0+ (`_GPU_DECODER_MAP["amd"]` 未登録、d3d11va soft path) |
 | その他 (mpeg2video, vc1, prores 等) | CPU | — | — | — |
 
 - VP9 は `_GPU_PREFERRED_CODECS` に残すが NVIDIA 経路 (`_GPU_DECODER_MAP["nvidia"]`) からは除外 (#538 / #549)。理由: ffmpeg 8.1 の `vp9_cuvid` は frame を `nv12 + csp:gbr` で tag し、後段の swscaler が gray 変換を `EOPNOTSUPP (-129)` として reject する。NVIDIA auto-select で GPU mode に振られても `_decode_chunk` は else branch (`-hwaccel auto`) を使い、ffmpeg 側で soft decode (native) が選ばれる (実測 speed 2.64x)。`vp9_cuvid` の ffmpeg 側修正が入った時点で NVIDIA 経路の復活検討。AMD は #553 で d3d11va 経路に統一しているため csp:gbr 問題なし (filter 先頭で `hwdownload,format=nv12` 経由で system memory に降ろす、ただし AMD 用 dict には vp9 未登録)。Intel は #582 で `vp9_qsv` を `_GPU_DECODER_MAP["intel"]` に追加 (QSV は decode 後の `hwdownload` で nv12 に明示 download するため csp:gbr 問題なし、Tiger Lake で 8.29x speed 実機確認)。

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -100,13 +100,19 @@ class TestDecodeChunk:
             ("av1", "av1_qsv"),
             ("hevc", "hevc_qsv"),
             ("h264", "h264_qsv"),
+            # #582 で追加。vp9_qsv は ffmpeg 8.1 に存在し、Tiger Lake
+            # 以降で QSV decode 対応 (実機 i7-1185G7 / Iris Xe で 8.29x
+            # speed @ 720p 確認)。NVIDIA vp9_cuvid (#538/#549 で除外) と
+            # 異なり QSV では csp:gbr 問題は発生せず、hwdownload 経由で
+            # 後段の fps/scale/format=gray と整合する。
+            ("vp9", "vp9_qsv"),
         ],
     )
     @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_hwaccel_qsv_for_intel_codecs(self, mock_run, codec, expected_decoder):
         """vendor=intel + codec で `-hwaccel qsv -hwaccel_output_format qsv
         -c:v {codec}_qsv` + `hwdownload,format=nv12,` filter prefix を
-        組み立てる (#550, #553 と同じ汎用機構を再利用).
+        組み立てる (#550 / #582, #553 と同じ汎用機構を再利用).
 
         QSV decoder は default で `pix_fmt=qsv` の GPU surface を出力し、
         後段の swscaler (`fps -> scale -> format=gray`) が `Function not
@@ -114,11 +120,12 @@ class TestDecodeChunk:
         "qsv" を加え、`-hwaccel_output_format qsv` で surface format を
         明示しつつ filter chain 先頭の `hwdownload,format=nv12,` で
         system memory に降ろすのが #550 実装の核心 (#553 の AMD d3d11va
-        と同じパターン)。
+        と同じパターン)。VP9 (#582) は同パターンで追加。
 
         実機検証 (i7-1185G7 / Iris Xe Graphics, ffmpeg 8.1):
         - h264_qsv: 13.7x speed (`-hwaccel_output_format qsv` + hwdownload)
         - hevc_qsv: 3.76x speed @ 720p
+        - vp9_qsv: 8.29x speed @ 720p (#582)
         - av1_qsv: Tiger Lake 非対応 -> VideoProcessingError -> CPU fallback
         """
         mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
@@ -148,20 +155,26 @@ class TestDecodeChunk:
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")
     def test_hwaccel_auto_for_intel_unsupported_codec(self, mock_run):
-        """vendor=intel + 非対応 codec (vp9/mpeg2 等) は legacy
-        `-hwaccel auto` に fallback (#550).
+        """vendor=intel + `_GPU_DECODER_MAP["intel"]` 未登録 codec
+        (mpeg2video / mpeg4 / vc1 等) は legacy `-hwaccel auto` に
+        fallback (#550 / #582).
 
-        Intel QSV は VP9 decode 自体は対応しているが、本 issue では
-        スコープ外として `_GPU_DECODER_MAP["intel"]` から除外している。
-        将来別 issue で追加検討。
+        現時点で Intel 用 dict は h264 / hevc / vp9 / av1 を登録。それ以外の
+        codec (例: mpeg2video / mpeg4) は QSV decoder (`mpeg2_qsv` / `vc1_qsv`)
+        が ffmpeg に存在しても `_GPU_DECODER_MAP["intel"]` には未登録のため
+        legacy path (-hwaccel auto) に落ち、ffmpeg 側で soft / 自動 hwaccel
+        decode が選ばれる。VP9 は #582 で intel dict に登録済みなので、
+        本テストは mpeg2video で代替。
         """
         mock_run.return_value = MagicMock(stdout=b"", stderr=b"", returncode=0)
-        _decode_chunk(Path("test.mp4"), 0.0, 10.0, 1.0, codec="vp9", vendor="intel")
+        _decode_chunk(
+            Path("test.mp4"), 0.0, 10.0, 1.0, codec="mpeg2video", vendor="intel"
+        )
 
         cmd = mock_run.call_args[0][0]
         hw_idx = cmd.index("-hwaccel")
         assert cmd[hw_idx + 1] == "auto"
-        assert "vp9_qsv" not in cmd
+        assert "mpeg2_qsv" not in cmd
         assert "-hwaccel_output_format" not in cmd
 
     @patch("allaganeye.video.gpu_detector.subprocess.run")


### PR DESCRIPTION
## Summary

#582 の対応。PR #581 (Intel QSV h264/hevc/av1) で deferred されていた `vp9_qsv` を `_GPU_DECODER_MAP["intel"]` に追加。

- `_GPU_DECODER_MAP["intel"]["vp9"] = "vp9_qsv"` 追加 (1 行)
- `_HWACCELS_NEED_HWDOWNLOAD` 機構 (#578 / #581 由来) をそのまま流用するため、`_decode_chunk` 等の組み立てロジックは無変更
- 既存テストの parametrize に vp9 ケース追加 + `test_hwaccel_auto_for_intel_unsupported_codec` の代替 codec を mpeg2video に変更
- docs (`video-processing.md` / `tuning-guide.md`) の Intel 行 VP9 を「除外」から実装済みに更新

## 実装上の注意点

VP9 は vendor 横断で扱いが分かれている。本 PR では Intel のみ HW decode を有効化:

| Vendor | VP9 | 理由 |
|---|---|---|
| NVIDIA | soft (#538 / #549 で除外) | `vp9_cuvid` が `nv12 + csp:gbr` を出力し swscaler gray 変換が `EOPNOTSUPP` で失敗 |
| AMD | soft (`_GPU_DECODER_MAP["amd"]` に未登録) | #553 / #578 で h264 / hevc / av1 のみ登録、vp9 は別途検討扱い |
| Intel | **HW decode (本 PR で追加)** | `vp9_qsv` は decode 後の `hwdownload` で nv12 に明示 download するため csp 問題なし。Tiger Lake (11th gen Iris Xe) で 8.29x speed 動作確認 |

## 受け入れ条件 (#582 元 issue より)

- [x] **Intel iGPU 環境で `vp9_qsv` decode の success/fallback を記録** — i7-1185G7 / Iris Xe Graphics (Tiger Lake) で検証。bare ffmpeg 8.29x speed @ 720p、E2E `allaganeye split --gpu-vendor intel` で `Pass 1 (GPU): 15 samples / 1s` 達成
- [x] **`_GPU_DECODER_MAP["intel"]` に `"vp9": "vp9_qsv"` 追加 + `_HWACCELS_NEED_HWDOWNLOAD` 経由で hwdownload filter 自動付与を確認** — diff 参照、テスト parametrize で `-hwaccel qsv -hwaccel_output_format qsv -c:v vp9_qsv` + filter 先頭 `hwdownload,format=nv12,` を検証
- [x] **テスト追加 (Intel VP9 happy path + 既存ケースとの整合)** — `test_hwaccel_qsv_for_intel_codecs[vp9-vp9_qsv]` parametrize に追加。既存 `test_hwaccel_auto_for_intel_unsupported_codec` は vp9 → mpeg2video に変更
- [x] **docs 反映** — `docs/video-processing.md` / `docs/tuning-guide.md` の Intel 行 vp9 列を実装済みに更新、AMD/NVIDIA 行は据え置き
- [x] **既存 NVIDIA / AMD 経路の VP9 (soft decode) 回帰なし** — pytest 803 passed (1 skipped, 37 deselected) / ruff / pyright clean。E2E 回帰: H.264 GPU (Pass 1 GPU 維持) / AV1 fallback (Pass 1 CPU 維持) で確認

## 実機検証ログ

i7-1185G7 / Iris Xe Graphics / ffmpeg 8.1:

\`\`\`
$ ffmpeg -hwaccel qsv -hwaccel_output_format qsv -c:v vp9_qsv \
    -i vp9_test.mp4 -vf "hwdownload,format=nv12,fps=1,scale=320:180,format=gray" \
    -f rawvideo -pix_fmt gray /tmp/vp9_qsv_decode.gray
frame=    3 fps=0.0 q=-0.0 Lsize=   169KiB time=00:00:03.00 bitrate=460.8kbits/s speed=8.29x

$ allaganeye split vp9_15s.mp4 --gpu --gpu-vendor intel -v
  Codec: vp9
  GPU vendor: intel
  Pass 1 (GPU): 15 samples, 0 blackout frames (0.0%), 0m01s
  Match 1:   00:00 -   00:15  (0m15s)  [unknown]

# 回帰確認
$ allaganeye split av1_test.mp4 --gpu --gpu-vendor intel -v
  Pass 1 (CPU (GPU fallback))   ← av1_qsv 非対応で fallback (#550 と同じ挙動)

$ allaganeye split h264_15s.mp4 --gpu --gpu-vendor intel -v
  Pass 1 (GPU): 15 samples / 1s   ← #550 から変化なし
\`\`\`

## Test plan

- [x] `pytest` 全件 (803 passed, +1 from #581 baseline)
- [x] `ruff check` / `ruff format --check` clean
- [x] `pyright` 0 errors
- [x] 実機 VP9 で QSV decode 動作確認 (Pass 1 GPU)
- [x] 実機 AV1 で `unsupported -> CPU fallback` 維持 (回帰防止)
- [x] 実機 H.264 で Pass 1 GPU 維持 (回帰防止)

## 関連

- Refs #582 (本 issue)
- Refs PR #581 (Intel QSV h264/hevc/av1 実装、本 PR の前段)
- Refs #538 / #549 (NVIDIA vp9_cuvid 除外の経緯)
- Refs #553 / #578 (AMD d3d11va、本実装が再利用する `_HWACCELS_NEED_HWDOWNLOAD` 機構の出所)
- Refs #414 (AV1/VP9 GPU decode 対応の歴史)