### PR TITLE
docs(detection): ffmpeg fps filter の version 依存制約を明記 (Refs #577)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 - 動作確認済み: ハイスペック PC（高速 SSD、高性能 GPU）での OBS 録画。試合間暗転 2-5 秒程度
 - 未検証: 低スペック環境でローディング画面が長い（10 秒超）ケース
 - 既知の制限: ローディング画面が純粋な黒画面でなく UI 要素（スピナー、ロゴ等）を含む場合、brightness が 15-55 の範囲で変動し暗転が分断されることがある。分断された各区間が `min_blackout_duration` 未満になると試合境界を検出できない
+- 既知の制限: ffmpeg `fps` filter のフレーム選択は version 依存。8.1 で output PTS と実フレーム内容に最大 ~1.1s のオフセットが発生する事例あり (#575)。極短 (< 1s) blackout の取りこぼしによる baseline drift は #576 で根本対策検討中。判定 flow は [`docs/testing-guide.md`](docs/testing-guide.md) §「baseline drift の判定」、検証データは [`docs/video-processing.md`](docs/video-processing.md) §「ffmpeg fps filter の version 依存制約」を参照
 
 **GPU モード** (`--gpu`)
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -116,6 +116,34 @@ def _ffmpeg_interval(request: pytest.FixtureRequest) -> None:
 
 この症状が出た場合は、`_ffmpeg_interval` のスリープ時間を増やすか、テストを個別に実行して問題の再現性を確認する。
 
+## baseline drift の判定
+
+`tests/test_scorebar_regression.py::TestNoResolutionCompat` 系の baseline mismatch が発生した場合、(A) 検知ロジック退行 vs (B) ffmpeg version 依存差異 を以下の手順で判別する。
+
+### 背景
+
+`_scan_cpu` (および GPU chunked decode) の `fps` filter は ffmpeg version 依存でフレーム選択タイミングが変動し、極短 (< 1s) blackout を取りこぼすことがある (PR #575 で確定)。version upgrade のタイミングで他 baseline でも再発する可能性があるため、mismatch 発生時はまず差異の原因を判別する。
+
+### 判定 flow
+
+1. `allaganeye debug-brightness <video>` で per-frame `-ss` probe による実 brightness を CSV 出力
+2. baseline 乖離が発生した timestamp 周辺で、極短 (< 1s) blackout (brightness < `blackout_threshold=15`) が存在するか確認
+3. `_scan_cpu` の chunked fps filter 経路と比較する。`ffmpeg -vf "fps=N,showinfo" ...` で output PTS と実フレーム内容を `mean:[Y ...]` から確認できる
+4. **per-frame probe で blackout を捕捉するが fps filter で捕捉しない場合** → (B) ffmpeg version 依存差異
+   - `pytest -m "slow or baseline_regen"` で baseline を再生成し、現環境の正しい結果に固定する
+   - 検知ロジック自体は安定しているため、他の baseline (`20260116` / `20260119` 等) は引き続き pass することを確認
+5. **per-frame probe でも blackout を捕捉しない場合** → (A) 検知ロジック退行
+   - 該当コミットを `git bisect` または review で特定
+   - (B) と異なり baseline 更新で対処してはならない (退行を「正」と認めることになる)
+
+### 事例
+
+PR #575 / issue #560: ffmpeg 8.1 で `20260118` baseline の Match 8 end が 281s 乖離。per-frame probe で 6184.0-6184.8 の 0.8s 幅 blackout を捕捉できたが、`fps=0.5` filter は output PTS 6184 のラベルで実際は ~6185.1s 時点のフレーム (Y-mean=45) をサンプリングしていた (`showinfo` で確認)。(B) 案で baseline を `6184.0 → 6465.25` に更新して対応。fps filter 廃止による根本対策は #576 で検討中。
+
+### 検証データの保存場所
+
+PR #575 で取得した brightness 比較表 (per-frame probe vs chunked fps の対比) は [`docs/video-processing.md`](video-processing.md) §「ffmpeg fps filter の version 依存制約」に記録されている。
+
 ## プラットフォーム固有の注意点
 
 ### Windows

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -123,6 +123,52 @@ ffmpeg -hwaccel auto -ss <chunk_start> -t <chunk_duration> -i input.mkv \
 
 **フォールバック**: GPU デコードに失敗した場合は `VideoProcessingError` を送出し、呼び出し元（`detector.py`）が自動で CPU モードにフォールバックする。
 
+### ffmpeg fps filter の version 依存制約（#577）
+
+`_scan_cpu` および GPU chunked decode で使用する `fps=N` filter は、ffmpeg version によりフレーム選択タイミングが変動する。極短時間 (< 1s) blackout の取りこぼしが起こりうる (PR #575 の root cause 分析で確定)。
+
+**検証データ (PR #575 / issue #560)**
+
+ffmpeg 8.1 / `sample_interval=2.0` で `20260118` video の同一 timestamp label を異なる経路で probe した結果:
+
+| timestamp label | per-frame `-ss` probe | `_scan_cpu` (chunked fps) | 差 |
+|---|---|---|---|
+| 6184.0 | **1.73 (BLACKOUT)** | 47.72 (transition) | -46 |
+| 6186.0 | 100.48 (normal) | 37.20 (transition) | +63 |
+
+per-frame `-ss` probe では 0.1s 解像度で 6184.0-6184.8 の **0.8s 幅 blackout** を捕捉できる:
+
+```text
+6184.00   1.73  <-- BLACKOUT
+6184.10   1.73
+6184.20   1.74
+...
+6184.70   1.88
+6184.80  13.54
+6184.90  23.79  <-- transition
+6185.10  43.82
+6185.30  59.06  <-- normal
+```
+
+しかし `_scan_cpu` の chunked decode は `fps=0.5` filter でこの 0.8s 短時間 blackout のサンプリングタイミングを外し、label "6184" に brightness 47.72 のフレーム (実際には video 時間 ~6185.1s) を割り当てる。`showinfo` filter の出力で挙動を確認可能:
+
+```text
+n: 4 pts:3092 pts_time:6184  mean:[45 127 128]  <-- output PTS 6184 のフレーム Y-mean=45
+```
+
+output PTS 6184 と称しながら ~1.1s 遅れた input frame をサンプリングしている (Y-mean=45 は実時間 6185.1s の brightness=43.82 と整合)。
+
+**影響**
+
+- `min(min_blackout_duration, _REFINED_MIN_BLACKOUT)=1.5s` 未満の極短 blackout は fps filter 経路で取りこぼされる
+- ffmpeg version upgrade で baseline drift が再発する可能性あり (#576 で `fps` filter 廃止 + chunk 内全フレームデコード→N-th sampling 方式が検討中)
+- Pass 2 精密計測 (#361 borderline refinement / 上方向ヒステリシス) は Pass 1 で取りこぼした blackout を救済できない (refine 対象に入らないため)
+- 一方、現環境の検知パスは安定しており、PR #575 では他 2 件の baseline (`20260116` / `20260119`) は引き続き完全一致を維持
+
+**判定 / 対応**
+
+baseline mismatch 発生時の判定 flow ((A) 検知ロジック退行 vs (B) ffmpeg version 依存差異) は [`docs/testing-guide.md`](testing-guide.md) §「baseline drift の判定」を参照。
+
 ### コーデック + vendor 自動選択（#334, #414, #546, #550）
 
 `--gpu` / `--no-gpu` 未指定時は probe で取得した codec と GPU vendor を元に GPU/CPU を自動選択する (`_resolve_gpu_mode`)。判定セットは `_GPU_PREFERRED_CODECS` に定義。


### PR DESCRIPTION
## Summary

- Issue #577 対応。PR #575 / issue #560 の root cause 分析で確定した ffmpeg `fps` filter の version 依存挙動 (output PTS と実フレーム内容の ~1.1s オフセット、極短 < 1s blackout 取りこぼし) を 3 ファイルに明記
- doc-only。実装変更なし
- 根本対策 (fps filter 廃止) は #576 で別途検討中、本 PR はあくまで現状制約の docs 化

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `CLAUDE.md` | §「検出の動作確認済み環境と制限事項」に 1 行追記 (testing-guide / video-processing へのリンク含む) |
| `docs/testing-guide.md` | 「baseline drift の判定」セクション新設 (per-frame probe vs chunked fps の比較で (A) ロジック退行 vs (B) ffmpeg version 依存差異 を判別する flow + PR #575 の 281s 乖離事例) |
| `docs/video-processing.md` | 「ffmpeg fps filter の version 依存制約」セクション新設 (PR #575 で取得した brightness 比較表 + showinfo 検証データ + Pass 2 borderline refinement で救済できない理由) |

## 元 issue の対応方針 (受け入れ条件相当)

- [x] **1.** CLAUDE.md §「検出の動作確認済み環境と制限事項」に 1-2 行追記 — `CLAUDE.md` 145 行目に新規箇条書きとして追加 (~1.1s オフセット / #575 / #576 言及)
- [x] **2.** `docs/testing-guide.md` に baseline drift 判定 flow を追記 — `docs/testing-guide.md` 119-145 行目に新規セクション。per-frame probe / chunked fps 比較 / (B) baseline 更新 / (A) bisect の flow + PR #575 事例
- [x] **3.** PR #575 で得た決定的証拠 (brightness 比較表) を `docs/video-processing.md` に記録 — `docs/video-processing.md` 126-171 行目に新規セクション。6184.0 / 6186.0 の per-frame vs chunked fps 対比表 + 0.1s 解像度 probe 結果 + showinfo 出力サンプル

## Test plan

- [x] doc-only のため pytest / ruff / pyright / cargo / npm 影響なし (実装変更なし)
- [x] 内部リンク確認: CLAUDE.md → testing-guide.md / video-processing.md のリンクが該当セクションを指す
- [x] 内部リンク確認: testing-guide.md → video-processing.md / video-processing.md → testing-guide.md の相互参照が成立

レビュー時の確認観点 (レビュアー向け、self-check 不可)

- 文面の整合性 (誇張・誤記がないか、PR #575 の root cause 分析と齟齬がないか)
- セクション挿入位置の妥当性

## 関連

- 元 issue: #577
- root cause 分析元 PR: #575 (merged)
- 関連 issue: #560 (closed) / #576 (open, 根本対策検討中) / #214 (ffmpeg seek 非決定性)
