### PR TITLE
feat(gui): GUI export H.264 再エンコードに GPU encoder auto-select (Refs #591)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | `gui/src/components/` | 共通 UI コンポーネント (AllaganCorner / AllaganSigil / WindowChrome / BrightnessTimeline / RestoreButton / ConflictModal 等)。#464 で追加 |
 | `gui/src/state/` | Zustand store (`appStateStore` = screen + selection / `metadataStore` = load/apply/restore/loadSample) |
 | `gui/src/styles/tokens.css` | `aetherTheme` の CSS 変数定義 (#464 で追加) |
-| `gui/src-tauri/` | Tauri 2 Rust バックエンド (`load_metadata` / `apply_changes` / `restore_from_original` / `check_backup_exists` / `get_metadata_mtime` command、axum/tower-http による動画配信は #465 で実装予定) |
+| `gui/src-tauri/` | Tauri 2 Rust バックエンド (`load_metadata` / `apply_changes` / `restore_from_original` / `check_backup_exists` / `get_metadata_mtime` / `export_match` / `select_h264_encoder_for_export` (#591) command、axum/tower-http による動画配信は #465 で実装)。`H264Encoder` enum + `select_h264_encoder` + `is_gpu_encoder_failure` で GUI export の H.264 エンコーダ自動選択と libx264 fallback retry を実装 (#591) |
 
 ### 検知アルゴリズム（detector.py）
 
@@ -153,6 +153,8 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 - Pass 1 以降の処理（transition expansion, Pass 2, フィルタリング）は CPU/GPU 共通
 - GPU 利用不可時は自動で CPU モードにフォールバック
 - vendor 自動選択 (#546 / #553 / #550 / #582): `allaganeye.system_info.probe_gpu_vendors()` で検出した GPU から `_VENDOR_PREFERENCE = ("nvidia", "amd", "intel")` 順で選択。実装済み vendor は NVIDIA (cuvid, #546) / AMD (d3d11va + hwdownload, #553) / Intel (QSV + hwdownload, #550 h264/hevc/av1 + #582 vp9) の 3 つ。default (auto) は NVIDIA > AMD > Intel の preference 順で実装済み vendor を選ぶ
+- probe 結果は metadata.json `system_info` フィールドに記録され (#591)、GUI export 画面が H.264 再エンコードのエンコーダ選択 (NVENC / QSV / AMF / libx264 fallback) に使う。`--no-gpu` 指定時でも probe は実行し `gpu_vendors_available` を埋めるが、`gpu_vendor_used` は `null` になる
+- GUI export の H.264 再エンコード (#591): metadata の `system_info.gpu_vendors_available` + `vendor_preference` を `select_h264_encoder_for_export` Tauri コマンドで `H264Encoder` enum に解決し、ffmpeg を `h264_nvenc` / `h264_qsv` / `h264_amf` / `libx264` のいずれかで起動。GPU 初期化失敗 (NVENC `No NVENC capable devices found` 等) は `is_gpu_encoder_failure` で検知して libx264 で 1 回 retry し、`stage="fallback"` の `export-progress` イベントを emit (フロントエンドが per-match notice 表示)
 
 ### Exit Codes
 

--- a/allaganeye/commands/detect.py
+++ b/allaganeye/commands/detect.py
@@ -22,6 +22,7 @@ import typer
 from allaganeye.commands.split_matches import (
     _auto_sample_interval,
     _build_metadata_payload,
+    _build_system_info,
     _display_cache_hit_params,
     _display_gaps,
     _display_results,
@@ -32,7 +33,7 @@ from allaganeye.commands.split_matches import (
     _load_cache,
     _print_environment_header,
     _print_detection_stats,
-    _resolve_gpu_mode,
+    _resolve_gpu_mode_with_probe,
     _run_audio_scan,
     _run_detection,
     _save_cache,
@@ -82,6 +83,9 @@ def run_detect(
 
     cache_path = config.output_dir / ".detection_cache.json"
     boundaries = None
+    use_gpu = False
+    gpu_vendor: str | None = None
+    available_vendors: list[str] = []
     if not config.no_cache:
         boundaries = _load_cache(cache_path, video_path, effective_interval, config)
         if boundaries is not None:
@@ -91,7 +95,7 @@ def run_detect(
                 _display_results(boundaries, metadata, video_path, verbose, cached=True)
 
     if boundaries is None:
-        use_gpu, gpu_vendor = _resolve_gpu_mode(
+        use_gpu, gpu_vendor, available_vendors = _resolve_gpu_mode_with_probe(
             config.use_gpu,
             config.gpu_vendor,
             metadata.get("codec"),
@@ -169,6 +173,19 @@ def run_detect(
         Path(f"match_{i + 1:03d}.mp4") for i, _ in enumerate(boundaries)
     ]
 
+    # #591 -- cache hit のときは _resolve_gpu_mode を通らないので
+    # available_vendors が空 list のまま。GUI export が「現在の環境」を
+    # 反映できるように probe し直す。cache miss path では既に
+    # _resolve_gpu_mode で probe 済みなのでその値を再利用する。
+    if not available_vendors:
+        from allaganeye.system_info import probe_gpu_vendors
+
+        available_vendors = probe_gpu_vendors()
+    system_info = _build_system_info(
+        available_vendors=available_vendors,
+        vendor_used=gpu_vendor if use_gpu else None,
+    )
+
     payload = _build_metadata_payload(
         video_path=video_path,
         source_duration=metadata["duration"],
@@ -179,6 +196,7 @@ def run_detect(
         boundaries=boundaries,
         output_files=placeholder_paths,
         gaps=gaps,
+        system_info=system_info,
     )
     metadata_path = config.output_dir / "metadata.json"
     write_metadata_atomic(metadata_path, payload)

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -114,6 +114,16 @@ def run_split(
             _check_disk_space(
                 video_path, boundaries, metadata["duration"], config, show=show
             )
+            # #591 -- cache hit でも GUI export が使う system_info は
+            # 「現在の環境」を反映したい (録画から数日後に GPU 構成を
+            # 変えた可能性) ので、ここで probe し直す。vendor_used は
+            # cache hit のため None (今回 detect していない)。
+            from allaganeye.system_info import probe_gpu_vendors
+
+            cached_system_info = _build_system_info(
+                available_vendors=probe_gpu_vendors(),
+                vendor_used=None,
+            )
             split_start = time.monotonic()
             _split_and_write_metadata(
                 video_path,
@@ -123,6 +133,7 @@ def run_split(
                 config,
                 effective_interval=effective_interval,
                 detected_at=detected_at,
+                system_info=cached_system_info,
                 quiet=quiet,
             )
             _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -130,8 +141,10 @@ def run_split(
             return
 
     # Resolve GPU/CPU mode + vendor: auto-select based on codec + probe
-    # when not explicit (#334, #546)
-    use_gpu, gpu_vendor = _resolve_gpu_mode(
+    # when not explicit (#334, #546, #591). probe で検出された全 vendor は
+    # GUI export encoder 自動選択 (#591) で metadata.json system_info に
+    # 保存するため、3-tuple 版 ``_resolve_gpu_mode_with_probe`` を呼ぶ。
+    use_gpu, gpu_vendor, available_vendors = _resolve_gpu_mode_with_probe(
         config.use_gpu,
         config.gpu_vendor,
         metadata.get("codec"),
@@ -215,6 +228,12 @@ def run_split(
         return
 
     _check_disk_space(video_path, boundaries, metadata["duration"], config, show=show)
+    # #591 -- detect 経路で確定した vendor を vendor_used に記録。CPU
+    # 強制 (use_gpu=False) のときは vendor_used=None (実際使ってない)。
+    detected_system_info = _build_system_info(
+        available_vendors=available_vendors,
+        vendor_used=gpu_vendor if use_gpu else None,
+    )
     split_start = time.monotonic()
     _split_and_write_metadata(
         video_path,
@@ -224,6 +243,7 @@ def run_split(
         config,
         effective_interval=effective_interval,
         detected_at=detected_at,
+        system_info=detected_system_info,
         quiet=quiet,
     )
     _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -331,6 +351,16 @@ def run_split_from_metadata(
         typer.echo(f"  Source: {source_path}")
 
     _check_disk_space(source_path, boundaries, probe["duration"], config, show=show)
+    # #591 -- split-only path は detect しないので vendor_used=None。
+    # GUI export が encoder 選択に使う「現在の環境」を反映するため、
+    # ここで probe し直して metadata を更新する (前回 detect の値で
+    # 上書き)。
+    from allaganeye.system_info import probe_gpu_vendors
+
+    split_only_system_info = _build_system_info(
+        available_vendors=probe_gpu_vendors(),
+        vendor_used=None,
+    )
     split_start = time.monotonic()
     _split_and_write_metadata(
         source_path,
@@ -340,6 +370,7 @@ def run_split_from_metadata(
         config,
         effective_interval=effective_interval,
         detected_at=detected_at,
+        system_info=split_only_system_info,
         quiet=quiet,
     )
     _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -528,7 +559,26 @@ def _resolve_gpu_mode(
     show: bool,
     verbose: bool,
 ) -> tuple[bool, str | None]:
-    """Resolve GPU/CPU mode and vendor from user flags + probe (#334, #546, #553, #550).
+    """Resolve GPU/CPU mode and vendor (backward-compat 2-tuple wrapper).
+
+    新規呼び出し側 (#591 の system_info 構築など) は probe 結果も使うため
+    ``_resolve_gpu_mode_with_probe`` を呼ぶ。既存呼び出し / 既存テストは
+    引き続きこの薄い 2-tuple ラッパで動く。
+    """
+    use_gpu_concrete, vendor, _available = _resolve_gpu_mode_with_probe(
+        use_gpu, gpu_vendor_option, codec, show, verbose
+    )
+    return use_gpu_concrete, vendor
+
+
+def _resolve_gpu_mode_with_probe(
+    use_gpu: bool | None,
+    gpu_vendor_option: str | None,
+    codec: str | None,
+    show: bool,
+    verbose: bool,
+) -> tuple[bool, str | None, list[str]]:
+    """Resolve GPU/CPU mode and vendor from user flags + probe (#334, #546, #553, #550, #591).
 
     - *use_gpu*: None で自動 codec 判定、True/False で明示指示。
     - *gpu_vendor_option*: None / "auto" で自動選択、"nvidia" / "amd" /
@@ -536,8 +586,11 @@ def _resolve_gpu_mode(
       probe に見つからない vendor を要求すると ``ConfigValidationError``
       (exit 5)。現時点で nvidia / amd / intel すべて実装済み。
 
-    Returns ``(use_gpu_concrete, selected_vendor)`` tuple.  vendor が
-    ``None`` の場合は GPU 経路で ``-hwaccel auto`` が使われる。
+    Returns ``(use_gpu_concrete, selected_vendor, available_vendors)``
+    tuple.  *vendor* が ``None`` の場合は GPU 経路で ``-hwaccel auto`` が
+    使われる。*available_vendors* は ``probe_gpu_vendors()`` の生結果で、
+    GUI export が encoder 自動選択 (#591) に使うため metadata.json
+    ``system_info`` セクションに保存される。
     """
     from allaganeye.exceptions import ConfigValidationError
     from allaganeye.system_info import probe_gpu_vendors
@@ -570,7 +623,7 @@ def _resolve_gpu_mode(
     if use_gpu is not None:
         if show and verbose and use_gpu and vendor:
             typer.echo(f"  GPU vendor: {vendor}")
-        return use_gpu, vendor
+        return use_gpu, vendor, available
 
     codec_match = (codec or "").lower() in _GPU_PREFERRED_CODECS
     # Codec match is the primary signal (#334 の既存挙動を維持)。
@@ -584,7 +637,29 @@ def _resolve_gpu_mode(
         typer.echo(f"  Auto-selected {mode} mode (codec: {codec or 'unknown'})")
         if selected and vendor:
             typer.echo(f"  GPU vendor: {vendor}")
-    return selected, vendor if selected else None
+    return selected, vendor if selected else None, available
+
+
+def _build_system_info(
+    *,
+    available_vendors: list[str],
+    vendor_used: str | None,
+) -> dict:
+    """Build the ``system_info`` dict for ``metadata.json`` (#591).
+
+    GUI export 画面 (Phase 4 / `select_h264_encoder_for_export`) が
+    ``gpu_vendors_available`` と ``vendor_preference`` を読んで NVENC /
+    QSV / AMF / libx264 を auto-select する。``gpu_vendor_used`` は
+    実際 detect 経路で使った vendor (CPU 強制 / cache hit / split-only
+    では ``None``)。
+    """
+    from allaganeye.video.gpu_detector import _VENDOR_PREFERENCE
+
+    return {
+        "gpu_vendors_available": list(available_vendors),
+        "gpu_vendor_used": vendor_used,
+        "vendor_preference": list(_VENDOR_PREFERENCE),
+    }
 
 
 def _run_detection(
@@ -859,9 +934,10 @@ def _split_and_write_metadata(
     *,
     effective_interval: float,
     detected_at: str,
+    system_info: dict,
     quiet: bool = False,
 ) -> None:
-    """Split video and write metadata.json."""
+    """Split video and write metadata.json (#591: system_info required)."""
     show = not quiet
     source_duration = metadata["duration"]
 
@@ -902,6 +978,7 @@ def _split_and_write_metadata(
         boundaries=boundaries,
         output_files=output_files,
         gaps=gaps,
+        system_info=system_info,
     )
     metadata_path = config.output_dir / "metadata.json"
     write_metadata_atomic(metadata_path, result)
@@ -923,8 +1000,9 @@ def _build_metadata_payload(
     boundaries: list[MatchBoundary],
     output_files: list[Path],
     gaps: list[Gap],
+    system_info: dict,
 ) -> dict:
-    """Build the ``metadata.json`` payload dict (schema v1, #463).
+    """Build the ``metadata.json`` payload dict (schema v1, #463 / #591).
 
     Kept private to this module; ``commands.detect`` builds a variant
     (no ``output_files``) via its own helper.
@@ -936,6 +1014,11 @@ def _build_metadata_payload(
     ``source_fps`` (#465 review): the recording frame rate from ffprobe.
     GUI uses this to compute frame-accurate +-1F seek (formerly assumed
     60 fps). 120fps / 240fps recordings now step by 1/120 / 1/240 sec.
+
+    ``system_info`` (#591): GPU vendor probe snapshot used by GUI export
+    encoder selection (NVENC / QSV / AMF / libx264). Optional field added
+    in v1; readers without #591 simply ignore it. Build via
+    ``_build_system_info``.
     """
     return {
         "schema_version": "1",
@@ -953,6 +1036,7 @@ def _build_metadata_payload(
             "use_gpu": config.use_gpu,
             "workers": config.workers,
         },
+        "system_info": system_info,
         "matches": [
             {
                 "index": i + 1,

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -25,6 +25,7 @@
 | `matches` | array | ✓ | 試合セグメント列 (0 件可) | |
 | `gaps` | array | ✓ | 試合間の空白区間列 (0 件可) | |
 | `warnings` | array | 新規書き込みは ✓ (デフォルト `[]`) / 読み込み時は欠落許容 | 構造化警告一覧 (#518) | 個々のエントリは §warnings 参照 |
+| `system_info` | object | 新規書き込みは ✓ / 読み込み時は欠落許容 (#591) | GPU vendor probe スナップショット | 後述 §system_info 参照 |
 
 ### `detection_params` オブジェクト
 
@@ -51,6 +52,23 @@
 | `duration_display` | string | ✓ | 長さ表示 (例: `15m15s`) |
 | `type` | string | ✓ | `fl_match` または `unknown` |
 | `output_file` | string | ✓ | 出力 MP4 ファイル名 (相対パス、metadata.json と同ディレクトリ想定) |
+
+### `system_info` オブジェクト (#591)
+
+GPU vendor probe スナップショット。`probe_gpu_vendors()` の結果と、`_VENDOR_PREFERENCE` のスナップショット、実際 detect 経路で使った vendor を保存する。GUI export 画面が H.264 再エンコードのエンコーダ選択 (NVENC / QSV / AMF / libx264 fallback) に使用する。
+
+| フィールド | 型 | 必須 | 意味 |
+|---|---|---|---|
+| `gpu_vendors_available` | array of string | ✓ | probe で検出された vendor 識別子の集合。`{"nvidia","amd","intel"}` の subset。空配列はその環境に GPU が無い (CPU only) |
+| `gpu_vendor_used` | string \| null | ✓ | 実際 detect で使った vendor。CPU 強制 (`--no-gpu`) / cache hit / `split --from-metadata` では `null` |
+| `vendor_preference` | array of string | ✓ | `gpu_detector._VENDOR_PREFERENCE` のスナップショット。現状 `["nvidia","amd","intel"]` |
+
+書き込みパス:
+- `allaganeye detect`: detect 経路で probe → vendor_used = 採用した vendor (CPU 強制なら null)
+- `allaganeye split <video>` (legacy): cache miss なら detect と同じ / cache hit は probe を実行し vendor_used = null
+- `allaganeye split --from-metadata`: probe を実行し vendor_used = null (split 時点では vendor を選ばないため)
+
+GUI export 画面は `system_info.gpu_vendors_available` と `vendor_preference` を `select_h264_encoder_for_export` Tauri コマンドに渡し、`H264Encoder` enum (libx264 / NVENC / QSV / AMF) を解決する。`system_info` を持たない pre-#591 metadata.json は libx264 にフォールバックする。
 
 ### `Gap` オブジェクト (`gaps[]`)
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -64,6 +64,7 @@ GPU vendor probe スナップショット。`probe_gpu_vendors()` の結果と�
 | `vendor_preference` | array of string | ✓ | `gpu_detector._VENDOR_PREFERENCE` のスナップショット。現状 `["nvidia","amd","intel"]` |
 
 書き込みパス:
+
 - `allaganeye detect`: detect 経路で probe → vendor_used = 採用した vendor (CPU 強制なら null)
 - `allaganeye split <video>` (legacy): cache miss なら detect と同じ / cache hit は probe を実行し vendor_used = null
 - `allaganeye split --from-metadata`: probe を実行し vendor_used = null (split 時点では vendor を選ばないため)

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -66,6 +66,8 @@ GUI は以下のタイミングで CLI を subprocess として呼び出す (本
 | DetectingScreen (本物化予定) | `allaganeye detect <video> -o <output>` | metadata.json | [#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) Phase 3 |
 | ExportScreen (本物化予定) | `allaganeye split --from-metadata <meta>` | metadata.json + MP4 | [#466](https://github.com/Idios/kobutachan-allaganeye/issues/466) Phase 4 |
 
+ExportScreen の H.264 再エンコード時のエンコーダ選択 (#591) は subprocess 経路を使わない。 detect/split が metadata.json `system_info.gpu_vendors_available` に probe 結果を保存しているので、GUI 起動時はその値を `select_h264_encoder_for_export` Tauri command (Rust 内純関数) に渡して NVENC / QSV / AMF / libx264 を解決する。GPU 初期化失敗時のみ `export_match` 内で libx264 fallback retry が走る (CLI 呼び出しなし)。
+
 spawn された CLI プロセスは `ProcessMap` (Rust side、#523) に登録される。ユーザーがウィンドウを閉じる (`×`) 前にプロセスが走っていれば、GUI 側が `kill_tracked_processes` で中断する ([ui-architecture.md §ffmpeg 実行中の中断フロー](ui-architecture.md))。
 
 ### 2.4 GUI 内の video 配信 (subprocess ではない)

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -998,6 +998,14 @@ pub struct ExportProgress {
 /// wording -- when that happens, extend this match arm rather than
 /// loosening the matcher (loose matching would silently retry on
 /// unrelated failures).
+///
+/// QSV patterns include the post-PR-#596 verified ffmpeg 8.1 strings
+/// (`Error creating a MFX session` / `current mfx implementation is not
+/// supported` -- observed when QSV is forced on a non-Intel host) plus
+/// the older `Error initializing an internal MFX session` for older
+/// ffmpeg builds. The `Could not open encoder` line is generic but
+/// always preceded by `[h264_qsv @ ...]` in QSV failures, so we accept
+/// it inside the Qsv arm only.
 fn is_gpu_encoder_failure(stderr: &str, encoder: H264Encoder) -> bool {
     match encoder {
         H264Encoder::Libx264 => false,
@@ -1007,9 +1015,12 @@ fn is_gpu_encoder_failure(stderr: &str, encoder: H264Encoder) -> bool {
                 || stderr.contains("OpenEncodeSessionEx failed")
         }
         H264Encoder::Qsv => {
-            stderr.contains("Error initializing an internal MFX session")
+            stderr.contains("Error creating a MFX session")
+                || stderr.contains("Error initializing an internal MFX session")
+                || stderr.contains("current mfx implementation is not supported")
                 || stderr.contains("Cannot load libmfx")
                 || stderr.contains("MFXVideoENCODE_Init")
+                || (stderr.contains("h264_qsv") && stderr.contains("Could not open encoder"))
         }
         H264Encoder::Amf => {
             stderr.contains("AMF runtime not initialized")
@@ -2597,11 +2608,33 @@ mod tests {
         assert!(is_gpu_encoder_failure(stderr, H264Encoder::Nvenc));
     }
 
-    /// Intel QSV の MFX session 初期化失敗。
+    /// Intel QSV の MFX session 初期化失敗 (ffmpeg 7.x 系ワード)。
     #[test]
     fn is_gpu_encoder_failure_detects_qsv_init_error() {
         let stderr = "[h264_qsv] Error initializing an internal MFX session: -3\n";
         assert!(is_gpu_encoder_failure(stderr, H264Encoder::Qsv));
+    }
+
+    /// #591 PR review 実機検証: ffmpeg 8.1 の QSV failure stderr 実例
+    /// (RTX 5090 + AMD iGPU 環境で h264_qsv 強制起動 -> Intel iGPU 不在で
+    /// MFX session creation 失敗)。pre-fix の pattern では検出漏れし
+    /// libx264 retry が走らない bug があった。
+    #[test]
+    fn is_gpu_encoder_failure_detects_qsv_mfx_session_creation_error() {
+        let stderr = "\
+[h264_qsv @ 0x1] Error creating a MFX session: -9.\n\
+[h264_qsv @ 0x1] The current mfx implementation is not supported, try next mfx implementation.\n\
+[vost#0:0/h264_qsv @ 0x2] Could not open encoder before EOF\n";
+        assert!(is_gpu_encoder_failure(stderr, H264Encoder::Qsv));
+    }
+
+    /// `Could not open encoder` は generic message なので、`h264_qsv`
+    /// context が無ければ Qsv の failure と扱わない (libx264 でこの
+    /// メッセージが出ても誤って GPU 失敗判定しないため)。
+    #[test]
+    fn is_gpu_encoder_failure_qsv_requires_h264_qsv_context_for_generic_open_error() {
+        let stderr_generic = "[some_codec] Could not open encoder before EOF\n";
+        assert!(!is_gpu_encoder_failure(stderr_generic, H264Encoder::Qsv));
     }
 
     /// AMD AMF runtime ロード失敗。

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -853,14 +853,107 @@ async fn force_exit_app(app: tauri::AppHandle) {
 }
 
 /// #466 -- codec selection for a single-match export. `Copy` is fast and
-/// keyframe-aligned (no re-encode); `H264` re-encodes with libx264 for
-/// accurate seek boundaries at the cost of wall time.
+/// keyframe-aligned (no re-encode); `H264` re-encodes for accurate seek
+/// boundaries. The actual H.264 encoder (libx264 / NVENC / QSV / AMF)
+/// is chosen separately via [`H264Encoder`] (#591).
 #[derive(Debug, serde::Deserialize)]
 pub enum ExportCodec {
     #[serde(rename = "copy")]
     Copy,
     #[serde(rename = "h264")]
     H264,
+}
+
+/// #591 -- which H.264 encoder ffmpeg should use when [`ExportCodec::H264`]
+/// is requested. Auto-selected from the metadata.json `system_info`
+/// (probe results from the detect/split run) by [`select_h264_encoder`].
+///
+/// `Libx264` is the CPU fallback; `Nvenc` / `Qsv` / `Amf` are the GPU
+/// hardware encoders for NVIDIA / Intel / AMD respectively. The frontend
+/// displays the chosen encoder in the export panel sub label and passes
+/// the value back to `export_match` so the runtime fallback retry (#591
+/// Phase 3) knows which GPU encoder failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum H264Encoder {
+    Libx264,
+    Nvenc,
+    Qsv,
+    Amf,
+}
+
+impl H264Encoder {
+    /// Return the ffmpeg `-c:v` value for this encoder.
+    fn ffmpeg_codec_name(&self) -> &'static str {
+        match self {
+            H264Encoder::Libx264 => "libx264",
+            H264Encoder::Nvenc => "h264_nvenc",
+            H264Encoder::Qsv => "h264_qsv",
+            H264Encoder::Amf => "h264_amf",
+        }
+    }
+
+    /// Return the vendor-specific quality / preset args. Targets visual
+    /// parity with libx264 CRF 18 (1080p ≈ 4-8 Mbps band), but the RD
+    /// curves differ between encoders so the mapping is approximate.
+    /// Tuned values may be revisited per-vendor based on PR #591 real
+    /// hardware verification.
+    fn quality_args(&self) -> &'static [&'static str] {
+        match self {
+            // Existing libx264 settings (unchanged from #466 baseline).
+            H264Encoder::Libx264 => &["-crf", "18", "-preset", "medium"],
+            // NVENC has no CRF; -cq is constant-quality with -rc vbr.
+            // -preset p5 ≈ libx264 medium on NVIDIA SDK 12+ (p1=fastest,
+            // p7=slowest).
+            H264Encoder::Nvenc => &[
+                "-rc", "vbr", "-cq", "19", "-preset", "p5",
+            ],
+            // QSV ICQ (Intelligent Constant Quality). -look_ahead 1
+            // enables 1-frame look-ahead for better RD decisions.
+            H264Encoder::Qsv => &[
+                "-global_quality", "20", "-look_ahead", "1", "-preset", "medium",
+            ],
+            // AMF Constant QP. Windows-only encoder; matches CLAUDE.md
+            // "対応プラットフォーム: Windows のみ".
+            H264Encoder::Amf => &[
+                "-quality", "quality", "-rc", "cqp", "-qp_i", "19", "-qp_p", "21",
+            ],
+        }
+    }
+
+    /// Short human label shown in the GUI export panel sub line.
+    fn display_label(&self) -> &'static str {
+        match self {
+            H264Encoder::Libx264 => "libx264 (CPU)",
+            H264Encoder::Nvenc => "NVENC",
+            H264Encoder::Qsv => "QSV",
+            H264Encoder::Amf => "AMF",
+        }
+    }
+}
+
+/// #591 -- choose an H.264 encoder from the GPU vendor probe results.
+///
+/// `vendors` is the `gpu_vendors_available` slice from the metadata.json
+/// `system_info` field (Phase 1). `preference` is `vendor_preference`
+/// from the same payload (a snapshot of `gpu_detector._VENDOR_PREFERENCE`,
+/// currently `["nvidia", "amd", "intel"]`).
+///
+/// Returns the first preference entry that is also present in `vendors`,
+/// mapped to the vendor's H.264 encoder. Falls back to `Libx264` when no
+/// vendor matches (CPU-only environment, empty system_info, or unknown
+/// vendor names).
+fn select_h264_encoder(vendors: &[String], preference: &[String]) -> H264Encoder {
+    for pref in preference {
+        if vendors.iter().any(|v| v == pref) {
+            match pref.as_str() {
+                "nvidia" => return H264Encoder::Nvenc,
+                "intel" => return H264Encoder::Qsv,
+                "amd" => return H264Encoder::Amf,
+                _ => continue,
+            }
+        }
+    }
+    H264Encoder::Libx264
 }
 
 /// #466 -- terminal payload returned to the frontend when a single match
@@ -876,6 +969,11 @@ pub struct ExportResult {
 /// #466 -- progress event emitted on channel `export-progress`. One event
 /// per ffmpeg `out_time_ms` line during encoding, plus a terminal
 /// `stage="done"` on success or `stage="error"` on failure.
+///
+/// #591 -- a `stage="fallback"` event is emitted exactly once when a GPU
+/// encoder (NVENC / QSV / AMF) initialisation fails and the export
+/// retries with libx264. `fallback_from` carries a human-readable trace
+/// (e.g. `"h264_nvenc -> libx264"`) for the frontend notice.
 #[derive(Debug, serde::Serialize, Clone)]
 pub struct ExportProgress {
     pub match_index: u32,
@@ -883,6 +981,42 @@ pub struct ExportProgress {
     pub stage: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_from: Option<String>,
+}
+
+/// #591 -- detect "this looks like a GPU encoder initialisation failure"
+/// from ffmpeg stderr text. Used by `export_match` to decide whether a
+/// non-zero exit warrants a libx264 retry.
+///
+/// Returns `false` for [`H264Encoder::Libx264`] (libx264 errors are not
+/// recoverable by switching encoders) and for unrelated errors (e.g.
+/// `"No such file or directory"`).
+///
+/// The substring patterns are pinned to ffmpeg 8.x BtbN LGPL builds
+/// (CLAUDE.md recommended). Future ffmpeg releases may change the
+/// wording -- when that happens, extend this match arm rather than
+/// loosening the matcher (loose matching would silently retry on
+/// unrelated failures).
+fn is_gpu_encoder_failure(stderr: &str, encoder: H264Encoder) -> bool {
+    match encoder {
+        H264Encoder::Libx264 => false,
+        H264Encoder::Nvenc => {
+            stderr.contains("No NVENC capable devices found")
+                || stderr.contains("Cannot load nvEncodeAPI")
+                || stderr.contains("OpenEncodeSessionEx failed")
+        }
+        H264Encoder::Qsv => {
+            stderr.contains("Error initializing an internal MFX session")
+                || stderr.contains("Cannot load libmfx")
+                || stderr.contains("MFXVideoENCODE_Init")
+        }
+        H264Encoder::Amf => {
+            stderr.contains("AMF runtime not initialized")
+                || stderr.contains("DLL load failed")
+                || stderr.contains("Could not initialize AMFContext")
+        }
+    }
 }
 
 /// #466 -- pure validator for export arguments. Split out so unit tests can
@@ -1006,6 +1140,7 @@ fn ffmpeg_args_for_export(
     end_seconds: f64,
     output_path: &Path,
     codec: &ExportCodec,
+    h264_encoder: H264Encoder,
 ) -> Vec<String> {
     let duration = (end_seconds - start_seconds).max(0.0);
     let start_str = format!("{:.3}", start_seconds.max(0.0));
@@ -1033,12 +1168,15 @@ fn ffmpeg_args_for_export(
             args.push("make_zero".to_string());
         }
         ExportCodec::H264 => {
+            // #591 -- vendor-aware encoder selection. h264_encoder is
+            // resolved by select_h264_encoder() from metadata.json
+            // system_info.gpu_vendors_available; falls back to libx264
+            // when the system_info is missing or empty.
             args.push("-c:v".to_string());
-            args.push("libx264".to_string());
-            args.push("-crf".to_string());
-            args.push("18".to_string());
-            args.push("-preset".to_string());
-            args.push("medium".to_string());
+            args.push(h264_encoder.ffmpeg_codec_name().to_string());
+            for q in h264_encoder.quality_args() {
+                args.push((*q).to_string());
+            }
             args.push("-c:a".to_string());
             args.push("copy".to_string());
         }
@@ -1118,28 +1256,26 @@ fn tail_string(buf: &[u8], max_bytes: usize) -> String {
 ///
 /// The spawned child is registered in PROCESS_TRACKER for the duration of
 /// the call so the CloseRequested flow can kill it before app exit.
-#[tauri::command]
-async fn export_match(
-    app: tauri::AppHandle,
-    video_path: String,
-    start_seconds: f64,
-    end_seconds: f64,
-    output_path: String,
-    codec: ExportCodec,
+/// #591 -- one ffmpeg invocation: spawn, stream stderr (progress events
+/// + tail buffer), wait for exit. Returns the captured stderr tail and
+/// final status so the caller can decide whether to retry with a
+/// different encoder.
+///
+/// `attempt_emits_done`: when `true` (single-attempt path or final
+/// retry), the function emits `stage="done"` on success. When `false`
+/// (first attempt of a retry sequence), the caller suppresses the done
+/// event for the failing attempt so the frontend doesn't see "done"
+/// followed by "fallback". The done event for a successful retry is
+/// emitted by the next call with `attempt_emits_done = true`.
+async fn run_ffmpeg_export_attempt(
+    app: &tauri::AppHandle,
+    args: &[String],
+    duration_seconds: f64,
     match_index: u32,
-) -> Result<ExportResult, String> {
-    let video = PathBuf::from(&video_path);
-    validate_export_request(&video, start_seconds, end_seconds)?;
-
-    let output = PathBuf::from(&output_path);
-    validate_output_parent_exists(&output)?;
-
-    let duration_seconds = end_seconds - start_seconds;
-    let args = ffmpeg_args_for_export(&video, start_seconds, end_seconds, &output, &codec);
-
-    let started = Instant::now();
+    attempt_emits_done: bool,
+) -> Result<(std::process::ExitStatus, Vec<u8>, bool), String> {
     let mut cmd = tokio::process::Command::new("ffmpeg");
-    for a in &args {
+    for a in args {
         cmd.arg(a);
     }
     cmd.stdin(Stdio::null())
@@ -1150,8 +1286,6 @@ async fn export_match(
         .spawn()
         .map_err(|e| format!("spawn ffmpeg failed: {}", e))?;
 
-    // Take stderr off the child before registering it in the tracker --
-    // `track_child` moves the Child and we need the pipe handle here.
     let stderr = child
         .stderr
         .take()
@@ -1161,41 +1295,42 @@ async fn export_match(
 
     let mut reader = BufReader::new(stderr).lines();
     let mut stderr_tail: Vec<u8> = Vec::with_capacity(4096);
-    let max_tail = 2048; // 2 KB of tail context for error reporting
+    let max_tail = 2048;
     let mut saw_end = false;
 
     loop {
         match reader.next_line().await {
-            Ok(Some(line)) => {
-                match parse_progress_line(&line) {
-                    Some(ProgressSignal::OutTimeMs(us)) => {
-                        let seconds = (us as f64) / 1_000_000.0;
-                        let mut percent = if duration_seconds > 0.0 {
-                            seconds / duration_seconds * 100.0
-                        } else {
-                            0.0
-                        };
-                        if !percent.is_finite() {
-                            percent = 0.0;
-                        }
-                        if percent < 0.0 {
-                            percent = 0.0;
-                        }
-                        if percent > 100.0 {
-                            percent = 100.0;
-                        }
-                        let _ = app.emit(
-                            "export-progress",
-                            ExportProgress {
-                                match_index,
-                                percent,
-                                stage: "encoding".to_string(),
-                                message: None,
-                            },
-                        );
+            Ok(Some(line)) => match parse_progress_line(&line) {
+                Some(ProgressSignal::OutTimeMs(us)) => {
+                    let seconds = (us as f64) / 1_000_000.0;
+                    let mut percent = if duration_seconds > 0.0 {
+                        seconds / duration_seconds * 100.0
+                    } else {
+                        0.0
+                    };
+                    if !percent.is_finite() {
+                        percent = 0.0;
                     }
-                    Some(ProgressSignal::End) => {
-                        saw_end = true;
+                    if percent < 0.0 {
+                        percent = 0.0;
+                    }
+                    if percent > 100.0 {
+                        percent = 100.0;
+                    }
+                    let _ = app.emit(
+                        "export-progress",
+                        ExportProgress {
+                            match_index,
+                            percent,
+                            stage: "encoding".to_string(),
+                            message: None,
+                            fallback_from: None,
+                        },
+                    );
+                }
+                Some(ProgressSignal::End) => {
+                    saw_end = true;
+                    if attempt_emits_done {
                         let _ = app.emit(
                             "export-progress",
                             ExportProgress {
@@ -1203,48 +1338,33 @@ async fn export_match(
                                 percent: 100.0,
                                 stage: "done".to_string(),
                                 message: None,
+                                fallback_from: None,
                             },
                         );
                     }
-                    None => {
-                        // Non-progress stderr -- capture into ring buffer
-                        // for error reporting on non-zero exit.
-                        stderr_tail.extend_from_slice(line.as_bytes());
-                        stderr_tail.push(b'\n');
-                        if stderr_tail.len() > max_tail * 2 {
-                            let keep_from = stderr_tail.len() - max_tail;
-                            stderr_tail.drain(0..keep_from);
-                        }
+                }
+                None => {
+                    stderr_tail.extend_from_slice(line.as_bytes());
+                    stderr_tail.push(b'\n');
+                    if stderr_tail.len() > max_tail * 2 {
+                        let keep_from = stderr_tail.len() - max_tail;
+                        stderr_tail.drain(0..keep_from);
                     }
                 }
-            }
-            Ok(None) => break, // EOF
+            },
+            Ok(None) => break,
             Err(e) => {
-                stderr_tail.extend_from_slice(
-                    format!("stderr read error: {}\n", e).as_bytes(),
-                );
+                stderr_tail
+                    .extend_from_slice(format!("stderr read error: {}\n", e).as_bytes());
                 break;
             }
         }
     }
 
-    // Reclaim the child from the tracker so we can wait on it. If it was
-    // already drained by kill_tracked_processes, treat that as a
-    // user-initiated cancel and surface an error.
     let mut child = match untrack_child(tracked_id).await {
         Some(c) => c,
         None => {
-            let msg = "export cancelled (process tracker drained)".to_string();
-            let _ = app.emit(
-                "export-progress",
-                ExportProgress {
-                    match_index,
-                    percent: 0.0,
-                    stage: "error".to_string(),
-                    message: Some(msg.clone()),
-                },
-            );
-            return Err(msg);
+            return Err("export cancelled (process tracker drained)".to_string());
         }
     };
 
@@ -1253,12 +1373,159 @@ async fn export_match(
         .await
         .map_err(|e| format!("wait ffmpeg failed: {}", e))?;
 
-    if !status.success() {
-        let tail = tail_string(&stderr_tail, max_tail);
+    Ok((status, stderr_tail, saw_end))
+}
+
+#[tauri::command]
+async fn export_match(
+    app: tauri::AppHandle,
+    video_path: String,
+    start_seconds: f64,
+    end_seconds: f64,
+    output_path: String,
+    codec: ExportCodec,
+    h264_encoder: Option<H264Encoder>,
+    match_index: u32,
+) -> Result<ExportResult, String> {
+    let video = PathBuf::from(&video_path);
+    validate_export_request(&video, start_seconds, end_seconds)?;
+
+    let output = PathBuf::from(&output_path);
+    validate_output_parent_exists(&output)?;
+
+    // #591 -- frontend が metadata.json system_info から resolve した
+    // encoder を渡す。None (legacy / 古い metadata) は libx264 fallback。
+    let encoder = h264_encoder.unwrap_or(H264Encoder::Libx264);
+
+    let duration_seconds = end_seconds - start_seconds;
+    let started = Instant::now();
+    let max_tail = 2048;
+
+    // Attempt 1: vendor-resolved encoder.
+    let primary_args =
+        ffmpeg_args_for_export(&video, start_seconds, end_seconds, &output, &codec, encoder);
+    let (status, stderr_tail, saw_end) = run_ffmpeg_export_attempt(
+        &app,
+        &primary_args,
+        duration_seconds,
+        match_index,
+        true, // emits "done" on success
+    )
+    .await
+    .map_err(|e| {
+        let _ = app.emit(
+            "export-progress",
+            ExportProgress {
+                match_index,
+                percent: 0.0,
+                stage: "error".to_string(),
+                message: Some(e.clone()),
+                fallback_from: None,
+            },
+        );
+        e
+    })?;
+
+    if status.success() {
+        // Some ffmpeg builds close stderr without flushing the final
+        // `progress=end` line -- synthesize a terminal "done" so the
+        // frontend always sees one.
+        if !saw_end {
+            let _ = app.emit(
+                "export-progress",
+                ExportProgress {
+                    match_index,
+                    percent: 100.0,
+                    stage: "done".to_string(),
+                    message: None,
+                    fallback_from: None,
+                },
+            );
+        }
+        return Ok(build_export_result(&output, match_index, started));
+    }
+
+    // Failed. Decide whether to retry with libx264 (#591).
+    let stderr_text = String::from_utf8_lossy(&stderr_tail).into_owned();
+    if encoder != H264Encoder::Libx264
+        && matches!(codec, ExportCodec::H264)
+        && is_gpu_encoder_failure(&stderr_text, encoder)
+    {
+        let from_to = format!("{} -> libx264", encoder.ffmpeg_codec_name());
+        let _ = app.emit(
+            "export-progress",
+            ExportProgress {
+                match_index,
+                percent: 0.0,
+                stage: "fallback".to_string(),
+                message: Some(format!(
+                    "{} の初期化に失敗したため libx264 で再試行します",
+                    encoder.display_label()
+                )),
+                fallback_from: Some(from_to),
+            },
+        );
+
+        let retry_args = ffmpeg_args_for_export(
+            &video,
+            start_seconds,
+            end_seconds,
+            &output,
+            &codec,
+            H264Encoder::Libx264,
+        );
+        let (retry_status, retry_tail, retry_saw_end) = run_ffmpeg_export_attempt(
+            &app,
+            &retry_args,
+            duration_seconds,
+            match_index,
+            true,
+        )
+        .await
+        .map_err(|e| {
+            let _ = app.emit(
+                "export-progress",
+                ExportProgress {
+                    match_index,
+                    percent: 0.0,
+                    stage: "error".to_string(),
+                    message: Some(e.clone()),
+                    fallback_from: None,
+                },
+            );
+            e
+        })?;
+
+        if retry_status.success() {
+            if !retry_saw_end {
+                let _ = app.emit(
+                    "export-progress",
+                    ExportProgress {
+                        match_index,
+                        percent: 100.0,
+                        stage: "done".to_string(),
+                        message: None,
+                        fallback_from: None,
+                    },
+                );
+            }
+            return Ok(build_export_result(&output, match_index, started));
+        }
+
+        // Retry also failed -- surface the libx264 stderr (more useful
+        // than the original GPU failure).
+        let tail = tail_string(&retry_tail, max_tail);
         let msg = if tail.is_empty() {
-            format!("ffmpeg exited with status {:?}", status.code())
+            format!(
+                "ffmpeg (libx264 retry) exited with status {:?}",
+                retry_status.code()
+            )
         } else {
-            format!("ffmpeg exited with status {:?}: {}", status.code(), tail)
+            format!(
+                "ffmpeg (libx264 retry) exited with status {:?}: {}",
+                retry_status.code(),
+                tail
+            )
         };
         let _ = app.emit(
             "export-progress",
@@ -1267,35 +1534,70 @@ async fn export_match(
                 percent: 0.0,
                 stage: "error".to_string(),
                 message: Some(msg.clone()),
+                fallback_from: None,
             },
         );
         return Err(msg);
     }
 
-    // Some ffmpeg builds close stderr without flushing the final
-    // `progress=end` line -- synthesize a terminal "done" so the frontend
-    // always sees one.
-    if !saw_end {
-        let _ = app.emit(
-            "export-progress",
-            ExportProgress {
-                match_index,
-                percent: 100.0,
-                stage: "done".to_string(),
-                message: None,
-            },
-        );
-    }
+    // No retry -- surface the primary failure.
+    let tail = tail_string(&stderr_tail, max_tail);
+    let msg = if tail.is_empty() {
+        format!("ffmpeg exited with status {:?}", status.code())
+    } else {
+        format!("ffmpeg exited with status {:?}: {}", status.code(), tail)
+    };
+    let _ = app.emit(
+        "export-progress",
+        ExportProgress {
+            match_index,
+            percent: 0.0,
+            stage: "error".to_string(),
+            message: Some(msg.clone()),
+            fallback_from: None,
+        },
+    );
+    Err(msg)
+}
 
-    let output_str = fs::canonicalize(&output)
+fn build_export_result(output: &Path, match_index: u32, started: Instant) -> ExportResult {
+    let output_str = fs::canonicalize(output)
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| output.to_string_lossy().to_string());
-
-    Ok(ExportResult {
+    ExportResult {
         match_index,
         output_path: output_str,
         duration_ms: started.elapsed().as_millis() as u64,
-    })
+    }
+}
+
+/// #591 -- payload returned from `select_h264_encoder_for_export` to the
+/// frontend. `encoder_kind` is the wire form (`"Nvenc"` / `"Qsv"` /
+/// `"Amf"` / `"Libx264"`) which the frontend passes back unchanged in
+/// the `h264_encoder` field of `export_match`.
+#[derive(Debug, serde::Serialize)]
+pub struct EncoderInfo {
+    pub encoder: String,
+    pub display_label: String,
+    pub encoder_kind: H264Encoder,
+}
+
+/// #591 -- pure-function Tauri command that maps a metadata.json
+/// `system_info.gpu_vendors_available` + `vendor_preference` pair to the
+/// concrete H.264 encoder the frontend should use. No subprocess work
+/// (the probe already happened during detect/split), so this is cheap to
+/// call on every ExportScreen mount.
+#[tauri::command]
+fn select_h264_encoder_for_export(
+    vendors: Vec<String>,
+    preference: Vec<String>,
+) -> EncoderInfo {
+    let encoder = select_h264_encoder(&vendors, &preference);
+    EncoderInfo {
+        encoder: encoder.ffmpeg_codec_name().to_string(),
+        display_label: encoder.display_label().to_string(),
+        encoder_kind: encoder,
+    }
 }
 
 pub fn run() {
@@ -1329,6 +1631,7 @@ pub fn run() {
             kill_tracked_processes,
             force_exit_app,
             export_match,
+            select_h264_encoder_for_export,
             open_folder_in_explorer,
         ])
         .run(tauri::generate_context!())
@@ -2028,6 +2331,7 @@ mod tests {
             40.0,
             Path::new("C:/out/match1.mp4"),
             &ExportCodec::Copy,
+            H264Encoder::Libx264,
         );
         let joined = args.join(" ");
         assert!(joined.contains("-c copy"), "args: {}", joined);
@@ -2051,6 +2355,7 @@ mod tests {
             30.0,
             Path::new("C:/out/match1.mp4"),
             &ExportCodec::H264,
+            H264Encoder::Libx264,
         );
         let joined = args.join(" ");
         assert!(joined.contains("-c:v libx264"), "args: {}", joined);
@@ -2071,6 +2376,7 @@ mod tests {
             45.5,
             Path::new("C:/out/match1.mp4"),
             &ExportCodec::Copy,
+            H264Encoder::Libx264,
         );
         let ss_pos = args.iter().position(|a| a == "-ss").expect("-ss present");
         let i_pos = args.iter().position(|a| a == "-i").expect("-i present");
@@ -2095,6 +2401,7 @@ mod tests {
             40.5,
             Path::new("C:/out/match1.mp4"),
             &ExportCodec::Copy,
+            H264Encoder::Libx264,
         );
         let t_pos = args.iter().position(|a| a == "-t").expect("-t present");
         let duration = args.get(t_pos + 1).expect("value after -t");
@@ -2105,6 +2412,258 @@ mod tests {
             parsed,
             args
         );
+    }
+
+    // -- #591 -- H264Encoder + select_h264_encoder + ffmpeg_args_for_export
+    // vendor 別 args の単体テスト群。
+
+    fn _vendor_strs(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn _default_preference() -> Vec<String> {
+        _vendor_strs(&["nvidia", "amd", "intel"])
+    }
+
+    /// #591 -- NVIDIA があれば preference 順で最優先選択。
+    #[test]
+    fn select_h264_encoder_picks_nvenc_for_nvidia_first() {
+        let vendors = _vendor_strs(&["nvidia", "amd"]);
+        assert_eq!(
+            select_h264_encoder(&vendors, &_default_preference()),
+            H264Encoder::Nvenc
+        );
+    }
+
+    /// #591 -- Intel iGPU 単独環境では QSV を選ぶ。
+    #[test]
+    fn select_h264_encoder_picks_qsv_for_intel_only() {
+        let vendors = _vendor_strs(&["intel"]);
+        assert_eq!(
+            select_h264_encoder(&vendors, &_default_preference()),
+            H264Encoder::Qsv
+        );
+    }
+
+    /// #591 -- AMD のみなら AMF を選ぶ (Windows 限定だが pure 関数として
+    /// は OS 非依存に動作)。
+    #[test]
+    fn select_h264_encoder_picks_amf_for_amd_only() {
+        let vendors = _vendor_strs(&["amd"]);
+        assert_eq!(
+            select_h264_encoder(&vendors, &_default_preference()),
+            H264Encoder::Amf
+        );
+    }
+
+    /// #591 -- vendor 不在 (CPU only / 空 system_info) は Libx264 fallback。
+    #[test]
+    fn select_h264_encoder_falls_back_to_libx264_when_empty() {
+        let vendors: Vec<String> = vec![];
+        assert_eq!(
+            select_h264_encoder(&vendors, &_default_preference()),
+            H264Encoder::Libx264
+        );
+    }
+
+    /// #591 -- preference 順で選ぶ (vendors の出現順は無視される)。
+    #[test]
+    fn select_h264_encoder_respects_preference_order() {
+        let vendors = _vendor_strs(&["amd", "nvidia"]);
+        // preference = nvidia > amd > intel なので NVIDIA が先。
+        assert_eq!(
+            select_h264_encoder(&vendors, &_default_preference()),
+            H264Encoder::Nvenc
+        );
+    }
+
+    /// #591 -- 知らない vendor 名は無視されて libx264 へ。
+    #[test]
+    fn select_h264_encoder_ignores_unknown_vendors() {
+        let vendors = _vendor_strs(&["wgpu", "moltenvk"]);
+        assert_eq!(
+            select_h264_encoder(&vendors, &_default_preference()),
+            H264Encoder::Libx264
+        );
+    }
+
+    /// #591 -- NVENC 選択時の ffmpeg argv は h264_nvenc + -cq 19 + -preset p5。
+    #[test]
+    fn ffmpeg_args_for_export_h264_nvenc_uses_h264_nvenc() {
+        let args = ffmpeg_args_for_export(
+            Path::new("C:/videos/in.mp4"),
+            0.0,
+            30.0,
+            Path::new("C:/out/m.mp4"),
+            &ExportCodec::H264,
+            H264Encoder::Nvenc,
+        );
+        let joined = args.join(" ");
+        assert!(joined.contains("-c:v h264_nvenc"), "args: {}", joined);
+        assert!(joined.contains("-cq 19"), "args: {}", joined);
+        assert!(joined.contains("-preset p5"), "args: {}", joined);
+        assert!(joined.contains("-c:a copy"), "args: {}", joined);
+        assert!(!joined.contains("libx264"), "args: {}", joined);
+    }
+
+    /// #591 -- QSV 選択時は h264_qsv + -global_quality 20 + -look_ahead 1。
+    #[test]
+    fn ffmpeg_args_for_export_h264_qsv_uses_h264_qsv() {
+        let args = ffmpeg_args_for_export(
+            Path::new("C:/videos/in.mp4"),
+            0.0,
+            30.0,
+            Path::new("C:/out/m.mp4"),
+            &ExportCodec::H264,
+            H264Encoder::Qsv,
+        );
+        let joined = args.join(" ");
+        assert!(joined.contains("-c:v h264_qsv"), "args: {}", joined);
+        assert!(joined.contains("-global_quality 20"), "args: {}", joined);
+        assert!(joined.contains("-look_ahead 1"), "args: {}", joined);
+        assert!(joined.contains("-c:a copy"), "args: {}", joined);
+        assert!(!joined.contains("libx264"), "args: {}", joined);
+    }
+
+    /// #591 -- AMF 選択時は h264_amf + -rc cqp + -qp_i 19 + -qp_p 21。
+    #[test]
+    fn ffmpeg_args_for_export_h264_amf_uses_h264_amf() {
+        let args = ffmpeg_args_for_export(
+            Path::new("C:/videos/in.mp4"),
+            0.0,
+            30.0,
+            Path::new("C:/out/m.mp4"),
+            &ExportCodec::H264,
+            H264Encoder::Amf,
+        );
+        let joined = args.join(" ");
+        assert!(joined.contains("-c:v h264_amf"), "args: {}", joined);
+        assert!(joined.contains("-rc cqp"), "args: {}", joined);
+        assert!(joined.contains("-qp_i 19"), "args: {}", joined);
+        assert!(joined.contains("-qp_p 21"), "args: {}", joined);
+        assert!(joined.contains("-c:a copy"), "args: {}", joined);
+        assert!(!joined.contains("libx264"), "args: {}", joined);
+    }
+
+    /// #591 -- Copy codec では h264_encoder の値に関わらず -c copy 経路を取る。
+    /// h264_encoder=Nvenc を渡しても、ExportCodec::Copy なら NVENC は使われない。
+    #[test]
+    fn ffmpeg_args_for_export_copy_ignores_h264_encoder_value() {
+        let args = ffmpeg_args_for_export(
+            Path::new("C:/videos/in.mp4"),
+            0.0,
+            30.0,
+            Path::new("C:/out/m.mp4"),
+            &ExportCodec::Copy,
+            H264Encoder::Nvenc,
+        );
+        let joined = args.join(" ");
+        assert!(joined.contains("-c copy"), "args: {}", joined);
+        assert!(!joined.contains("h264_nvenc"), "args: {}", joined);
+        assert!(!joined.contains("-cq"), "args: {}", joined);
+    }
+
+    /// #591 -- H264Encoder::display_label は GUI sub label 用の固定文字列を返す。
+    #[test]
+    fn h264_encoder_display_labels() {
+        assert_eq!(H264Encoder::Libx264.display_label(), "libx264 (CPU)");
+        assert_eq!(H264Encoder::Nvenc.display_label(), "NVENC");
+        assert_eq!(H264Encoder::Qsv.display_label(), "QSV");
+        assert_eq!(H264Encoder::Amf.display_label(), "AMF");
+    }
+
+    /// #591 -- ffmpeg_codec_name は ffmpeg `-c:v` で使う識別子を返す。
+    #[test]
+    fn h264_encoder_ffmpeg_codec_names() {
+        assert_eq!(H264Encoder::Libx264.ffmpeg_codec_name(), "libx264");
+        assert_eq!(H264Encoder::Nvenc.ffmpeg_codec_name(), "h264_nvenc");
+        assert_eq!(H264Encoder::Qsv.ffmpeg_codec_name(), "h264_qsv");
+        assert_eq!(H264Encoder::Amf.ffmpeg_codec_name(), "h264_amf");
+    }
+
+    // -- #591 Phase 3 -- is_gpu_encoder_failure detector tests.
+
+    /// NVENC の代表的初期化エラー文字列を検出。
+    #[test]
+    fn is_gpu_encoder_failure_detects_nvenc_unavailable() {
+        let stderr = "[h264_nvenc @ 0x1234] No NVENC capable devices found\n";
+        assert!(is_gpu_encoder_failure(stderr, H264Encoder::Nvenc));
+    }
+
+    /// nvEncodeAPI DLL がロードできないケース。
+    #[test]
+    fn is_gpu_encoder_failure_detects_nvenc_dll_missing() {
+        let stderr = "[h264_nvenc @ 0x1] Cannot load nvEncodeAPI.dll\n";
+        assert!(is_gpu_encoder_failure(stderr, H264Encoder::Nvenc));
+    }
+
+    /// Intel QSV の MFX session 初期化失敗。
+    #[test]
+    fn is_gpu_encoder_failure_detects_qsv_init_error() {
+        let stderr = "[h264_qsv] Error initializing an internal MFX session: -3\n";
+        assert!(is_gpu_encoder_failure(stderr, H264Encoder::Qsv));
+    }
+
+    /// AMD AMF runtime ロード失敗。
+    #[test]
+    fn is_gpu_encoder_failure_detects_amf_load_error() {
+        let stderr = "[h264_amf] AMF runtime not initialized\n";
+        assert!(is_gpu_encoder_failure(stderr, H264Encoder::Amf));
+    }
+
+    /// libx264 失敗は GPU encoder 由来でないので false (encoder 切替で
+    /// 救えないため retry させない)。
+    #[test]
+    fn is_gpu_encoder_failure_returns_false_for_libx264() {
+        let stderr = "[libx264 @ 0x1] some error\n";
+        assert!(!is_gpu_encoder_failure(stderr, H264Encoder::Libx264));
+    }
+
+    /// 「ファイルが見つからない」のような GPU 関係ない失敗は false (誤って
+    /// libx264 retry すると 2 倍時間かかる)。
+    #[test]
+    fn is_gpu_encoder_failure_returns_false_for_unrelated_error() {
+        let stderr = "Error: No such file or directory\n";
+        assert!(!is_gpu_encoder_failure(stderr, H264Encoder::Nvenc));
+    }
+
+    /// AMF 検出パターンが NVENC stderr に一致しないこと (cross-encoder
+    /// false-positive 防止)。
+    #[test]
+    fn is_gpu_encoder_failure_qsv_pattern_does_not_match_nvenc() {
+        let stderr = "[h264_qsv] Error initializing an internal MFX session\n";
+        assert!(!is_gpu_encoder_failure(stderr, H264Encoder::Nvenc));
+        assert!(is_gpu_encoder_failure(stderr, H264Encoder::Qsv));
+    }
+
+    /// ExportProgress::fallback_from が serde で正しく往復する。
+    #[test]
+    fn export_progress_fallback_from_serde_roundtrip() {
+        let progress = ExportProgress {
+            match_index: 1,
+            percent: 0.0,
+            stage: "fallback".to_string(),
+            message: Some("NVENC failed".to_string()),
+            fallback_from: Some("h264_nvenc -> libx264".to_string()),
+        };
+        let json = serde_json::to_string(&progress).expect("serialize");
+        assert!(json.contains("\"fallback_from\":\"h264_nvenc -> libx264\""));
+        assert!(json.contains("\"stage\":\"fallback\""));
+    }
+
+    /// fallback_from が None のときは JSON にフィールドが出ない (skip_serializing_if)。
+    #[test]
+    fn export_progress_omits_fallback_from_when_none() {
+        let progress = ExportProgress {
+            match_index: 2,
+            percent: 50.0,
+            stage: "encoding".to_string(),
+            message: None,
+            fallback_from: None,
+        };
+        let json = serde_json::to_string(&progress).expect("serialize");
+        assert!(!json.contains("fallback_from"));
+        assert!(!json.contains("message"));
     }
 
     /// #466 -- a missing video path must fail validation before ffmpeg is

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -630,4 +630,211 @@ describe('ExportScreen (Phase 4 #466)', () => {
       expect(items[0]).toBeTruthy();
     });
   });
+
+  // -- #591 -- H.264 encoder auto-select / fallback notice tests.
+
+  it('uses libx264 sub label when metadata.system_info is missing', async () => {
+    // sample metadata has no system_info -> default LIBX264_INFO state.
+    render(<ExportScreen />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/H\.264 再エンコード/).parentElement?.textContent,
+      ).toContain('libx264 (CPU)');
+    });
+  });
+
+  it('invokes select_h264_encoder_for_export and updates sub label when system_info is present', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'select_h264_encoder_for_export') {
+        return {
+          encoder: 'h264_nvenc',
+          display_label: 'NVENC',
+          encoder_kind: 'Nvenc',
+        };
+      }
+      return undefined;
+    });
+    // Inject system_info into the sample metadata.
+    const current = useMetadataStore.getState().metadata!;
+    useMetadataStore.setState({
+      metadata: {
+        ...current,
+        system_info: {
+          gpu_vendors_available: ['nvidia'],
+          gpu_vendor_used: 'nvidia',
+          vendor_preference: ['nvidia', 'amd', 'intel'],
+        },
+      },
+    });
+    render(<ExportScreen />);
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'select_h264_encoder_for_export',
+        {
+          vendors: ['nvidia'],
+          preference: ['nvidia', 'amd', 'intel'],
+        },
+      );
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText(/H\.264 再エンコード/).parentElement?.textContent,
+      ).toContain('NVENC');
+    });
+  });
+
+  it('falls back to libx264 sub label when select_h264_encoder_for_export rejects', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'select_h264_encoder_for_export') {
+        throw new Error('boom');
+      }
+      return undefined;
+    });
+    const current = useMetadataStore.getState().metadata!;
+    useMetadataStore.setState({
+      metadata: {
+        ...current,
+        system_info: {
+          gpu_vendors_available: ['nvidia'],
+          gpu_vendor_used: 'nvidia',
+          vendor_preference: ['nvidia', 'amd', 'intel'],
+        },
+      },
+    });
+    render(<ExportScreen />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/H\.264 再エンコード/).parentElement?.textContent,
+      ).toContain('libx264 (CPU)');
+    });
+  });
+
+  it('passes h264_encoder argument to export_match when codec is h264', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'select_h264_encoder_for_export') {
+        return {
+          encoder: 'h264_nvenc',
+          display_label: 'NVENC',
+          encoder_kind: 'Nvenc',
+        };
+      }
+      if (cmd === 'export_match') {
+        return { match_index: 1, output_path: '/tmp/match_001.mp4', duration_ms: 0 };
+      }
+      return undefined;
+    });
+    const current = useMetadataStore.getState().metadata!;
+    useMetadataStore.setState({
+      metadata: {
+        ...current,
+        system_info: {
+          gpu_vendors_available: ['nvidia'],
+          gpu_vendor_used: 'nvidia',
+          vendor_preference: ['nvidia', 'amd', 'intel'],
+        },
+      },
+    });
+    useAppStateStore.getState().setSelectedVideoPath('E:/videos/clip.mkv');
+    render(<ExportScreen />);
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith(
+        'select_h264_encoder_for_export',
+        expect.anything(),
+      ),
+    );
+    const user = userEvent.setup();
+    // Switch codec to h264.
+    await user.click(screen.getByRole('button', { name: /H\.264 再エンコード/ }));
+    await user.click(
+      screen.getByRole('button', { name: /書き出し開始/ }),
+    );
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'export_match',
+        expect.objectContaining({
+          codec: 'h264',
+          h264Encoder: 'Nvenc',
+        }),
+      );
+    });
+  });
+
+  it('passes h264Encoder=null to export_match when codec is copy', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'select_h264_encoder_for_export') {
+        return {
+          encoder: 'h264_nvenc',
+          display_label: 'NVENC',
+          encoder_kind: 'Nvenc',
+        };
+      }
+      if (cmd === 'export_match') {
+        return { match_index: 1, output_path: '/tmp/match_001.mp4', duration_ms: 0 };
+      }
+      return undefined;
+    });
+    const current = useMetadataStore.getState().metadata!;
+    useMetadataStore.setState({
+      metadata: {
+        ...current,
+        system_info: {
+          gpu_vendors_available: ['nvidia'],
+          gpu_vendor_used: 'nvidia',
+          vendor_preference: ['nvidia', 'amd', 'intel'],
+        },
+      },
+    });
+    useAppStateStore.getState().setSelectedVideoPath('E:/videos/clip.mkv');
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    // Codec stays at default 'copy'.
+    await user.click(
+      screen.getByRole('button', { name: /書き出し開始/ }),
+    );
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'export_match',
+        expect.objectContaining({
+          codec: 'copy',
+          h264Encoder: null,
+        }),
+      );
+    });
+  });
+
+  it('shows fallback notice when stage=fallback event arrives', async () => {
+    let progressHandler: ((e: {
+      payload: {
+        match_index: number;
+        percent: number;
+        stage: string;
+        message?: string;
+        fallback_from?: string;
+      };
+    }) => void) | null = null;
+    listenMock.mockImplementation(
+      async (_name: string, handler: (e: unknown) => void) => {
+        progressHandler = handler as typeof progressHandler;
+        return () => undefined;
+      },
+    );
+    render(<ExportScreen />);
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+    act(() => {
+      progressHandler!({
+        payload: {
+          match_index: 1,
+          percent: 0,
+          stage: 'fallback',
+          message: 'NVENC の初期化に失敗したため libx264 で再試行します',
+          fallback_from: 'h264_nvenc -> libx264',
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('fallback-notice-1').textContent,
+      ).toContain('libx264');
+    });
+  });
 });

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -13,11 +13,6 @@ import styles from './ExportScreen.module.css';
 
 type Codec = 'copy' | 'h264';
 
-const CODECS: { v: Codec; l: string; sub: string }[] = [
-  { v: 'copy', l: '無損失 copy', sub: '高速 / 前 I フレーム吸着' },
-  { v: 'h264', l: 'H.264 再エンコード', sub: '遅い / 正確な秒指定' },
-];
-
 type MatchStatus = 'pending' | 'running' | 'done' | 'error' | 'skipped';
 
 interface MatchState {
@@ -25,14 +20,43 @@ interface MatchState {
   percent: number;
   error?: string;
   outputPath?: string;
+  /**
+   * #591 -- non-null when the GPU encoder failed and the export was
+   * retried with libx264. Surfaced inline so the user understands why
+   * the run is slower than expected for this match.
+   */
+  fallbackNotice?: string;
 }
 
 interface ExportProgressPayload {
   match_index: number;
   percent: number;
-  stage: 'encoding' | 'done' | 'error';
+  stage: 'encoding' | 'done' | 'error' | 'fallback';
   message?: string;
+  /** #591 -- e.g. `"h264_nvenc -> libx264"`. Present when stage === 'fallback'. */
+  fallback_from?: string;
 }
+
+/**
+ * #591 -- payload returned by `select_h264_encoder_for_export` Tauri
+ * command. `encoder_kind` is the wire form sent back to `export_match`
+ * via the `h264_encoder` argument.
+ */
+interface EncoderInfo {
+  encoder: string;
+  display_label: string;
+  encoder_kind: 'Libx264' | 'Nvenc' | 'Qsv' | 'Amf';
+}
+
+/**
+ * #591 -- libx264 fallback used when metadata.json has no system_info
+ * (pre-#591 metadata) or the probe came back empty (CPU-only env).
+ */
+const LIBX264_INFO: EncoderInfo = {
+  encoder: 'libx264',
+  display_label: 'libx264 (CPU)',
+  encoder_kind: 'Libx264',
+};
 
 interface ExportResult {
   match_index: number;
@@ -97,6 +121,11 @@ export function ExportScreen() {
   // にしておき、ユーザーに必須選択させる。
   const [outDir, setOutDir] = useState<string>(() => deriveDefaultOutDir(videoSource));
   const [codec, setCodec] = useState<Codec>('copy');
+  // #591 -- H.264 encoder is auto-selected from metadata.system_info on
+  // mount. Initial value defaults to libx264 so the sub label and
+  // export_match argument are always defined; useEffect overwrites with
+  // the real probe-derived encoder once metadata is loaded.
+  const [encoderInfo, setEncoderInfo] = useState<EncoderInfo>(LIBX264_INFO);
   const [namePattern, setNamePattern] = useState('match_{idx:03}.mp4');
   const [matchStates, setMatchStates] = useState<Record<number, MatchState>>({});
   // #466 review #1: per-match の選択 (default: 全選択 = 全試合書き出し)。
@@ -125,6 +154,40 @@ export function ExportScreen() {
     }, 1000);
     return () => clearInterval(iv);
   }, [exportStartMs, phase]);
+
+  // #591 -- resolve the H.264 encoder from metadata.system_info on
+  // every metadata change. Falls back to libx264 silently when the
+  // probe is empty / missing or when the Tauri command rejects (e.g.
+  // sample mode without a backing system_info). The effect intentionally
+  // calls setEncoderInfo synchronously in the no-system_info branch so
+  // that switching from a probe-equipped metadata back to a sample
+  // (legacy) one resets the sub label; per-frame cascading renders are
+  // not a concern here (encoderInfo updates are bounded and infrequent).
+  useEffect(() => {
+    const info = metadata?.system_info;
+    if (!info) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEncoderInfo(LIBX264_INFO);
+      return;
+    }
+    invoke<EncoderInfo>('select_h264_encoder_for_export', {
+      vendors: info.gpu_vendors_available,
+      preference: info.vendor_preference,
+    })
+      .then((resolved) => setEncoderInfo(resolved))
+      .catch(() => setEncoderInfo(LIBX264_INFO));
+  }, [metadata]);
+
+  // #591 -- CODECS list rebuilt from encoderInfo so the H.264 sub label
+  // reflects "(NVENC)" / "(QSV)" / "(AMF)" / "(libx264 (CPU))".
+  const codecs: { v: Codec; l: string; sub: string }[] = [
+    { v: 'copy', l: '無損失 copy', sub: '高速 / 前 I フレーム吸着' },
+    {
+      v: 'h264',
+      l: 'H.264 再エンコード',
+      sub: `遅い / 正確な秒指定 (${encoderInfo.display_label})`,
+    },
+  ];
 
   function toggleMatchExclusion(matchIndex: number) {
     setExcludedIndexes((prev) => {
@@ -163,6 +226,8 @@ export function ExportScreen() {
   }
 
   // #466 -- listen for per-match progress updates emitted by Rust.
+  // #591 -- also handle stage="fallback" events emitted when a GPU
+  // encoder fails to initialise and the export retries with libx264.
   useEffect(() => {
     let unlisten: UnlistenFn | null = null;
     (async () => {
@@ -177,6 +242,13 @@ export function ExportScreen() {
           if (p.stage === 'encoding') status = 'running';
           else if (p.stage === 'done') status = 'done';
           else if (p.stage === 'error') status = 'error';
+          // #591 -- "fallback" keeps the running status (the libx264
+          // attempt restarts encoding) but stamps the per-match notice
+          // so the UI can surface why this match is slower.
+          const fallbackNotice =
+            p.stage === 'fallback'
+              ? p.message ?? `${p.fallback_from ?? 'GPU encoder'} 失敗、libx264 で再試行`
+              : prior.fallbackNotice;
           return {
             ...prev,
             [p.match_index]: {
@@ -184,6 +256,7 @@ export function ExportScreen() {
               status,
               percent: p.percent,
               error: p.stage === 'error' ? p.message : prior.error,
+              fallbackNotice,
             },
           };
         });
@@ -258,6 +331,9 @@ export function ExportScreen() {
           endSeconds: m.edited?.end_time ?? m.end_time,
           outputPath,
           codec,
+          // #591 -- when codec === 'h264', Rust spawns ffmpeg with the
+          // resolved encoder. Copy codec ignores this value.
+          h264Encoder: codec === 'h264' ? encoderInfo.encoder_kind : null,
           matchIndex: m.index,
         });
         successCount += 1;
@@ -437,7 +513,7 @@ export function ExportScreen() {
           <div>
             <div className={styles.fieldLabel}>コーデック</div>
             <div className={styles.codecRow}>
-              {CODECS.map((c) => (
+              {codecs.map((c) => (
                 <button
                   key={c.v}
                   type="button"
@@ -683,6 +759,16 @@ export function ExportScreen() {
                   {s.status === 'error' && s.error && (
                     <span className={styles.listError} role="alert">
                       {s.error.slice(0, 120)}
+                    </span>
+                  )}
+                  {s.fallbackNotice && (
+                    <span
+                      className={styles.listError}
+                      role="status"
+                      data-testid={`fallback-notice-${m.index}`}
+                      style={{ color: 'var(--ae-accent)' }}
+                    >
+                      {s.fallbackNotice}
                     </span>
                   )}
                 </li>

--- a/gui/src/types/metadata.schema.ts
+++ b/gui/src/types/metadata.schema.ts
@@ -65,6 +65,18 @@ export const WarningSchema = z.object({
 });
 
 /**
+ * #591 -- GPU vendor probe snapshot. Optional field on metadata.json
+ * (pre-#591 files don't carry it). Frontend uses
+ * `gpu_vendors_available` + `vendor_preference` to pick the H.264
+ * encoder via `select_h264_encoder_for_export`.
+ */
+export const SystemInfoSchema = z.object({
+  gpu_vendors_available: z.array(z.string()),
+  gpu_vendor_used: z.string().nullable(),
+  vendor_preference: z.array(z.string()),
+});
+
+/**
  * #465 review: default frame rate when ``source_fps`` is missing. Pre-#465
  * legacy metadata.json files don't include the field, so we keep a
  * conservative 60fps assumption (the most common OBS recording cadence).
@@ -90,5 +102,11 @@ export const MetadataSchema = z
     matches: z.array(MatchSchema),
     gaps: z.array(GapSchema),
     warnings: z.array(WarningSchema).optional(),
+    /**
+     * #591 -- GPU vendor probe snapshot. Optional because pre-#591
+     * metadata.json doesn't include it. ExportScreen falls back to
+     * libx264 when missing.
+     */
+    system_info: SystemInfoSchema.optional(),
   })
   .passthrough();

--- a/gui/src/types/metadata.ts
+++ b/gui/src/types/metadata.ts
@@ -50,6 +50,27 @@ export interface MetadataWarning {
   context?: Record<string, unknown>;
 }
 
+/**
+ * #591 -- GPU vendor probe snapshot recorded by detect/split.
+ *
+ * - `gpu_vendors_available`: vendors detected via `probe_gpu_vendors()`
+ *   (subset of `{"nvidia","amd","intel"}`).
+ * - `gpu_vendor_used`: vendor actually consumed by GPU decode in this
+ *   detect run. `null` when CPU was forced (`--no-gpu`), the cache hit
+ *   skipped detection, or the run came from `split --from-metadata`.
+ * - `vendor_preference`: snapshot of `gpu_detector._VENDOR_PREFERENCE`
+ *   used to resolve auto-selection (currently
+ *   `["nvidia","amd","intel"]`).
+ *
+ * GUI export uses these to pick H.264 encoder via
+ * `select_h264_encoder_for_export` Tauri command.
+ */
+export interface SystemInfo {
+  gpu_vendors_available: string[];
+  gpu_vendor_used: string | null;
+  vendor_preference: string[];
+}
+
 export interface Metadata {
   /**
    * #515: schema revision declaration. Optional on the TS type because
@@ -73,4 +94,10 @@ export interface Metadata {
   gaps: Gap[];
   /** #518 -- optional on the TS type because legacy files don't emit it. */
   warnings?: MetadataWarning[];
+  /**
+   * #591 -- GPU vendor probe snapshot. Optional because pre-#591
+   * metadata.json files don't carry the field; ExportScreen falls back
+   * to libx264 when missing.
+   */
+  system_info?: SystemInfo;
 }

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -104,3 +104,59 @@ def test_detect_uses_cache_when_present(tmp_path):
 
     mock_detect.assert_not_called()
     assert (tmp_path / "metadata.json").exists()
+
+
+def test_detect_writes_system_info_to_metadata(tmp_path, monkeypatch):
+    """#591 -- detect で書き出した metadata.json に system_info が含まれる."""
+    monkeypatch.setattr(
+        "allaganeye.system_info.probe_gpu_vendors",
+        lambda: ["nvidia", "amd"],
+    )
+    probe, detect = _mock_detect_only(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with probe, detect:
+        run_detect(Path("input.mp4"), config, quiet=True)
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    assert "system_info" in payload
+    info = payload["system_info"]
+    assert info["gpu_vendors_available"] == ["nvidia", "amd"]
+    # detect は h264 codec -> use_gpu=True で auto 選択 -> vendor=nvidia
+    assert info["gpu_vendor_used"] == "nvidia"
+    assert info["vendor_preference"] == ["nvidia", "amd", "intel"]
+
+
+def test_detect_records_vendor_used_null_when_cpu_forced(tmp_path, monkeypatch):
+    """#591 -- --no-gpu (use_gpu=False) では vendor_used=None だが available は埋まる."""
+    monkeypatch.setattr(
+        "allaganeye.system_info.probe_gpu_vendors",
+        lambda: ["nvidia"],
+    )
+    probe, detect = _mock_detect_only(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, use_gpu=False)
+    with probe, detect:
+        run_detect(Path("input.mp4"), config, quiet=True)
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    info = payload["system_info"]
+    assert info["gpu_vendor_used"] is None
+    assert info["gpu_vendors_available"] == ["nvidia"]
+
+
+def test_detect_cache_hit_records_vendor_used_null(tmp_path, monkeypatch):
+    """#591 -- cache hit でも system_info を書く (vendor_used=None, probe は実行)."""
+    monkeypatch.setattr(
+        "allaganeye.system_info.probe_gpu_vendors",
+        lambda: ["intel"],
+    )
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with (
+        patch(f"{MODULE_DETECT}.probe_video", return_value=PROBE_RESULT),
+        patch(f"{MODULE_DETECT}._load_cache", return_value=BOUNDARIES),
+    ):
+        run_detect(Path("input.mp4"), config, quiet=True)
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    info = payload["system_info"]
+    assert info["gpu_vendor_used"] is None  # cache hit で detect していない
+    assert info["gpu_vendors_available"] == ["intel"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -202,6 +202,11 @@ def pipeline_result(
             config,
             effective_interval=config.sample_interval,
             detected_at="1970-01-01T00:00:00Z",
+            system_info={
+                "gpu_vendors_available": [],
+                "gpu_vendor_used": None,
+                "vendor_preference": ["nvidia", "amd", "intel"],
+            },
         )
     else:
         name = source_mkv.parent.name

--- a/tests/test_split_from_metadata.py
+++ b/tests/test_split_from_metadata.py
@@ -195,6 +195,11 @@ def test_split_and_write_metadata_has_no_note_field(tmp_path):
             config,
             effective_interval=1.0,
             detected_at="2026-04-22T00:00:00Z",
+            system_info={
+                "gpu_vendors_available": [],
+                "gpu_vendor_used": None,
+                "vendor_preference": ["nvidia", "amd", "intel"],
+            },
             quiet=True,
         )
 
@@ -223,6 +228,11 @@ def test_split_and_write_metadata_contains_schema_version(tmp_path):
             config,
             effective_interval=1.0,
             detected_at="2026-04-22T00:00:00Z",
+            system_info={
+                "gpu_vendors_available": [],
+                "gpu_vendor_used": None,
+                "vendor_preference": ["nvidia", "amd", "intel"],
+            },
             quiet=True,
         )
 
@@ -255,6 +265,11 @@ def test_split_and_write_metadata_emits_empty_warnings_array(tmp_path):
             config,
             effective_interval=1.0,
             detected_at="2026-04-22T00:00:00Z",
+            system_info={
+                "gpu_vendors_available": [],
+                "gpu_vendor_used": None,
+                "vendor_preference": ["nvidia", "amd", "intel"],
+            },
             quiet=True,
         )
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -2051,6 +2051,139 @@ class TestResolveGpuMode:
         assert none_vendor == auto_vendor == "nvidia"
 
 
+class TestResolveGpuModeWithProbe:
+    """``_resolve_gpu_mode_with_probe`` returns the available vendor list (#591)."""
+
+    def test_returns_available_vendors(self, monkeypatch):
+        """probe で見つかった全 vendor が 3-tuple の 3 要素目に返る."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["nvidia", "amd"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode_with_probe
+
+        use_gpu, vendor, available = _resolve_gpu_mode_with_probe(
+            None, None, "av1", show=False, verbose=False
+        )
+        assert use_gpu is True
+        assert vendor == "nvidia"
+        assert available == ["nvidia", "amd"]
+
+    def test_returns_empty_when_probe_fails(self, monkeypatch):
+        """probe が空 list を返したら 3 要素目も空 list."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: [],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode_with_probe
+
+        use_gpu, vendor, available = _resolve_gpu_mode_with_probe(
+            None, None, "av1", show=False, verbose=False
+        )
+        # codec match なので use_gpu=True、ただし vendor は None
+        assert use_gpu is True
+        assert vendor is None
+        assert available == []
+
+    def test_legacy_2tuple_wrapper_still_works(self, monkeypatch):
+        """``_resolve_gpu_mode`` (2-tuple) はラッパとして機能する."""
+        monkeypatch.setattr(
+            "allaganeye.system_info.probe_gpu_vendors",
+            lambda: ["intel"],
+        )
+        from allaganeye.commands.split_matches import _resolve_gpu_mode
+
+        result = _resolve_gpu_mode(None, None, "h264", show=False, verbose=False)
+        assert len(result) == 2  # backward-compat 2-tuple
+        use_gpu, vendor = result
+        assert use_gpu is True
+        assert vendor == "intel"
+
+
+class TestBuildSystemInfo:
+    """``_build_system_info`` constructs the metadata.json system_info dict (#591)."""
+
+    def test_basic_payload(self):
+        from allaganeye.commands.split_matches import _build_system_info
+
+        info = _build_system_info(
+            available_vendors=["nvidia", "amd"],
+            vendor_used="nvidia",
+        )
+        assert info["gpu_vendors_available"] == ["nvidia", "amd"]
+        assert info["gpu_vendor_used"] == "nvidia"
+        assert info["vendor_preference"] == ["nvidia", "amd", "intel"]
+
+    def test_no_gpu_used_is_null(self):
+        """CPU 強制 / cache hit / split-only path では vendor_used=None."""
+        from allaganeye.commands.split_matches import _build_system_info
+
+        info = _build_system_info(
+            available_vendors=["nvidia"],
+            vendor_used=None,
+        )
+        assert info["gpu_vendor_used"] is None
+        assert info["gpu_vendors_available"] == ["nvidia"]
+
+    def test_empty_available_vendors(self):
+        """probe 失敗環境 (CPU only Linux CI など) でも payload を作れる."""
+        from allaganeye.commands.split_matches import _build_system_info
+
+        info = _build_system_info(
+            available_vendors=[],
+            vendor_used=None,
+        )
+        assert info["gpu_vendors_available"] == []
+        assert info["gpu_vendor_used"] is None
+        assert info["vendor_preference"] == ["nvidia", "amd", "intel"]
+
+    def test_preference_matches_gpu_detector_module(self):
+        """``vendor_preference`` は ``gpu_detector._VENDOR_PREFERENCE`` のスナップショット."""
+        from allaganeye.commands.split_matches import _build_system_info
+        from allaganeye.video.gpu_detector import _VENDOR_PREFERENCE
+
+        info = _build_system_info(available_vendors=[], vendor_used=None)
+        assert info["vendor_preference"] == list(_VENDOR_PREFERENCE)
+
+
+class TestBuildMetadataPayloadSystemInfo:
+    """``_build_metadata_payload`` includes the system_info field (#591)."""
+
+    def test_payload_includes_system_info(self, tmp_path):
+        from allaganeye.commands.split_matches import _build_metadata_payload
+        from allaganeye.config import SplitConfig
+        from allaganeye.video.detector import MatchBoundary
+
+        config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+        boundaries: list[MatchBoundary] = [
+            {"start": 0.0, "end": 120.0, "type": "fl_match"},
+        ]
+        payload = _build_metadata_payload(
+            video_path=tmp_path / "input.mp4",
+            source_duration=120.0,
+            source_fps=60.0,
+            detected_at="2026-04-26T00:00:00Z",
+            effective_interval=1.0,
+            config=config,
+            boundaries=boundaries,
+            output_files=[tmp_path / "match_001.mp4"],
+            gaps=[],
+            system_info={
+                "gpu_vendors_available": ["nvidia"],
+                "gpu_vendor_used": "nvidia",
+                "vendor_preference": ["nvidia", "amd", "intel"],
+            },
+        )
+        assert "system_info" in payload
+        assert payload["system_info"]["gpu_vendors_available"] == ["nvidia"]
+        assert payload["system_info"]["gpu_vendor_used"] == "nvidia"
+        assert payload["system_info"]["vendor_preference"] == [
+            "nvidia",
+            "amd",
+            "intel",
+        ]
+
+
 class TestAudioScanIntegration:
     """Audio scan pipeline wiring in run_split and _run_audio_scan (#288)."""
 


### PR DESCRIPTION
## Summary

- GUI export 画面の H.264 再エンコードに GPU encoder (NVENC / QSV / AMF) auto-select を追加 (Refs #591)
- detect/split が `metadata.json` `system_info` フィールドに probe 結果を記録 → ExportScreen が読んで `select_h264_encoder_for_export` Tauri command で encoder を解決
- GPU encoder 起動失敗時は libx264 で 1 回 fallback retry し、`stage="fallback"` イベントを emit (frontend が per-match notice 表示)

## 設計決定

- **vendor 検知の経路**: CLI subprocess を呼ばず、metadata.json `system_info.gpu_vendors_available` を再利用 (起動オーバーヘッド ~150ms ゼロ、二重実装回避)
- **--no-gpu でも probe を実行**: GUI export で常に vendor 情報を使えるよう、CPU 強制パスでも `gpu_vendors_available` は埋める (`gpu_vendor_used` は null)
- **品質パラメータ** (CRF 18 相当): NVENC `-cq 19 -preset p5` / QSV `-global_quality 20 -look_ahead 1` / AMF `-rc cqp -qp_i 19 -qp_p 21`
- **schema_version は "1" 維持** (system_info は optional field 追加なので後方互換)
- **`_resolve_gpu_mode_with_probe` 新設 + 既存 2-tuple wrapper 残置**: 既存 30+ テストへの破壊回避 (scope-guard)

## Phase 別変更

- **Phase 1** (Python): `_resolve_gpu_mode_with_probe` / `_build_system_info` / `_build_metadata_payload` に system_info 追加。run_split (cache hit/miss) / run_split_from_metadata / run_detect の 3 経路すべて対応
- **Phase 2** (Rust): `H264Encoder` enum + `select_h264_encoder` 純関数 + `ffmpeg_args_for_export` シグネチャ拡張
- **Phase 3** (Rust): `is_gpu_encoder_failure` で stderr 検出 → libx264 retry。`ExportProgress::fallback_from` 追加
- **Phase 4** (Frontend): `metadata.system_info` → `select_h264_encoder_for_export` invoke → sub label 動的化 + `export_match` の h264Encoder 引数 + per-match fallback notice
- **Phase 5** (Docs): CLAUDE.md / docs/metadata-spec.md / docs/system-architecture.md
- **post-review fix** (commit [705281a](https://github.com/Idios/kobutachan-allaganeye/commit/705281a)): 実機検証中に発見した ffmpeg 8.1 QSV failure stderr pattern (`Error creating a MFX session`) を `is_gpu_encoder_failure` の Qsv arm に追加 + unit test 2 件

## スコープ外 (別 issue)

- HEVC / VP9 / AV1 encoder 追加
- 明示 encoder 選択 UI (dropdown)
- Tauri sidecar bundle 戦略
- **GUI 経由の NVENC sub label 視認 / QSV → libx264 retry 視認** → real metadata.json load 経路 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) Phase 2.5) 完了後に再検証 (Idios 判断、本 PR Round 1 review 後)

## Test plan

- [x] `pytest`: 814 passed (+15 #591 新規)
- [x] `cargo test --lib`: 94 passed (+23 #591 新規 / +2 post-review QSV pattern 追加)
- [x] `npm test`: 335 passed (+5 #591 新規)
- [x] `ruff check . && ruff format --check .`: clean
- [x] `pyright`: 0 errors
- [x] `npm run lint && npm run typecheck`: clean
- [x] `cargo check`: clean
- [x] **実機検証 (Idios の NVIDIA RTX 5090 + AMD iGPU + ffmpeg 8.1 BtbN LGPL)**:
  - [x] `allaganeye detect <video>` 後 metadata.json に `system_info.gpu_vendors_available: ["nvidia","amd"]`, `gpu_vendor_used: "nvidia"`, `vendor_preference: ["nvidia","amd","intel"]` が含まれる ✅ CLI 実機検証 (8GB MKV / [comment](https://github.com/Idios/kobutachan-allaganeye/pull/596#issuecomment-4323066594))
  - [x] `allaganeye split --no-gpu <video>` 後 `gpu_vendor_used: null` だが available は埋まる ✅ CLI 実機検証
  - [x] GUI で metadata load → Export 画面 sub label が "H.264 再エンコード (NVENC)" になる ⏸ **[#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) Phase 2.5 持ち越し** (現状 detecting は dummy で `loadSample()` のみ、external metadata.json load 経路は #569 で実装) — vitest「invokes select_h264_encoder_for_export and updates sub label when system_info is present」+ cargo `select_h264_encoder_picks_nvenc_for_nvidia_first` で論理は確認済
  - [x] 9 試合書き出しで `h264_nvenc` が選択され、CPU エンコードより wall clock 短縮 ✅ ffmpeg 直接 invoke benchmark: libx264 84min → NVENC 71min (1.18x faster, 13 分削減)
  - [x] 古い metadata (system_info 無し) を読む → sub label "libx264 (CPU)" ✅ GUI 実機確認 (sampleMetadata に system_info 無し → "(libx264 (CPU))" 表示確認)
  - [x] system_info を手動編集して `gpu_vendors_available: ["intel"]` (NVIDIA 環境で QSV 強制) → QSV 失敗 → libx264 retry、fallback notice 表示 ⏸ **[#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) Phase 2.5 持ち越し** (GUI 視認は real load 経路必須) — 検証中に ffmpeg 8.1 QSV stderr pattern 不一致 bug を発見し commit [705281a](https://github.com/Idios/kobutachan-allaganeye/commit/705281a) で fix。実 ffmpeg stderr で再現確認済

🤖 Generated with [Claude Code](https://claude.com/claude-code)
