### PR TITLE
[doc] UI interaction spec §3 拡充 + 既存 doc / CLAUDE.md からのリンク (Refs #590)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | `audio/refs/` | 同梱参照特徴量（`fanfare.npz`） |
 | `commands/detect.py` | detect コマンド。検知のみ実行し metadata.json を出力 (#463) |
 | `detection/` | 検知パイプラインの共有ヘルパ (#463)。`format.py` (フォーマッタ) / `metadata_writer.py` (atomic read/write) |
-| `gui/` | L2a Tauri GUI (React 19 + TS + Vite + Zustand + zod)。`#483` で bootstrap、`#463` で data 層、`#464` で画面骨格 + CSS Modules、`#516` で `[元に戻す]` 機能、`#514` で排他管理 (mtime 検知 + ConflictModal)。詳細は [docs/gui-development.md](docs/gui-development.md) / [docs/design/README.md](docs/design/README.md) / [docs/ui-architecture.md](docs/ui-architecture.md) |
+| `gui/` | L2a Tauri GUI (React 19 + TS + Vite + Zustand + zod)。`#483` で bootstrap、`#463` で data 層、`#464` で画面骨格 + CSS Modules、`#516` で `[元に戻す]` 機能、`#514` で排他管理 (mtime 検知 + ConflictModal)。詳細は [docs/gui-development.md](docs/gui-development.md) / [docs/design/README.md](docs/design/README.md) / [docs/ui-architecture.md](docs/ui-architecture.md) / [docs/ui-interaction-spec.md](docs/ui-interaction-spec.md) (#590, UI 部品ごとの操作 → 状態遷移 / store mutation / 例外処理) |
 | `gui/src/screens/` | 5 画面 (drop / detecting / complete / preview / export) + phase reducer。#464 で追加 |
 | `gui/src/components/` | 共通 UI コンポーネント (AllaganCorner / AllaganSigil / WindowChrome / BrightnessTimeline / RestoreButton / ConflictModal 等)。#464 で追加 |
 | `gui/src/state/` | Zustand store (`appStateStore` = screen + selection / `metadataStore` = load/apply/restore/loadSample) |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -147,7 +147,7 @@ Electron / Tauri の両方で最小プロトタイプを構築し F1-F5 を計�
 
 ## 画面ごとの仕様
 
-各画面の詳細は handoff HTML の該当 jsx を参照。主要ポイント:
+各画面の **UI 部品ごとの操作 → 状態遷移 / store mutation / 例外処理** は [`../ui-interaction-spec.md`](../ui-interaction-spec.md) を参照。本節は機能仕様の概要のみで、詳細は handoff HTML の該当 jsx を参照。主要ポイント:
 
 ### 1. drop
 

--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -1,6 +1,6 @@
 # Allagan Eye GUI — UI Architecture (Phase 2)
 
-> **スコープ**: 本 doc は **L2a GUI (Tauri 2 + React 19) の UI 基盤のみ**を扱う。CLI (`allaganeye` サブコマンド) は [cli-spec.md](cli-spec.md)、CLI と GUI の全体構成・起動経路は [system-architecture.md](system-architecture.md) を参照。
+> **スコープ**: 本 doc は **L2a GUI (Tauri 2 + React 19) の UI 基盤のみ**を扱う。CLI (`allaganeye` サブコマンド) は [cli-spec.md](cli-spec.md)、CLI と GUI の全体構成・起動経路は [system-architecture.md](system-architecture.md)、各画面の **UI 部品ごとの操作 → 状態遷移 / store mutation / 例外処理** は [ui-interaction-spec.md](ui-interaction-spec.md) を参照。
 
 本 doc は L2a GUI Phase 2 (#464) で確立した UI 基盤を記録する。Phase 3/4 の実装が参照する source of truth。
 

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -833,13 +833,15 @@ global toast 未採用 (画面が log 中心で各情報源と表示位置が固
 | store mutation | なし |
 | 例外 / edge case | 通常フロー (complete から [全試合書き出し] / preview から [書き出し →]) では到達しない。dev StateSwitcher 経由のみ表示。文言 / 戻り導線 ([参照…] / drop へ) は [#587](https://github.com/Idios/kobutachan-allaganeye/issues/587) a11y/polish で議論 |
 
-## 3. 既存 doc との分担
+## 3. 既存 doc との分担 + クロスリファレンス
+
+### 3.1 doc 分担
 
 | doc | スコープ |
 |---|---|
 | [ui-architecture.md](ui-architecture.md) | screen / phase 2 層 state machine、screen 間遷移、コンポーネント階層、CSS Modules 慣例、性能目標 |
 | [design/README.md](design/README.md) | デザインシステム (色 / タイポ)、画面レイアウト原本 (handoff bundle)、各画面の機能仕様 |
-| [metadata-spec.md](metadata-spec.md) | metadata.json スキーマ・読み書き契約 (CLI / GUI 共通)・排他管理 (#514) ・draft auto-save (#517) |
+| [metadata-spec.md](metadata-spec.md) | metadata.json スキーマ・読み書き契約 (CLI / GUI 共通)・排他管理 ([#514](https://github.com/Idios/kobutachan-allaganeye/issues/514)) ・draft auto-save ([#517](https://github.com/Idios/kobutachan-allaganeye/issues/517)) |
 | **本 doc** | **各画面 UI 部品ごとの操作 → store mutation → 例外処理の状態機械 + 共通原則** |
 
 責務の境界:
@@ -847,6 +849,33 @@ global toast 未採用 (画面が log 中心で各情報源と表示位置が固
 - **画面間遷移は ui-architecture.md** が source of truth。本 doc は画面間遷移を再記述しない (「→ navigate('complete')」程度の参照のみ)
 - **ピクセル / 色 / タイポは design/README.md** が source of truth。本 doc は disabled の見た目等を「`var(--ae-text-dim)` 系」のような token 参照で記述
 - **metadata.json の field 仕様は metadata-spec.md** が source of truth。本 doc は store mutation の対象 field を field 名のみで参照
+
+### 3.2 状態名と mermaid 対応表
+
+5 画面の便宜状態名 (§2 各画面ヘッダで定義) と [ui-architecture.md](ui-architecture.md) §各画面 mermaid の状態を対応付ける。差異は意図的な分担 (§3.3 で集約) であり矛盾ではない。
+
+| 画面 | reducer | 本 doc 状態 (§2.x ヘッダ) | mermaid 状態 ([ui-architecture.md](ui-architecture.md)) | 差異 |
+|---|---|---|---|---|
+| drop (§2.1) | あり ([reducers/drop.ts](../gui/src/screens/reducers/drop.ts)) | `idle / selecting / probing / selected / probeError` | `drop_idle / drop_selecting / drop_probing / drop_selected / drop_probeError` | なし (本 doc は接頭辞 `drop_` 省略のみ) |
+| detecting (§2.2) | あり ([reducers/detecting.ts](../gui/src/screens/reducers/detecting.ts)) | `running / cancelling / cancelled / completed / error` | `detecting_running / detecting_cancelling / detecting_cancelled / detecting_completed / detecting_error` | なし (本 doc は接頭辞 `detecting_` 省略のみ) |
+| complete (§2.3) | なし | `complete_empty / complete_idle / complete_restoring` | `complete_idle / complete_restoring / complete_restoreError` | `complete_empty` は本 doc のみ (entry-time 特殊状態、§2.3.11 emptyNote と対応) / `complete_restoreError` は mermaid のみ (RestoreButton 共通 component 内 inline alert、§2.3.4 で扱う) |
+| preview (§2.4) | なし | `preview_empty / preview_idle / preview_applying / preview_applyError / preview_restoring` | `preview_idle / preview_applying / preview_applyError / preview_restoring / preview_restoreError` | `preview_empty` は本 doc のみ (§2.4.15 emptyNote) / `preview_restoreError` は mermaid のみ (§2.4.13 RestoreButton 共通 component) |
+| export (§2.5) | あり ([reducers/export.ts](../gui/src/screens/reducers/export.ts)) | `idle / running / cancelling / completed / error` | `export_idle / export_running / export_cancelling / export_completed / export_error` | 本 doc は接頭辞 `export_` 省略 (実装の `phase: ExportPhase` 直値に揃える)。mermaid `export_cancelling → export_idle: ffmpeg 停止` と内部 reducer `cancelling → idle (CANCEL_CONFIRMED)` は同形状簡略化 |
+
+### 3.3 「entry-time 特殊状態」「sub-component エラー」の扱い
+
+complete / preview の 2 画面で本 doc は 2 種の状態を **mermaid と非対称** に扱う:
+
+1. **`*_empty` (entry-time 特殊状態)**: `metadata === null` (complete §2.3.11) や `match` 解決失敗 (preview §2.4.15) を「画面 entry 時に発生しうる特殊 idle」として独立状態化。mermaid では entry エッジを暗黙化 (drop → detecting → complete の通常フローで到達しないため)。本 doc は §2.x.N emptyNote と対応付けて明示する
+2. **`*_restoreError` (sub-component エラー)**: RestoreButton ([components/RestoreButton.tsx](../gui/src/components/RestoreButton.tsx)) は `restoreError` を inline `role="alert"` で表示する共通 component。mermaid は画面レベル状態として記述するが、本 doc は §2.3.4 / §2.4.13 で RestoreButton 自身の状態 (`idle` / `busy` / `disabled`) として扱い、画面ヘッダの便宜状態列挙からは除外する
+
+両方とも意図的な分担で、**画面間遷移の正準は引き続き ui-architecture.md mermaid**。本 doc の §2.x ヘッダは「画面実装が明示的に持つ状態 + 表示が条件分岐する状態」を列挙する設計で揃えている。
+
+### 3.4 §1 共通原則の例外規定
+
+§2 画面別の記述から派生し、§1 共通原則の例外として明文化したもの:
+
+- **§1.1 例外 (export 画面の session-local config)**: `outDir` / `namePattern` / `codec` / `excludedIndexes` は match 編集ではない一時的な書き出し設定であり `metadataStore` に commit しない (§2.5 ヘッダで宣言)。同様の「画面マウント中のみ有効な session-local config」は今後追加する場合も local state で保持する。`updateMatch` 経由の §1.1 規律は **match 編集 (start/end/name/type) 限定** と読む
 
 ## 関連
 


### PR DESCRIPTION
## 概要

[#590](https://github.com/Idios/kobutachan-allaganeye/issues/590) 着手フロー Step 3 の「§3 相互リンク + 既存 doc クロスリファレンス」を実装する。§2.4 / §2.5 マージ時に約束した「全画面分の状態名と mermaid の対応関係を一括整理」を §3.2 / §3.3 として追加し、§1.1 の export 例外規定を §3.4 として明文化。加えて 3 doc に本 doc へのリンクを追加。

**本 PR マージで残る受け入れ条件は「既存 issue sync」のみ**。

## §3 拡充内容

### §3.1 doc 分担 (旧 §3 を維持、節番号付与)

ui-architecture.md / design/README.md / metadata-spec.md / 本 doc の責務境界。

### §3.2 NEW: 状態名と mermaid 対応表

5 画面の便宜状態名 (§2 各画面ヘッダで定義) と ui-architecture.md §各画面 mermaid の状態を対応付ける。差異は意図的な分担 (§3.3 で集約) であり矛盾ではない。

| 画面 | reducer | 本 doc 状態 | mermaid 状態 | 差異 |
|---|---|---|---|---|
| drop | あり | `idle / selecting / probing / selected / probeError` | `drop_*` 5 状態 | 接頭辞のみ |
| detecting | あり | `running / cancelling / cancelled / completed / error` | `detecting_*` 5 状態 | 接頭辞のみ |
| complete | なし | `complete_empty / complete_idle / complete_restoring` | `complete_idle / complete_restoring / complete_restoreError` | `complete_empty` は本 doc のみ / `complete_restoreError` は mermaid のみ |
| preview | なし | `preview_empty / preview_idle / preview_applying / preview_applyError / preview_restoring` | mermaid 5 状態 (`*_restoreError` 含む) | `preview_empty` 本 doc のみ / `preview_restoreError` mermaid のみ |
| export | あり | `idle / running / cancelling / completed / error` | `export_*` 5 状態 | 内部 reducer は接頭辞 `export_` 省略、`export_cancelling → export_idle` と `cancelling → idle (CANCEL_CONFIRMED)` は同形状簡略化 |

### §3.3 NEW: 「entry-time 特殊状態」「sub-component エラー」の扱い

complete / preview の 2 画面で本 doc が **mermaid と非対称** に扱う 2 種を集約:

1. **`*_empty` (entry-time 特殊状態)**: `metadata === null` (complete §2.3.11) や `match` 解決失敗 (preview §2.4.15) を独立状態化。mermaid では entry エッジを暗黙化
2. **`*_restoreError` (sub-component エラー)**: RestoreButton 共通 component の `restoreError` inline alert は §2.3.4 / §2.4.13 の RestoreButton 自身の状態として扱い、画面ヘッダの便宜状態列挙からは除外

両方とも意図的な分担で、画面間遷移の正準は引き続き ui-architecture.md mermaid。

### §3.4 NEW: §1 共通原則の例外規定

§2 から派生し §1 例外として明文化:

- **§1.1 例外 (export 画面の session-local config)**: `outDir` / `namePattern` / `codec` / `excludedIndexes` は match 編集ではない一時的な書き出し設定であり `metadataStore` に commit しない (§2.5 ヘッダで宣言)。`updateMatch` 経由の §1.1 規律は **match 編集 (start/end/name/type) 限定** と読む

## 既存 doc / CLAUDE.md へのリンク追加 (#590 受け入れ条件)

| ファイル | 追加位置 | 内容 |
|---|---|---|
| `docs/ui-architecture.md` | 冒頭スコープ宣言 | cli-spec.md / system-architecture.md と並べて ui-interaction-spec.md を参照 |
| `docs/design/README.md` | 「画面ごとの仕様」見出し直下 | 「UI 部品ごとの操作 → 状態遷移 / store mutation / 例外処理は ui-interaction-spec.md を参照」 |
| `CLAUDE.md` | `gui/` モジュール行 | 関連 doc リスト (`gui-development.md` / `design/README.md` / `ui-architecture.md`) に `ui-interaction-spec.md` を追加 (#590 注記付き) |

## 受け入れ条件 (本 PR スコープ)

- [x] `docs/ui-interaction-spec.md` の **§3 を網羅** (§3.1 doc 分担 + §3.2 状態名 mermaid 対応表 + §3.3 entry-time 特殊状態 / sub-component エラー方針 + §3.4 §1 例外規定)
- [x] 既存 doc (`ui-architecture.md` / `design/README.md`) から本 doc へのリンク追加
- [x] CLAUDE.md に doc リンク追加
- [x] markdownlint pass (markdownlint-cli2 v0.18 / CI 同等版で 4 ファイル全て 0 errors)

**本 PR マージで残る受け入れ条件は「既存 issue sync (#569 / #466 / #589 / #586 / #587 / #588)」のみ**。後続最終 PR で対応。

## レビュー観点

- §3.2 対応表の差異列が §2.4 / §2.5 ヘッダの「mermaid 対応」段落と整合しているか
- §3.3 集約セクションが complete / preview の非対称扱いを後続レビュアにとって理解可能な深さで記述しているか
- §3.4 §1.1 例外規定が「match 編集限定」という解釈で §2.4 (PreviewScreen の §1.1 違反 #589) と矛盾しないか
- 既存 doc 3 つへのリンク挿入位置 (cli-spec.md / system-architecture.md と並列の参照リスト形式 / 「画面ごとの仕様」見出し直下 / `gui/` モジュール行末) が本来の doc 構造を壊していないか

## Test plan

- [x] `markdownlint-cli2 docs/ui-interaction-spec.md docs/ui-architecture.md docs/design/README.md CLAUDE.md` で 0 errors (CI 同等版で確認)
- [x] §3 内のリンク (§2.x.N emptyNote / RestoreButton.tsx / reducers/*.ts) の形式確認

レビュー (Idios) はマージ前のゲートとして PR ステータスで管理する。

## 関連

- 起票元: [#590](https://github.com/Idios/kobutachan-allaganeye/issues/590)
- 前段: [#593](https://github.com/Idios/kobutachan-allaganeye/pull/593) (§1) → [#598](https://github.com/Idios/kobutachan-allaganeye/pull/598) (§2.1 drop) → [#600](https://github.com/Idios/kobutachan-allaganeye/pull/600) (§2.2 detecting) → [#603](https://github.com/Idios/kobutachan-allaganeye/pull/603) (§2.3 complete) → [#605](https://github.com/Idios/kobutachan-allaganeye/pull/605) (§2.4 preview) → [#608](https://github.com/Idios/kobutachan-allaganeye/pull/608) (§2.5 export)
- 後続 (最終 PR): 既存 issue sync (#569 / #466 / #589 / #586 / #587 / #588)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
