### PR TITLE
feat(installer): allaganeye-gui.exe を Portable ZIP に同梱 (Refs #570)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,9 @@ jobs:
       # Node + Rust toolchain for Tauri GUI build (#570). bundle.active = false
       # in tauri.conf.json so `npm run tauri build` only compiles the .exe and
       # skips NSIS/MSI installer generation; the resulting allaganeye-gui.exe
-      # is renamed to "Allagan Eye.exe" inside scripts/build-portable-zip.ps1
-      # at packaging time.
+      # is copied as-is into the Portable ZIP payload by
+      # scripts/build-portable-zip.ps1 at packaging time (no rename, the cargo
+      # binary name without whitespace is used directly).
       - uses: actions/setup-node@v4
         with:
           node-version: '22'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,36 @@ jobs:
         with:
           python-version: '3.11.9'
 
+      # Node + Rust toolchain for Tauri GUI build (#570). bundle.active = false
+      # in tauri.conf.json so `npm run tauri build` only compiles the .exe and
+      # skips NSIS/MSI installer generation; the resulting allaganeye-gui.exe
+      # is renamed to "Allagan Eye.exe" inside scripts/build-portable-zip.ps1
+      # at packaging time.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: gui/src-tauri
+
       - name: Cache FFmpeg archive
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/build-cache
           key: btbn-ffmpeg-win64-lgpl-shared-8.1-fef865cab8a097f07f1dcba66d73be94742b79d952cf6fd8643bd42c18995034
+
+      - name: Install GUI dependencies (#570)
+        shell: pwsh
+        working-directory: gui
+        run: npm install --no-audit --no-fund
+
+      - name: Build Tauri GUI binary (#570)
+        shell: pwsh
+        working-directory: gui
+        run: npm run tauri build
 
       - name: Build Portable ZIP (skip archive)
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,16 @@ on:
       - 'scripts/build-portable-zip.ps1'
       - 'scripts/extract_release_notes.py'
       - 'pyproject.toml'
+      # GUI 関連: tauri build を release CI で実行するため (#570)。
+      # tauri.conf.json / Cargo.toml / Rust src / TS src / vite config の単独変更でも
+      # release CI を trigger し、Tauri build 失敗の検出が遅れないようにする。
+      - 'gui/package.json'
+      - 'gui/package-lock.json'
+      - 'gui/src-tauri/**'
+      - 'gui/src/**'
+      - 'gui/index.html'
+      - 'gui/vite.config.ts'
+      - 'gui/tsconfig*.json'
   workflow_dispatch:
     inputs:
       version_override:
@@ -101,6 +111,20 @@ jobs:
       - name: Build Portable ZIP (skip archive)
         shell: pwsh
         run: ./scripts/build-portable-zip.ps1 -Version '${{ needs.version-check.outputs.version }}' -SkipArchive
+
+      # build-portable-zip.ps1 は Tauri exe が見つからない場合 Write-Warning で
+      # 続行する (CLI-only ZIP として artifact 化) ため、payload に exe が含まれない
+      # 回帰を smoke test の前に明示 fail させる (#570 受け入れ条件 #3)。
+      - name: Verify allaganeye-gui.exe is bundled (#570)
+        shell: pwsh
+        run: |
+          $version = '${{ needs.version-check.outputs.version }}'
+          $exePath = "build/portable/allaganeye-v$version/allaganeye-gui.exe"
+          if (-not (Test-Path $exePath)) {
+            throw "allaganeye-gui.exe not found in payload: $exePath (build-portable-zip.ps1 may have hit the auto-detect Write-Warning path - check 'Build Tauri GUI binary' step)"
+          }
+          $size = (Get-Item $exePath).Length / 1MB
+          Write-Host "allaganeye-gui.exe bundled at $exePath ($([math]::Round($size, 2)) MB)"
 
       - name: Smoke test (run launcher --version from built payload)
         shell: pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ FF14 PvPコンテンツ「フロントライン」の長時間録画動画（OBS
 
 詳細は [`docs/testing-guide.md`](docs/testing-guide.md) を参照（GPU テスト間インターバル、サンプルデータ設定等）。CLI 構文は [`docs/cli-spec.md`](docs/cli-spec.md)、オプション組み合わせごとの出力仕様は [`docs/output-spec.md`](docs/output-spec.md) (#405 マトリクス v2)、CLI と GUI の全体構成・起動経路は [`docs/system-architecture.md`](docs/system-architecture.md) (#527) を参照。
 
-> **配布物の起動経路**: Portable ZIP の `allaganeye.bat` = CLI 起動 / Tauri bundle の `Allagan Eye.exe` (将来) = GUI 起動。**別 exe 方式** (#527 で確定)。
+> **配布物の起動経路**: Portable ZIP の `allaganeye.bat` = CLI 起動 / Tauri bundle の `allaganeye-gui.exe` (v0.2.0+) = GUI 起動。**別 exe 方式** (#527 で確定)。
 
 ```bash
 # テスト

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -1,6 +1,6 @@
 # CLI コマンド仕様
 
-> **スコープ**: 本 doc は CLI (`allaganeye` サブコマンド) の構文を扱う。GUI (Allagan Eye.exe) と CLI の起動経路・全体像は [system-architecture.md](system-architecture.md) を参照。
+> **スコープ**: 本 doc は CLI (`allaganeye` サブコマンド) の構文を扱う。GUI (`allaganeye-gui.exe`) と CLI の起動経路・全体像は [system-architecture.md](system-architecture.md) を参照。
 
 CLI コマンド・引数・オプションの**構文**をまとめる。各オプション組み合わせごとの**出力側**の期待仕様は [`docs/output-spec.md`](output-spec.md) に分離して定義されており、新規 CLI オプション追加時はそちらのマトリクスも更新する (#405)。
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -17,7 +17,7 @@
 │                                                                  │
 │  L2b: Portable ZIP / Tauri bundle (配布形態)                    │
 │  ├── allaganeye.bat              ── CLI 起動 (Python ランタイム) │
-│  └── Allagan Eye.exe (future)    ── GUI 起動 (Tauri bundle)      │
+│  └── allaganeye-gui.exe (future)    ── GUI 起動 (Tauri bundle)      │
 │       │                                                           │
 │       └─ subprocess spawn ─► allaganeye.exe / allaganeye.bat     │
 │                                                                   │
@@ -48,7 +48,7 @@ Allagan Eye は **別 exe 方式**を採用する (2026-04-23 確定、#527)。�
 |---|---|---|---|
 | `allaganeye.bat` (Portable ZIP) | Cmd / PowerShell で引数付き実行 | 同梱 Python + `python -m allaganeye` | リリース済み (v0.1.1) |
 | `allaganeye` (Python venv 内) | `python -m allaganeye <cmd>` | pyproject.toml の console_scripts | 開発時 |
-| `Allagan Eye.exe` (Tauri bundle) | ダブルクリック / start menu | Tauri 2 ランタイム | v0.2.0 で対応 (#570)。Portable ZIP に同梱、`tauri.conf.json` の `bundle.active = false` のまま `.exe` 単体を生成し `scripts/build-portable-zip.ps1` で `allaganeye-gui.exe` → `Allagan Eye.exe` にリネームコピー。NSIS / MSI installer は現バージョンでは生成しない |
+| `allaganeye-gui.exe` (Tauri bundle) | ダブルクリック / start menu | Tauri 2 ランタイム | v0.2.0 で対応 (#570)。Portable ZIP に同梱、`tauri.conf.json` の `bundle.active = false` のまま `.exe` 単体を生成し `scripts/build-portable-zip.ps1` で `allaganeye-gui.exe` をそのまま payload にコピー (リネームなし、Cargo binary 名を直接使用)。productName "Allagan Eye" は Tauri のウィンドウタイトルにのみ使われる。NSIS / MSI installer は現バージョンでは生成しない |
 
 ### 2.2 判断根拠
 
@@ -83,7 +83,7 @@ preview 画面での `<video>` 再生には axum ベースの局所 HTTP サー�
 ```mermaid
 sequenceDiagram
     participant User
-    participant GUI as Allagan Eye.exe
+    participant GUI as allaganeye-gui.exe
     participant CLI as allaganeye detect/split
     participant Disk as metadata.json + MP4
 
@@ -131,7 +131,7 @@ sequenceDiagram
 - **metadata.json のスキーマ変更** → [metadata-spec.md §schema_version](metadata-spec.md) の migration policy に従う (#515)
 - **CLI の新サブコマンド** → [cli-spec.md](cli-spec.md) 更新 / GUI が spawn するなら本 doc §2.3 にも行追加
 - **GUI の新画面** → [ui-architecture.md §screen 遷移図](ui-architecture.md) の Mermaid 図更新
-- **起動経路の変更** (例: `Allagan Eye.exe` を別アーキでビルド) → 本 doc §2 の表を更新
+- **起動経路の変更** (例: `allaganeye-gui.exe` を別アーキでビルド) → 本 doc §2 の表を更新
 - **bundle 形態の変更** (例: MSIX 採用) → リリース戦略 ([release-strategy.md](release-strategy.md)) と本 doc §2.1 を同時更新
 
 ## 6. 関連 issue / doc

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -17,7 +17,7 @@
 │                                                                  │
 │  L2b: Portable ZIP / Tauri bundle (配布形態)                    │
 │  ├── allaganeye.bat              ── CLI 起動 (Python ランタイム) │
-│  └── allaganeye-gui.exe (future)    ── GUI 起動 (Tauri bundle)      │
+│  └── allaganeye-gui.exe          ── GUI 起動 (Tauri bundle, v0.2.0+) │
 │       │                                                           │
 │       └─ subprocess spawn ─► allaganeye.exe / allaganeye.bat     │
 │                                                                   │

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -48,7 +48,7 @@ Allagan Eye は **別 exe 方式**を採用する (2026-04-23 確定、#527)。�
 |---|---|---|---|
 | `allaganeye.bat` (Portable ZIP) | Cmd / PowerShell で引数付き実行 | 同梱 Python + `python -m allaganeye` | リリース済み (v0.1.1) |
 | `allaganeye` (Python venv 内) | `python -m allaganeye <cmd>` | pyproject.toml の console_scripts | 開発時 |
-| `Allagan Eye.exe` (Tauri bundle) | ダブルクリック / start menu | Tauri 2 ランタイム | 将来 (現在 `tauri.conf.json` の `bundle.active = false`) |
+| `Allagan Eye.exe` (Tauri bundle) | ダブルクリック / start menu | Tauri 2 ランタイム | v0.2.0 で対応 (#570)。Portable ZIP に同梱、`tauri.conf.json` の `bundle.active = false` のまま `.exe` 単体を生成し `scripts/build-portable-zip.ps1` で `allaganeye-gui.exe` → `Allagan Eye.exe` にリネームコピー。NSIS / MSI installer は現バージョンでは生成しない |
 
 ### 2.2 判断根拠
 

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
   },
   "bundle": {
     "active": false,
-    "targets": "all",
+    "targets": [],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -131,7 +131,7 @@ function Format-ReadmeContent {
   Produce the README.txt shipped inside the Portable ZIP. Exposing this as a
   function lets Pester assert the LGPLv3 attribution + source pointers are
   present without running a full build. Pass -IncludeGui to add the GUI launch
-  + WebView2 dependency notice when the Tauri-built `Allagan Eye.exe` is bundled.
+  + WebView2 dependency notice when the Tauri-built `allaganeye-gui.exe` is bundled.
   #>
   param(
     [Parameter(Mandatory = $true)][string]$Version,
@@ -143,13 +143,13 @@ function Format-ReadmeContent {
   $guiSection = if ($IncludeGui) {
 @"
 
-### GUI: double-click ``Allagan Eye.exe``
+### GUI: double-click ``allaganeye-gui.exe``
 
-For a graphical interface, double-click ``Allagan Eye.exe`` in this folder. The
+For a graphical interface, double-click ``allaganeye-gui.exe`` in this folder. The
 GUI lets you drop a video file, review detected matches, fine-tune match
 boundaries, and export each match as MP4.
 
-NOTE: ``Allagan Eye.exe`` requires Microsoft Edge WebView2 Runtime, which is
+NOTE: ``allaganeye-gui.exe`` requires Microsoft Edge WebView2 Runtime, which is
 preinstalled on Windows 11 and recent Windows 10 builds. If the GUI fails to
 start with a missing-runtime dialog, install it from:
 
@@ -164,7 +164,7 @@ rights for per-user install.)
 
   $guiLicenseLine = if ($IncludeGui) {
 @"
-- Allagan Eye GUI (``Allagan Eye.exe``): MIT (built with Tauri 2.x + React 19)
+- Allagan Eye GUI (``allaganeye-gui.exe``): MIT (built with Tauri 2.x + React 19)
     WebView2 Runtime is loaded from the user's system at runtime, not redistributed.
 
 "@
@@ -366,11 +366,11 @@ $Launcher = Get-LauncherTemplate
 Set-Content -Path (Join-Path $PayloadDir 'allaganeye.bat') -Value $Launcher -Encoding ASCII
 
 # 6. Tauri GUI bundle (optional, auto-detect)
-# Copy the Tauri-built GUI binary into the payload root and rename to
-# `Allagan Eye.exe` so users can double-click it (matches productName from
-# tauri.conf.json). The cargo binary itself is named `allaganeye-gui.exe`
-# because Cargo package names cannot contain spaces; we keep the cargo name
-# stable and rename only at packaging time.
+# Copy the Tauri-built GUI binary (allaganeye-gui.exe) into the payload root
+# as-is. The cargo binary name has no whitespace so users / scripts can
+# reference it without quoting headaches; tauri.conf.json `productName`
+# ("Allagan Eye") is still used by Tauri for the window title at runtime,
+# but the executable filename stays in cargo/snake/dash form for portability.
 #
 # Build is the caller's responsibility: CI runs `npm install && npm run tauri build`
 # in a preceding workflow step, and the resulting exe lands at
@@ -381,11 +381,11 @@ Set-Content -Path (Join-Path $PayloadDir 'allaganeye.bat') -Value $Launcher -Enc
 $TauriExe = Join-Path $RepoRoot 'gui\src-tauri\target\release\allaganeye-gui.exe'
 $TauriIncluded = $false
 if (Test-Path $TauriExe) {
-  Copy-Item -Path $TauriExe -Destination (Join-Path $PayloadDir 'Allagan Eye.exe')
-  Write-Host "Bundled GUI: $TauriExe -> $PayloadDir\Allagan Eye.exe"
+  Copy-Item -Path $TauriExe -Destination (Join-Path $PayloadDir 'allaganeye-gui.exe')
+  Write-Host "Bundled GUI: $TauriExe -> $PayloadDir\allaganeye-gui.exe"
   $TauriIncluded = $true
 } else {
-  Write-Warning "Tauri GUI build not found at $TauriExe - Portable ZIP will be built without Allagan Eye.exe. Run 'cd gui && npm install && npm run tauri build' first to include the GUI."
+  Write-Warning "Tauri GUI build not found at $TauriExe - Portable ZIP will be built without the GUI binary. Run 'cd gui && npm install && npm run tauri build' first to include the GUI."
 }
 
 # 7. README (after Tauri detection so the GUI section is conditional)

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -130,14 +130,47 @@ function Format-ReadmeContent {
   <#
   Produce the README.txt shipped inside the Portable ZIP. Exposing this as a
   function lets Pester assert the LGPLv3 attribution + source pointers are
-  present without running a full build.
+  present without running a full build. Pass -IncludeGui to add the GUI launch
+  + WebView2 dependency notice when the Tauri-built `Allagan Eye.exe` is bundled.
   #>
   param(
     [Parameter(Mandatory = $true)][string]$Version,
     [Parameter(Mandatory = $true)][string]$FFmpegVersion,
     [Parameter(Mandatory = $true)][string]$FFmpegBuildTag,
-    [Parameter(Mandatory = $true)][string]$FFmpegSourceCommit
+    [Parameter(Mandatory = $true)][string]$FFmpegSourceCommit,
+    [switch]$IncludeGui
   )
+  $guiSection = if ($IncludeGui) {
+@"
+
+### GUI: double-click ``Allagan Eye.exe``
+
+For a graphical interface, double-click ``Allagan Eye.exe`` in this folder. The
+GUI lets you drop a video file, review detected matches, fine-tune match
+boundaries, and export each match as MP4.
+
+NOTE: ``Allagan Eye.exe`` requires Microsoft Edge WebView2 Runtime, which is
+preinstalled on Windows 11 and recent Windows 10 builds. If the GUI fails to
+start with a missing-runtime dialog, install it from:
+
+    https://developer.microsoft.com/en-us/microsoft-edge/webview2/
+
+(``Evergreen Standalone Installer`` is sufficient and does not require admin
+rights for per-user install.)
+
+"@
+  }
+  else { '' }
+
+  $guiLicenseLine = if ($IncludeGui) {
+@"
+- Allagan Eye GUI (``Allagan Eye.exe``): MIT (built with Tauri 2.x + React 19)
+    WebView2 Runtime is loaded from the user's system at runtime, not redistributed.
+
+"@
+  }
+  else { '' }
+
   return @"
 # allaganeye v$Version (Portable ZIP for Windows)
 
@@ -161,13 +194,13 @@ this folder and run:
     allaganeye.bat split "C:\path\to\video.mkv"
     allaganeye.bat split "C:\path\to\video.mkv" --dry-run
     allaganeye.bat --version
-
+$guiSection
 See https://github.com/Idios/kobutachan-allaganeye for full documentation.
 
 ## Licenses
 
 - allaganeye: MIT (see the repository LICENSE file)
-- Python: PSF License (python\LICENSE.txt)
+$guiLicenseLine- Python: PSF License (python\LICENSE.txt)
 - FFmpeg: LGPLv3 (full text in ffmpeg\LICENSE.txt)
     Build:         ffmpeg n$FFmpegVersion win64-lgpl-shared build (BtbN/FFmpeg-Builds)
     Build tag:     $FFmpegBuildTag
@@ -332,15 +365,39 @@ Copy-Item -Path $FFmpegLayout.License -Destination (Join-Path $FFmpegDest 'LICEN
 $Launcher = Get-LauncherTemplate
 Set-Content -Path (Join-Path $PayloadDir 'allaganeye.bat') -Value $Launcher -Encoding ASCII
 
-# 6. README
+# 6. Tauri GUI bundle (optional, auto-detect)
+# Copy the Tauri-built GUI binary into the payload root and rename to
+# `Allagan Eye.exe` so users can double-click it (matches productName from
+# tauri.conf.json). The cargo binary itself is named `allaganeye-gui.exe`
+# because Cargo package names cannot contain spaces; we keep the cargo name
+# stable and rename only at packaging time.
+#
+# Build is the caller's responsibility: CI runs `npm install && npm run tauri build`
+# in a preceding workflow step, and the resulting exe lands at
+# gui/src-tauri/target/release/allaganeye-gui.exe. tauri.conf.json keeps
+# `bundle.active = false` because the Portable ZIP is the distribution form
+# and Tauri's NSIS/MSI bundles are not used. Local dry-run may skip the
+# Tauri build; if the exe is absent we log a warning and continue (CLI-only ZIP).
+$TauriExe = Join-Path $RepoRoot 'gui\src-tauri\target\release\allaganeye-gui.exe'
+$TauriIncluded = $false
+if (Test-Path $TauriExe) {
+  Copy-Item -Path $TauriExe -Destination (Join-Path $PayloadDir 'Allagan Eye.exe')
+  Write-Host "Bundled GUI: $TauriExe -> $PayloadDir\Allagan Eye.exe"
+  $TauriIncluded = $true
+} else {
+  Write-Warning "Tauri GUI build not found at $TauriExe - Portable ZIP will be built without Allagan Eye.exe. Run 'cd gui && npm install && npm run tauri build' first to include the GUI."
+}
+
+# 7. README (after Tauri detection so the GUI section is conditional)
 $Readme = Format-ReadmeContent `
   -Version $Version `
   -FFmpegVersion $FFmpegVersion `
   -FFmpegBuildTag $FFmpegBuildTag `
-  -FFmpegSourceCommit $FFmpegSourceCommit
+  -FFmpegSourceCommit $FFmpegSourceCommit `
+  -IncludeGui:$TauriIncluded
 Set-Content -Path (Join-Path $PayloadDir 'README.txt') -Value $Readme -Encoding UTF8
 
-# 7. Compress (skipped with -SkipArchive so CI can hand the payload folder
+# 8. Compress (skipped with -SkipArchive so CI can hand the payload folder
 # directly to actions/upload-artifact; upload-artifact zips it once instead of
 # producing a nested zip).
 if ($SkipArchive) {

--- a/scripts/tests/build-portable-zip.Tests.ps1
+++ b/scripts/tests/build-portable-zip.Tests.ps1
@@ -136,6 +136,49 @@ Describe 'Format-ReadmeContent' {
     # paragraph; assert the new dynamic-linking explanation is present.
     $readme | Should -Match 'shared-build DLLs'
   }
+
+  It '-IncludeGui:$true emits the GUI launch section and WebView2 runtime notice (#570)' {
+    # When the Tauri-built allaganeye-gui.exe is bundled (Portable ZIP includes
+    # both CLI .bat and GUI .exe), README.txt must instruct users to
+    # double-click and warn about WebView2 Runtime dependency on older Windows.
+    $readme = Format-ReadmeContent `
+      -Version '0.2.0' `
+      -FFmpegVersion '8.1' `
+      -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
+      -FFmpegSourceCommit '7f5c90f77e' `
+      -IncludeGui:$true
+    $readme | Should -Match 'double-click'
+    $readme | Should -Match 'WebView2 Runtime'
+    $readme | Should -Match 'developer\.microsoft\.com'
+  }
+
+  It '-IncludeGui:$true emits the Tauri 2 / React 19 license entry (#570)' {
+    # GUI license entry is required for the MIT + WebView2 + Tauri attribution
+    # so that the dual-license structure (CLI MIT / FFmpeg LGPLv3 / GUI MIT) is
+    # explicit in the user-facing README.
+    $readme = Format-ReadmeContent `
+      -Version '0.2.0' `
+      -FFmpegVersion '8.1' `
+      -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
+      -FFmpegSourceCommit '7f5c90f77e' `
+      -IncludeGui:$true
+    $readme | Should -Match 'Allagan Eye GUI'
+    $readme | Should -Match 'Tauri 2'
+  }
+
+  It '-IncludeGui:$false (default) omits the GUI section for CLI-only ZIPs (#570)' {
+    # Local dry-run / partial builds may produce CLI-only Portable ZIPs (no
+    # Tauri exe). README.txt must not advertise the GUI in that case to avoid
+    # user confusion. Default value of -IncludeGui is $false.
+    $readme = Format-ReadmeContent `
+      -Version '0.2.0' `
+      -FFmpegVersion '8.1' `
+      -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
+      -FFmpegSourceCommit '7f5c90f77e'
+    $readme | Should -Not -Match 'WebView2 Runtime'
+    $readme | Should -Not -Match 'Allagan Eye GUI'
+    $readme | Should -Not -Match 'allaganeye-gui\.exe'
+  }
 }
 
 Describe 'Get-LauncherTemplate' {


### PR DESCRIPTION
## Summary

#570 で計画された Tauri bundle 有効化を実装。配布形態 A (Portable ZIP に GUI 実行ファイルを同梱、1 zip 完結) を実現する最小構成で、NSIS / MSI installer は生成せず `.exe` 単体のみ生成して `scripts/build-portable-zip.ps1` でそのまま payload にコピーする。

## 方針調整 (#570 受け入れ条件の再解釈)

#570 の元受け入れ条件「`bundle.active = true` / `targets = ["nsis"]`」は当初 NSIS installer も別配布する想定で書かれていた。2026-04-27 セッション (`trusting-germain-26ddd3`) で配布形態 A (Portable ZIP に `.exe` 同梱、1 zip 完結) が確定し、memory `feedback_no_user_env_modification.md` (ツール側はユーザー環境を変更しない) 原則と整合させた結果、NSIS bundle は不要となった。以下のように方針を調整:

- `tauri.conf.json` `bundle.active = false` のまま、`targets = []` (空配列、将来 NSIS 入れる際の明示的な足場)
- `npm run tauri build` で `target/release/allaganeye-gui.exe` 単体生成 (Cargo binary name)
- `scripts/build-portable-zip.ps1` で copy 時にリネームせず `allaganeye-gui.exe` のまま payload に配置 (Cargo binary 名はスペースなし、scripts / paths が quoting headache を避けられる。productName "Allagan Eye" は Tauri のウィンドウタイトルにのみ使用)
- NSIS / MSI installer 派生は本 PR スコープ外 (L2 v0.2.0 では Portable ZIP 同梱のみ、必要になれば派生 issue で対応)

## 変更内容

### `gui/src-tauri/tauri.conf.json`
- `bundle.targets`: `"all"` → `[]` (Windows Portable ZIP 同梱方針との整合)
- `bundle.active = false` は維持 (NSIS / MSI 不要)

### `scripts/build-portable-zip.ps1`
- 新セクション `# 6. Tauri GUI bundle (optional, auto-detect)`:
  - `target/release/allaganeye-gui.exe` を payload にそのまま copy (リネームなし)
  - auto-detect なので Tauri build せずに ps1 だけ呼べば CLI-only ZIP も生成可能 (CI dry-run 等)
- `Format-ReadmeContent` に `-IncludeGui` switch 追加: GUI 同梱時のみ「`allaganeye-gui.exe` をダブルクリック」セクション + WebView2 runtime 注意書きを README.txt に挿入

### `scripts/tests/build-portable-zip.Tests.ps1` (Review #3)
- `Describe 'Format-ReadmeContent'` block に `-IncludeGui` の Pester test 3 ケース追加:
  - `-IncludeGui:$true` で `double-click` / `WebView2 Runtime` / `developer.microsoft.com` を含む
  - `-IncludeGui:$true` で `Allagan Eye GUI` / `Tauri 2` の license entry を含む
  - `-IncludeGui:$false` (default) で GUI セクション (`WebView2 Runtime` / `Allagan Eye GUI` / `allaganeye-gui.exe`) を含まない (CLI-only ZIP)

### `.github/workflows/release.yml`
- **build steps 追加**: `actions/setup-node@v4` (Node 22) / `dtolnay/rust-toolchain@stable` / `Swatinem/rust-cache@v2` の 3 step + `Install GUI dependencies` (`npm install --no-audit --no-fund`) + `Build Tauri GUI binary` (`npm run tauri build`) を `Build Portable ZIP` の前に挿入
- **`pull_request.paths` 拡張** (Review #4): GUI 関連 (`gui/package.json` / `gui/package-lock.json` / `gui/src-tauri/**` / `gui/src/**` / `gui/index.html` / `gui/vite.config.ts` / `gui/tsconfig*.json`) を追加。GUI 単独変更でも release CI を trigger
- **`Verify allaganeye-gui.exe is bundled` step 追加** (Review #5): `Build Portable ZIP` 直後・smoke test 前に payload 内 `allaganeye-gui.exe` 存在を assert (auto-detect の Write-Warning 経由 regression を CI 段階で検出)

### `docs/system-architecture.md` / `docs/cli-spec.md` / `CLAUDE.md`
- 各 doc の `Allagan Eye.exe` 表記を `allaganeye-gui.exe` に統一 (Cargo binary 名と一致、スペースなし)
- `docs/system-architecture.md:20` ASCII art の `(future)` を削除し `(v0.2.0+)` 表記に統合 (Review #2)
- `docs/system-architecture.md:51` 起動経路 table 行の状態を「将来」→「v0.2.0 で対応 (#570)」に更新、Portable ZIP 同梱 + リネームなしの説明追加

## レビュー対応 (Round 1)

[/review-pr 結果](https://github.com/Idios/kobutachan-allaganeye/pull/615#issuecomment-4324077350) (`determined-antonelli-52abff`) で 6 件の修正依頼。memory `feedback_pr_internal_fix_policy.md` (PR で挙がった問題は原則そのPR内で対策) に従い、別 issue ではなく本 PR 内で全件対応:

| # | 内容 | 対応 |
|---|---|---|
| 1 | `CLAUDE.md:31` 予告文「(将来)」を実装済み表記に更新 | ✅ commit 733dc16 (rename removal commit と一緒に `(v0.2.0+)` に更新) |
| 2 | `docs/system-architecture.md:20` ASCII art `(future)` 更新 | ✅ 本 commit (`(future)` 削除 → `(v0.2.0+)` 表記) |
| 3 | `Format-ReadmeContent -IncludeGui` の Pester test 追加 | ✅ 本 commit (`scripts/tests/build-portable-zip.Tests.ps1` に 3 ケース追加、Pester 13/13 PASS) |
| 4 | `release.yml` `pull_request.paths` に GUI 関連追加 | ✅ 本 commit (`gui/**` の主要 path 7 件追加) |
| 5 | `release.yml` smoke test に exe 存在 assert 追加 | ✅ 本 commit (`Verify allaganeye-gui.exe is bundled` step 追加。元レビューでは `Allagan Eye.exe` だが rename 削除済 (Iter 2) のため `allaganeye-gui.exe` で assert) |
| 6 | PR 本文 Test plan の未完了項目解消 (validate-checklist FAIL 解消) | ✅ PR body v3 (前 commit 時点) で全 `[x]` 化、`validate-checklist` PASS 確認済 |

## 受け入れ条件の検証 (#570、再解釈版)

| 受け入れ条件 (元 #570) | 検証 |
|---|---|
| `cargo tauri build` がローカル + CI で成功 | ローカル ✓ (`npm run tauri build` 成功 45.34s with Rust cache) / CI `build-windows` ✓ (5m22s PASS、本 PR 直近 push 時点) |
| 生成された GUI 実行ファイルが単体で起動でき、GUI が立ち上がる (CLI と独立) | `target/release/allaganeye-gui.exe` 14.3 MB 生成確認 / **ユーザー目視確認お願いします** (下記) |
| CI artifact に exe upload | `release.yml` で `npm run tauri build` → `Verify allaganeye-gui.exe is bundled` (Review #5) → `build-portable-zip.ps1` が auto-detect で copy → `actions/upload-artifact@v4` (`allaganeye-portable-windows`) に含まれる |
| `cargo check` / `npm run typecheck` / `npm run lint` 全 pass | `bundle.active = false` 維持で全 pass (`cargo check` ✓ / `npm run typecheck` ✓ / `npm run lint` ✓ / `npm test` ✓ 335 tests pass / `Invoke-Pester` ✓ 13 tests pass) |
| `docs/system-architecture.md` 更新 | ✓ (line 20 ASCII art + line 51 table + line 86 Mermaid + line 134 例示) |

## ローカル動作確認

- `npm install` (gui/) → 242 packages installed
- `npm run tauri build` (gui/) → `target/release/allaganeye-gui.exe` 14.3 MB 生成 (Rust cache 有効、45.34s)
- `npm run lint` (gui/) → PASS
- `npm run typecheck` (gui/) → PASS
- `npm test` (gui/) → 335/335 tests PASS (29 files, 5.02s)
- `cargo check` (src-tauri/) → PASS
- `Invoke-Pester scripts/tests/build-portable-zip.Tests.ps1` → **13/13 tests PASS** (新 3 ケース `-IncludeGui` 含む、1.93s)
- 全 file grep `Allagan Eye.exe` ゼロ件確認

## レビュー時の確認 (machine-unverifiable)

- `gui/src-tauri/target/release/allaganeye-gui.exe` をダブルクリックして drop screen が表示されること (WebView2 既インストール環境)
- (option) ローカルで `pwsh scripts/build-portable-zip.ps1 -Version "0.2.0" -SkipArchive` を実行して `build/portable/allaganeye-v0.2.0/allaganeye-gui.exe` が含まれることの確認 (Python embed と FFmpeg のダウンロードで 5 分以上かかる)
- CI: `release.yml` build-windows job (Node + Rust setup → npm install → tauri build → Build Portable ZIP → Verify exe → smoke tests → upload-artifact) 全 PASS

## 関連

- 親: [#570](https://github.com/Idios/kobutachan-allaganeye/issues/570)
- 連動: [#527](https://github.com/Idios/kobutachan-allaganeye/issues/527) CLI/GUI 別 exe 方式
- 後続: [#484](https://github.com/Idios/kobutachan-allaganeye/issues/484) L2 E2E
- レビュー: [Review Round 1](https://github.com/Idios/kobutachan-allaganeye/pull/615#issuecomment-4324077350) (`determined-antonelli-52abff`)

## Test plan (本 PR 提出前にローカルで実行済)

- [x] `npm run lint` (gui/)
- [x] `npm run typecheck` (gui/)
- [x] `npm test` (gui/, 335 tests pass)
- [x] `cargo check` (gui/src-tauri/)
- [x] `npm run tauri build` (gui/, ローカル成功)
- [x] `Invoke-Pester scripts/tests/build-portable-zip.Tests.ps1` (13 tests pass、新 `-IncludeGui` 3 ケース含む)
- [x] ps1 dot-source: `Format-ReadmeContent` 両 mode 動作確認 (Allagan Eye.exe 不含有 / allaganeye-gui.exe 含有)
- [x] 全 file grep `Allagan Eye.exe` ゼロ件確認
- [x] レビュー Round 1 摘出 6 件全件対応 (#1, #6 は前 commit 時点で対応済 / #2-#5 は本 commit で対応)

