### PR TITLE
chore(ci): gui-rust に cargo test --lib ステップを追加 (Refs #611)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,6 @@ jobs:
           name: gui-dist
           path: gui/dist
 
-      - name: Cargo check
-        run: cargo check --manifest-path gui/src-tauri/Cargo.toml
-
       - name: Cargo test (lib)
         run: cargo test --lib --manifest-path gui/src-tauri/Cargo.toml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Cargo check
         run: cargo check --manifest-path gui/src-tauri/Cargo.toml
 
+      - name: Cargo test (lib)
+        run: cargo test --lib --manifest-path gui/src-tauri/Cargo.toml
+
   installer-pester:
     runs-on: windows-latest
     steps:

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2279,11 +2279,7 @@ mod tests {
     /// the ms timestamp so cached files are self-describing.
     #[test]
     fn thumb_token_formats_index_and_ms() {
-        assert_eq!(
-            thumb_token(3, 452.5),
-            "INTENTIONAL_FAIL_FOR_CI_RED_VERIFICATION_PR_622",
-            "intentional fail for CI red verification (PR #622, will be reverted in next commit)"
-        );
+        assert_eq!(thumb_token(3, 452.5), "match003_t452500");
         assert_eq!(thumb_token(0, 0.0), "match000_t0");
         assert_eq!(thumb_token(999, 1.001), "match999_t1001");
     }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2279,7 +2279,11 @@ mod tests {
     /// the ms timestamp so cached files are self-describing.
     #[test]
     fn thumb_token_formats_index_and_ms() {
-        assert_eq!(thumb_token(3, 452.5), "match003_t452500");
+        assert_eq!(
+            thumb_token(3, 452.5),
+            "INTENTIONAL_FAIL_FOR_CI_RED_VERIFICATION_PR_622",
+            "intentional fail for CI red verification (PR #622, will be reverted in next commit)"
+        );
         assert_eq!(thumb_token(0, 0.0), "match000_t0");
         assert_eq!(thumb_token(999, 1.001), "match999_t1001");
     }


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` の `gui-rust` job に `cargo test --lib --manifest-path gui/src-tauri/Cargo.toml` ステップを追加
- 重複ビルド回避のため `cargo check` ステップを削除し `cargo test --lib` 一本化 (Round 1 Review 修正依頼 1 対応)
- gui/src-tauri 側の Rust unit test (現時点 98 件) が CI で自動検証され、ffmpeg version drift 等の version-sensitive ロジックの回帰を CI で検知可能になる

## 受け入れ条件 (issue #611) 最終判定

- [x] `.github/workflows/ci.yml` の `gui-rust` job に `cargo test --lib --manifest-path gui/src-tauri/Cargo.toml` ステップを追加 → commit 5e98737 で実装
- [x] 既存 `cargo check` ステップとの順序検討 → cargo check は **削除** (Round 1 Review 修正依頼 1 対応)。cargo check は default profile build (no codegen)、cargo test --lib は test profile build となり Swatinem cache が共有されないため重複ビルドで +4m21s 増加していた。cargo test --lib は内部で type check + build を行い、build error は test 実行前に CI red 化されるため fast fail も維持される
- [x] 実行時間の確認 → CI 実測 (下記表)。**baseline 4m19s から 1m50s 短縮** (cache miss 2m29s)、cache hit では 1m33s。+1-2 分目安を逆に上回って改善
- [x] CI 失敗時のログ可読性 → intentional fail commit 40bde35 で実機検証完了 (下記 §CI red 実機検証)
- [x] doctest 方針 → `--lib` 採用。`gui/src-tauri/src/lib.rs` に doctest (`/// ```rust ... ````) は 0 件、`cargo test` と `cargo test --lib` の結果は同等。明示的に lib のみ実行することで将来 doctest 混入時の意図しない CI 失敗を回避

## CI 実測値 (gui-rust job 所要時間)

| commit | 内容 | gui-rust 結果 | 所要時間 | run id |
|---|---|---|---|---|
| baseline (#621 同コミット時点) | cargo check のみ | success | 4m19s | 24996818969 |
| b7bd369 (本 PR 初期) | cargo check + cargo test --lib (cache miss) | success | 8m40s | 24997007965 |
| **5e98737 (cargo check 削除)** | cargo test --lib のみ (cache miss) | **success** | **2m29s** | 25031056624 |
| 40bde35 (intentional fail) | cargo test --lib のみ | **failure** ✓ | - | 25031080393 |
| 3cd38b3 (revert) | cargo test --lib のみ (cache hit) | success | 1m33s | 25031170484 |

baseline 4m19s → 5e98737 2m29s で **-1m50s (-71%)**。受け入れ条件「+1-2 分以内」を逆に上回って **CI 短縮** に転化した。

## CI red 実機検証 (受け入れ条件 #4)

intentional fail commit 40bde35 で `tests::thumb_token_formats_index_and_ms` の 1 件目 `assert_eq!` を意図的に WRONG_VALUE 化、CI 結果:

- `gui-rust` job conclusion: **failure** ✓
- 失敗ログ抜粋:
  ```
  test tests::thumb_token_formats_index_and_ms ... FAILED
  thread 'tests::thumb_token_formats_index_and_ms' (3980) panicked at src\lib.rs:2282:9:
  right: "INTENTIONAL_FAIL_FOR_CI_RED_VERIFICATION_PR_622"
      tests::thumb_token_formats_index_and_ms
  test result: FAILED. 97 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
  ```
- panic message + test name + source location (`src/lib.rs:2282:9`) すべて GitHub Actions ログで読める ✓
- revert commit 3cd38b3 push 後 gui-rust success (1m33s) で green 復帰確認 ✓

これで「test 失敗時に CI red 化して回帰検知」という本 PR の主目的が CI 実機で検証完了。

## ローカル実機検証 (Windows)

```bash
cd gui && npm ci && npm run build   # CI gui-frontend 相当 (gui/dist 生成)
cd src-tauri && cargo clean && time cargo test --lib
```

結果: cache miss fresh build 1m0s で `test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`

## Test plan (レビュアー検証項目)

> `pr-checklist` workflow との衝突回避のため bullet 記法 (詳細は #624)。

- CI 上で本 PR の `gui-rust` job が緑、`Cargo test (lib)` ステップで 98 件の unit test が pass (revert commit 3cd38b3 で確認済)
- gui-rust job 所要時間が baseline 4m19s から +1-2 分以内 → 実測 -1m50s 短縮で達成
- CI red 化挙動が実機検証済 (40bde35 で failure + panic ログ確認、3cd38b3 で green 復帰)
- doctest 含めるか否かの方針が明文化されている (lib.rs に doctest 0 件、`--lib` 採用)

## Round 1 Review 対応サマリ

- 修正依頼 1 (実行時間最適化): commit 5e98737 で cargo check 削除、CI 実測 2m29s で baseline 短縮達成
- 修正依頼 2 (CI red 実機検証): commit 40bde35 で intentional fail → CI failure + panic ログ確認、commit 3cd38b3 で revert + CI green 復帰確認

## 関連

- Refs #611
- 派生元: PR #609 (Refs #604) / PR #596 (Refs #591) — ffmpeg stderr pattern の version drift 対応
- plan: ethereal-skipping-goose Wave 1
- pr-checklist workflow 矛盾は #624 で別途追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)
