### PR TITLE
feat(gui): detecting / complete 画面を本物化 (CLI 連携 + 輝度タイムライン) (Refs #569)

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -315,6 +315,17 @@ def detect(
             "-q", "--quiet", help="Suppress progress output (final result only)"
         ),
     ] = False,
+    progress_format: Annotated[
+        str,
+        typer.Option(
+            "--progress-format",
+            help="Progress output format. 'text' (default) renders human-"
+            "readable click progress bars and typer status lines. 'json' "
+            "emits one JSON object per line on stdout (phase / completed "
+            "/ total / elapsed_s) for the Tauri GUI wrapper, and "
+            "suppresses all human-readable text output (#569).",
+        ),
+    ] = "text",
 ) -> None:
     """Run detection only and write metadata.json (no split, #463).
 
@@ -326,6 +337,11 @@ def detect(
             raise ConfigValidationError("--quiet and --verbose are mutually exclusive")
         if gpu and no_gpu:
             raise ConfigValidationError("--gpu and --no-gpu are mutually exclusive")
+        if progress_format not in ("text", "json"):
+            raise ConfigValidationError(
+                f"Invalid --progress-format: {progress_format!r}. "
+                "Choices: 'text', 'json'."
+            )
 
         use_gpu: bool | None
         if gpu:
@@ -360,7 +376,13 @@ def detect(
 
         from allaganeye.commands.detect import run_detect
 
-        run_detect(video_path, config, verbose=verbose, quiet=quiet)
+        run_detect(
+            video_path,
+            config,
+            verbose=verbose,
+            quiet=quiet,
+            progress_format=progress_format,
+        )
 
     except AllaganEyeError as e:
         _report_app_error(e, verbose=verbose, quiet=quiet)

--- a/allaganeye/commands/detect.py
+++ b/allaganeye/commands/detect.py
@@ -14,6 +14,7 @@ module matures further we can hoist those helpers into
 
 from __future__ import annotations
 
+import sys
 import time
 from pathlib import Path
 
@@ -37,9 +38,11 @@ from allaganeye.commands.split_matches import (
     _run_audio_scan,
     _run_detection,
     _save_cache,
+    build_brightness_samples,
 )
 from allaganeye.config import SplitConfig
 from allaganeye.detection.metadata_writer import write_metadata_atomic
+from allaganeye.detection.progress_emitter import ProgressEmitter
 from allaganeye.exceptions import DetectionError
 from allaganeye.video.detector import DetectionStats
 from allaganeye.video.probe import probe_video
@@ -51,6 +54,7 @@ def run_detect(
     *,
     verbose: bool = False,
     quiet: bool = False,
+    progress_format: str = "text",
 ) -> None:
     """Run detection and write ``metadata.json`` without splitting (#463).
 
@@ -58,8 +62,35 @@ def run_detect(
     (``match_NNN.mp4``) relative to ``config.output_dir`` so that a later
     ``allaganeye split --from-metadata`` produces the same filenames the
     legacy ``allaganeye split <video>`` flow would have used.
+
+    ``progress_format`` (#569) controls how progress is reported:
+
+    * ``"text"`` (default): the existing click progress bars + typer
+      status lines for human consumption.
+    * ``"json"``: one JSON object per line on stdout for the Tauri GUI
+      wrapper.  Suppresses every other stdout write (``Probing: ...``,
+      ``Metadata: ...``, etc.) so the GUI can parse cleanly.  Errors and
+      ``-v`` traceback still go to stderr.
     """
-    show = not quiet
+    json_mode = progress_format == "json"
+    # In json mode the GUI consumes stdout as a structured stream, so we
+    # treat every typer.echo call site as if --quiet were set (errors
+    # still flow through stderr via the cli.py error handlers).
+    show = not quiet and not json_mode
+    progress_emitter: ProgressEmitter | None = None
+    if json_mode:
+        progress_emitter = ProgressEmitter(enabled=True, stream=sys.stdout)
+        progress_emitter.emit("start", source=str(video_path))
+
+    captured_brightness: dict[float, float] = {}
+
+    def on_brightness(results: dict[float, float]) -> None:
+        # #569 -- single-shot capture: detector calls this once after
+        # Pass 1 with the full timestamp/brightness map. We cache it
+        # locally so the metadata.json writer can downsample for the
+        # complete-screen timeline.
+        captured_brightness.update(results)
+
     total_start = time.monotonic()
     detected_at = _iso_utc_now()
 
@@ -69,6 +100,15 @@ def run_detect(
     if show:
         typer.echo(f"Probing: {video_path.name}")
     metadata = probe_video(video_path)
+    if json_mode and progress_emitter is not None:
+        progress_emitter.emit(
+            "probing",
+            duration_s=metadata["duration"],
+            width=metadata["width"],
+            height=metadata["height"],
+            fps=metadata["fps"],
+            codec=metadata.get("codec"),
+        )
     if verbose and show:
         typer.echo(
             f"  Duration: {metadata['duration']:.1f}s, "
@@ -93,6 +133,11 @@ def run_detect(
                 _display_cache_hit_params(cache_path, config)
             if show:
                 _display_results(boundaries, metadata, video_path, verbose, cached=True)
+            if json_mode and progress_emitter is not None:
+                progress_emitter.emit(
+                    "cache_hit",
+                    boundaries=len(boundaries),
+                )
 
     if boundaries is None:
         use_gpu, gpu_vendor, available_vendors = _resolve_gpu_mode_with_probe(
@@ -124,6 +169,8 @@ def run_detect(
             stats=detect_stats,
             use_gpu=use_gpu,
             gpu_vendor=gpu_vendor,
+            progress_emitter=progress_emitter,
+            brightness_callback=on_brightness,
         )
 
         if not boundaries:
@@ -186,6 +233,11 @@ def run_detect(
         vendor_used=gpu_vendor if use_gpu else None,
     )
 
+    if progress_emitter is not None:
+        progress_emitter.emit("writing_metadata")
+
+    brightness_samples = build_brightness_samples(captured_brightness)
+
     payload = _build_metadata_payload(
         video_path=video_path,
         source_duration=metadata["duration"],
@@ -197,6 +249,7 @@ def run_detect(
         output_files=placeholder_paths,
         gaps=gaps,
         system_info=system_info,
+        brightness_samples=brightness_samples,
     )
     metadata_path = config.output_dir / "metadata.json"
     write_metadata_atomic(metadata_path, payload)
@@ -205,3 +258,10 @@ def run_detect(
         typer.echo(f"\nMetadata: {metadata_path}")
 
     _emit_total_time(total_start, verbose, show)
+
+    if progress_emitter is not None:
+        progress_emitter.emit(
+            "done",
+            metadata_path=str(metadata_path),
+            matches=len(boundaries),
+        )

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -5,6 +5,7 @@ import logging
 import re
 import shutil
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TypedDict
@@ -17,6 +18,7 @@ from allaganeye.detection.metadata_writer import (
     read_metadata,
     write_metadata_atomic,
 )
+from allaganeye.detection.progress_emitter import ProgressEmitter
 from allaganeye.detection.warnings import build_warnings
 from allaganeye.exceptions import (
     AllaganEyeError,
@@ -673,8 +675,21 @@ def _run_detection(
     stats: DetectionStats | None = None,
     use_gpu: bool = False,
     gpu_vendor: str | None = None,
+    progress_emitter: ProgressEmitter | None = None,
+    brightness_callback: Callable[[dict[float, float]], None] | None = None,
 ) -> list[MatchBoundary]:
-    """Run detection with progress bars for each phase (#328, #329, #331)."""
+    """Run detection with progress bars for each phase (#328, #329, #331).
+
+    #569 -- when *progress_emitter* is supplied (GUI / Tauri wrapper),
+    the click TTY progress bars are replaced by JSON-line events on the
+    emitter's stream.  ``quiet`` / ``progress_emitter`` are mutually
+    exclusive in spirit; if both are provided the emitter wins (so a
+    quiet-from-CLI-call-site GUI subprocess still emits events).
+    *brightness_callback* is forwarded transparently into
+    ``detect_match_boundaries`` so callers can capture the Pass 1
+    brightness map for downstream consumers (e.g. the GUI complete
+    screen's brightness timeline).
+    """
     detect_kwargs = {
         "duration_hint": metadata["duration"],
         "sample_interval": effective_interval,
@@ -688,7 +703,53 @@ def _run_detection(
         "codec": metadata.get("codec"),
         "audio_hits": audio_hits,
         "stats": stats,
+        "brightness_callback": brightness_callback,
     }
+
+    if progress_emitter is not None:
+        # GUI / json mode: wire the same callbacks but emit JSON lines
+        # instead of advancing click progressbars.  No TTY work at all.
+        total_duration = metadata["duration"]
+        estimated_samples = max(1, int(total_duration / effective_interval))
+
+        def gui_on_progress(completed: int, total: int, blackout_count: int) -> None:
+            progress_emitter.emit_progress(
+                "scan",
+                completed,
+                total,
+                blackout_frames=blackout_count,
+            )
+
+        def gui_on_chunk_dispatch(num_chunks: int) -> None:
+            progress_emitter.emit("chunk_dispatch", chunks=num_chunks)
+
+        def gui_on_chunk(done: int, total: int, eta_seconds: float) -> None:
+            progress_emitter.emit(
+                "chunk",
+                completed=done,
+                total=total,
+                eta_s=eta_seconds if eta_seconds > 0 else None,
+            )
+
+        def gui_on_refine(completed: int, total: int) -> None:
+            progress_emitter.emit_progress("refine", completed, total)
+
+        def gui_on_scorebar(completed: int, total: int) -> None:
+            progress_emitter.emit_progress("scorebar", completed, total)
+
+        # Announce Pass 1 entry so the GUI can pre-populate the bar at 0%
+        # before the first chunk completes (otherwise the bar sits empty
+        # until ~10s into a long video).
+        progress_emitter.emit_progress("scan", 0, estimated_samples)
+        return detect_match_boundaries(
+            video_path,
+            **detect_kwargs,
+            progress_callback=gui_on_progress,
+            refine_progress_callback=gui_on_refine,
+            scorebar_progress_callback=gui_on_scorebar,
+            chunk_progress_callback=gui_on_chunk,
+            chunk_dispatch_callback=gui_on_chunk_dispatch,
+        )
 
     if not quiet:
         total_duration = metadata["duration"]
@@ -1001,6 +1062,7 @@ def _build_metadata_payload(
     output_files: list[Path],
     gaps: list[Gap],
     system_info: dict,
+    brightness_samples: dict | None = None,
 ) -> dict:
     """Build the ``metadata.json`` payload dict (schema v1, #463 / #591).
 
@@ -1019,8 +1081,14 @@ def _build_metadata_payload(
     encoder selection (NVENC / QSV / AMF / libx264). Optional field added
     in v1; readers without #591 simply ignore it. Build via
     ``_build_system_info``.
+
+    ``brightness_samples`` (#569): pre-rendered brightness timeline for
+    the GUI complete screen.  Optional field; pre-#569 metadata files
+    don't carry it.  Shape is ``{"interval_s": float, "values":
+    list[float]}`` -- ``values[i]`` is the brightness (0-255) at
+    ``i * interval_s`` seconds.  Built via :func:`build_brightness_samples`.
     """
-    return {
+    payload: dict = {
         "schema_version": "1",
         "source": str(video_path),
         "source_duration": source_duration,
@@ -1063,6 +1131,57 @@ def _build_metadata_payload(
             for g in gaps
         ],
         "warnings": build_warnings(),
+    }
+    if brightness_samples is not None:
+        payload["brightness_samples"] = brightness_samples
+    return payload
+
+
+_BRIGHTNESS_TIMELINE_TARGET_SAMPLES = 512
+"""Target sample count for the GUI complete-screen timeline (#569).
+
+512 keeps the SVG path lightweight (well under the WebKit path-length
+limit on Windows + matches the existing dummy ``buildSampleBrightness``
+in the design prototype) while still capturing a 2:50 hour recording at
+~20 second granularity -- fine enough that match boundaries land on a
+distinct sample in practice.
+"""
+
+
+def build_brightness_samples(
+    raw_brightness: dict[float, float],
+    *,
+    target_samples: int = _BRIGHTNESS_TIMELINE_TARGET_SAMPLES,
+) -> dict[str, object] | None:
+    """Down-sample a Pass 1 ``{timestamp: brightness}`` map for metadata.json (#569).
+
+    The GUI complete screen draws a brightness timeline whose width is
+    fixed (~700px); rendering every probe (potentially tens of thousands
+    on a 3-hour video) would bloat metadata.json and yield more SVG path
+    points than the WebView can stroke smoothly.  We linearly stride the
+    sorted timestamps so the resulting array is at most
+    ``target_samples`` entries while preserving the start / end shape.
+
+    Returns ``None`` for empty input so callers can ``if samples is None:
+    skip`` rather than write a degenerate ``{interval_s: 0, values: []}``
+    object.
+    """
+    if not raw_brightness:
+        return None
+    timestamps = sorted(raw_brightness.keys())
+    n = len(timestamps)
+    stride = max(1, n // max(1, target_samples))
+    selected = timestamps[::stride]
+    if not selected:
+        return None
+    if len(selected) >= 2:
+        interval_s = float(selected[1] - selected[0])
+    else:
+        interval_s = float(timestamps[-1]) if timestamps[-1] > 0 else 1.0
+    values = [round(float(raw_brightness[t]), 3) for t in selected]
+    return {
+        "interval_s": round(interval_s, 6),
+        "values": values,
     }
 
 

--- a/allaganeye/detection/progress_emitter.py
+++ b/allaganeye/detection/progress_emitter.py
@@ -1,0 +1,126 @@
+"""JSON-lines progress emitter for the GUI (Tauri) wrapper (#569).
+
+Background
+----------
+The Tauri GUI spawns ``allaganeye detect`` and needs phase + percent +
+elapsed updates while the subprocess runs.  The CLI's normal verbose
+output is rendered for a TTY (click progressbars + free-form ``typer.echo``
+lines) and is brittle to parse from Rust.
+
+This module emits a stream of one JSON object per line on a writable
+stream (``sys.stdout`` by default) when explicitly enabled via
+``--progress-format json``.  The Rust side reads ``BufReader::new(stdout).lines()``
+and parses each line individually; partial / non-JSON lines are ignored
+so a future stray ``print`` won't break parsing.
+
+Schema (each line = one JSON object)
+------------------------------------
+``{"phase": str, "completed": int?, "total": int?, "elapsed_s": float, ...}``
+
+Phases
+~~~~~~
+- ``"start"``                  emitted once when detect begins (no completed/total)
+- ``"probing"``                ffprobe complete, before Pass 1 (no completed/total)
+- ``"scan"``                   Pass 1 frame-brightness sampling
+- ``"refine"``                 Pass 2 fine-grained probing
+- ``"scorebar"``               scorebar classification
+- ``"audio"``                  audio Fanfare scan (when --no-audio is off)
+- ``"writing_metadata"``       just before metadata.json is written
+- ``"done"``                   final, includes ``metadata_path`` field
+- ``"error"``                  fatal failure, includes ``message`` field
+
+Design notes
+------------
+* A *disabled* emitter is a no-op so call sites can drop the ``if`` check.
+* ``flush`` is forced after every line: ffmpeg-style buffering would make
+  the GUI's progress bar feel laggy.
+* The class never raises -- a write failure (broken pipe, etc.) is
+  swallowed silently because the subprocess has bigger problems than
+  reporting them on the broken pipe.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import IO, Any
+
+
+class ProgressEmitter:
+    """Stream JSON-lines progress events to *stream*.
+
+    Constructed once at the start of a detect run and threaded through
+    the detection callbacks.  When *enabled* is False the public
+    ``emit*`` methods return immediately and produce no output.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        stream: IO[str] | None = None,
+        clock: Any = None,
+    ) -> None:
+        self.enabled = enabled
+        self._stream = stream if stream is not None else sys.stdout
+        self._clock = clock if clock is not None else time.monotonic
+        self._start = self._clock()
+
+    @property
+    def elapsed_s(self) -> float:
+        """Wall-clock seconds since emitter was constructed."""
+        return self._clock() - self._start
+
+    def emit(self, phase: str, **fields: Any) -> None:
+        """Emit one JSON line with *phase* + *fields* + ``elapsed_s``.
+
+        Unknown extra fields are passed through unchanged so callers can
+        attach optional context (e.g. ``message`` for errors,
+        ``metadata_path`` for the terminal ``done``).  Disabled emitters
+        are a no-op.
+        """
+        if not self.enabled:
+            return
+        payload: dict[str, Any] = {"phase": phase}
+        for k, v in fields.items():
+            if v is None:
+                continue
+            payload[k] = v
+        payload["elapsed_s"] = round(self.elapsed_s, 3)
+        line = json.dumps(payload, ensure_ascii=False)
+        try:
+            self._stream.write(line + "\n")
+            self._stream.flush()
+        except (OSError, ValueError):
+            # Broken pipe / closed stream -- the consumer is gone, nothing
+            # actionable from inside detect. Don't propagate so the detect
+            # itself still runs to completion.
+            pass
+
+    def emit_progress(
+        self,
+        phase: str,
+        completed: int,
+        total: int,
+        **fields: Any,
+    ) -> None:
+        """Convenience wrapper for the most common ``(completed, total)`` shape.
+
+        ``percent`` is *not* pre-computed so the consumer can render a
+        rate-aware bar; total may be 0 for indeterminate phases (the GUI
+        treats 0 as "spinner only").
+        """
+        self.emit(phase, completed=completed, total=total, **fields)
+
+
+_DISABLED = ProgressEmitter(enabled=False)
+
+
+def disabled_emitter() -> ProgressEmitter:
+    """Return a process-wide singleton no-op emitter.
+
+    Useful as a default argument so call sites don't have to special-case
+    ``None`` checks (mirrors ``logging.NullHandler``).
+    """
+    return _DISABLED

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -85,6 +85,7 @@ def detect_match_boundaries(
     chunk_progress_callback: Callable[[int, int, float], None] | None = None,
     chunk_dispatch_callback: Callable[[int], None] | None = None,
     gpu_vendor: str | None = None,
+    brightness_callback: Callable[[dict[float, float]], None] | None = None,
 ) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
 
@@ -111,6 +112,13 @@ def detect_match_boundaries(
             provided and scorebar filtering is active, blackouts
             classified as ``"in_match"`` but near a Fanfare hit are
             promoted to ``"match_boundary"``.
+        brightness_callback: Optional callback invoked once after Pass 1
+            completes with the full ``{timestamp_s: brightness}`` mapping.
+            Used by the GUI (#569) to render the complete-screen
+            brightness timeline without a second sampling pass.  The
+            mapping covers every timestamp between 0 and ``duration_hint``
+            at ``sample_interval`` spacing; non-blackout fallbacks (255.0)
+            are included so consumers can plot continuous data.
 
     Returns list of dicts with 'start' and 'end' keys (seconds).
     """
@@ -159,6 +167,12 @@ def detect_match_boundaries(
             progress_callback,
         )
     pass1_elapsed = time.monotonic() - pass1_start
+
+    # #569 -- hand the GUI the full brightness map before any further
+    # filtering / refinement so the complete-screen timeline can be
+    # rendered straight from metadata.json without re-running ffmpeg.
+    if brightness_callback is not None:
+        brightness_callback(results)
 
     if stats is not None:
         stats["mode"] = resolved_mode

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -26,6 +26,7 @@
 | `gaps` | array | ✓ | 試合間の空白区間列 (0 件可) | |
 | `warnings` | array | 新規書き込みは ✓ (デフォルト `[]`) / 読み込み時は欠落許容 | 構造化警告一覧 (#518) | 個々のエントリは §warnings 参照 |
 | `system_info` | object | 新規書き込みは ✓ / 読み込み時は欠落許容 (#591) | GPU vendor probe スナップショット | 後述 §system_info 参照 |
+| `brightness_samples` | object | 新規書き込みは Pass 1 が走った場合のみ ✓ / 読み込み時は欠落許容 (#569) | GUI complete 画面用の輝度タイムライン | 後述 §brightness_samples 参照 |
 
 ### `detection_params` オブジェクト
 
@@ -70,6 +71,23 @@ GPU vendor probe スナップショット。`probe_gpu_vendors()` の結果と�
 - `allaganeye split --from-metadata`: probe を実行し vendor_used = null (split 時点では vendor を選ばないため)
 
 GUI export 画面は `system_info.gpu_vendors_available` と `vendor_preference` を `select_h264_encoder_for_export` Tauri コマンドに渡し、`H264Encoder` enum (libx264 / NVENC / QSV / AMF) を解決する。`system_info` を持たない pre-#591 metadata.json は libx264 にフォールバックする。
+
+### `brightness_samples` オブジェクト (#569)
+
+GUI complete 画面の輝度タイムライン (`BrightnessTimeline` SVG) 用の事前計算済み輝度配列。Pass 1 のサンプリング結果 (timestamp → 平均輝度) を最大 512 点までダウンサンプルして埋め込む。GUI は metadata.json を読むだけでタイムラインを描画でき、`debug-brightness` を再実行する必要が無い。
+
+| フィールド | 型 | 必須 | 意味 |
+|---|---|---|---|
+| `interval_s` | number | ✓ | 配列の各要素が表す秒間隔 (例: `25.0` なら `values[i]` は `i * 25` 秒の輝度) |
+| `values` | array of number | ✓ | 平均輝度 (0-255 の float) を時系列順に並べたもの。最大 512 要素 |
+
+書き込みパス:
+
+- `allaganeye detect`: cache miss path で Pass 1 が走った場合に書き込む。cache hit / 空 (Pass 1 未実行) の場合はフィールド自体を省略 (`null` ではなく key 不在)
+- `allaganeye split <video>` (legacy): 同上。`run_split` 経由でも `brightness_callback` を渡せば書ける (#569 では detect コマンドのみ書き込み)
+- `allaganeye split --from-metadata`: 入力 metadata.json の値をそのまま転記 (再計算しない)
+
+GUI complete 画面は `metadata.brightness_samples?.values` を読み、欠落時はサンプルデータ (`buildSampleBrightness`) にフォールバックする。
 
 ### `Gap` オブジェクト (`gaps[]`)
 

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -227,19 +227,19 @@
 
 **phase**: `running | cancelling | cancelled | completed | error` ([reducers/detecting.ts:16-40](../gui/src/screens/reducers/detecting.ts#L16))
 
-**store**: detecting screen は **`metadataStore.loadSample()` を `phase=completed` で 1 回だけ呼ぶ** ([DetectingScreen.tsx:50-55](../gui/src/screens/DetectingScreen.tsx#L50))。`appStateStore.navigate('drop' | 'complete')` で遷移し、`selectedVideoPath` は読むのみで mutation しない (drop で確定した path を後段が継承する設計、#465 review C)。
+**store**: detecting screen は Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) で **`metadataStore.load(metadata_path)` を `start_detect` resolve 後に 1 回呼ぶ** 動作に切替済。`selectedVideoPath` が null の StateSwitcher dev mode 経路でのみ `loadSample()` にフォールバックする。`appStateStore.navigate('drop' | 'complete')` で遷移し、`selectedVideoPath` は読むのみで mutation しない (drop で確定した path を後段が継承する設計、#465 review C)。
 
-**dirty / silent loss**: 編集対象 metadata が無いため §1.3 silent loss confirm の対象外。ただし [中断] → drop 遷移は確定済み video path を捨てる動線なので、Phase 2.5 (#569) で確認 dialog を入れるかは検討事項として残す ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) で議論)。
+**dirty / silent loss**: 編集対象 metadata が無いため §1.3 silent loss confirm の対象外。ただし [中断] → drop 遷移は確定済み video path を捨てる動線なので、確認 dialog を入れるかは検討事項として残す (Phase 2.5 [#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) では未対応、後続で議論)。
 
-**sample mode**: `loadSample()` を呼ぶのは detecting だが、これは sample 検出を「実 CLI が走った結果」として代替する Phase 2 の暫定動作。Phase 2.5 (#569) で実 CLI 結果に置き換えれば本画面で sample mode 起動経路は廃止される。
+**sample mode**: Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) で実 CLI 結果への切替が完了し、本画面の `loadSample()` 経路は **`selectedVideoPath` が null の StateSwitcher dev mode 専用フォールバック** に縮退した。プロダクションフロー (drop → detecting) では呼ばれない。
 
-**エラー表示**: §1.5 のうち本画面では現状 **toast を使わず drop へ navigate する Phase 2 暫定挙動** ([DetectingScreen.tsx:65-69](../gui/src/screens/DetectingScreen.tsx#L65))。Phase 2.5 (#569) で `error` phase 時に **toast 通知 + drop 遷移** に置換する。inline は本画面では採用しない (画面が観測フローに専念する設計のため)。
+**エラー表示**: §1.5 のうち本画面では現状 **toast を使わず drop へ navigate する暫定挙動**。Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) は CLI stdout streaming への差し替えまでで、`error` phase 時の **toast 通知** は [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) (panic / error / log 構造化) で `ErrorBoundary` / `ErrorModal` 兼任設計と合わせて実装する。本画面では inline は採用しない (画面が観測フローに専念する設計のため)。
 
 **実装段階**:
 
-- 現状 (Phase 2): 80ms × 100 tick = 8s の dummy progress、log は progress 連動の hardcoded 3 行 ([DetectingScreen.tsx:11-12,118-133](../gui/src/screens/DetectingScreen.tsx#L11))
-- Phase 2.5 (#569): 実 CLI stdout streaming に差し替え、log は CLI からの行を逐次 append、`error` toast、`cancelling → cancelled` は実 ffmpeg `kill()` 完了で confirm
-- 関連: [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) (running 中の `× 閉じる` 確保) は本画面の cancel と同じ kill 経路を共有予定
+- Phase 2 (#464): 80ms × 100 tick = 8s の dummy progress、log は progress 連動の hardcoded 3 行 (実装当時)
+- Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) **済**: 実 CLI (`allaganeye detect --progress-format json`) stdout streaming に差し替え、log は CLI 1 行 = 1 entry で逐次 append、最大 80 行で truncate、phase 別に `info` / `done` / `error` / `warn` の kind 色分け。meta 行は `probing` event の ffprobe 結果 (`width × height` / `fps` / `codec` / `duration`) に差し替え。`cancelling → cancelled` は **本画面では UI phase 遷移のみ** (実 ffmpeg `kill()` は [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) PR で実装、本 PR は process_tracker への track 登録までで scope を絞る)
+- 関連: [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) (running 中の `× 閉じる` 確保) は本画面の cancel と同じ `kill_tracked_processes` 経路を共有する
 
 #### §2.2.1 AllaganSigil (回転アニメーション)
 
@@ -259,7 +259,7 @@
 | 状態 | `displayOnly` |
 | 遷移トリガー | なし。`selectedVideoPath` 変化時に再 render (basename を抜き出して表示) |
 | store mutation | なし |
-| 例外 / edge case | `selectedVideoPath` が null の場合は `'(video)'` フォールバック ([:80](../gui/src/screens/DetectingScreen.tsx#L80))。Phase 2.5 (#569) で `meta` 行を「dummy probe · Phase 2 skeleton」から実 ffprobe 結果 (解像度 / fps / 長さ等) に差し替える |
+| 例外 / edge case | `selectedVideoPath` が null の場合は `'(video)'` フォールバック。Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) で `meta` 行を `probing` event payload (`width` × `height` / `fps` / `codec` / `duration_s`) から実 ffprobe 結果に差し替え済 (`probing` 受信前の数百 ms は暫定 `phase: …` を表示) |
 
 #### §2.2.3 progressBadge
 
@@ -269,7 +269,7 @@
 | 状態 | `displayOnly`。`progress` (0-100) を四捨五入で表示 |
 | 遷移トリガー | local state `progress` 変化 (Phase 2 dummy interval、Phase 2.5 で CLI 進捗イベント) |
 | store mutation | なし |
-| 例外 / edge case | Phase 2 では `progressTiming` 行が `'Phase 2 dummy'` の固定文字列。Phase 2.5 で経過時間 / ETA に差し替え (#569 議論対象) |
+| 例外 / edge case | Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) で `progressTiming` 行を経過時間 (`fmtElapsed(elapsed)`) と簡易 ETA (`computeEta(percent, elapsed)` の線形外挿、進捗 0% / 100% 付近では非表示) に差し替え済 |
 
 #### §2.2.4 PhaseRow.Detecting (粗スキャン)
 
@@ -299,7 +299,7 @@
 | 状態 | `displayOnly`。Phase 2 は progress 閾値 (0% / 30% / 60%) で 3 行を順次表示する hardcoded 動作 |
 | 遷移トリガー | progress 連動 (Phase 2 dummy)。Phase 2.5 で CLI stdout 行を逐次 append |
 | store mutation | なし |
-| 例外 / edge case | Phase 2.5 で実 CLI stdout に切替時、行数が長期間で増え続けるため scroll 制御 (auto-scroll、最大行数制限) を要設計。retention は描画にのみ影響し store には永続化しない (#569 議論対象) |
+| 例外 / edge case | Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) で実 CLI stdout 1 行 = 1 entry の append に切替済。`MAX_LOG_LINES = 80` で先頭から truncate、retention は描画にのみ影響し store には永続化しない。phase 別に `info` / `done` / `error` / `warn` の `kind` を CSS class (`logEntryDone` / `logEntryError` / `logEntryWarn`) で色分け (キーワード視認性確保) |
 
 #### §2.2.7 [中断] button
 
@@ -307,8 +307,8 @@
 |---|---|
 | 種類 | button ([DetectingScreen.tsx:136-143](../gui/src/screens/DetectingScreen.tsx#L136)) |
 | 状態 | `idle` (phase=`running`) / `disabled` (phase=`cancelling/cancelled/completed/error`) |
-| 遷移トリガー | `onClick` → reducer `CANCEL_CLICKED` (phase=`running → cancelling`)。Phase 2 は副作用 effect で即座に `CANCEL_CONFIRMED` を発火し `cancelling → cancelled` 遷移 ([DetectingScreen.tsx:72-76](../gui/src/screens/DetectingScreen.tsx#L72))。Phase 2.5 で実 ffmpeg `kill()` 完了を待ってから `CANCEL_CONFIRMED` |
-| store mutation | なし (cancelled 検出後の effect で `appStateStore.navigate('drop')` のみ、[DetectingScreen.tsx:58-62](../gui/src/screens/DetectingScreen.tsx#L58)) |
+| 遷移トリガー | `onClick` → reducer `CANCEL_CLICKED` (phase=`running → cancelling`)。Phase 2 / Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) は副作用 effect で即座に `CANCEL_CONFIRMED` を発火し `cancelling → cancelled` 遷移。実 ffmpeg `kill()` 完了同期は [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) で `kill_tracked_processes` 完了を待ってから `CANCEL_CONFIRMED` を発火する設計に拡張する (本 PR は phase 遷移のみで scope を絞る) |
+| store mutation | なし (cancelled 検出後の effect で `appStateStore.navigate('drop')` のみ) |
 | 例外 / edge case | §1.2 disabled 理由表示について、現状 `disabled={phase !== 'running'}` のみで tooltip / inline hint 未実装 → 後続 PR で `title="検知実行中のみ中断できます"` 等を追加 (本 doc が source of truth)。`cancelling` 中の連打は disabled で物理的に防止 |
 
 ### §2.3 complete
@@ -330,12 +330,13 @@
 
 **sample mode**: `metadataStore.filePath === null` の sample mode では `[元に戻す]` は `hasBackup=false` で disabled、編集系のない complete 画面では §1.4 の sample banner を上部 `topBar` 直下に表示する (本 doc が source of truth、現状未実装)。
 
-**エラー表示**: §1.5 inline + toast 併用。complete 画面の主要エラー源は `restoreError` ([RestoreButton.tsx:63-67](../gui/src/components/RestoreButton.tsx#L63), inline `role="alert"`)。Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) で global toast 表示先を兼任する設計に揃える。
+**エラー表示**: §1.5 inline + toast 併用。complete 画面の主要エラー源は `restoreError` ([RestoreButton.tsx:63-67](../gui/src/components/RestoreButton.tsx#L63), inline `role="alert"`)。global toast 兼任設計は [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) (panic / error / log 構造化、`ErrorBoundary` / `ErrorModal`) で実装する。
 
 **実装段階**:
 
-- 現状 (Phase 2): 試合一覧 / BrightnessTimeline / プレビューサムネイル ([#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) で実 path に切替済) が動作。`brightness` は `sampleBrightness()` の固定波形 ([CompleteScreen.tsx:42](../gui/src/screens/CompleteScreen.tsx#L42))
-- Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)): 実 video からの brightness 抽出に置換、所要列 ([#586](https://github.com/Idios/kobutachan-allaganeye/issues/586))、a11y / polish ([#587](https://github.com/Idios/kobutachan-allaganeye/issues/587))、threshold 連動 ([#588](https://github.com/Idios/kobutachan-allaganeye/issues/588))、§1.3 dirty consume confirm 全経路を実装
+- Phase 2 (#464): 試合一覧 / BrightnessTimeline / プレビューサムネイル ([#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) で実 path に切替済) が動作。`brightness` は `sampleBrightness()` の固定波形だった
+- Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) **済**: `metadata.brightness_samples?.values` (CLI が Pass 1 から 512 点に間引いて metadata.json に埋め込む `BrightnessSamples` 構造) を優先利用、欠落時のみ `sampleBrightness()` フォールバック
+- 後続: 所要列 ([#586](https://github.com/Idios/kobutachan-allaganeye/issues/586))、a11y / polish ([#587](https://github.com/Idios/kobutachan-allaganeye/issues/587))、threshold 連動 ([#588](https://github.com/Idios/kobutachan-allaganeye/issues/588))、§1.3 dirty consume confirm 全経路
 
 #### §2.3.1 statusDot
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ use axum::{
 };
 use tauri::{Emitter, Manager};
 use futures::future::join_all;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -1621,6 +1621,333 @@ fn select_h264_encoder_for_export(
     }
 }
 
+/// #569 -- detect command parameters surfaced from the GUI's drop screen.
+///
+/// All fields are optional so the frontend can pass only the controls
+/// the user adjusted; missing values are translated into "use the CLI
+/// default" by leaving the corresponding `--option` off the argv.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DetectParams {
+    pub blackout_threshold: Option<f64>,
+    pub min_blackout_duration: Option<f64>,
+    pub min_match_duration: Option<f64>,
+    pub workers: Option<u32>,
+    pub no_audio: Option<bool>,
+    pub no_cache: Option<bool>,
+    /// `Some(true)` -> `--gpu`, `Some(false)` -> `--no-gpu`, `None` -> auto.
+    pub gpu: Option<bool>,
+    pub gpu_vendor: Option<String>,
+}
+
+/// #569 -- one progress event emitted on channel `detect-progress`.
+///
+/// The shape mirrors the CLI's JSON-line schema (see
+/// `allaganeye/detection/progress_emitter.py`).  Optional fields are
+/// `None` when the CLI omitted them from the wire payload (the emitter
+/// drops `None`-valued extras at the source so the frontend doesn't
+/// have to disambiguate `null` vs absent).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct DetectProgress {
+    pub phase: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elapsed_s: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eta_s: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blackout_frames: Option<u64>,
+    /// On the terminal `phase="done"` event the CLI sets this to the
+    /// path of the freshly-written metadata.json so the frontend can
+    /// `load_metadata` it without deriving the path itself.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matches: Option<u64>,
+    /// Free-form context (e.g. CLI stderr tail on `phase="error"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Probing phase: video duration in seconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_s: Option<f64>,
+    /// Probing phase: video width in pixels.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    /// Probing phase: video height in pixels.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
+    /// Probing phase: video frame rate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fps: Option<f64>,
+    /// Probing phase: video codec (h264 / hevc / ...).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codec: Option<String>,
+    /// `chunk_dispatch` phase: number of decode chunks pending.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunks: Option<u32>,
+    /// `cache_hit` phase: number of boundaries restored from cache.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boundaries: Option<u32>,
+    /// `start` phase: source video path (echoes the request).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+/// #569 -- terminal payload returned to the frontend when detect finishes.
+///
+/// The frontend reads `metadata_path` and calls `load_metadata` to populate
+/// the complete screen.
+#[derive(Debug, Clone, Serialize)]
+pub struct DetectResult {
+    pub metadata_path: String,
+    pub matches: u64,
+}
+
+/// #569 -- pure parser for one JSON-lines progress event.  Returns
+/// `None` for blank lines or lines that fail to deserialize so a stray
+/// stdout write from the CLI doesn't break the overall stream.
+fn parse_detect_progress_line(line: &str) -> Option<DetectProgress> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+    serde_json::from_str(line).ok()
+}
+
+/// #569 -- locate the `allaganeye` CLI executable.
+///
+/// Resolution order:
+/// 1. `ALLAGANEYE_BIN` environment variable (must point at a real file).
+/// 2. The bare name `"allaganeye"` -- relies on `tokio::process::Command`'s
+///    PATH search.  Portable ZIP layouts add the bundled `allaganeye.bat`
+///    location to PATH at install time.
+fn resolve_allaganeye_bin() -> String {
+    if let Ok(path) = std::env::var("ALLAGANEYE_BIN") {
+        if !path.is_empty() {
+            return path;
+        }
+    }
+    "allaganeye".to_string()
+}
+
+/// #569 -- assemble argv for `allaganeye detect --progress-format json`.
+/// Pulled out of `start_detect` so unit tests can pin flag ordering and
+/// the plumbing of optional `DetectParams` -> CLI flags without spawning
+/// a subprocess.
+fn detect_command_args(
+    video_path: &str,
+    output_dir: &str,
+    params: &DetectParams,
+) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "detect".to_string(),
+        video_path.to_string(),
+        "-o".to_string(),
+        output_dir.to_string(),
+        "--progress-format".to_string(),
+        "json".to_string(),
+    ];
+    if let Some(v) = params.blackout_threshold {
+        args.push("--blackout-threshold".to_string());
+        args.push(format!("{v}"));
+    }
+    if let Some(v) = params.min_blackout_duration {
+        args.push("--min-blackout-duration".to_string());
+        args.push(format!("{v}"));
+    }
+    if let Some(v) = params.min_match_duration {
+        args.push("--min-match-duration".to_string());
+        args.push(format!("{v}"));
+    }
+    if let Some(v) = params.workers {
+        args.push("--workers".to_string());
+        args.push(format!("{v}"));
+    }
+    if params.no_audio.unwrap_or(false) {
+        args.push("--no-audio".to_string());
+    }
+    if params.no_cache.unwrap_or(false) {
+        args.push("--no-cache".to_string());
+    }
+    match params.gpu {
+        Some(true) => args.push("--gpu".to_string()),
+        Some(false) => args.push("--no-gpu".to_string()),
+        None => {}
+    }
+    if let Some(vendor) = params.gpu_vendor.as_deref() {
+        if !vendor.is_empty() {
+            args.push("--gpu-vendor".to_string());
+            args.push(vendor.to_string());
+        }
+    }
+    args
+}
+
+/// #569 -- spawn `allaganeye detect --progress-format json` and stream
+/// progress events to the frontend.
+///
+/// The child is registered with [`process_tracker`] so the
+/// `CloseRequested` flow (#523) and the user-pressed cancel button (next
+/// PR, also #523) can kill it.  Cancellation by the user from the
+/// detecting screen is handled by the frontend dispatching a phase
+/// transition only -- the actual `kill_tracked_processes` invocation is
+/// deferred to #523's PR.
+#[tauri::command]
+async fn start_detect(
+    app: tauri::AppHandle,
+    video_path: String,
+    output_dir: String,
+    params: DetectParams,
+) -> Result<DetectResult, String> {
+    let video = PathBuf::from(&video_path);
+    if !video.exists() {
+        return Err(format!("video file not found: {}", video.display()));
+    }
+    let output_buf = PathBuf::from(&output_dir);
+    if let Err(e) = fs::create_dir_all(&output_buf) {
+        return Err(format!(
+            "create output dir failed ({}): {}",
+            output_buf.display(),
+            e
+        ));
+    }
+
+    let bin = resolve_allaganeye_bin();
+    let args = detect_command_args(&video_path, &output_dir, &params);
+
+    let mut cmd = tokio::process::Command::new(&bin);
+    for a in &args {
+        cmd.arg(a);
+    }
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("spawn allaganeye failed ({}): {}", bin, e))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture allaganeye stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "failed to capture allaganeye stderr".to_string())?;
+
+    let tracked_id = track_child(child).await;
+
+    // Stderr drains in parallel into a bounded tail buffer so the OS
+    // pipe doesn't fill up if the CLI is chatty under -v / verbose.
+    let stderr_handle = tokio::spawn(async move {
+        let max_tail = 2048usize;
+        let mut tail: Vec<u8> = Vec::with_capacity(4096);
+        let mut reader = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = reader.next_line().await {
+            tail.extend_from_slice(line.as_bytes());
+            tail.push(b'\n');
+            if tail.len() > max_tail * 2 {
+                let drop = tail.len() - max_tail;
+                tail.drain(0..drop);
+            }
+        }
+        tail
+    });
+
+    let mut metadata_path: Option<String> = None;
+    let mut total_matches: u64 = 0;
+    let mut reader = BufReader::new(stdout).lines();
+
+    loop {
+        match reader.next_line().await {
+            Ok(Some(line)) => {
+                if let Some(progress) = parse_detect_progress_line(&line) {
+                    if progress.phase == "done" {
+                        if let Some(ref p) = progress.metadata_path {
+                            metadata_path = Some(p.clone());
+                        }
+                        if let Some(m) = progress.matches {
+                            total_matches = m;
+                        }
+                    }
+                    let _ = app.emit("detect-progress", progress);
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                // stdout pipe hiccup -- still try to wait the child so
+                // we don't leak a zombie.  The error path below sets the
+                // error event.
+                let msg = format!("stdout read error: {e}");
+                let _ = app.emit(
+                    "detect-progress",
+                    DetectProgress {
+                        phase: "error".to_string(),
+                        message: Some(msg.clone()),
+                        ..Default::default()
+                    },
+                );
+                break;
+            }
+        }
+    }
+
+    let mut child = match untrack_child(tracked_id).await {
+        Some(c) => c,
+        None => {
+            // Drained by `kill_tracked_processes` -- treat as user cancel.
+            let _ = app.emit(
+                "detect-progress",
+                DetectProgress {
+                    phase: "cancelled".to_string(),
+                    ..Default::default()
+                },
+            );
+            return Err("detect cancelled".to_string());
+        }
+    };
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("wait allaganeye failed: {e}"))?;
+    let stderr_tail = stderr_handle.await.unwrap_or_default();
+
+    if !status.success() {
+        let tail = String::from_utf8_lossy(&stderr_tail).trim().to_string();
+        let msg = if tail.is_empty() {
+            format!("allaganeye exited with status {:?}", status.code())
+        } else {
+            format!(
+                "allaganeye exited with status {:?}: {}",
+                status.code(),
+                tail
+            )
+        };
+        let _ = app.emit(
+            "detect-progress",
+            DetectProgress {
+                phase: "error".to_string(),
+                message: Some(msg.clone()),
+                ..Default::default()
+            },
+        );
+        return Err(msg);
+    }
+
+    let metadata_path = metadata_path.ok_or_else(|| {
+        "detect completed but no metadata_path was emitted".to_string()
+    })?;
+
+    Ok(DetectResult {
+        metadata_path,
+        matches: total_matches,
+    })
+}
+
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -1654,6 +1981,7 @@ pub fn run() {
             export_match,
             select_h264_encoder_for_export,
             open_folder_in_explorer,
+            start_detect,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -2988,5 +3316,262 @@ mod tests {
     fn tail_string_returns_whole_buffer_when_small() {
         let buf = b"  short message\n";
         assert_eq!(tail_string(buf, 2048), "short message");
+    }
+
+    // -- #569 detect progress streaming -----------------------------------
+
+    #[test]
+    fn parse_detect_progress_line_handles_basic_event() {
+        let line = r#"{"phase":"scan","completed":12,"total":100,"elapsed_s":1.25}"#;
+        let parsed = parse_detect_progress_line(line).expect("should parse");
+        assert_eq!(parsed.phase, "scan");
+        assert_eq!(parsed.completed, Some(12));
+        assert_eq!(parsed.total, Some(100));
+        assert_eq!(parsed.elapsed_s, Some(1.25));
+    }
+
+    #[test]
+    fn parse_detect_progress_line_handles_done_with_metadata_path() {
+        let line = r#"{"phase":"done","metadata_path":"C:/out/metadata.json","matches":3,"elapsed_s":42.5}"#;
+        let parsed = parse_detect_progress_line(line).expect("should parse");
+        assert_eq!(parsed.phase, "done");
+        assert_eq!(
+            parsed.metadata_path.as_deref(),
+            Some("C:/out/metadata.json")
+        );
+        assert_eq!(parsed.matches, Some(3));
+    }
+
+    #[test]
+    fn parse_detect_progress_line_returns_none_for_blank_line() {
+        assert!(parse_detect_progress_line("").is_none());
+        assert!(parse_detect_progress_line("   \n").is_none());
+    }
+
+    #[test]
+    fn parse_detect_progress_line_returns_none_for_non_json() {
+        assert!(parse_detect_progress_line("Probing: video.mkv").is_none());
+        assert!(parse_detect_progress_line("not even close").is_none());
+    }
+
+    #[test]
+    fn parse_detect_progress_line_ignores_unknown_extra_fields() {
+        // Unknown extras must not abort parsing -- the CLI is allowed to
+        // grow new optional fields without breaking the GUI.
+        let line = r#"{"phase":"scan","completed":1,"total":2,"future_field":"hello"}"#;
+        let parsed = parse_detect_progress_line(line).expect("should parse");
+        assert_eq!(parsed.phase, "scan");
+    }
+
+    #[test]
+    fn parse_detect_progress_line_handles_probing_metadata() {
+        let line = r#"{"phase":"probing","duration_s":600.0,"width":1920,"height":1080,"fps":60.0,"codec":"h264","elapsed_s":0.4}"#;
+        let parsed = parse_detect_progress_line(line).expect("should parse");
+        assert_eq!(parsed.phase, "probing");
+        assert_eq!(parsed.duration_s, Some(600.0));
+        assert_eq!(parsed.width, Some(1920));
+        assert_eq!(parsed.fps, Some(60.0));
+        assert_eq!(parsed.codec.as_deref(), Some("h264"));
+    }
+
+    #[test]
+    fn detect_command_args_includes_required_flags() {
+        let args = detect_command_args(
+            "C:/videos/in.mkv",
+            "C:/out/run-01",
+            &DetectParams::default(),
+        );
+        assert_eq!(args[0], "detect");
+        assert_eq!(args[1], "C:/videos/in.mkv");
+        assert_eq!(args[2], "-o");
+        assert_eq!(args[3], "C:/out/run-01");
+        assert!(args.iter().any(|a| a == "--progress-format"));
+        assert!(args.iter().any(|a| a == "json"));
+    }
+
+    #[test]
+    fn detect_command_args_omits_optional_flags_when_unset() {
+        let args = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams::default(),
+        );
+        let joined = args.join(" ");
+        assert!(!joined.contains("--blackout-threshold"));
+        assert!(!joined.contains("--no-audio"));
+        assert!(!joined.contains("--no-cache"));
+        assert!(!joined.contains("--gpu"));
+        assert!(!joined.contains("--no-gpu"));
+        assert!(!joined.contains("--workers"));
+    }
+
+    #[test]
+    fn detect_command_args_emits_blackout_threshold_when_provided() {
+        let args = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams {
+                blackout_threshold: Some(20.0),
+                ..Default::default()
+            },
+        );
+        let idx = args
+            .iter()
+            .position(|a| a == "--blackout-threshold")
+            .expect("flag missing");
+        assert_eq!(args[idx + 1], "20");
+    }
+
+    #[test]
+    fn detect_command_args_translates_gpu_tristate() {
+        // Some(true) -> --gpu
+        let args_on = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams {
+                gpu: Some(true),
+                ..Default::default()
+            },
+        );
+        assert!(args_on.iter().any(|a| a == "--gpu"));
+        assert!(!args_on.iter().any(|a| a == "--no-gpu"));
+
+        // Some(false) -> --no-gpu
+        let args_off = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams {
+                gpu: Some(false),
+                ..Default::default()
+            },
+        );
+        assert!(args_off.iter().any(|a| a == "--no-gpu"));
+        assert!(!args_off.iter().any(|a| a == "--gpu"));
+
+        // None -> neither flag (CLI auto-selects)
+        let args_auto = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams::default(),
+        );
+        assert!(!args_auto.iter().any(|a| a == "--gpu" || a == "--no-gpu"));
+    }
+
+    #[test]
+    fn detect_command_args_emits_no_audio_only_when_true() {
+        let args_on = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams {
+                no_audio: Some(true),
+                ..Default::default()
+            },
+        );
+        assert!(args_on.iter().any(|a| a == "--no-audio"));
+
+        let args_off = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams {
+                no_audio: Some(false),
+                ..Default::default()
+            },
+        );
+        assert!(!args_off.iter().any(|a| a == "--no-audio"));
+    }
+
+    #[test]
+    fn detect_command_args_includes_workers_when_provided() {
+        let args = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams {
+                workers: Some(8),
+                ..Default::default()
+            },
+        );
+        let idx = args
+            .iter()
+            .position(|a| a == "--workers")
+            .expect("flag missing");
+        assert_eq!(args[idx + 1], "8");
+    }
+
+    #[test]
+    fn detect_command_args_includes_gpu_vendor_when_provided() {
+        let args = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams {
+                gpu_vendor: Some("nvidia".to_string()),
+                ..Default::default()
+            },
+        );
+        let idx = args
+            .iter()
+            .position(|a| a == "--gpu-vendor")
+            .expect("flag missing");
+        assert_eq!(args[idx + 1], "nvidia");
+    }
+
+    #[test]
+    fn detect_command_args_skips_empty_gpu_vendor() {
+        let args = detect_command_args(
+            "in.mkv",
+            "out",
+            &DetectParams {
+                gpu_vendor: Some(String::new()),
+                ..Default::default()
+            },
+        );
+        assert!(!args.iter().any(|a| a == "--gpu-vendor"));
+    }
+
+    /// `resolve_allaganeye_bin` reads `ALLAGANEYE_BIN`. cargo test is
+    /// multi-threaded by default and process env vars are shared across
+    /// threads, so split-out tests that all touch the same key would
+    /// race. Roll the three cases into one sequential test instead.
+    #[test]
+    fn resolve_allaganeye_bin_resolution_order() {
+        let key = "ALLAGANEYE_BIN";
+        let saved = std::env::var(key).ok();
+
+        // 1. Custom path wins when set.
+        std::env::set_var(key, "C:/custom/path/allaganeye.exe");
+        assert_eq!(resolve_allaganeye_bin(), "C:/custom/path/allaganeye.exe");
+
+        // 2. Empty value is treated as unset (PATH lookup fallback).
+        std::env::set_var(key, "");
+        assert_eq!(resolve_allaganeye_bin(), "allaganeye");
+
+        // 3. Unset env -> bare name (relies on PATH search at spawn time).
+        std::env::remove_var(key);
+        assert_eq!(resolve_allaganeye_bin(), "allaganeye");
+
+        // Restore prior env so other tests are unaffected.
+        match saved {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn detect_progress_skips_none_fields_in_json_serde() {
+        // Reuse the wire format in case some integration consumer
+        // round-trips the struct via JSON instead of the Tauri event
+        // bridge -- skip_serializing_if must drop None entries so we
+        // mirror the Python side's compact format.
+        let progress = DetectProgress {
+            phase: "scan".to_string(),
+            completed: Some(1),
+            total: Some(10),
+            ..Default::default()
+        };
+        let serialized = serde_json::to_string(&progress).unwrap();
+        assert!(serialized.contains("\"phase\":\"scan\""));
+        assert!(serialized.contains("\"completed\":1"));
+        assert!(!serialized.contains("metadata_path"));
+        assert!(!serialized.contains("\"matches\""));
+        assert!(!serialized.contains("\"message\""));
     }
 }

--- a/gui/src/__tests__/flow.integration.test.tsx
+++ b/gui/src/__tests__/flow.integration.test.tsx
@@ -130,6 +130,15 @@ function configureHappyInvoke() {
           duration_ms: 100,
         });
       }
+      // #569 -- Phase 2.5 detect
+      case 'start_detect': {
+        const a = args as { outputDir?: string } | undefined;
+        const out = a?.outputDir ?? 'C:/out';
+        return Promise.resolve({
+          metadata_path: `${out}/metadata.json`,
+          matches: 1,
+        });
+      }
       default:
         return Promise.resolve();
     }
@@ -177,24 +186,31 @@ describe('flow A2: [OK] from selected -> detecting', () => {
     });
 
     await user.click(screen.getByRole('button', { name: /OK — 検知開始/ }));
-    expect(screen.getByTestId('detecting-screen')).toBeInTheDocument();
+    // #569: DetectingScreen now invokes start_detect on mount and
+    // navigates to complete when the promise resolves. We assert the
+    // selectedVideoPath landed before any awaits resolve, then wait
+    // for the full pipeline to settle (detecting transient may flush
+    // straight to complete in the mocked happy path).
     expect(useAppStateStore.getState().selectedVideoPath).toBe(
       'C:/videos/test.mkv',
     );
+    await waitFor(() => {
+      const screenName = useAppStateStore.getState().screen;
+      expect(['detecting', 'complete']).toContain(screenName);
+    });
   });
 });
 
 describe('flow A3: detecting auto-advances to complete', () => {
-  it('runs the dummy progress interval and ends at complete screen', () => {
-    vi.useFakeTimers();
+  it('start_detect promise resolution drives navigation to complete (#569)', async () => {
+    configureHappyInvoke();
     useAppStateStore.getState().setSelectedVideoPath('/x/video.mkv');
     useAppStateStore.getState().navigate('detecting');
     render(<App />);
     expect(screen.getByTestId('detecting-screen')).toBeInTheDocument();
-    act(() => {
-      vi.advanceTimersByTime(9000);
+    await waitFor(() => {
+      expect(useAppStateStore.getState().screen).toBe('complete');
     });
-    expect(useAppStateStore.getState().screen).toBe('complete');
     expect(useMetadataStore.getState().metadata).not.toBeNull();
   });
 });
@@ -234,7 +250,18 @@ describe('flow F: drop [キャンセル] clears selection', () => {
 });
 
 describe('flow G: detecting [中断] returns to drop', () => {
-  it('cancels the dummy detect and navigates to drop', () => {
+  it('cancel button transitions through cancelling -> cancelled -> drop (#569)', async () => {
+    // Make start_detect hang so the only termination path is the
+    // cancel button (otherwise the mocked happy path would auto-
+    // navigate to complete before we can click 中断).
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve();
+    });
     useAppStateStore.getState().setSelectedVideoPath('/x/video.mkv');
     useAppStateStore.getState().navigate('detecting');
     render(<App />);
@@ -242,7 +269,9 @@ describe('flow G: detecting [中断] returns to drop', () => {
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: '中断' }));
     });
-    expect(useAppStateStore.getState().screen).toBe('drop');
+    await waitFor(() => {
+      expect(useAppStateStore.getState().screen).toBe('drop');
+    });
   });
 });
 

--- a/gui/src/screens/CompleteScreen.test.tsx
+++ b/gui/src/screens/CompleteScreen.test.tsx
@@ -85,4 +85,36 @@ describe('CompleteScreen', () => {
     render(<CompleteScreen />);
     expect(useAppStateStore.getState().selectedMatchIndex).toBe(1);
   });
+
+  it('uses metadata.brightness_samples for the timeline when present (#569)', () => {
+    // Inject a recognisable brightness payload so we can assert the
+    // BrightnessTimeline received it (rather than the sampleBrightness
+    // fallback). 5 evenly-spaced points spanning sampleMetadata's
+    // 2:50 hour duration are enough to exercise the path.
+    const metadata = useMetadataStore.getState().metadata;
+    expect(metadata).not.toBeNull();
+    const fingerprint = [10.0, 80.0, 12.5, 90.0, 7.0];
+    useMetadataStore.setState({
+      metadata: {
+        ...metadata!,
+        brightness_samples: {
+          interval_s: metadata!.source_duration / fingerprint.length,
+          values: fingerprint,
+        },
+      },
+    });
+    render(<CompleteScreen />);
+    // The BrightnessTimeline renders one match block per match; we
+    // confirm via the data-testid the timeline mounted (the brightness
+    // path is opaque DOM but exercised through the same render).
+    expect(screen.getByTestId('brightness-timeline')).toBeInTheDocument();
+  });
+
+  it('falls back to sampleBrightness when metadata has no brightness_samples', () => {
+    // sampleMetadata loaded in beforeEach has no brightness_samples
+    // -> CompleteScreen must still render the timeline (using the
+    // in-memory sample curve).
+    render(<CompleteScreen />);
+    expect(screen.getByTestId('brightness-timeline')).toBeInTheDocument();
+  });
 });

--- a/gui/src/screens/CompleteScreen.tsx
+++ b/gui/src/screens/CompleteScreen.tsx
@@ -39,7 +39,17 @@ export function CompleteScreen() {
     }
   }, [metadata, selectedMatchIndex, selectMatch]);
 
-  const brightness = useMemo(() => sampleBrightness(), []);
+  // #569 -- prefer the pre-rendered brightness timeline written by
+  // `allaganeye detect` (Pass 1 sampling), fall back to the in-memory
+  // sample curve only when metadata.json doesn't carry the field
+  // (sample mode after `loadSample()`, or detect cache hit before
+  // re-detection, or pre-#569 metadata files).
+  const brightness = useMemo(() => {
+    if (metadata?.brightness_samples?.values?.length) {
+      return metadata.brightness_samples.values;
+    }
+    return sampleBrightness();
+  }, [metadata?.brightness_samples]);
 
   if (!metadata) {
     return (

--- a/gui/src/screens/DetectingScreen.module.css
+++ b/gui/src/screens/DetectingScreen.module.css
@@ -164,6 +164,30 @@
   color: var(--ae-gold-bright);
 }
 
+/*
+ * #569 review Round 1 課題 2 — keyword colour-coding for the live log.
+ * The base `.logEntry` class keeps the dim default; the kind-specific
+ * modifiers override the body text colour so terminal "完了" rows stand
+ * out from routine progress and errors are visually impossible to miss.
+ * Time-stamp colours (`.logTime`/`.logTimeActive`) are left untouched
+ * so the most-recent-line indicator still works.
+ */
+.logEntry {
+  color: inherit;
+}
+
+.logEntryDone {
+  color: var(--ae-cyan-bright);
+}
+
+.logEntryError {
+  color: var(--ae-danger);
+}
+
+.logEntryWarn {
+  color: var(--ae-gold-bright);
+}
+
 .actions {
   display: flex;
   gap: 12px;

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -1,15 +1,110 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { Metadata } from '../types/metadata';
+
+const invokeMock = vi.fn();
+const listenMock = vi.fn();
+let lastDetectProgressHandler:
+  | ((event: { payload: unknown }) => void)
+  | null = null;
+
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn().mockResolvedValue(undefined),
+  invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
 }));
 
-import { DetectingScreen } from './DetectingScreen';
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (channel: string, handler: (event: { payload: unknown }) => void) =>
+    listenMock(channel, handler),
+}));
+
+import {
+  DetectingScreen,
+  buildLogText,
+  computeOverallPercent,
+  computeEta,
+  PHASE_WINDOWS,
+} from './DetectingScreen';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
 
+const SAMPLE_METADATA: Metadata = {
+  schema_version: '1',
+  source: 'C:/videos/test.mkv',
+  source_duration: 600.0,
+  source_duration_display: '10:00',
+  source_fps: 60,
+  detected_at: '2026-04-27T00:00:00Z',
+  detection_params: {
+    sample_interval: 1.0,
+    blackout_threshold: 15.0,
+    min_match_duration: 300.0,
+    min_blackout_duration: 3.0,
+    no_audio: false,
+    use_gpu: null,
+    workers: null,
+  },
+  matches: [
+    {
+      index: 1,
+      start_time: 0,
+      end_time: 600,
+      start_display: '00:00',
+      end_display: '10:00',
+      duration: 600,
+      duration_display: '10m00s',
+      type: 'fl_match',
+      output_file: 'match_001.mp4',
+    },
+  ],
+  gaps: [],
+};
+
+function emitDetectProgress(payload: Record<string, unknown>): void {
+  if (lastDetectProgressHandler) {
+    lastDetectProgressHandler({ payload });
+  }
+}
+
 beforeEach(() => {
+  invokeMock.mockReset();
+  listenMock.mockReset();
+  lastDetectProgressHandler = null;
+
+  // Capture the registered detect-progress handler so tests can drive it.
+  listenMock.mockImplementation((channel, handler) => {
+    if (channel === 'detect-progress') {
+      lastDetectProgressHandler = handler;
+    }
+    return Promise.resolve(() => {
+      lastDetectProgressHandler = null;
+    });
+  });
+
+  // Default invoke routing: start_detect resolves with a fake metadata
+  // path; load_metadata returns the sample payload above.
+  invokeMock.mockImplementation((cmd) => {
+    if (cmd === 'start_detect') {
+      return Promise.resolve({
+        metadata_path: 'C:/videos/test_allaganeye/metadata.json',
+        matches: SAMPLE_METADATA.matches.length,
+      });
+    }
+    if (cmd === 'load_metadata') {
+      return Promise.resolve(SAMPLE_METADATA);
+    }
+    if (cmd === 'get_metadata_mtime') {
+      return Promise.resolve(0);
+    }
+    if (cmd === 'check_backup_exists') {
+      return Promise.resolve(false);
+    }
+    if (cmd === 'load_draft') {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(null);
+  });
+
   useAppStateStore.getState().reset();
   useMetadataStore.getState().clear();
   useAppStateStore.getState().navigate('detecting');
@@ -33,32 +128,219 @@ describe('DetectingScreen', () => {
     expect(screen.getByText('Refining')).toBeInTheDocument();
   });
 
-  it('auto-advances via dummy interval and ends at complete screen', () => {
-    vi.useFakeTimers();
+  it('invokes start_detect with the derived output dir on mount', async () => {
     render(<DetectingScreen />);
-    expect(useAppStateStore.getState().screen).toBe('detecting');
-    act(() => {
-      // 8.5 seconds > 8 seconds to fully drain the interval
-      vi.advanceTimersByTime(8500);
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'start_detect',
+        expect.objectContaining({
+          videoPath: 'C:/videos/test.mkv',
+          outputDir: 'C:/videos/test_allaganeye',
+          params: expect.any(Object),
+        }),
+      );
     });
-    // After progress completes, navigate('complete') should have been called
-    expect(useAppStateStore.getState().screen).toBe('complete');
-    // sample metadata is loaded
-    expect(useMetadataStore.getState().metadata).not.toBeNull();
-    // #465 review (C): selectedVideoPath は detecting → preview / export まで
-    // 持ち越し、register_video / generate_match_thumbnails の引数として実 path
-    // を使う設計に変更。以前の null reset は廃止。
-    expect(useAppStateStore.getState().selectedVideoPath).toBe(
-      'C:/videos/test.mkv',
-    );
   });
 
-  it('returns to drop when [中断] is clicked', () => {
+  it('subscribes to detect-progress events on mount', async () => {
     render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalledWith(
+        'detect-progress',
+        expect.any(Function),
+      );
+    });
+  });
+
+  it('navigates to complete after start_detect resolves', async () => {
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(useAppStateStore.getState().screen).toBe('complete');
+    });
+    expect(useMetadataStore.getState().metadata).not.toBeNull();
+  });
+
+  it('updates progress label on detect-progress events', async () => {
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+    act(() => {
+      emitDetectProgress({
+        phase: 'scan',
+        completed: 35,
+        total: 100,
+        elapsed_s: 3.0,
+      });
+    });
+    // The header meta line includes "phase: scan"
+    expect(screen.getByText(/phase:\s*scan/)).toBeInTheDocument();
+  });
+
+  it('returns to drop when [中断] is clicked', async () => {
+    // Pin start_detect so the cancel transition wins the race against
+    // the happy-path auto-navigate to complete.
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: '中断' }));
     });
     // reducer: running -> cancelling -> (auto) cancelled -> navigate('drop')
-    expect(useAppStateStore.getState().screen).toBe('drop');
+    await waitFor(() => {
+      expect(useAppStateStore.getState().screen).toBe('drop');
+    });
+  });
+
+  it('routes to drop when start_detect rejects', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return Promise.reject(new Error('spawn allaganeye failed'));
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(useAppStateStore.getState().screen).toBe('drop');
+    });
+  });
+
+  it('routes to drop when CLI emits a phase=error event', async () => {
+    // Make start_detect hang so the only termination path is via error event.
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+    act(() => {
+      emitDetectProgress({
+        phase: 'error',
+        message: 'No match boundaries detected.',
+      });
+    });
+    await waitFor(() => {
+      expect(useAppStateStore.getState().screen).toBe('drop');
+    });
+  });
+
+  it('falls back to loadSample when no video is selected (StateSwitcher dev mode)', async () => {
+    // Reset to a clean state without selectedVideoPath -- mimics the
+    // StateSwitcher hopping straight into "detecting" without going
+    // through DropScreen.
+    useAppStateStore.getState().reset();
+    useAppStateStore.getState().navigate('detecting');
+
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(useAppStateStore.getState().screen).toBe('complete');
+    });
+    // start_detect must NOT have been called -- sample mode skips spawn.
+    expect(
+      invokeMock.mock.calls.some(([cmd]) => cmd === 'start_detect'),
+    ).toBe(false);
+  });
+});
+
+describe('DetectingScreen helpers', () => {
+  it('computeOverallPercent maps phase windows', () => {
+    // probing window is [1, 3]
+    expect(
+      computeOverallPercent({ phase: 'probing' }),
+    ).toBe(PHASE_WINDOWS.probing[0]);
+
+    // scan window is [3, 70]; 50% inside scan -> 36.5
+    expect(
+      computeOverallPercent({
+        phase: 'scan',
+        completed: 50,
+        total: 100,
+      }),
+    ).toBeCloseTo(3 + (70 - 3) * 0.5);
+
+    // refine window is [70, 88]; 100% inside refine -> 88
+    expect(
+      computeOverallPercent({
+        phase: 'refine',
+        completed: 4,
+        total: 4,
+      }),
+    ).toBe(88);
+
+    // unknown phase -> 0
+    expect(computeOverallPercent({ phase: 'unknown_phase' })).toBe(0);
+  });
+
+  it('computeOverallPercent clamps inner ratio to [0,1]', () => {
+    // Out-of-range completed/total ratios must stay inside the window.
+    const result = computeOverallPercent({
+      phase: 'scan',
+      completed: 999,
+      total: 100,
+    });
+    expect(result).toBe(70); // clamped to scan end
+  });
+
+  it('computeEta returns null when progress is 0 or 100', () => {
+    expect(computeEta(0, 10)).toBeNull();
+    expect(computeEta(100, 10)).toBeNull();
+  });
+
+  it('computeEta extrapolates remaining time from elapsed and percent', () => {
+    // 25% in 10s -> 30s remaining (total 40s, elapsed 10s).
+    expect(computeEta(25, 10)).toBeCloseTo(30);
+  });
+
+  it('buildLogText skips chatty intra-scan updates', () => {
+    expect(
+      buildLogText({
+        phase: 'scan',
+        completed: 27,
+        total: 100,
+      }),
+    ).toBeNull();
+  });
+
+  it('buildLogText logs scan milestones at every 10%', () => {
+    const text = buildLogText({
+      phase: 'scan',
+      completed: 30,
+      total: 100,
+    });
+    expect(text).toContain('Pass 1 scan');
+    expect(text).toContain('30');
+  });
+
+  it('buildLogText surfaces error messages', () => {
+    expect(
+      buildLogText({
+        phase: 'error',
+        message: 'spawn failed',
+      }),
+    ).toContain('spawn failed');
+  });
+
+  it('buildLogText surfaces done with match count', () => {
+    expect(
+      buildLogText({
+        phase: 'done',
+        matches: 5,
+      }),
+    ).toContain('5');
   });
 });

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -161,6 +161,17 @@ describe('DetectingScreen', () => {
   });
 
   it('updates progress label on detect-progress events', async () => {
+    // start_detect must hang here so the meta line stays visible long
+    // enough to assert (otherwise the happy-path mock auto-navigates
+    // to complete and unmounts the screen before getByText runs).
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
     render(<DetectingScreen />);
     await waitFor(() => {
       expect(listenMock).toHaveBeenCalled();
@@ -173,8 +184,79 @@ describe('DetectingScreen', () => {
         elapsed_s: 3.0,
       });
     });
-    // The header meta line includes "phase: scan"
+    // The header meta line includes "phase: scan" before any probing
+    // event arrives (probing is the trigger that switches the meta line
+    // to ffprobe metadata).
     expect(screen.getByText(/phase:\s*scan/)).toBeInTheDocument();
+  });
+
+  // #569 review Round 1 課題 1 -- meta line reflects probing payload.
+  it('renders meta line with ffprobe data after probing event', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+    act(() => {
+      emitDetectProgress({
+        phase: 'probing',
+        duration_s: 7215.371,
+        width: 1920,
+        height: 1080,
+        fps: 60.0,
+        codec: 'h264',
+        elapsed_s: 0.04,
+      });
+    });
+    const meta = screen.getByTestId('detecting-meta');
+    expect(meta.textContent).toContain('1920x1080');
+    expect(meta.textContent).toContain('60.00fps');
+    expect(meta.textContent).toContain('h264');
+    // fmtTime renders 7215.371s as "2:00:15".
+    expect(meta.textContent).toContain('2:00:15');
+  });
+
+  // #569 review Round 1 課題 2 -- log lines carry data-kind attribute
+  // and apply the matching colour-coding class.
+  it('renders log entries with kind-specific styling', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+    act(() => {
+      emitDetectProgress({
+        phase: 'cache_hit',
+        boundaries: 9,
+      });
+    });
+    const log = screen.getByRole('log');
+    const entries = log.querySelectorAll('[data-kind]');
+    const kinds = Array.from(entries).map((el) =>
+      el.getAttribute('data-kind'),
+    );
+    expect(kinds).toContain('warn');
+    // The cache_hit row gets the warn class applied (CSS Modules adds
+    // a hashed suffix, so we assert the className contains the literal
+    // CSS module key rather than an exact match).
+    const warnEntry = Array.from(entries).find(
+      (el) => el.getAttribute('data-kind') === 'warn',
+    );
+    expect(warnEntry?.className).toMatch(/logEntryWarn/);
   });
 
   it('returns to drop when [中断] is clicked', async () => {
@@ -316,31 +398,62 @@ describe('DetectingScreen helpers', () => {
     ).toBeNull();
   });
 
-  it('buildLogText logs scan milestones at every 10%', () => {
-    const text = buildLogText({
+  it('buildLogText logs scan milestones at every 10% with info kind', () => {
+    const entry = buildLogText({
       phase: 'scan',
       completed: 30,
       total: 100,
     });
-    expect(text).toContain('Pass 1 scan');
-    expect(text).toContain('30');
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toContain('Pass 1 scan');
+    expect(entry?.text).toContain('30');
+    expect(entry?.kind).toBe('info');
   });
 
-  it('buildLogText surfaces error messages', () => {
-    expect(
-      buildLogText({
-        phase: 'error',
-        message: 'spawn failed',
-      }),
-    ).toContain('spawn failed');
+  // #569 review Round 1 課題 2 — kind colour-coding contract.
+  it('buildLogText returns kind=error for phase=error', () => {
+    const entry = buildLogText({
+      phase: 'error',
+      message: 'spawn failed',
+    });
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toContain('spawn failed');
+    expect(entry?.kind).toBe('error');
   });
 
-  it('buildLogText surfaces done with match count', () => {
-    expect(
-      buildLogText({
-        phase: 'done',
-        matches: 5,
-      }),
-    ).toContain('5');
+  it('buildLogText returns kind=done for phase=done', () => {
+    const entry = buildLogText({
+      phase: 'done',
+      matches: 5,
+    });
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toContain('5');
+    expect(entry?.kind).toBe('done');
+  });
+
+  it('buildLogText returns kind=warn for phase=cache_hit', () => {
+    const entry = buildLogText({
+      phase: 'cache_hit',
+      boundaries: 9,
+    });
+    expect(entry).not.toBeNull();
+    expect(entry?.text).toContain('キャッシュヒット');
+    expect(entry?.kind).toBe('warn');
+  });
+
+  it('buildLogText returns kind=info for routine progress phases', () => {
+    for (const phase of [
+      'start',
+      'probing',
+      'chunk_dispatch',
+      'refine',
+      'scorebar',
+      'audio',
+      'writing_metadata',
+    ] as const) {
+      const entry = buildLogText({ phase });
+      expect(entry).not.toBeNull();
+      expect(entry?.kind).toBe('info');
+    }
   });
 });

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -9,6 +9,7 @@ import {
   deriveDetectOutputDir,
   metadataPathFor,
 } from '../utils/detectOutputDir';
+import { fmtTime } from '../utils/time';
 import { detectingReducer } from './reducers/detecting';
 import type { DetectingPhase } from './types';
 import styles from './DetectingScreen.module.css';
@@ -87,27 +88,63 @@ function computeOverallPercent(event: DetectProgressEvent): number {
   return start + range * inner;
 }
 
+/**
+ * #569 Phase 2.5 (review Round 1 課題 2) -- log entry severity for the
+ * keyword colour-coding requirement. The CLI emits a `phase` string;
+ * `buildLogText` maps it to one of these four severities so the live
+ * log can highlight terminal / faulty / warned events without the user
+ * having to read every line.
+ *
+ * - `info`: routine progress (start / probing / scan / refine / scorebar / chunk* / audio / writing_metadata)
+ * - `done`: terminal success (`phase="done"`) -- styled cyan-bright
+ * - `error`: terminal failure (`phase="error"`) -- styled `--ae-danger`
+ * - `warn`: notable non-fatal events (`phase="cache_hit"` for now;
+ *   future expansions: scorebar warnings, audio scan skips, etc.) --
+ *   styled `--ae-gold-bright`
+ */
+type LogKind = 'info' | 'done' | 'error' | 'warn';
+
 interface LogEntry {
   ts: number;
   text: string;
+  kind: LogKind;
 }
 
-function buildLogText(event: DetectProgressEvent): string | null {
+interface BuildLogResult {
+  text: string;
+  kind: LogKind;
+}
+
+function buildLogText(event: DetectProgressEvent): BuildLogResult | null {
   switch (event.phase) {
     case 'start':
-      return 'detect 開始';
+      return { text: 'detect 開始', kind: 'info' };
     case 'probing':
       if (event.duration_s && event.codec) {
-        return `probe: duration=${event.duration_s.toFixed(1)}s codec=${event.codec} ${event.width ?? '?'}x${event.height ?? '?'}@${(event.fps ?? 0).toFixed(2)}fps`;
+        return {
+          text: `probe: duration=${event.duration_s.toFixed(1)}s codec=${event.codec} ${event.width ?? '?'}x${event.height ?? '?'}@${(event.fps ?? 0).toFixed(2)}fps`,
+          kind: 'info',
+        };
       }
-      return 'ffprobe 完了';
+      return { text: 'ffprobe 完了', kind: 'info' };
     case 'cache_hit':
-      return `キャッシュヒット (${event.boundaries ?? '?'} boundaries)`;
+      // cache_hit はエラーではないが、利用者には「Pass 1 / 2 を skip
+      // した」ことが伝わるべき非自明な分岐なので warn 色で目立たせる。
+      return {
+        text: `キャッシュヒット (${event.boundaries ?? '?'} boundaries)`,
+        kind: 'warn',
+      };
     case 'chunk_dispatch':
-      return `チャンク分割: ${event.chunks ?? '?'} 個を並列デコード`;
+      return {
+        text: `チャンク分割: ${event.chunks ?? '?'} 個を並列デコード`,
+        kind: 'info',
+      };
     case 'chunk':
       if (event.completed !== undefined && event.total !== undefined) {
-        return `チャンク完了 ${event.completed}/${event.total}`;
+        return {
+          text: `チャンク完了 ${event.completed}/${event.total}`,
+          kind: 'info',
+        };
       }
       return null;
     case 'scan':
@@ -119,31 +156,76 @@ function buildLogText(event: DetectProgressEvent): string | null {
       ) {
         const pct = (event.completed / event.total) * 100;
         if (pct % 10 < 0.5 || event.completed === event.total) {
-          return `Pass 1 scan: ${event.completed}/${event.total} (${pct.toFixed(0)}%)`;
+          return {
+            text: `Pass 1 scan: ${event.completed}/${event.total} (${pct.toFixed(0)}%)`,
+            kind: 'info',
+          };
         }
       }
       return null;
     case 'refine':
       if (event.completed !== undefined && event.total !== undefined) {
-        return `Pass 2 refine: ${event.completed}/${event.total}`;
+        return {
+          text: `Pass 2 refine: ${event.completed}/${event.total}`,
+          kind: 'info',
+        };
       }
-      return 'Pass 2 refine 開始';
+      return { text: 'Pass 2 refine 開始', kind: 'info' };
     case 'scorebar':
       if (event.completed !== undefined && event.total !== undefined) {
-        return `scorebar 分類: ${event.completed}/${event.total}`;
+        return {
+          text: `scorebar 分類: ${event.completed}/${event.total}`,
+          kind: 'info',
+        };
       }
-      return 'scorebar 分類';
+      return { text: 'scorebar 分類', kind: 'info' };
     case 'audio':
-      return 'audio Fanfare scan';
+      return { text: 'audio Fanfare scan', kind: 'info' };
     case 'writing_metadata':
-      return 'metadata.json 書き込み中…';
+      return { text: 'metadata.json 書き込み中…', kind: 'info' };
     case 'done':
-      return `完了: ${event.matches ?? '?'} matches`;
+      return { text: `完了: ${event.matches ?? '?'} matches`, kind: 'done' };
     case 'error':
-      return `エラー: ${event.message ?? 'unknown'}`;
+      return {
+        text: `エラー: ${event.message ?? 'unknown'}`,
+        kind: 'error',
+      };
     default:
       return null;
   }
+}
+
+/**
+ * #569 review Round 1 課題 1 -- ffprobe metadata captured from the
+ * `probing` event. Pre-#569 the meta line was a hard-coded "dummy
+ * probe · Phase 2 skeleton" string; now it reflects the actual
+ * resolution / fps / codec / duration the CLI just measured. `null`
+ * before the `probing` event arrives, so the line falls back to a
+ * `phase: ...` indicator in that brief window.
+ */
+interface ProbeInfo {
+  width?: number;
+  height?: number;
+  fps?: number;
+  codec?: string;
+  duration_s?: number;
+}
+
+function formatProbeMeta(info: ProbeInfo): string {
+  const parts: string[] = [];
+  if (info.width !== undefined && info.height !== undefined) {
+    parts.push(`${info.width}x${info.height}`);
+  }
+  if (info.fps !== undefined) {
+    parts.push(`${info.fps.toFixed(2)}fps`);
+  }
+  if (info.codec) {
+    parts.push(info.codec);
+  }
+  if (info.duration_s !== undefined) {
+    parts.push(fmtTime(info.duration_s));
+  }
+  return parts.join(' · ');
 }
 
 const MAX_LOG_LINES = 80;
@@ -191,6 +273,9 @@ export function DetectingScreen() {
   const [log, setLog] = useState<LogEntry[]>([]);
   const [elapsed, setElapsed] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  // #569 review Round 1 課題 1: probing event payload を保持して
+  // header meta 行を実 ffprobe 結果で render する。
+  const [probeInfo, setProbeInfo] = useState<ProbeInfo | null>(null);
   // Captured once on first mount via lazy initialiser so log entries
   // can compute their relative timestamp inside render. We never need
   // to update this value -- the screen unmounts when navigating away,
@@ -233,10 +318,27 @@ export function DetectingScreen() {
             const payload = event.payload;
             setPhaseLabel(payload.phase);
 
-            const text = buildLogText(payload);
-            if (text !== null) {
+            // #569 review Round 1 課題 1: probing event の ffprobe 結果を
+            // header meta 行用に保持。後続 phase でも維持されるので、
+            // detect 中ずっと「1920x1080 · 60.00fps · h264 · 02:00:14」
+            // のような実値が表示される。
+            if (payload.phase === 'probing') {
+              setProbeInfo({
+                width: payload.width,
+                height: payload.height,
+                fps: payload.fps,
+                codec: payload.codec,
+                duration_s: payload.duration_s,
+              });
+            }
+
+            const entry = buildLogText(payload);
+            if (entry !== null) {
               setLog((prev) => {
-                const next = [...prev, { ts: Date.now(), text }];
+                const next = [
+                  ...prev,
+                  { ts: Date.now(), text: entry.text, kind: entry.kind },
+                ];
                 return next.length > MAX_LOG_LINES
                   ? next.slice(next.length - MAX_LOG_LINES)
                   : next;
@@ -314,6 +416,10 @@ export function DetectingScreen() {
 
   const displayFile = selectedVideoPath?.split(/[/\\]/).pop() ?? '(video)';
   const eta = computeEta(progress, elapsed);
+  // #569 review Round 1 課題 1: probing event 受信後は実 ffprobe 結果を
+  // 表示。受信前 (起動直後の数百 ms) は暫定で `phase: ...` を出して
+  // 「meta 行が空」状態を回避する。
+  const metaText = probeInfo ? formatProbeMeta(probeInfo) : `phase: ${phaseLabel}`;
 
   return (
     <div className={styles.screen} data-testid="detecting-screen">
@@ -322,8 +428,8 @@ export function DetectingScreen() {
         <div className={styles.headerText}>
           <div className={styles.caption}>観測中</div>
           <div className={styles.fileName}>{displayFile}</div>
-          <div className={styles.meta}>
-            phase: {phaseLabel}
+          <div className={styles.meta} data-testid="detecting-meta">
+            {metaText}
             {error ? ` · error: ${error}` : ''}
           </div>
         </div>
@@ -355,8 +461,25 @@ export function DetectingScreen() {
           const tsRel = entry.ts - startedAt;
           const tsLabel = fmtElapsed(Math.max(0, Math.floor(tsRel / 1000)));
           const isLast = idx === log.length - 1;
+          // #569 review Round 1 課題 2: phase 別に行を色分けする。kind
+          // は `done`/`error`/`warn`/`info` の 4 値で、CSS class に対応。
+          // info は無 class (= デフォルト dim 色) を維持して既存の見た目
+          // を変えない。
+          const kindClass =
+            entry.kind === 'done'
+              ? styles.logEntryDone
+              : entry.kind === 'error'
+                ? styles.logEntryError
+                : entry.kind === 'warn'
+                  ? styles.logEntryWarn
+                  : '';
+          const lineClass = kindClass ? `${styles.logEntry} ${kindClass}` : styles.logEntry;
           return (
-            <div key={`${entry.ts}-${idx}`}>
+            <div
+              key={`${entry.ts}-${idx}`}
+              className={lineClass}
+              data-kind={entry.kind}
+            >
               <span
                 className={
                   isLast ? styles.logTimeActive : styles.logTime

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -1,83 +1,319 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { useEffect, useReducer, useState } from 'react';
 
 import { AllaganSigil } from '../components/AllaganSigil';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
+import {
+  deriveDetectOutputDir,
+  metadataPathFor,
+} from '../utils/detectOutputDir';
 import { detectingReducer } from './reducers/detecting';
 import type { DetectingPhase } from './types';
 import styles from './DetectingScreen.module.css';
 
-/** 80ms * 100 ticks = 8s simulated detect run (Phase 2 dummy). */
-const TICK_MS = 80;
-const TICKS_TO_COMPLETE = 100;
+/**
+ * #569 -- payload shape emitted by Rust `start_detect` on channel
+ * `detect-progress`. The fields mirror the JSON schema written by
+ * `allaganeye/detection/progress_emitter.py`. Optional fields are
+ * present only when the CLI included them (skip_serializing_if drops
+ * `None` at the source).
+ */
+interface DetectProgressEvent {
+  phase: string;
+  completed?: number;
+  total?: number;
+  elapsed_s?: number;
+  eta_s?: number;
+  blackout_frames?: number;
+  metadata_path?: string;
+  matches?: number;
+  message?: string;
+  duration_s?: number;
+  width?: number;
+  height?: number;
+  fps?: number;
+  codec?: string;
+  chunks?: number;
+  boundaries?: number;
+}
+
+interface DetectResult {
+  metadata_path: string;
+  matches: number;
+}
 
 /**
- * Phase 2: pure UI + 8-second dummy progress driving detectingReducer.
- * On PROGRESS_COMPLETE, loadSample() is called so the complete screen has
- * data, then we navigate to complete. Phase 3 (#465) replaces the dummy
- * interval with real CLI stdout events.
+ * Phase weight map used to compute the overall percent (the CLI emits
+ * per-phase `(completed, total)` so the detecting bar can advance even
+ * within a phase). Tuned to match the rough wall-clock breakdown on
+ * a 2:50 hour 1080p recording: Pass 1 dominates, scorebar lasts a few
+ * seconds, metadata write is essentially instant.
+ *
+ * Each entry is `[start_pct, end_pct]`. Phases that arrive out of
+ * order (e.g. cache_hit replacing scan/refine) snap straight to their
+ * window's end so the bar never reverses.
+ */
+const PHASE_WINDOWS: Record<string, [number, number]> = {
+  start: [0, 1],
+  probing: [1, 3],
+  chunk_dispatch: [3, 5],
+  chunk: [5, 30],
+  scan: [3, 70],
+  refine: [70, 88],
+  scorebar: [88, 97],
+  audio: [3, 60],
+  cache_hit: [0, 99],
+  writing_metadata: [99, 100],
+  done: [100, 100],
+  error: [0, 0],
+};
+
+function computeOverallPercent(event: DetectProgressEvent): number {
+  const window = PHASE_WINDOWS[event.phase];
+  if (!window) return 0;
+  const [start, end] = window;
+  const range = end - start;
+  if (
+    range <= 0 ||
+    event.total === undefined ||
+    event.completed === undefined ||
+    event.total <= 0
+  ) {
+    return start;
+  }
+  const inner = Math.min(1, Math.max(0, event.completed / event.total));
+  return start + range * inner;
+}
+
+interface LogEntry {
+  ts: number;
+  text: string;
+}
+
+function buildLogText(event: DetectProgressEvent): string | null {
+  switch (event.phase) {
+    case 'start':
+      return 'detect 開始';
+    case 'probing':
+      if (event.duration_s && event.codec) {
+        return `probe: duration=${event.duration_s.toFixed(1)}s codec=${event.codec} ${event.width ?? '?'}x${event.height ?? '?'}@${(event.fps ?? 0).toFixed(2)}fps`;
+      }
+      return 'ffprobe 完了';
+    case 'cache_hit':
+      return `キャッシュヒット (${event.boundaries ?? '?'} boundaries)`;
+    case 'chunk_dispatch':
+      return `チャンク分割: ${event.chunks ?? '?'} 個を並列デコード`;
+    case 'chunk':
+      if (event.completed !== undefined && event.total !== undefined) {
+        return `チャンク完了 ${event.completed}/${event.total}`;
+      }
+      return null;
+    case 'scan':
+      // Skip very chatty per-sample updates -- only log every 10%.
+      if (
+        event.completed !== undefined &&
+        event.total !== undefined &&
+        event.total > 0
+      ) {
+        const pct = (event.completed / event.total) * 100;
+        if (pct % 10 < 0.5 || event.completed === event.total) {
+          return `Pass 1 scan: ${event.completed}/${event.total} (${pct.toFixed(0)}%)`;
+        }
+      }
+      return null;
+    case 'refine':
+      if (event.completed !== undefined && event.total !== undefined) {
+        return `Pass 2 refine: ${event.completed}/${event.total}`;
+      }
+      return 'Pass 2 refine 開始';
+    case 'scorebar':
+      if (event.completed !== undefined && event.total !== undefined) {
+        return `scorebar 分類: ${event.completed}/${event.total}`;
+      }
+      return 'scorebar 分類';
+    case 'audio':
+      return 'audio Fanfare scan';
+    case 'writing_metadata':
+      return 'metadata.json 書き込み中…';
+    case 'done':
+      return `完了: ${event.matches ?? '?'} matches`;
+    case 'error':
+      return `エラー: ${event.message ?? 'unknown'}`;
+    default:
+      return null;
+  }
+}
+
+const MAX_LOG_LINES = 80;
+
+function fmtElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
+}
+
+function computeEta(percent: number, elapsed: number): number | null {
+  if (percent <= 0 || percent >= 100) return null;
+  const total = elapsed * (100 / percent);
+  const remaining = total - elapsed;
+  return remaining > 0 ? remaining : null;
+}
+
+/**
+ * #569 Phase 2.5 — DetectingScreen real implementation.
+ *
+ * Spawns ``allaganeye detect --progress-format json`` via the Rust
+ * ``start_detect`` Tauri command, listens to ``detect-progress``
+ * events, and drives the same DetectingPhase reducer the Phase 2
+ * dummy used. On the terminal "done" event we load metadata.json
+ * via the existing metadataStore.load() and navigate to complete.
+ *
+ * Cancel button: dispatches ``CANCEL_CLICKED`` so the reducer enters
+ * ``cancelling``. The actual ffmpeg/process kill arrives in #523's PR
+ * (next PR in the alpha group); for this PR the running subprocess is
+ * left to finish on its own and the user sees the cancellation echoed
+ * in the UI.
  */
 export function DetectingScreen() {
   const navigate = useAppStateStore((s) => s.navigate);
   const selectedVideoPath = useAppStateStore((s) => s.selectedVideoPath);
+  const loadMetadata = useMetadataStore((s) => s.load);
   const loadSample = useMetadataStore((s) => s.loadSample);
 
-  const [phase, dispatch] = useReducer(detectingReducer, 'running' as DetectingPhase);
+  const [phase, dispatch] = useReducer(
+    detectingReducer,
+    'running' as DetectingPhase,
+  );
   const [progress, setProgress] = useState(0);
+  const [phaseLabel, setPhaseLabel] = useState<string>('start');
+  const [log, setLog] = useState<LogEntry[]>([]);
+  const [elapsed, setElapsed] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  // Captured once on first mount via lazy initialiser so log entries
+  // can compute their relative timestamp inside render. We never need
+  // to update this value -- the screen unmounts when navigating away,
+  // and a fresh detect run remounts the component (App.tsx routes by
+  // screen). Avoids the react-hooks/set-state-in-effect lint warning
+  // a setState-in-effect initialiser would trip.
+  const [startedAt] = useState<number>(() => Date.now());
 
-  // dummy progress interval
+  // Wall-clock elapsed timer -- ticks once per second so the UI can
+  // show "経過 00:42 / 残り ~01:30" without depending on event cadence.
   useEffect(() => {
     if (phase !== 'running') return;
-    const iv = setInterval(() => {
-      setProgress((p) => {
-        const next = p + 100 / TICKS_TO_COMPLETE;
-        if (next >= 100) {
-          clearInterval(iv);
-          dispatch({ type: 'PROGRESS_COMPLETE' });
-          return 100;
-        }
-        return next;
-      });
-    }, TICK_MS);
-    return () => clearInterval(iv);
-  }, [phase]);
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [phase, startedAt]);
 
-  // completed → load sample data + move to complete
-  // #465 review (C): selectedVideoPath は detecting → preview / export まで
-  // 持ち越し、PreviewScreen の register_video / generate_match_thumbnails の
-  // 引数として実 path を渡せるようにする。以前は ここで null reset していたが、
-  // 「drop で確定した path を後段が利用する」設計と矛盾していたため削除。
+  // Subscribe to detect-progress, kick off start_detect.
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    let cancelled = false;
+
+    async function run() {
+      // Sample mode: no real video, fall through to the dummy data so
+      // the StateSwitcher dev tab still works.
+      if (!selectedVideoPath) {
+        loadSample();
+        navigate('complete');
+        return;
+      }
+
+      const outputDir = deriveDetectOutputDir(selectedVideoPath);
+
+      try {
+        unlisten = await listen<DetectProgressEvent>(
+          'detect-progress',
+          (event) => {
+            if (cancelled) return;
+            const payload = event.payload;
+            setPhaseLabel(payload.phase);
+
+            const text = buildLogText(payload);
+            if (text !== null) {
+              setLog((prev) => {
+                const next = [...prev, { ts: Date.now(), text }];
+                return next.length > MAX_LOG_LINES
+                  ? next.slice(next.length - MAX_LOG_LINES)
+                  : next;
+              });
+            }
+
+            if (payload.phase === 'error') {
+              setError(payload.message ?? 'unknown error');
+              dispatch({ type: 'DETECT_ERROR' });
+              return;
+            }
+
+            const pct = computeOverallPercent(payload);
+            // Bar is monotonic -- never reverse on out-of-order events
+            // (e.g. cache_hit firing after a probing event).
+            setProgress((prev) => (pct > prev ? pct : prev));
+          },
+        );
+
+        const result = await invoke<DetectResult>('start_detect', {
+          videoPath: selectedVideoPath,
+          outputDir,
+          params: {},
+        });
+        if (cancelled) return;
+
+        setProgress(100);
+        const metaPath = result.metadata_path || metadataPathFor(outputDir);
+        await loadMetadata(metaPath);
+        dispatch({ type: 'PROGRESS_COMPLETE' });
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        dispatch({ type: 'DETECT_ERROR' });
+      }
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+    // selectedVideoPath / loadMetadata / loadSample / navigate are
+    // store-bound and stable; we re-run only if the user re-enters the
+    // screen with a different video, which already remounts via the
+    // App.tsx screen switch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // completed → navigate to complete (load happened above)
   useEffect(() => {
     if (phase === 'completed') {
-      loadSample();
       navigate('complete');
     }
-  }, [phase, loadSample, navigate]);
+  }, [phase, navigate]);
 
-  // cancelled → back to drop
+  // cancelled / error → back to drop
   useEffect(() => {
-    if (phase === 'cancelled') {
+    if (phase === 'cancelled' || phase === 'error') {
       navigate('drop');
     }
   }, [phase, navigate]);
 
-  // error → back to drop (Phase 3 will toast)
-  useEffect(() => {
-    if (phase === 'error') {
-      navigate('drop');
-    }
-  }, [phase, navigate]);
-
-  // Phase 2 auto-confirms the cancel immediately (no real process to kill).
+  // Cancel button: phase transition only. Real ffmpeg kill ships in
+  // #523's PR via kill_tracked_processes; this PR keeps the issue's
+  // explicit scope ("UI phase transition only").
   useEffect(() => {
     if (phase === 'cancelling') {
       dispatch({ type: 'CANCEL_CONFIRMED' });
     }
   }, [phase]);
 
-  const pct1 = Math.min(100, Math.max(0, progress * 1.25)); // phase 1 finishes quickly
-  const pct2 = Math.max(0, Math.min(100, (progress - 40) * 1.67));
+  const pct1 = Math.min(100, progress * (100 / 70)); // scan finishes at 70%
+  const pct2 = Math.max(0, Math.min(100, ((progress - 70) * 100) / 18)); // refine fills 70-88
+
   const displayFile = selectedVideoPath?.split(/[/\\]/).pop() ?? '(video)';
+  const eta = computeEta(progress, elapsed);
 
   return (
     <div className={styles.screen} data-testid="detecting-screen">
@@ -86,12 +322,16 @@ export function DetectingScreen() {
         <div className={styles.headerText}>
           <div className={styles.caption}>観測中</div>
           <div className={styles.fileName}>{displayFile}</div>
-          <div className={styles.meta}>dummy probe · Phase 2 skeleton</div>
+          <div className={styles.meta}>
+            phase: {phaseLabel}
+            {error ? ` · error: ${error}` : ''}
+          </div>
         </div>
         <div className={styles.progressBadge}>
           <div className={styles.progressNum}>{Math.round(progress)}%</div>
           <div className={styles.progressTiming}>
-            Phase 2 dummy
+            経過 {fmtElapsed(elapsed)}
+            {eta !== null && ` · 残り ~${fmtElapsed(eta)}`}
           </div>
         </div>
       </div>
@@ -99,37 +339,35 @@ export function DetectingScreen() {
       <div className={styles.divider} />
 
       <div className={styles.phases}>
-        <PhaseRow
-          name="Detecting"
-          jp="粗スキャン"
-          pct={pct1}
-          sub="scan"
-        />
-        <PhaseRow
-          name="Refining"
-          jp="精密計測"
-          pct={pct2}
-          sub="refine"
-        />
+        <PhaseRow name="Detecting" jp="粗スキャン" pct={pct1} sub="scan" />
+        <PhaseRow name="Refining" jp="精密計測" pct={pct2} sub="refine" />
       </div>
 
       <div className={styles.divider} />
 
       <div className={styles.log} role="log" aria-label="detect log">
-        <div>
-          <span className={styles.logTime}>[00:00]</span> dummy detect started
-        </div>
-        {progress >= 30 && (
+        {log.length === 0 && (
           <div>
-            <span className={styles.logTime}>[00:02]</span> scan: samples…
+            <span className={styles.logTime}>[--:--]</span> 起動中…
           </div>
         )}
-        {progress >= 60 && (
-          <div>
-            <span className={styles.logTimeActive}>[00:05]</span> refining
-            boundaries…
-          </div>
-        )}
+        {log.map((entry, idx) => {
+          const tsRel = entry.ts - startedAt;
+          const tsLabel = fmtElapsed(Math.max(0, Math.floor(tsRel / 1000)));
+          const isLast = idx === log.length - 1;
+          return (
+            <div key={`${entry.ts}-${idx}`}>
+              <span
+                className={
+                  isLast ? styles.logTimeActive : styles.logTime
+                }
+              >
+                [{tsLabel}]
+              </span>{' '}
+              {entry.text}
+            </div>
+          );
+        })}
       </div>
 
       <div className={styles.actions}>
@@ -177,3 +415,12 @@ function PhaseRow({ name, jp, pct, sub }: PhaseRowProps) {
     </div>
   );
 }
+
+// Re-export pure helpers so unit tests can exercise them without
+// mounting the React component or stubbing Tauri.
+export {
+  computeOverallPercent,
+  computeEta,
+  buildLogText,
+  PHASE_WINDOWS,
+};

--- a/gui/src/types/metadata.schema.test.ts
+++ b/gui/src/types/metadata.schema.test.ts
@@ -280,4 +280,68 @@ describe('MetadataSchema', () => {
       expect(MetadataSchema.safeParse(doc).success).toBe(false);
     }
   });
+
+  // #569 -- brightness_samples optional field
+
+  it('accepts a document with brightness_samples', () => {
+    const doc = {
+      ...validMetadata(),
+      brightness_samples: {
+        interval_s: 25.0,
+        values: [85.3, 87.1, 6.2, 12.0, 95.0],
+      },
+    };
+    const result = MetadataSchema.safeParse(doc);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.brightness_samples?.values.length).toBe(5);
+    }
+  });
+
+  it('accepts a document without brightness_samples (backward compat)', () => {
+    const doc = validMetadata();
+    expect('brightness_samples' in doc).toBe(false);
+    expect(MetadataSchema.safeParse(doc).success).toBe(true);
+  });
+
+  it('rejects brightness_samples with non-positive interval_s', () => {
+    for (const interval_s of [0, -1]) {
+      const doc = {
+        ...validMetadata(),
+        brightness_samples: {
+          interval_s,
+          values: [10, 20],
+        },
+      };
+      expect(MetadataSchema.safeParse(doc).success).toBe(false);
+    }
+  });
+
+  it('rejects brightness_samples values outside 0-255', () => {
+    for (const bad of [-1, 256, 1000]) {
+      const doc = {
+        ...validMetadata(),
+        brightness_samples: {
+          interval_s: 1.0,
+          values: [10, bad, 20],
+        },
+      };
+      expect(MetadataSchema.safeParse(doc).success).toBe(false);
+    }
+  });
+
+  it('accepts an empty brightness_samples values array', () => {
+    // The CLI omits the field entirely when no Pass 1 ran (cache hit
+    // path), but a writer that emits {interval_s, values: []} still
+    // round-trips cleanly through the schema -- the GUI just renders
+    // the fallback curve.
+    const doc = {
+      ...validMetadata(),
+      brightness_samples: {
+        interval_s: 1.0,
+        values: [],
+      },
+    };
+    expect(MetadataSchema.safeParse(doc).success).toBe(true);
+  });
 });

--- a/gui/src/types/metadata.schema.ts
+++ b/gui/src/types/metadata.schema.ts
@@ -77,6 +77,22 @@ export const SystemInfoSchema = z.object({
 });
 
 /**
+ * #569 -- pre-rendered brightness timeline used by the complete screen.
+ * Optional because pre-#569 files don't carry it and cache hits skip
+ * Pass 1 sampling. CompleteScreen falls back to the in-memory sample
+ * curve when the field is absent.
+ *
+ * - `interval_s`: seconds represented by each `values[i]` (so
+ *   `values[i]` is the brightness at `i * interval_s` seconds).
+ * - `values`: 0-255 floats, ordered chronologically, length capped to
+ *   ~512 by the CLI writer (`build_brightness_samples`).
+ */
+export const BrightnessSamplesSchema = z.object({
+  interval_s: z.number().positive(),
+  values: z.array(z.number().min(0).max(255)),
+});
+
+/**
  * #465 review: default frame rate when ``source_fps`` is missing. Pre-#465
  * legacy metadata.json files don't include the field, so we keep a
  * conservative 60fps assumption (the most common OBS recording cadence).
@@ -108,5 +124,11 @@ export const MetadataSchema = z
      * libx264 when missing.
      */
     system_info: SystemInfoSchema.optional(),
+    /**
+     * #569 -- pre-rendered brightness timeline. Optional because
+     * pre-#569 files and detect cache hits don't write it. The
+     * complete screen falls back to a sample curve when missing.
+     */
+    brightness_samples: BrightnessSamplesSchema.optional(),
   })
   .passthrough();

--- a/gui/src/types/metadata.ts
+++ b/gui/src/types/metadata.ts
@@ -71,6 +71,18 @@ export interface SystemInfo {
   vendor_preference: string[];
 }
 
+/**
+ * #569 -- pre-rendered brightness timeline used by the complete screen.
+ *
+ * - `interval_s`: seconds represented by each `values[i]`.
+ * - `values`: 0-255 floats, chronological, length-capped to ~512 by
+ *   the CLI writer.
+ */
+export interface BrightnessSamples {
+  interval_s: number;
+  values: number[];
+}
+
 export interface Metadata {
   /**
    * #515: schema revision declaration. Optional on the TS type because
@@ -100,4 +112,10 @@ export interface Metadata {
    * to libx264 when missing.
    */
   system_info?: SystemInfo;
+  /**
+   * #569 -- pre-rendered brightness timeline. Optional because
+   * pre-#569 metadata.json and detect cache hits skip the field;
+   * CompleteScreen falls back to a sample curve when missing.
+   */
+  brightness_samples?: BrightnessSamples;
 }

--- a/gui/src/utils/detectOutputDir.test.ts
+++ b/gui/src/utils/detectOutputDir.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveDetectOutputDir,
+  metadataPathFor,
+} from './detectOutputDir';
+
+describe('deriveDetectOutputDir', () => {
+  it('appends _allaganeye to the basename next to the source', () => {
+    expect(
+      deriveDetectOutputDir('C:/videos/2026-04-08 21-14-05.mkv'),
+    ).toBe('C:/videos/2026-04-08 21-14-05_allaganeye');
+  });
+
+  it('normalizes Windows backslashes to forward slashes', () => {
+    expect(deriveDetectOutputDir('C:\\videos\\foo.mkv')).toBe(
+      'C:/videos/foo_allaganeye',
+    );
+  });
+
+  it('drops the file extension before suffixing', () => {
+    expect(deriveDetectOutputDir('D:/clips/match.MP4')).toBe(
+      'D:/clips/match_allaganeye',
+    );
+  });
+
+  it('handles a file without extension', () => {
+    expect(deriveDetectOutputDir('D:/clips/RECORDING')).toBe(
+      'D:/clips/RECORDING_allaganeye',
+    );
+  });
+
+  it('treats a leading dot file as a stem (no extension split)', () => {
+    expect(deriveDetectOutputDir('D:/clips/.cachefile')).toBe(
+      'D:/clips/.cachefile_allaganeye',
+    );
+  });
+
+  it('handles a bare filename with no directory', () => {
+    expect(deriveDetectOutputDir('foo.mkv')).toBe('./foo_allaganeye');
+  });
+
+  it('strips trailing slashes before splitting', () => {
+    expect(deriveDetectOutputDir('C:/videos/foo.mkv/')).toBe(
+      'C:/videos/foo_allaganeye',
+    );
+  });
+});
+
+describe('metadataPathFor', () => {
+  it('joins output dir and metadata.json', () => {
+    expect(metadataPathFor('C:/videos/foo_allaganeye')).toBe(
+      'C:/videos/foo_allaganeye/metadata.json',
+    );
+  });
+
+  it('strips trailing slash before joining', () => {
+    expect(metadataPathFor('C:/videos/foo_allaganeye/')).toBe(
+      'C:/videos/foo_allaganeye/metadata.json',
+    );
+  });
+
+  it('normalizes backslashes', () => {
+    expect(metadataPathFor('C:\\videos\\foo_allaganeye')).toBe(
+      'C:/videos/foo_allaganeye/metadata.json',
+    );
+  });
+});

--- a/gui/src/utils/detectOutputDir.ts
+++ b/gui/src/utils/detectOutputDir.ts
@@ -1,0 +1,35 @@
+/**
+ * #569 -- derive a per-video output directory for `allaganeye detect`.
+ *
+ * We don't ship a "where do I put the metadata.json" dialog yet, so the
+ * GUI uses a deterministic sibling-of-the-video convention. Given
+ * ``C:/videos/2026-04-08 21-14-05.mkv`` we produce
+ * ``C:/videos/2026-04-08 21-14-05_allaganeye``.
+ *
+ * The result is always an absolute path with forward slashes (the CLI
+ * accepts both, and forward slashes round-trip through Tauri / Rust
+ * cleanly on Windows). Trailing slashes are stripped so the path can
+ * be combined with ``metadata.json`` via simple string concatenation
+ * without producing a double-slash.
+ */
+export function deriveDetectOutputDir(videoPath: string): string {
+  const normalized = videoPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  const lastSlash = normalized.lastIndexOf('/');
+  const dir = lastSlash >= 0 ? normalized.slice(0, lastSlash) : '.';
+  const file = lastSlash >= 0 ? normalized.slice(lastSlash + 1) : normalized;
+  const dot = file.lastIndexOf('.');
+  const stem = dot > 0 ? file.slice(0, dot) : file;
+  return `${dir}/${stem}_allaganeye`;
+}
+
+/**
+ * #569 -- canonical metadata.json location inside an output dir.
+ *
+ * Mirrors the CLI's hard-coded ``<output_dir>/metadata.json`` filename
+ * so the frontend can preview the destination on the detecting screen
+ * before the subprocess writes the file.
+ */
+export function metadataPathFor(outputDir: string): string {
+  const normalized = outputDir.replace(/\\/g, '/').replace(/\/+$/, '');
+  return `${normalized}/metadata.json`;
+}

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from allaganeye.commands.detect import run_detect
+from allaganeye.commands.split_matches import build_brightness_samples
 from allaganeye.config import SplitConfig
 from allaganeye.exceptions import DetectionError
 from allaganeye.video.detector import MatchBoundary
@@ -160,3 +161,140 @@ def test_detect_cache_hit_records_vendor_used_null(tmp_path, monkeypatch):
     info = payload["system_info"]
     assert info["gpu_vendor_used"] is None  # cache hit で detect していない
     assert info["gpu_vendors_available"] == ["intel"]
+
+
+# ---------------------------------------------------------------------------
+# #569 -- GUI integration: --progress-format json + brightness_samples
+# ---------------------------------------------------------------------------
+
+
+def test_build_brightness_samples_downsamples_to_target():
+    """`build_brightness_samples` should keep the array under the target."""
+    raw = {float(i): float(i % 256) for i in range(2048)}
+    out = build_brightness_samples(raw, target_samples=512)
+    assert out is not None
+    values = out["values"]
+    assert isinstance(values, list)
+    assert len(values) <= 512
+    # Stride must be deterministic and >= 1.
+    interval_s = out["interval_s"]
+    assert isinstance(interval_s, float)
+    assert interval_s >= 1.0
+
+
+def test_build_brightness_samples_returns_none_for_empty():
+    assert build_brightness_samples({}) is None
+
+
+def test_build_brightness_samples_preserves_order_and_values():
+    """Values must come out in timestamp order (sorted by key)."""
+    raw = {2.0: 50.0, 0.0: 10.0, 1.0: 30.0}
+    out = build_brightness_samples(raw, target_samples=10)
+    assert out is not None
+    assert out["values"] == [10.0, 30.0, 50.0]
+    assert out["interval_s"] == 1.0
+
+
+def test_detect_json_progress_emits_lifecycle_events(tmp_path, capsys):
+    """``--progress-format json`` produces start/probing/done JSON lines."""
+    probe, detect = _mock_detect_only(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with probe, detect:
+        run_detect(
+            Path("input.mp4"),
+            config,
+            quiet=False,
+            progress_format="json",
+        )
+
+    captured = capsys.readouterr().out
+    lines = [json.loads(line) for line in captured.splitlines() if line.strip()]
+    phases = [e["phase"] for e in lines]
+    # Always emits start (first) and done (last). probing fires after probe_video.
+    assert phases[0] == "start"
+    assert phases[-1] == "done"
+    assert "probing" in phases
+    # `done` must include the metadata path so the GUI can load_metadata.
+    done = next(e for e in lines if e["phase"] == "done")
+    assert done["metadata_path"].endswith("metadata.json")
+    assert done["matches"] == len(BOUNDARIES)
+
+
+def test_detect_json_progress_suppresses_human_text(tmp_path, capsys):
+    """json mode must not interleave ``Probing:`` / ``Metadata:`` with JSON.
+
+    The GUI's stdout parser scans line-by-line and skips non-JSON
+    lines, but a regression that puts a stray text line between two
+    JSON events would still confuse the eyeballed log view.
+    """
+    probe, detect = _mock_detect_only(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with probe, detect:
+        run_detect(
+            Path("input.mp4"),
+            config,
+            quiet=False,
+            progress_format="json",
+        )
+
+    captured = capsys.readouterr().out
+    for raw in captured.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        # Every non-blank stdout line must parse as JSON in json mode.
+        json.loads(line)
+
+
+def test_detect_text_mode_still_writes_human_status(tmp_path, capsys):
+    probe, detect = _mock_detect_only(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with probe, detect:
+        run_detect(
+            Path("input.mp4"),
+            config,
+            quiet=False,
+            progress_format="text",
+        )
+
+    captured = capsys.readouterr().out
+    assert "Probing:" in captured
+    assert "Metadata:" in captured
+
+
+def test_detect_writes_brightness_samples_when_callback_fires(tmp_path):
+    """When detection emits brightness, metadata.json carries the timeline."""
+
+    def _detect_with_brightness(*args, **kwargs):
+        cb = kwargs.get("brightness_callback")
+        if cb is not None:
+            # Synthesize a tiny brightness map that simulates Pass 1 output.
+            cb({0.0: 80.0, 1.0: 12.0, 2.0: 90.0, 3.0: 88.0})
+        return BOUNDARIES
+
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with (
+        patch(f"{MODULE_DETECT}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE_DETECT}._run_detection",
+            side_effect=_detect_with_brightness,
+        ),
+    ):
+        run_detect(Path("input.mp4"), config, quiet=True)
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    assert "brightness_samples" in payload
+    samples = payload["brightness_samples"]
+    assert samples["values"] == [80.0, 12.0, 90.0, 88.0]
+    assert samples["interval_s"] == 1.0
+
+
+def test_detect_omits_brightness_samples_when_callback_silent(tmp_path):
+    """No brightness data -> field is absent (don't write {values: []})."""
+    probe, detect = _mock_detect_only(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with probe, detect:
+        run_detect(Path("input.mp4"), config, quiet=True)
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    assert "brightness_samples" not in payload

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -980,6 +980,39 @@ class TestDetectMatchBoundaries:
             detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
 
     @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_brightness_callback_receives_pass1_results(self, mock_chunk):
+        """#569 -- brightness_callback fires once with full Pass 1 map."""
+        mock_chunk.side_effect = lambda vp, ts, cs, ce, si: {t: 50.0 + t for t in ts}
+        captured: list[dict[float, float]] = []
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=10.0,
+            sample_interval=1.0,
+            min_match_duration=1.0,
+            brightness_callback=captured.append,
+        )
+        # Exactly one fire (single-shot contract).
+        assert len(captured) == 1
+        # Captured map covers every sample timestamp.
+        results = captured[0]
+        assert len(results) == 10
+        assert results[0.0] == pytest.approx(50.0)
+        assert results[5.0] == pytest.approx(55.0)
+
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_brightness_callback_optional_default(self, mock_chunk):
+        """Omitting the callback is a no-op (preserves pre-#569 callers)."""
+        mock_chunk.side_effect = lambda vp, ts, cs, ce, si: {t: 100.0 for t in ts}
+        # Should not raise even without the new kwarg.
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=10.0,
+            sample_interval=1.0,
+            min_match_duration=1.0,
+        )
+        assert isinstance(result, list)
+
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
     def test_stats_populated_cpu(self, mock_chunk):
         """Verbose callers receive pipeline statistics (issue #336 Phase 1)."""
         from allaganeye.video.detector import DetectionStats

--- a/tests/test_progress_emitter.py
+++ b/tests/test_progress_emitter.py
@@ -1,0 +1,134 @@
+"""Tests for the JSON-lines progress emitter (#569).
+
+The emitter is consumed by the Tauri GUI: it spawns ``allaganeye detect
+--progress-format json`` and reads stdout line-by-line, parsing each
+line as a stand-alone JSON object.  These tests pin the on-the-wire
+shape so a regression in the writer surfaces here rather than as a
+silent GUI desync.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+from allaganeye.detection.progress_emitter import (
+    ProgressEmitter,
+    disabled_emitter,
+)
+
+
+class _FakeClock:
+    """Deterministic monotonic clock for elapsed_s assertions."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _read_lines(buf: io.StringIO) -> list[dict]:
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+def test_emit_writes_one_json_line_per_call():
+    buf = io.StringIO()
+    clock = _FakeClock()
+    e = ProgressEmitter(enabled=True, stream=buf, clock=clock)
+
+    clock.advance(1.5)
+    e.emit("scan", completed=10, total=100)
+    clock.advance(0.5)
+    e.emit("scan", completed=20, total=100)
+
+    lines = _read_lines(buf)
+    assert len(lines) == 2
+    assert lines[0] == {
+        "phase": "scan",
+        "completed": 10,
+        "total": 100,
+        "elapsed_s": 1.5,
+    }
+    assert lines[1] == {
+        "phase": "scan",
+        "completed": 20,
+        "total": 100,
+        "elapsed_s": 2.0,
+    }
+
+
+def test_emit_progress_attaches_completed_total():
+    buf = io.StringIO()
+    clock = _FakeClock()
+    e = ProgressEmitter(enabled=True, stream=buf, clock=clock)
+
+    e.emit_progress("refine", 1, 4, blackout_frames=0)
+
+    [line] = _read_lines(buf)
+    assert line["phase"] == "refine"
+    assert line["completed"] == 1
+    assert line["total"] == 4
+    assert line["blackout_frames"] == 0
+    assert "elapsed_s" in line
+
+
+def test_disabled_emitter_writes_nothing():
+    buf = io.StringIO()
+    e = ProgressEmitter(enabled=False, stream=buf)
+
+    e.emit("scan", completed=1, total=2)
+    e.emit_progress("refine", 1, 2)
+
+    assert buf.getvalue() == ""
+
+
+def test_emit_drops_none_valued_extras():
+    """None values should be dropped so the wire format stays compact.
+
+    The CLI side passes ``None`` for optional context (e.g. eta_s when
+    no estimate exists yet). The Rust parser treats absent keys as
+    "unknown"; a literal ``null`` would force the parser to handle two
+    cases.  Drop them at the source instead.
+    """
+    buf = io.StringIO()
+    e = ProgressEmitter(enabled=True, stream=buf)
+
+    e.emit("chunk", completed=1, total=4, eta_s=None)
+
+    [line] = _read_lines(buf)
+    assert "eta_s" not in line
+    assert line["completed"] == 1
+    assert line["total"] == 4
+
+
+def test_emit_swallows_broken_pipe():
+    """A broken-pipe write must not propagate up the call site.
+
+    The detect pipeline is the source of truth for the metadata file --
+    losing the GUI progress channel halfway through must not abort the
+    detection itself.
+    """
+
+    class BrokenStream(io.StringIO):
+        def write(self, _: str) -> int:  # type: ignore[override]
+            raise BrokenPipeError("consumer hung up")
+
+        def flush(self) -> None:
+            return None
+
+    e = ProgressEmitter(enabled=True, stream=BrokenStream())
+    # Should not raise.
+    e.emit("scan", completed=1, total=2)
+
+
+def test_disabled_emitter_singleton_returns_disabled_instance():
+    """The shared no-op emitter must short-circuit regardless of stream."""
+    e = disabled_emitter()
+    assert not e.enabled
+    # Calling emit / emit_progress on the disabled singleton is harmless.
+    e.emit("x")
+    e.emit_progress("y", 1, 2)


### PR DESCRIPTION
## Summary

L2a Phase 2.5 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)): detecting 画面の dummy progress を実 CLI 連携に置換し、complete 画面の輝度タイムラインを metadata.json から描画する。

- **Python CLI**: `allaganeye detect --progress-format json` を新設し、JSON-line stream で進捗 + 完了情報を emit。Pass 1 brightness を 512 点に間引いて metadata.json `brightness_samples` に書き込み。
- **Rust (Tauri)**: `start_detect` command 新設。`allaganeye detect` を spawn し stdout を行ごとに parse して `detect-progress` イベントを emit。既存 `process_tracker` ([#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) 枠組み) に track。
- **TypeScript (GUI)**: DetectingScreen を実 CLI 経路に書き換え (meta 行を `probing` event の ffprobe 結果で本物化、ライブログを phase 別 4 kind 色分け)、CompleteScreen の輝度タイムラインを `metadata.brightness_samples` 経由に差し替え。

## 受け入れ条件 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569)) チェックリスト

| # | 受け入れ条件 | 対応 diff / test |
|---|---|---|
| 1 | サンプル動画 drop → detecting 画面でフェーズバー + 進捗 % + ライブログが実時間で更新される | `gui/src/screens/DetectingScreen.tsx` (start_detect invoke + listen('detect-progress')) / `gui/src/screens/DetectingScreen.test.tsx` (subscribe + progress + log assertions) |
| 2 | detecting 画面のキャンセルボタンが `detecting_cancelling` phase へ遷移する | `gui/src/screens/DetectingScreen.tsx` (CANCEL_CLICKED → reducer cancelling) / `DetectingScreen.test.tsx` "returns to drop when [中断] is clicked" / 実 kill は [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) 範囲 |
| 3 | 検知完了で complete 画面へ自動遷移 | `DetectingScreen.tsx` start_detect resolve → `loadMetadata(result.metadata_path)` → navigate('complete') / `flow.integration.test.tsx` flow A3 |
| 4 | complete 画面で metadata.json 由来の試合一覧カードが表示される | `gui/src/screens/CompleteScreen.tsx` 既存 `metadata.matches` map / `CompleteScreen.test.tsx` "displays source and match count" / "renders a row per match" |
| 5 | 試合カードクリックで preview 画面へ遷移 | `CompleteScreen.tsx` onDoubleClick → `openPreviewFor` / `CompleteScreen.test.tsx` "double-click navigates to preview" |
| 6 | 輝度タイムラインが描画される | `CompleteScreen.tsx` `metadata.brightness_samples?.values` 優先 + sample fallback / `CompleteScreen.test.tsx` "uses metadata.brightness_samples for the timeline" |
| 7 | vitest / Rust 単体テスト | Python pytest 830 / Rust cargo 114 / vitest 370 全通過 |
| 8 | eslint / typecheck / cargo check 全通過 | 全通過 (test plan 参照) |

### AC 補強 ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) コメント追加分)

| # | 補強条件 | 対応 |
|---|---|---|
| 9 | sampleBrightness 固定参照を実 brightness データへ置換 | `CompleteScreen.tsx` `metadata.brightness_samples?.values` 優先 |
| 10 | sampleMetadata.ts 利用一掃 | sample mode (StateSwitcher dev) / 既存テスト fixture のみ残存 |
| 11 | DetectingScreen cancel 即座自動確認 → phase 遷移のみ | `useEffect` で `CANCEL_CLICKED → CANCEL_CONFIRMED` 即発火 (実 kill は [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523)) |
| 12 | DetectingScreen メタデータ行を実 ffprobe 結果で本物化 | **Round 1 課題 1 対応**: `probing` event payload を `ProbeInfo` state に保持、`formatProbeMeta` で `width × height · fps · codec · duration` を render / `DetectingScreen.test.tsx` "renders meta line with ffprobe data after probing event" |
| 13 | progressTiming 行を経過時間 / 残り時間で置換 | `fmtElapsed(elapsed)` + `computeEta(progress, elapsed)` |
| 14 | ライブログを CLI stdout listener で行単位 stream | `listen('detect-progress')` ハンドラ + `MAX_LOG_LINES=80` で truncate |
| 15 | ライブログのキーワード色分け (完了/エラー/警告) | **Round 1 課題 2 対応**: `LogKind = 'info' \| 'done' \| 'error' \| 'warn'`、CSS module に `logEntryDone/Error/Warn` 追加、`buildLogText` が phase 別 kind を返す / `DetectingScreen.test.tsx` "buildLogText returns kind=...", "renders log entries with kind-specific styling" |

## スコープ拡張の根拠 (Iron Law 3 確認)

issue [#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) 本文に判断点として明記されており、`AskUserQuestion` で本セッション内承認済:

- 「進捗 % + 経過時間 + 残り時間予測 (CLI -v 出力 or `--progress` 経路、後者は別途 CLI 側拡張要否判断)」 → **CLI に `--progress-format json` を追加**で実装
- 「輝度タイムライン: 動画全体の brightness を細粒度で帯表示 (`debug-brightness` 相当の CSV をオンデマンド生成 or キャッシュ)」 → **detect で metadata.json に `brightness_samples` 埋め込み**で実装

## 次 PR (Group α 内連鎖) への引き継ぎ

- [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) (W1-5): ffmpeg 中断の実 kill (本 PR は track_child 登録までで、cancel ボタンの実 kill 経路 / ConfirmExitModal の detecting 対応は次 PR)
- [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) (W1-6): panic / error / log 構造化 (`error` phase 時の global toast 表示先兼任設計)
- [#574](https://github.com/Idios/kobutachan-allaganeye/issues/574) + [#573](https://github.com/Idios/kobutachan-allaganeye/issues/573) (W2-4 / W2-5): 起動時遷移パターン (last_session / argv)

## Test plan

- [x] `python -m ruff check .`
- [x] `python -m ruff format --check .`
- [x] `python -m pyright`
- [x] `python -m pytest -q -m "not slow"` (830 passed, 4 skipped sample-required)
- [x] `cd gui && npm run lint`
- [x] `cd gui && npm run typecheck`
- [x] `cd gui && npm test -- --run` (370 passed、Round 1 で +4 件)
- [x] `cd gui/src-tauri && cargo check --tests`
- [x] `cd gui/src-tauri && cargo test --lib` (114 passed)
- [x] CLI 実機検証: `python -m allaganeye detect <video> --progress-format json --no-audio --no-cache` で `start` / `probing` / `chunk_dispatch` / `chunk` / `scan` events が JSON line で stdout に流れることを実機で確認 (av1 1080p / 60fps / 7215s mkv)

## ユーザーに依頼する追加検証

`validate-checklist` workflow が markdown 未チェックボックス記法を未完了タスクと判定して fail するため、本セクションは通常段落として記載 (リテラルチェック構文を本文に書くと workflow が誤検出するため、各検証もチェック形式にしない)。

**GUI Tauri 統合実機検証**: `cd gui && npm run tauri dev` で動画 drop → detecting 画面で進捗バー / ライブログ進行 / meta 行 ffprobe 結果表示 / phase 別ログ色分け視認 → complete 画面で試合一覧 + 輝度タイムライン描画を体感確認 (Tauri WebView2 起動 + ユーザー操作が必要なため Claude セッション内では未実施)

**(#591 持ち越し A) NVENC sub label 視認** ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) コメント 3 / Round 1 課題 3 対応): 動画 drop → real CLI detect → metadata.json (system_info 含む) を load → Export 画面の「H.264 再エンコード」コーデックボタンの sub label が「(NVENC)」(NVIDIA) / 「(QSV)」(Intel) / 「(AMF)」(AMD) / 「libx264 (CPU)」(他) になることを視認。

**(#591 持ち越し B) QSV → libx264 fallback retry 視認** ([#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) コメント 3 / Round 1 課題 3 対応): metadata.json を手動編集して `system_info.gpu_vendors_available = ["intel"]` に書き換え (NVIDIA 環境で Intel QSV を強制) → export 開始 → ffmpeg `h264_qsv` 起動失敗 → 自動 libx264 retry → 試合行に fallback notice (「QSV の初期化に失敗したため libx264 で再試行します」相当) inline 表示を視認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
