### PR TITLE
feat(gui): DropScreen DnD 機能を実装 (Refs #568)

### DIFF
--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -60,7 +60,7 @@ stateDiagram-v2
     drop_idle --> drop_selecting: [参照...] 押下
     drop_selecting --> drop_idle: dialog cancel
     drop_selecting --> drop_probing: ファイル選択
-    drop_idle --> drop_probing: D&D (Phase 3)
+    drop_idle --> drop_probing: D&D
     drop_probing --> drop_selected: probe OK
     drop_probing --> drop_probeError: probe fail
     drop_selected --> drop_idle: [キャンセル]
@@ -173,7 +173,7 @@ Phase 2 は dummy なので `×` 即時 exit。Phase 3/4 では以下を実装 (
 |---|---|---|
 | 素の起動 | `drop_idle` | Phase 2 |
 | 動画を [参照...] | `drop_idle → selecting → probing → selected → detecting → completed → complete` | Phase 2 (detecting/probing は dummy) |
-| 動画を D&D | (Phase 3) `drop_idle → probing → selected → detecting → completed → complete` | #465 |
+| 動画を D&D | `drop_idle → probing → selected → detecting → completed → complete` | #568 |
 | argv に動画 path | (将来) | Phase 2 外 |
 | 前回 metadata 自動再現 | (将来) | #517 |
 
@@ -303,7 +303,6 @@ Phase 3 で追加される目標:
 
 | 場所 | Phase 2 状態 | Phase 3/4 での差し替え |
 |---|---|---|
-| DropScreen onDrop ハンドラ | UI のみ | #465: 動画ファイル D&D → detect 発火 |
 | DropScreen dummyProbeVideo | sleep + 固定値 | #465: `invoke('probe_video', { path })` |
 | DetectingScreen dummy progress | 80ms × 100 tick | #465: 実 CLI stdout イベント + event listener |
 | metadataStore.loadSample | Phase 2 専用 in-memory | #465: 実 `load_metadata(generatedPath)` に差し替え |

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -181,7 +181,7 @@
 | 状態 | `idle` (phase=`selected` のみ表示) |
 | 遷移トリガー | `onClick` → `cancelSelection()` → reducer `CANCEL_SELECTION` (phase=`selected → idle`) + `setProbeInfo(null)` |
 | store mutation | なし (`appStateStore.setSelectedVideoPath` は §2.1.6 でしか呼ばれていないので、リセットも不要) |
-| 例外 / edge case | confirm ダイアログなし (まだ §1.3 dirty 編集なし)。Phase 3 で D&D 経由 selection も同 phase に集約されるため挙動を共通化する |
+| 例外 / edge case | confirm ダイアログなし (まだ §1.3 dirty 編集なし)。D&D 経由 selection も同 phase (`selected`) に集約済み (§2.1.1 D&D zone → reducer `DND_DROPPED` → `PROBE_OK` → `selected` で SelectedCard 共通経路、[#568](https://github.com/Idios/kobutachan-allaganeye/issues/568) で実装) |
 
 #### §2.1.6 [OK — 検知開始] button (SelectedCard 内)
 

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -137,11 +137,11 @@
 
 | 項目 | 内容 |
 |---|---|
-| 種類 | drop zone (div、Phase 3 で `onDrop` ハンドラを実装、現状は visual のみ) |
-| 状態 | `idle` (待受) / `dragOver` (Phase 3、ハイライト) / `disabled` (phase=`selecting/probing/selected/probeError` 時は受け付けない) |
-| 遷移トリガー | Phase 3: native HTML `drop` event → reducer `DND_DROPPED` → phase `idle → probing` ([#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) でハンドラ実装) |
-| store mutation | Phase 3: `setSelectedVideoPath(path)` (ハンドラ内、probe 成功後に発火) |
-| 例外 / edge case | 拡張子バリデーション (`.mp4 / .mkv / .avi / .mov`)、複数ファイルドロップ時は最初の 1 件のみ採用、フォルダドロップは reject。**Phase 3 (#465) で実装**: 現状は `RECENT_DUMMY` 表示のみで `onDrop` 未配線 |
+| 種類 | drop zone (div、Tauri webview `onDragDropEvent` 購読 + HTML5 D&D fallback。[#568](https://github.com/Idios/kobutachan-allaganeye/issues/568) で実装) |
+| 状態 | `idle` (待受、gold 破線) / `over-valid` (cyan 破線 + 薄背景、受付可能拡張子の drag-over 中) / `over-invalid` (danger 破線 + `⊘` icon + 「非対応形式 (.mp4 / .mkv / .avi / .mov のみ)」 inline、非対応形式の drag-over 中) / `disabled` (phase=`selecting/probing/selected/probeError` 時は drag を ignore、視覚不変) |
+| 遷移トリガー | Tauri webview `onDragDropEvent` (drop 種別) → 拡張子 validation pass → reducer `DND_DROPPED` → phase `idle → probing` → probe → `selected/probeError`。HTML5 経路は jsdom テスト fallback (`dragDropEnabled: true` (default) のため実機では Tauri が intercept して発火しない) |
+| store mutation | drop 経路は drop 後に `[OK — 検知開始]` 確定で `setSelectedVideoPath(path)` (`§2.1.6 [OK]` と同経路) |
+| 例外 / edge case | 拡張子は大文字小文字非区別 (`.mp4 / .mkv / .avi / .mov`)、複数ファイル drop は最初の valid 拡張子 1 件のみ採用、フォルダ drop は拡張子マッチなしで自動 reject (`probeFn` 未呼出 + phase 不変)。drag-over 中の拒否表示は drop zone 内 inline (toast なし)、drag-leave で復帰。`phase !== 'idle'` 時は drag を ignore (probing 中の干渉防止) |
 
 #### §2.1.2 [参照…] button
 

--- a/gui/src/App.test.tsx
+++ b/gui/src/App.test.tsx
@@ -16,6 +16,14 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: () => Promise.resolve(() => undefined),
 }));
 
+// #568: DropScreen subscribes to webview onDragDropEvent on mount; stub
+// it so the App test tree can render under jsdom.
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn().mockResolvedValue(() => undefined),
+  }),
+}));
+
 import App from './App';
 import { useAppStateStore } from './state/appStateStore';
 import { useMetadataStore } from './state/metadataStore';

--- a/gui/src/__tests__/flow.integration.test.tsx
+++ b/gui/src/__tests__/flow.integration.test.tsx
@@ -40,6 +40,16 @@ vi.mock('@tauri-apps/api/event', () => ({
   },
 }));
 
+// #568: DropScreen subscribes to webview onDragDropEvent on mount. The
+// real getCurrentWebview() reaches into Tauri's native shim which is
+// absent under vitest; stub it to a no-op that returns a no-op
+// unsubscribe so the integration flow tests don't crash on mount.
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn().mockResolvedValue(() => undefined),
+  }),
+}));
+
 import App from '../App';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';

--- a/gui/src/screens/DropScreen.module.css
+++ b/gui/src/screens/DropScreen.module.css
@@ -61,6 +61,32 @@
   background: rgba(var(--ae-gold-rgb), 0.03);
 }
 
+.dropZoneDragOverValid {
+  border: 1px dashed var(--ae-cyan);
+  background: rgba(var(--ae-cyan-rgb), 0.06);
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.dropZoneDragOverInvalid {
+  border: 1px dashed var(--ae-danger);
+  background: rgba(var(--ae-danger-rgb), 0.06);
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.dropZoneIconReject {
+  font-family: var(--ae-font-ui);
+  font-size: 28px;
+  color: var(--ae-danger);
+  margin-bottom: 4px;
+  line-height: 1;
+}
+
+.dropZoneRejectMessage {
+  font-family: var(--ae-font-body);
+  font-size: 13px;
+  color: var(--ae-danger);
+}
+
 .dropZoneLabel {
   font-family: var(--ae-font-body);
   font-size: 13px;

--- a/gui/src/screens/DropScreen.test.tsx
+++ b/gui/src/screens/DropScreen.test.tsx
@@ -239,6 +239,69 @@ describe('DropScreen', () => {
       expect(probeFn).toHaveBeenCalledWith('C:/b.mkv');
     });
 
+    it('accepts uppercase extension paths (.MKV / .MP4 / .AVI / .MOV)', async () => {
+      // 設計判断: 拡張子は大文字小文字非区別 (PR #625 / docs/ui-interaction-spec.md
+      // §2.1.1 例外/edge case)。実装は `lower.endsWith(ext)` で対応済みだが、
+      // T1-T9 がすべて小文字 fixture のため大文字回帰防止 test を別途追加する。
+      const mock = createMockDragSubscriber();
+      const probeFn = vi.fn().mockResolvedValue({
+        path: 'C:/videos/X.MKV',
+        fileName: 'X.MKV',
+        sizeBytes: 1,
+        durationSeconds: 1,
+        width: 1920,
+        height: 1080,
+        fps: 60,
+        codec: 'h264',
+      });
+      render(<DropScreen dragSubscriber={mock.subscribe} probeFn={probeFn} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      // enter で over-valid 判定されることを確認 (drag-over phase の回帰)
+      act(() =>
+        mock.fire({
+          type: 'enter',
+          paths: ['C:/videos/X.MKV'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      expect(screen.getByTestId('drop-zone').dataset.dragState).toBe(
+        'over-valid',
+      );
+      // drop で uppercase path が probe に渡されることを確認
+      act(() =>
+        mock.fire({
+          type: 'drop',
+          paths: ['C:/videos/X.MKV'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('drop-selected-card')).toBeInTheDocument();
+      });
+      expect(probeFn).toHaveBeenCalledWith('C:/videos/X.MKV');
+    });
+
+    it.each([
+      { ext: '.MP4', path: 'C:/videos/Y.MP4' },
+      { ext: '.AVI', path: 'C:/videos/Y.AVI' },
+      { ext: '.MOV', path: 'C:/videos/Y.MOV' },
+      { ext: '.Mp4', path: 'C:/videos/Y.Mp4' }, // mixed case
+    ])('treats $ext as valid on drag-over', async ({ path }) => {
+      const mock = createMockDragSubscriber();
+      render(<DropScreen dragSubscriber={mock.subscribe} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'enter',
+          paths: [path],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      expect(screen.getByTestId('drop-zone').dataset.dragState).toBe(
+        'over-valid',
+      );
+    });
+
     it('rejects folder drop (no matching extension)', async () => {
       const mock = createMockDragSubscriber();
       const probeFn = vi.fn();

--- a/gui/src/screens/DropScreen.test.tsx
+++ b/gui/src/screens/DropScreen.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -23,8 +23,33 @@ vi.mock('@tauri-apps/api/core', () => ({
   }),
 }));
 
-import { DropScreen } from './DropScreen';
+// #568: DropScreen の default dragSubscriber は
+// `getCurrentWebview().onDragDropEvent` を呼ぶ。jsdom 上で安全に
+// no-op を返す mock を入れる。個別 test で override したい場合は
+// `dragSubscriber` props を渡す。
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn().mockResolvedValue(() => undefined),
+  }),
+}));
+
+import { DropScreen, type TauriDragDropEvent } from './DropScreen';
 import { useAppStateStore } from '../state/appStateStore';
+
+function createMockDragSubscriber() {
+  let listener: ((e: TauriDragDropEvent) => void) | null = null;
+  const subscribe = (cb: (e: TauriDragDropEvent) => void) => {
+    listener = cb;
+    return Promise.resolve(() => {
+      listener = null;
+    });
+  };
+  return {
+    subscribe,
+    fire: (e: TauriDragDropEvent) => listener?.(e),
+    isSubscribed: () => listener !== null,
+  };
+}
 
 beforeEach(() => {
   useAppStateStore.getState().reset();
@@ -103,5 +128,216 @@ describe('DropScreen', () => {
     expect(screen.getByText(/bad file/)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: '閉じる' }));
     expect(screen.getByTestId('drop-screen').dataset.phase).toBe('idle');
+  });
+
+  // #568: D&D 機能 — Tauri webview onDragDropEvent 経由の挙動。
+  describe('drag & drop (#568)', () => {
+    it('highlights drop zone with cyan when valid extension is dragged over', async () => {
+      const mock = createMockDragSubscriber();
+      render(<DropScreen dragSubscriber={mock.subscribe} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'enter',
+          paths: ['C:/videos/x.mkv'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      const zone = screen.getByTestId('drop-zone');
+      expect(zone.dataset.dragState).toBe('over-valid');
+      expect(zone.className).toMatch(/dropZoneDragOverValid/);
+    });
+
+    it('shows reject inline message when invalid extension is dragged over', async () => {
+      const mock = createMockDragSubscriber();
+      render(<DropScreen dragSubscriber={mock.subscribe} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'enter',
+          paths: ['C:/somewhere/notes.txt'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      const zone = screen.getByTestId('drop-zone');
+      expect(zone.dataset.dragState).toBe('over-invalid');
+      expect(zone.className).toMatch(/dropZoneDragOverInvalid/);
+      expect(screen.getByText(/非対応形式/)).toBeInTheDocument();
+      expect(screen.getByText('⊘')).toBeInTheDocument();
+    });
+
+    it('returns to idle on drag-leave', async () => {
+      const mock = createMockDragSubscriber();
+      render(<DropScreen dragSubscriber={mock.subscribe} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'enter',
+          paths: ['C:/videos/x.mkv'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      expect(screen.getByTestId('drop-zone').dataset.dragState).toBe(
+        'over-valid',
+      );
+      act(() => mock.fire({ type: 'leave' }));
+      expect(screen.getByTestId('drop-zone').dataset.dragState).toBe('idle');
+    });
+
+    it('dispatches DND_DROPPED and calls probeFn on valid drop', async () => {
+      const mock = createMockDragSubscriber();
+      const probeFn = vi.fn().mockResolvedValue({
+        path: 'C:/videos/x.mkv',
+        fileName: 'x.mkv',
+        sizeBytes: 1,
+        durationSeconds: 1,
+        width: 1920,
+        height: 1080,
+        fps: 60,
+        codec: 'h264',
+      });
+      render(<DropScreen dragSubscriber={mock.subscribe} probeFn={probeFn} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'drop',
+          paths: ['C:/videos/x.mkv'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('drop-selected-card')).toBeInTheDocument();
+      });
+      expect(probeFn).toHaveBeenCalledWith('C:/videos/x.mkv');
+      expect(screen.getByTestId('drop-screen').dataset.phase).toBe('selected');
+    });
+
+    it('picks first valid extension when multiple paths are dropped', async () => {
+      const mock = createMockDragSubscriber();
+      const probeFn = vi.fn().mockResolvedValue({
+        path: 'C:/videos/b.mkv',
+        fileName: 'b.mkv',
+        sizeBytes: 1,
+        durationSeconds: 1,
+        width: 1920,
+        height: 1080,
+        fps: 60,
+        codec: 'h264',
+      });
+      render(<DropScreen dragSubscriber={mock.subscribe} probeFn={probeFn} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'drop',
+          paths: ['C:/a.txt', 'C:/b.mkv', 'C:/c.mp4'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('drop-selected-card')).toBeInTheDocument();
+      });
+      expect(probeFn).toHaveBeenCalledWith('C:/b.mkv');
+    });
+
+    it('rejects folder drop (no matching extension)', async () => {
+      const mock = createMockDragSubscriber();
+      const probeFn = vi.fn();
+      render(<DropScreen dragSubscriber={mock.subscribe} probeFn={probeFn} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'drop',
+          paths: ['C:/some-folder'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      // give microtasks a chance to run
+      await Promise.resolve();
+      expect(probeFn).not.toHaveBeenCalled();
+      expect(screen.getByTestId('drop-screen').dataset.phase).toBe('idle');
+    });
+
+    it('ignores drag events while phase is not idle', async () => {
+      const mock = createMockDragSubscriber();
+      const openDialog = vi.fn().mockResolvedValue('C:/videos/x.mkv');
+      // make probe slow so we can observe `probing` phase
+      let resolveProbe: (info: unknown) => void = () => undefined;
+      const probeFn = vi.fn(
+        () =>
+          new Promise((res) => {
+            resolveProbe = res;
+          }),
+      );
+      render(
+        <DropScreen
+          dragSubscriber={mock.subscribe}
+          openDialogFn={openDialog}
+          probeFn={probeFn as never}
+        />,
+      );
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: /参照/ }));
+      await waitFor(() => {
+        expect(screen.getByTestId('drop-screen').dataset.phase).toBe('probing');
+      });
+      // drag-over while probing — must not change dragState
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'enter',
+          paths: ['C:/videos/y.mkv'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      // dropZone is hidden while probing (selected/probeError/probing branch),
+      // so we just verify phase didn't change to selected via spurious DND.
+      expect(screen.getByTestId('drop-screen').dataset.phase).toBe('probing');
+      // unblock probe to keep test clean
+      resolveProbe({
+        path: 'C:/videos/x.mkv',
+        fileName: 'x.mkv',
+        sizeBytes: 1,
+        durationSeconds: 1,
+        width: 1920,
+        height: 1080,
+        fps: 60,
+        codec: 'h264',
+      });
+    });
+
+    it('does not transition phase on invalid drop', async () => {
+      const mock = createMockDragSubscriber();
+      const probeFn = vi.fn();
+      render(<DropScreen dragSubscriber={mock.subscribe} probeFn={probeFn} />);
+      await waitFor(() => expect(mock.isSubscribed()).toBe(true));
+      act(() =>
+        mock.fire({
+          type: 'drop',
+          paths: ['C:/foo.txt'],
+          position: { x: 0, y: 0 },
+        }),
+      );
+      await Promise.resolve();
+      expect(probeFn).not.toHaveBeenCalled();
+      expect(screen.getByTestId('drop-screen').dataset.phase).toBe('idle');
+      expect(screen.getByTestId('drop-zone').dataset.dragState).toBe('idle');
+    });
+
+    it('reflects HTML5 onDragOver fallback in dragState (jsdom path)', async () => {
+      // No dragSubscriber here — only HTML5 fallback should fire because the
+      // default subscriber mock returns no-op. fireEvent.dragOver with valid
+      // mime should still highlight the drop zone (test-only fallback).
+      render(<DropScreen />);
+      const zone = screen.getByTestId('drop-zone');
+      fireEvent.dragOver(zone, {
+        dataTransfer: {
+          items: [{ kind: 'file', type: 'video/mp4' }],
+        },
+      });
+      expect(zone.dataset.dragState).toBe('over-valid');
+      fireEvent.dragLeave(zone);
+      expect(zone.dataset.dragState).toBe('idle');
+    });
   });
 });

--- a/gui/src/screens/DropScreen.tsx
+++ b/gui/src/screens/DropScreen.tsx
@@ -1,6 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
+import type { UnlistenFn } from '@tauri-apps/api/event';
+import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { open } from '@tauri-apps/plugin-dialog';
-import { useReducer, useState } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 
 import { AllaganFrame } from '../components/AllaganFrame';
 import { AllaganSigil } from '../components/AllaganSigil';
@@ -8,6 +10,48 @@ import { useAppStateStore } from '../state/appStateStore';
 import { dropReducer } from './reducers/drop';
 import type { DropPhase, VideoProbeInfo } from './types';
 import styles from './DropScreen.module.css';
+
+/**
+ * #568: drop zone の drag state。Tauri webview の `onDragDropEvent` で
+ * 更新される。`over-valid` は受付可能な拡張子、`over-invalid` は非対応形式。
+ */
+type DragState = 'idle' | 'over-valid' | 'over-invalid';
+
+/**
+ * Tauri 2 webview onDragDropEvent の payload 型。
+ * `enter` と `drop` は `paths: string[]` (絶対 path) を含む。
+ */
+export type TauriDragDropEvent =
+  | { type: 'enter'; paths: string[]; position: { x: number; y: number } }
+  | { type: 'over'; position: { x: number; y: number } }
+  | { type: 'drop'; paths: string[]; position: { x: number; y: number } }
+  | { type: 'leave' };
+
+export type DragSubscriber = (
+  cb: (e: TauriDragDropEvent) => void,
+) => Promise<UnlistenFn>;
+
+const ACCEPTED_EXTENSIONS = ['.mp4', '.mkv', '.avi', '.mov'] as const;
+
+function isAcceptedVideoExtension(name: string): boolean {
+  const lower = name.toLowerCase();
+  return ACCEPTED_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+function pickFirstAcceptedPath(paths: readonly string[]): string | null {
+  for (const p of paths) {
+    if (isAcceptedVideoExtension(p)) return p;
+  }
+  return null;
+}
+
+async function defaultDragSubscriber(
+  cb: (e: TauriDragDropEvent) => void,
+): Promise<UnlistenFn> {
+  return getCurrentWebview().onDragDropEvent((event) => {
+    cb(event.payload as TauriDragDropEvent);
+  });
+}
 
 const RECENT_DUMMY = [
   { name: '2026-04-08 21-14-05.mkv', size: '38.2 GB', dur: '2:50:28' },
@@ -32,15 +76,38 @@ export interface DropScreenProps {
   probeFn?: (path: string) => Promise<VideoProbeInfo>;
   /** Injection hook for tests. Defaults to @tauri-apps/plugin-dialog open(). */
   openDialogFn?: () => Promise<string | null>;
+  /**
+   * Injection hook for tests. Defaults to subscribing the Tauri webview
+   * `onDragDropEvent`. Tests pass a controllable subscriber that captures
+   * the callback so they can synthesize drag-drop events.
+   */
+  dragSubscriber?: DragSubscriber;
 }
 
-export function DropScreen({ probeFn, openDialogFn }: DropScreenProps = {}) {
+export function DropScreen({
+  probeFn,
+  openDialogFn,
+  dragSubscriber,
+}: DropScreenProps = {}) {
   const navigate = useAppStateStore((s) => s.navigate);
   const setSelectedVideoPath = useAppStateStore((s) => s.setSelectedVideoPath);
 
   const [phase, dispatch] = useReducer(dropReducer, 'idle' as DropPhase);
   const [probeInfo, setProbeInfo] = useState<VideoProbeInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [dragState, setDragState] = useState<DragState>('idle');
+
+  async function probeAndDispatch(path: string): Promise<void> {
+    setError(null);
+    try {
+      const info = await (probeFn ?? probeVideo)(path);
+      setProbeInfo(info);
+      dispatch({ type: 'PROBE_OK' });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      dispatch({ type: 'PROBE_FAIL' });
+    }
+  }
 
   async function pickAndProbe() {
     dispatch({ type: 'BROWSE_CLICKED' });
@@ -58,14 +125,84 @@ export function DropScreen({ probeFn, openDialogFn }: DropScreenProps = {}) {
       return;
     }
     dispatch({ type: 'FILE_PICKED' });
-    try {
-      const info = await (probeFn ?? probeVideo)(selected);
-      setProbeInfo(info);
-      dispatch({ type: 'PROBE_OK' });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      dispatch({ type: 'PROBE_FAIL' });
-    }
+    await probeAndDispatch(selected);
+  }
+
+  // #568: Tauri webview onDragDropEvent を購読し、drag-over の visual
+  // フィードバックと drop での probing 遷移を実装する。`dragDropEnabled`
+  // が default `true` のため OS-level drop は Tauri が intercept し
+  // HTML5 onDrop は実機で発火しない。HTML5 handler は jsdom テスト用
+  // fallback として併設している。
+  useEffect(() => {
+    const subscribe = dragSubscriber ?? defaultDragSubscriber;
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    void (async () => {
+      const u = await subscribe((e) => {
+        // phase が idle 以外は drag を ignore (probing 中の干渉防止 +
+        // probeError card 表示中に dragState が裏で更新されないように)。
+        if (phase !== 'idle') {
+          if (e.type === 'leave') setDragState('idle');
+          return;
+        }
+        switch (e.type) {
+          case 'enter':
+            setDragState(
+              pickFirstAcceptedPath(e.paths) ? 'over-valid' : 'over-invalid',
+            );
+            return;
+          case 'over':
+            // 'over' は paths を含まないことが多い (Tauri 2 仕様)。
+            // 'enter' で決めた dragState を維持する。
+            return;
+          case 'leave':
+            setDragState('idle');
+            return;
+          case 'drop': {
+            const path = pickFirstAcceptedPath(e.paths);
+            setDragState('idle');
+            if (!path) return; // invalid drop は phase 遷移しない
+            dispatch({ type: 'DND_DROPPED' });
+            void probeAndDispatch(path);
+            return;
+          }
+        }
+      });
+      if (cancelled) u();
+      else unlisten = u;
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dragSubscriber, phase]);
+
+  function onDragOverHTML(e: React.DragEvent) {
+    e.preventDefault();
+    if (phase !== 'idle') return;
+    const items = Array.from(e.dataTransfer?.items ?? []);
+    const valid =
+      items.length > 0 &&
+      items.every(
+        (it) =>
+          it.kind === 'file' &&
+          (it.type.startsWith('video/') || it.type === ''),
+      );
+    setDragState(valid ? 'over-valid' : 'over-invalid');
+  }
+
+  function onDragLeaveHTML() {
+    if (phase !== 'idle') return;
+    setDragState('idle');
+  }
+
+  function onDropHTML(e: React.DragEvent) {
+    // 実機では Tauri が intercept するためここは発火しない。jsdom 上で
+    // のみ発火する経路で、path が取れないので visual のリセットだけ行う。
+    e.preventDefault();
+    e.stopPropagation();
+    setDragState('idle');
   }
 
   function confirm() {
@@ -138,23 +275,55 @@ export function DropScreen({ probeFn, openDialogFn }: DropScreenProps = {}) {
       ) : (
         <>
           <AllaganFrame style={{ width: '78%', padding: 2, zIndex: 2 }}>
-            <div className={styles.dropZone}>
-              <div className={styles.dropZoneLabel}>
-                ⬦ ここに録画ファイルをドロップ
-              </div>
-              <div className={styles.dropZoneHint}>
-                or{' '}
-                <button
-                  type="button"
-                  className={styles.browseButton}
-                  disabled={phase === 'selecting' || phase === 'probing'}
-                  onClick={pickAndProbe}
-                >
-                  参照…
-                </button>
-                {phase === 'selecting' && <span className={styles.loading}> (選択中)</span>}
-                {phase === 'probing' && <span className={styles.loading}> (解析中)</span>}
-              </div>
+            <div
+              className={[
+                styles.dropZone,
+                dragState === 'over-valid' ? styles.dropZoneDragOverValid : '',
+                dragState === 'over-invalid'
+                  ? styles.dropZoneDragOverInvalid
+                  : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              data-testid="drop-zone"
+              data-drag-state={dragState}
+              onDragOver={onDragOverHTML}
+              onDragLeave={onDragLeaveHTML}
+              onDrop={onDropHTML}
+            >
+              {dragState === 'over-invalid' ? (
+                <>
+                  <div className={styles.dropZoneIconReject} aria-hidden>
+                    ⊘
+                  </div>
+                  <div className={styles.dropZoneRejectMessage}>
+                    非対応形式 (.mp4 / .mkv / .avi / .mov のみ)
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className={styles.dropZoneLabel}>
+                    ⬦ ここに録画ファイルをドロップ
+                  </div>
+                  <div className={styles.dropZoneHint}>
+                    or{' '}
+                    <button
+                      type="button"
+                      className={styles.browseButton}
+                      disabled={phase === 'selecting' || phase === 'probing'}
+                      onClick={pickAndProbe}
+                    >
+                      参照…
+                    </button>
+                    {phase === 'selecting' && (
+                      <span className={styles.loading}> (選択中)</span>
+                    )}
+                    {phase === 'probing' && (
+                      <span className={styles.loading}> (解析中)</span>
+                    )}
+                  </div>
+                </>
+              )}
             </div>
           </AllaganFrame>
 

--- a/gui/src/styles/tokens.css
+++ b/gui/src/styles/tokens.css
@@ -55,6 +55,7 @@
   /* Rgba compositing tokens (used for hover/dim overlays) */
   --ae-gold-rgb: 200, 163, 92;
   --ae-cyan-rgb: 74, 195, 217;
+  --ae-danger-rgb: 200, 112, 88;
   --ae-bg-rgb: 10, 14, 20;
 }
 


### PR DESCRIPTION
## Summary

L2a Tauri GUI の DropScreen に **ドラッグ&ドロップ機能** を実装し、reducer に既に定義済みだった `DND_DROPPED` event を画面側で dispatch できるように配線する。Phase 2 (#526) で骨格、Phase 3 (#540) で probe が本物化済みだったが、DnD handler だけが未実装のままだった。

- Tauri 2 webview の `onDragDropEvent` を購読し、`enter` / `over` / `drop` / `leave` を処理
- drag-over 時に drop zone を視覚フィードバック (`over-valid`: cyan / `over-invalid`: danger + `⊘` icon + 「非対応形式」 inline message)
- drag-leave で復帰、`phase !== 'idle'` 時は drag を ignore (probing 中の干渉防止)
- 既存 `pickAndProbe` から probe ロジックを `probeAndDispatch(path)` に抽出して D&D 経路と共有

## 受け入れ条件 (#568) と対応

| # | 受け入れ条件 | 実証 |
|---|---|---|
| 1 | drop で `DND_DROPPED` dispatch + `probing` 遷移 | DropScreen.test.tsx T4 (drop dispatches DND_DROPPED + calls probeFn) |
| 2 | drag-over で drop zone 強調 | T1 (over-valid + `dropZoneDragOverValid` class) |
| 3 | drag-leave で復帰 | T3 (returns to idle on drag-leave) |
| 4 | 非対応形式 drag-over で「非対応形式」表示 | T2 (over-invalid + `⊘` icon + 「非対応形式 (.mp4 / .mkv / .avi / .mov のみ)」 inline) |
| 5 | vitest 単体テスト | 9 ケース新規 (T1-T9) + 既存 7 ケース全 pass |

## 設計判断 (ユーザー確定済み)

- 拒否表示方法: drop zone 内 inline + アイコン変更 (toast なし)
- 拡張子は大文字小文字非区別 (`.mp4 / .mkv / .avi / .mov`)
- 複数ファイル drop は最初の valid 拡張子 1 件のみ採用
- フォルダ drop は拡張子マッチなしで自動 reject
- Tauri webview event 経路を主軸 (HTML5 経路は `dragDropEnabled: true` で実機発火しないため jsdom テスト fallback として併設)

## 変更ファイル

| ファイル | 変更概要 |
|---|---|
| `gui/src/screens/DropScreen.tsx` | `dragState` state + `probeAndDispatch` 抽出 + Tauri `onDragDropEvent` 購読 useEffect + JSX modifier class / アイコン切替 / 拒否 inline message。`DropScreenProps` に `dragSubscriber` injection prop |
| `gui/src/screens/DropScreen.module.css` | `.dropZoneDragOverValid` / `.dropZoneDragOverInvalid` / `.dropZoneIconReject` / `.dropZoneRejectMessage` 4 class 追加 (camelCase で既存命名と統一) |
| `gui/src/styles/tokens.css` | `--ae-danger-rgb: 200, 112, 88;` を 1 行追加 (既存 `--ae-gold-rgb` / `--ae-cyan-rgb` と同パターン) |
| `gui/src/screens/DropScreen.test.tsx` | DnD 9 テストケース追加 + `@tauri-apps/api/webview` mock |
| `gui/src/__tests__/flow.integration.test.tsx` | `@tauri-apps/api/webview` no-op mock 追加 (App test tree が DropScreen mount 時にクラッシュしないように) |
| `gui/src/App.test.tsx` | 同上 |
| `docs/ui-interaction-spec.md` §2.1.1 | D&D zone の 4 セルを「実装済み (#568)」前提に書き換え |
| `docs/ui-architecture.md` | line 63 / 176 の `(Phase 3)` 注記を削除、line 306 の `DropScreen onDrop ハンドラ` 行を Phase 3/4 引き継ぎ表から削除 |

`gui/src/screens/reducers/drop.ts` は変更なし (`DND_DROPPED` 遷移は既に定義済み)。`gui/src-tauri/src/lib.rs` も変更なし (`onDragDropEvent` は webview event のみで完結)。

## スコープから明示的に除外

- `RECENT_DUMMY` 直近録画リスト本物化 → #571 (W2-6)
- 詳細設定パネル (blackout_threshold / workers / no_audio / gpu) → #613 (W2-1, #569 依存)
- a11y polish (`aria-live` 等) → #587 系
- error toast 共通化 → 別 issue

## Group β 連鎖の進行状況

| W | issue | 状態 |
|---|---|---|
| W1-1 | #568 | **本 PR** |
| W2-1 | #613 | 未着手 (#569 依存) |
| W2-6 | #571 | 未着手 |

## Test plan (本 PR 提出前にローカルで実行済)

- [x] `npm run typecheck` (gui/, tsc --noEmit) PASS
- [x] `npm run lint` (gui/, eslint .) PASS
- [x] `npm test` (gui/, vitest) 344/344 PASS (新規 9 + 既存全件)
- [x] `cargo check` (gui/src-tauri/) PASS
- [x] `npm run build` (gui/, vite build) PASS

## レビュー時の確認 (machine-unverifiable)

`npm run tauri dev` で起動して以下を逐条確認 (Iron Law 1 受け入れ条件 1-4 の実機ゲート):

- `.mkv` ファイルを drop → drop zone が cyan ハイライト → probing → selected card → `[OK]` で detecting 遷移 (条件 #1)
- `.mkv` を drag-over 中 → cyan ハイライトが drop までの間維持 (条件 #2)
- drag-over 中に zone から外す → gold dashed border に戻る (条件 #3)
- `.txt` / `.zip` を drag-over → danger 色 + `⊘` + 「非対応形式 (.mp4 / .mkv / .avi / .mov のみ)」 inline 表示 (条件 #4)
- `.txt` を drop → 何も起きない (phase 維持)
- 複数ファイル (.txt + .mkv) drop → `.mkv` のみ probe される
- フォルダ drop → 何も起きない
- `[参照…]` 経由の既存フローが regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
