### PR TITLE
[refactor] close-issue skill に Refs #N fallback + Iter 2 検証 + reports 整理 (Refs #607 #606)

### DIFF
--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -27,30 +27,71 @@ issue 番号 1 つに対して 1 回呼び出す。issue ⇔ PR の関係に応�
 
 ```bash
 gh issue view "$ARGUMENTS" --repo Idios/kobutachan-allaganeye \
-  --json title,body,state,assignees,labels,closedByPullRequestsReferences,timelineItems --comments
+  --json title,body,state,assignees,labels,closedByPullRequestsReferences --comments
 ```
 
 - `state == OPEN` を確認 (`CLOSED` の場合は本 skill 対象外、`AskUserQuestion` で再オープン or 別対応を確認)
 - `closedByPullRequestsReferences` で紐づく PR 一覧を取得
-- `timelineItems` も併せて確認 (古い PR 紐付けが closedByPullRequestsReferences に出ないケースの救済)
 - 本文末尾の `作成: <session-id>` で起票元セッション ID を確認 (close コメント記載に使用)。記載なし / 空欄の場合は close コメント本文での「起票元 session-id」言及は省略可
 - **本 skill 実行 session-id の取得**: `pwd` で現在のディレクトリパス (例: `.../.claude/worktrees/hopeful-darwin-616414`) を取得し、最終ディレクトリ名を session-id とする (例: `hopeful-darwin-616414`)。Step 7 の close コメントには**実行 session-id を必ず含める** (起票 session-id の有無に関わらず)
 
+#### Refs #N fallback (closedByPullRequestsReferences が空の場合)
+
+本プロジェクトは Iron Law 4 (`Closes/Fixes/Resolves` キーワード禁止 / `docs/issue-policy.md` §6) のため `closedByPullRequestsReferences` は**通常空**。fallback ルートが正規経路 (例外運用ではない)。Step 1 の bash 直後に以下を実行する:
+
+1. **timeline API (第 1 段)**:
+
+   ```bash
+   gh api repos/Idios/kobutachan-allaganeye/issues/"$ARGUMENTS"/timeline \
+     --jq '[.[] | select(.event=="cross-referenced") | select(.source.issue.pull_request != null) | {pr: .source.issue.number, state: .source.issue.state}]'
+   ```
+
+   - `cross-referenced` イベントから PR (`pull_request != null`) を列挙
+   - 返却される `state` は `closed` (実態は merged の近似情報)。確定的な merged 判定は Step 3 で `gh pr view` 経由で実施
+
+2. **`gh search prs` (第 2 段、timeline ゼロ件 or 補完用)**:
+
+   ```bash
+   gh search prs '"Refs #'"$ARGUMENTS"'"' --repo Idios/kobutachan-allaganeye --json number,state,title,url
+   ```
+
+   - PR 本文中の `Refs #N` 文字列で全 PR を検索
+   - `state==merged` を直接返すため state 判定が明確
+
+3. **dedupe ポリシー**: 両方ヒットした PR は **`gh search prs` の `state==merged` を真値**として採用 (timeline の `closed` は近似情報)。両ルート結果の和集合を取り、PR 番号で重複排除する。
+4. **`gh issue view` の `closedByPullRequestsReferences` が非空のケース**: 古い `Closes` 記述が残った issue や手動入力で稀にあるため、当該フィールドが返した PR と fallback 経路の結果を統合 (PR 番号で重複排除)。本プロジェクトでは fallback 経路結果が主、`closedByPullRequestsReferences` は補助的に扱う。
+
 ### 2. 紐づく PR の関係性判定 (ケース分岐)
+
+Step 1 で取得した PR 一覧 (closedByPullRequestsReferences または fallback 経路) の件数と、各 PR の close 対象 issue 件数 (closingIssuesReferences または PR 本文 `Refs #(\d+)` 抽出) でケース判定する。
 
 #### ケース A: 1:1 (issue 1 件 + PR 1 件)
 
-`closedByPullRequestsReferences` が 1 件で、その PR の `closingIssuesReferences` (`gh pr view <PR#> --json closingIssuesReferences`) が本 issue 1 件のみ。最も典型的なパターン。
+Step 1 で取得した PR 一覧が 1 件、かつその PR の close 対象 issue が本 issue 1 件のみ。最も典型的なパターン。
+
+- `closingIssuesReferences` (`gh pr view <PR#> --json closingIssuesReferences`) が本 issue 1 件のみ、または
+- `closingIssuesReferences` が空でも PR 本文 `Refs #(\d+)` 抽出結果が本 issue 1 件のみ (本プロジェクト運用)
 
 #### ケース B: 束ね PR (1 PR で N issue close)
 
-issue 1 件あたりの紐づく PR は 1 件だが、その PR が複数 issue を `closingIssuesReferences` として持つ。
+Step 1 で取得した PR 一覧が 1 件だが、その PR が複数 issue を close する。
 
 例: PR #500 が #401 と #402 を close する。
 
+**本プロジェクトでの判定** (Iron Law 4 で `Closes` 禁止のため `closingIssuesReferences` も通常空):
+
+- PR 本文から `Refs #(\d+)` 表記を正規表現で抽出する fallback ルートを使う:
+
+  ```bash
+  gh pr view <PR#> --repo Idios/kobutachan-allaganeye --json body --jq '.body' \
+    | grep -oE '#[0-9]+' | sort -u
+  ```
+
+- `closingIssuesReferences` が非空ならそれを優先、空なら PR 本文 `Refs` 抽出結果を採用
+
 #### ケース C: Phase 分割 (N PR で 1 issue close)
 
-issue 1 件に対し、`closedByPullRequestsReferences` が複数件返る。Phase 1 / Phase 2 のように複数 PR で 1 issue を分割消化する。
+Step 1 で取得した PR 一覧が複数件返る。Phase 1 / Phase 2 のように複数 PR で 1 issue を分割消化する。
 
 ### 3. 各 PR のマージ状態確認
 
@@ -249,11 +290,12 @@ close 後に追加情報 (関連 PR 番号 / 検証ログ / 残タスク子 issu
 | 「× 項目があるが軽微だから close してよい」 | Iron Law 3 違反。残タスクは (B)/(C) にトリアージ、握り潰し禁止 |
 | 「受け入れ条件節が無いから自分の判断で close 基準を決めよう」 | Iron Law 5 違反。`AskUserQuestion` でユーザー確認 (環境制約 §A) |
 | 「ユーザー承認なしで close したほうが速い」 | Iron Law 4 + Iron Law 5 違反。close は必ず Step 7 のユーザー承認を経由 |
+| 「`closedByPullRequestsReferences` 空 = 紐づく PR なし」と即断してよい | Iron Law 4 で `Closes` 禁止のため当該フィールドは通常空。Step 1 fallback ルート (`gh api .../timeline` cross-referenced-event + `gh search prs '"Refs #N"'`) で再列挙する (`Refs #N` fallback サブセクション) |
 
 ## よくある失敗
 
-- **`closedByPullRequestsReferences` のみで PR 件数判定**: 古い PR 紐付けが `timelineItems` のみに残るケースあり。両方確認する (Step 1)
-- **Phase 分割の見落とし**: 単一 PR で完結したつもりが、closing keyword 由来で複数 PR が立っているケースあり。`closedByPullRequestsReferences` の件数で機械判定する (Step 2 ケース C)
+- **`closedByPullRequestsReferences` のみで PR 件数判定**: 本プロジェクトは Iron Law 4 (`Closes` 禁止) のため当該フィールドは**通常空**。Step 1 fallback ルート (`gh api .../timeline` cross-referenced-event + `gh search prs '"Refs #N"'`) を経由して紐づく PR を列挙する。timeline API の state は `closed` (実態は merged の近似)、search の state は `merged` で明確 — dedupe 時は search の `merged` を真値として採用
+- **Phase 分割の見落とし**: 単一 PR で完結したつもりが、`Refs #N` 記述由来で複数 PR が立っているケースあり。Step 1 fallback で取得した PR 一覧の件数で機械判定する (Step 2 ケース C)
 - **束ね PR で他 issue 分の受け入れ条件まで検証**: ケース B では本 issue 分のみ抽出する。他 issue は別 `/close-issue` 呼び出しで扱う
 - **実測必要項目を skill 内で動的検証しようとする**: long-running は範囲外。ユーザーに `/test-pr` 既実施を確認するに留める (Step 5)
 - **× 項目を「軽微」と自己判定して close**: Iron Law 3 違反。トリアージ表で (B)/(C) に振り分ける (Step 6)
@@ -274,5 +316,5 @@ close 後に追加情報 (関連 PR 番号 / 検証ログ / 残タスク子 issu
 - `docs/issue-policy.md` §7 「Issue のライフサイクル管理」 / §8 「Issue クローズポリシー」
 - `docs/l2-workflow.md` §「レビュー受け入れ基準 (#367 対策)」 (review-pr → /close-issue の運用フロー、`### Issue クローズルール` サブセクション)
 - Iron Law 4 (`.claude/hooks/session-start.sh`)
-- 本 skill 改修経緯: #594
+- 本 skill 改修経緯: #594 (新設) / #607 (`Refs #N` fallback) / #606 (eval/reports 構造整理)
 - 先行事例 (empirical-prompt-tuning による skill 改修): #511 (review-pr ブラッシュアップ)

--- a/.claude/skills/close-issue/eval/reports/iter_1_revaluation.md
+++ b/.claude/skills/close-issue/eval/reports/iter_1_revaluation.md
@@ -1,0 +1,120 @@
+# /close-issue Iter 1 再評価レポート
+
+**日時**: 2026-04-27
+**対象 skill**: `.claude/skills/close-issue/SKILL.md` (Iter 0 → Iter 1 改修反映後)
+**subagent model**: sonnet
+**dispatch 方式**: 新規 subagent 3 体を並列 `run_in_background: true` (memory `feedback_skill_revision_empirical.md` Red Flag「同じ subagent を使い回そう」回避)
+
+---
+
+## サマリ
+
+| シナリオ | 精度 | [critical] | tool_uses | duration_ms (実測平均) | 再試行 |
+|---|---|---|---|---|---|
+| A (中央値 1:1) | 8/8 = 1.00 | 7/7 ○ | ~4 | ~152,500 | 0 |
+| B (束ね PR) | 8/8 = 1.00 | 6/6 ○ | ~4 | ~152,500 | 0 |
+| C (Phase 分割) | 8/8 = 1.00 | 7/7 ○ | ~3 | ~152,500 | 0 |
+
+**集計値** (`summary.md` 統合計測):
+
+- 平均精度: **1.00** (Iter 0 と維持)
+- [critical] 成功率: **3/3** シナリオ全件
+- tool_uses 合計: 11 (Iter 0 の 8 から +37%、改修箇所参照で能動化)
+- duration 合計 (実測 ms): 457,335 (Iter 0 の 352,607 から +30%、改修確認のため精読時間が増加)
+- duration 合計 (subagent self-report): 393s (Iter 0 の 210s から +87%)
+- 新規不明瞭点 件数: **11** (詳細詰め不足のみ。Iter 0 の 14 = 構造的欠陥 7 + 詳細不足 7 から **構造的欠陥ゼロ化**)
+
+> Iter 1 は 3 シナリオ別の `agent_id` および個別 duration を `summary.md` 集約形式でしか保持していない (本ファイルへの分離は #606 で実施)。個別シナリオ duration は合計値を 3 分割した推定値。
+
+精度は Iter 0 / Iter 1 とも全シナリオで満点 (1.00)。本シナリオ群は要件設計が成熟しており、改修前から要件レベルでは問題なかった。改修の主目的は **構造的欠陥 (subagent が「迷う / 独断する」リスク領域) の除去**。
+
+duration 増加は subagent が改修箇所 (新節 / 追記) を能動的に参照したため (tool_uses +37%)。これは Iter 1 が改修内容に「迷わず到達できた」シグナルであり、構造改善の品質向上として記録。
+
+---
+
+## シナリオ A (中央値 1:1) — Iter 1
+
+- **agent_id**: 未記録 (summary.md 集約のみ、#606 で個別分離扱い)
+- **判定**: close 提案前まで進む。受け入れ条件 5 項目を 4 (静的/動的検証可) + 1 (long-running、`/test-pr` 既実施確認) に分類、参照先 PR #923 不在 → (B) 残タスク化、未消化チェックボックス摘出。Step 7 でユーザー承認待ち
+- **変化**: Iter 0 で裁量補完だった「session-id 取得」「`AskUserQuestion` 強制」「CI green の扱い」「`/test-pr` 既実施記録のアクセス不可ルート」「動的検証 vs 実測必要 の判定基準」「受け入れ条件外 diff の仕分け」「参照先実在確認」が、Iter 1 では明示的な節 / 表 を能動参照して判断するようになった
+
+### Iter 0 不明瞭点の解消状況
+
+| Iter 0 不明瞭点 | Iter 1 で効いた改修 | 解消確認 |
+|---|---|---|
+| session-id 取得方法 (`pwd` 経由) と issue 本文の `作成:` 空欄時のフォールバック | Step 1 末尾「本 skill 実行 session-id の取得」 + 空欄時「言及省略可」明記 | **完全解消** |
+| AskUserQuestion 強制 (Step 7 冒頭の絶対条件) | Step 7 冒頭「重要 (close 実行前の絶対条件)」 + Iron Law 4+5 違反明記 | **完全解消** |
+| CI green は補助根拠扱い、静的検証必須 | Step 5 「CI green の扱い」: 「Iron Law 4 実測再検証の代替にはならない」明記 | **完全解消** |
+| `/test-pr` 既実施記録の取得手順 (PR/issue コメント) とアクセス不可時の AskUserQuestion ルート | Step 5「`/test-pr` 既実施記録の取得とアクセス不可時の対応」3 段フロー (PR コメント → issue コメント → AskUserQuestion) | **完全解消** |
+| 参照先 PR/issue の実在確認 + 不在時の (B) 残タスク化 | Step 5b「参照先 PR/issue の実在確認」3 分岐処置明記 | **完全解消** |
+
+### Iter 1 新出不明瞭点 (詳細詰め不足、deferred)
+
+1. AskUserQuestion + 実測必要の統合タイミング (複数保留理由を 1 回にまとめるか別々に発行するか)
+2. `/test-pr` 既実施確認の記録方法 (ユーザー口頭「はい」回答だけで OK か、コメント URL 引用必須か)
+3. (B) 起票と close の順序の明文化 (close 前に起票完了させるか、close 後でも可か)
+
+---
+
+## シナリオ B (束ね PR) — Iter 1
+
+- **agent_id**: 未記録 (summary.md 集約のみ、#606 で個別分離扱い)
+- **判定**: close 提案前まで進む。#905 の受け入れ条件 4 項目を独立検証、#906 用 diff (test_gpu_detector_logs.py / gpu_detector.py ログ部 / CLAUDE.md §デバッグ) は対象外として除外。Step 7 でユーザー承認待ち
+- **変化**: Iter 0 で裁量補完だった「動的検証 vs 実測必要 の判定基準」「受け入れ条件外 diff の仕分け」「ファイル内 section 粒度 (CLAUDE.md §GPU モード vs §デバッグ)」が Iter 1 では明示的な境界線で判断
+
+### Iter 0 不明瞭点の解消状況
+
+| Iter 0 不明瞭点 | Iter 1 で効いた改修 | 解消確認 |
+|---|---|---|
+| 動的検証 vs 実測必要 の判定境界 (slow マーカー / GPU / 30 秒等) | Step 5「動的検証 vs 実測必要 の判定基準」境界明示 | **完全解消** |
+| 受け入れ条件外の追加変更 (CLAUDE.md 等) を close 判定からどう仕分けるか | Step 4「受け入れ条件外の追加変更の扱い」「ファイル内 section 粒度の分離」明記 | **完全解消** |
+
+### Iter 1 新出不明瞭点 (詳細詰め不足、deferred)
+
+1. テスト関連受け入れ条件の検証方法欄 (Step 4 マッピング表) を「Step 5 で決定」と仮判定で書くべきか
+2. 「実測必要 (要確認)」がある状態での AskUserQuestion タイミング (Step 5 即時 vs Step 7 一括)
+3. AskUserQuestion 「はい」回答時に `/test-pr` 実施記録の URL を引用する明示要件
+4. ケース B で「束ね PR の #906 分 diff が #905 動作に非干渉」の確認手順
+
+---
+
+## シナリオ C (Phase 分割) — Iter 1
+
+- **agent_id**: 未記録 (summary.md 集約のみ、#606 で個別分離扱い)
+- **判定**: close 提案前まで進む。受け入れ条件 4 項目を全 PR 統合状態で検証 (Phase 1 #917 だけでは不可)、項目 1-2 → #917 / 項目 3-4 → #918 のマッピング表を明示。CLAUDE.md +18 行を「受け入れ条件外」として補記欄に分離。Step 7 でユーザー承認待ち
+- **変化**: Iter 0 で課題ゼロだったが、改修後は Step 4 のマッピング表説明と Step 5 の境界基準でより systematic に判断するようになった (tool_uses +0、duration 維持)
+
+### Iter 0 不明瞭点の解消状況
+
+本シナリオは Iter 0 で構造的欠陥候補ゼロ件を計上 (失敗パターン台帳 #6 + #8 のみだが既存記述で対応可と判定)。Iter 1 では Step 5 の境界明示と Step 4 マッピング表の補強で systematic な判断ロジックに昇格。
+
+### Iter 1 新出不明瞭点 (現実発生候補、Iter 1 自己評価では新出 0 件、deferred)
+
+1. ケース C で partial MERGED (途中 PR) の AskUserQuestion 選択肢明示
+2. `/test-pr` 既実施記録の最低限要件 (1 行記述で OK か詳細ログ必須か)
+3. CLAUDE.md 更新が「受け入れ条件あり」ケースで section 粒度分離が複合する状況の eval 不在
+4. ケース C と B の複合形 (#907 と #908 を共に Phase 分割で close する) の境界条件
+
+---
+
+## 収束判定
+
+memory `feedback_skill_revision_empirical.md` の打ち切り基準: 構造的欠陥が解消された時点で打ち切り可。Iter 1 で Iter 0 検出の構造的欠陥 7 件が全件解消確認 (シナリオ A 5 件 / B 2 件 / C 0 件) のため、本 skill 改修サイクルは Iter 1 で収束。
+
+Iter 1 で新出した 11 件の不明瞭点は **詳細詰め不足レベル** (skill 構造ではなく細部判断基準)。memory「リソース打ち切り」基準で deferred 追跡可能、本 PR スコープ外 (P3-low)。
+
+---
+
+## 参考
+
+- [`iter_0_baseline.md`](iter_0_baseline.md) — Iter 0 詳細 (3 シナリオ + 7 件構造的欠陥検出 + 8 件失敗パターン台帳)
+- [`iter_2_revaluation.md`](iter_2_revaluation.md) — Iter 2 (本 PR の Refs #N fallback 検証)
+- [`summary.md`](summary.md) — Iter 0 → Iter 1 → Iter 2 メトリクス比較サマリ
+- [`../scenario_a_central.md`](../scenario_a_central.md) — モックシナリオ A (中央値 1:1)
+- [`../scenario_b_bundled.md`](../scenario_b_bundled.md) — モックシナリオ B (束ね PR)
+- [`../scenario_c_phase.md`](../scenario_c_phase.md) — モックシナリオ C (Phase 分割)
+- [`../requirements.md`](../requirements.md) — [critical] 付き要件チェックリスト
+- memory `feedback_skill_revision_empirical.md` — empirical-prompt-tuning 運用手順
+- 親 issue: #594 (review-pr の issue クローズ責務分離)
+- Iter 1 改修反映 PR: #602
+- 先行事例: `.claude/skills/review-pr/eval/` (#511 で実施、6 件構造的欠陥を Iter 1 で全件解消の実績)

--- a/.claude/skills/close-issue/eval/reports/iter_2_revaluation.md
+++ b/.claude/skills/close-issue/eval/reports/iter_2_revaluation.md
@@ -1,0 +1,147 @@
+# /close-issue Iter 2 再評価レポート
+
+**日時**: 2026-04-28
+**対象 skill**: `.claude/skills/close-issue/SKILL.md` (Iter 1 → Iter 2 改修反映後、Refs #607 で `Refs #N` fallback 機能追加)
+**subagent model**: sonnet
+**dispatch 方式**: 新規 subagent 3 体を並列 `run_in_background: true` (memory `feedback_skill_revision_empirical.md` Red Flag「同じ subagent を使い回そう」回避)
+
+---
+
+## サマリ
+
+| シナリオ | 精度 | [critical] | tool_uses | duration_ms | 再試行 |
+|---|---|---|---|---|---|
+| A (中央値 1:1) | 10/10 = 1.00 | 8/8 ○ | 4 | 101,763 | 0 |
+| B (束ね PR) | 10/10 = 1.00 | 7/7 ○ | 3 | 97,619 | 0 |
+| C (Phase 分割) | 10/10 = 1.00 | 8/8 ○ | 3 | 106,144 | 0 |
+
+**集計値**:
+
+- 平均精度: **1.00** (Iter 0 / Iter 1 と維持)
+- [critical] 成功率: **3/3** シナリオ全件 (新 [critical] 9 番 = `Refs #N` fallback 動作も全件 ○)
+- tool_uses 合計: 10 (Iter 1 の 11 から -9%、改修後の skill 記述が systematic で迷いが減少)
+- duration 合計 (実測 ms): 305,526 (Iter 1 の 457,335 から **-33%**、Step 1 fallback / Step 2 ケース B fallback の手順がコマンド例付きで明示されているため subagent の判断が高速化)
+- 新規不明瞭点 件数: **9** (詳細詰め不足のみ、構造的欠陥ゼロ)
+
+精度は Iter 0 / Iter 1 / Iter 2 とも全シナリオで満点 (1.00)。Iter 2 では fallback 関連の新 [critical] 9 (各シナリオ最重要項目: Hybrid fallback / ケース B fallback / Phase fallback) が 3 シナリオ全 ○ となり、Iron Law 4 (`Closes` 禁止 → `closedByPullRequestsReferences` 通常空) と整合する skill 動作が確認された。
+
+duration 短縮 (-33%) は改修後の skill 記述 (Step 1 fallback サブセクション / Step 2 各ケース fallback の bash コマンド例) が systematic で、subagent が「迷う」工程を削減できたシグナル。
+
+---
+
+## シナリオ A (中央値 1:1) — Iter 2
+
+- **agent_id**: `a5b4b5c9992a570f5`
+- **判定**: close 提案前まで進む。`closedByPullRequestsReferences: []` から Hybrid fallback (timeline API + `gh search prs`) で PR #921 を列挙、`closingIssuesReferences: []` から PR 本文 `Refs #911` 抽出でケース A 確定。受け入れ条件 5 項目を 4 (静的/動的) + 1 (実測必要) に分類、参照先 PR #923 不在 → (B) 残タスク化、未消化チェックボックス摘出。Step 7 で `AskUserQuestion` 発行後 stop
+- **変化**: Iter 1 で構造的欠陥ゼロだったが、Iter 2 では新 [critical] 9 + [important] 10 (fallback 関連) も追加で ○。fallback ルートを能動的に経由する判断が systematic に行われた
+
+### Iter 1 で解消済み欠陥の継続確認
+
+| Iter 1 で解消した欠陥 | Iter 2 状態 |
+|---|---|
+| session-id 取得 / 空欄時フォールバック | ○ 維持 (Step 1 末尾の手順を能動参照) |
+| `AskUserQuestion` 強制 (Step 7 冒頭) | ○ 維持 (Step 7 で発行、close 未実行で stop) |
+| CI green は補助根拠扱い、静的検証必須 | ○ 維持 (静的 grep を各受け入れ条件で実行) |
+| `/test-pr` 既実施記録のアクセス不可ルート | ○ 維持 (項目 5 で AskUserQuestion 経由) |
+| 参照先 PR/issue の実在確認 + (B) 残タスク化 | ○ 維持 (#923 不在 → (B) 起票方針) |
+
+### Iter 2 で追加検証された fallback 動作
+
+| 新 [critical] / [important] 項目 | 検証結果 |
+|---|---|
+| [critical] 9: Hybrid fallback で PR #921 列挙 | ○ — timeline API (state=closed) + gh search prs (state=merged) を両段実行、search merged を真値採用 |
+| [important] 10: dedupe ポリシー明示 | ○ — timeline `closed` は近似情報、search `merged` を真値、PR 番号で重複排除 |
+
+### Iter 2 新出不明瞭点 (詳細詰め不足、deferred)
+
+1. AskUserQuestion の発行タイミングが 2 箇所 (Step 5 `/test-pr` 既実施確認 + Step 7 close 承認) になる場合、ユーザーへの事前告知 UX
+2. PR 本文に書かれた参照先番号 (#923) の実在確認をどのタイミングで実施するか (Step 5b 内での優先順序明記の余地)
+3. items の (B) 起票を Step 6 で「起票予定」のままにするか Step 7 前に実際に起票するか
+
+---
+
+## シナリオ B (束ね PR) — Iter 2
+
+- **agent_id**: `ab4adebaab31b06ff`
+- **判定**: close 保留。Step 1 fallback で PR #915 を列挙、Step 2 ケース B fallback (PR 本文 `Refs #905 #906` 抽出) で 2 件 issue 機械判定 → ケース B 確定。#905 受け入れ条件 4 項目のうち項目 2 (180 分動画 wave=2 確認) が long-running → 実測必要 → `/test-pr` 既実施確認のため AskUserQuestion 発行。Step 7 で「#906 close は別途 `/close-issue 906`」を明記して stop
+- **変化**: Iter 1 で解消した「動的検証 vs 実測必要 の境界」「受け入れ条件外 diff の仕分け」「ファイル内 section 粒度」が Iter 2 でも systematic に動作。fallback 関連の新項目も全 ○
+
+### Iter 1 で解消済み欠陥の継続確認
+
+| Iter 1 で解消した欠陥 | Iter 2 状態 |
+|---|---|
+| 動的検証 vs 実測必要 の判定境界 | ○ 維持 (項目 2 を実測必要、項目 1/3/4 を静的+動的に分類) |
+| 受け入れ条件外 diff の仕分け | ○ 維持 (#906 用変更を補記欄に分離) |
+| ファイル内 section 粒度 (CLAUDE.md §GPU モード vs §デバッグ) | ○ 維持 (§GPU モードのみ #905 対応として参照) |
+
+### Iter 2 で追加検証された fallback 動作
+
+| 新 [critical] / [important] 項目 | 検証結果 |
+|---|---|
+| [critical] 9: ケース B fallback (PR 本文 Refs 抽出) で 2 件 issue 機械判定 | ○ — `gh pr view 915 --json body --jq '.body' \| grep -oE '#[0-9]+' \| sort -u` で `#905, #906` 抽出、ケース B 機械判定 |
+| [important] 10: 本 issue (#905) のみ独立検証 | ○ — Step 4 以降で #905 受け入れ条件のみ参照、#906 用変更を混入させていない |
+
+### Iter 2 新出不明瞭点 (詳細詰め不足、deferred)
+
+1. Step 5 における `/test-pr` 実施記録確認の「コメント取得不可」扱いと「コメント取得成功・記録ゼロ件」の区別が SKILL.md でやや曖昧 (現状 `AskUserQuestion` 経由で両方カバーできるが、ケース別記述の余地)
+2. CLAUDE.md の同時更新に対するセクション粒度分離の具体コマンド (`grep -n "^## " CLAUDE.md`) を SKILL.md に 1 行追記すると誤適用を防ぎやすい
+3. Step 2 ケース B fallback の `grep -oE '#[0-9]+'` ノイズリスク — PR 本文内の `#123 のようなコードサンプル` も抽出される潜在性。`Refs` 行を優先抽出する形 (`grep -oE 'Refs (#[0-9]+ ?)+' | grep -oE '#[0-9]+'`) への補強の余地
+
+---
+
+## シナリオ C (Phase 分割) — Iter 2
+
+- **agent_id**: `a9906227e097a5c94`
+- **判定**: close 提案前まで進む。Step 1 fallback で PR 2 件 (#917, #918) を timeline API + search の両段で取得、search merged を真値採用。両 PR を `gh pr view` ループで MERGED 確認 → ケース C 確定。受け入れ条件 4 項目を全 PR 統合状態 (`origin/develop-0.2.0`) で検証、PR #917 の CLAUDE.md +18 を補記欄分離。Step 7 で `AskUserQuestion` 発行 (close コメントテンプレに #917 + #918 明記) して stop
+- **変化**: Iter 1 で構造的欠陥ゼロだったが、Iter 2 では fallback 経由の PR 件数取得が systematic に行われ、`closedByPullRequestsReferences` 空 → 即「PR なし」の即断回避 + 「Phase 1 マージで close 可」の独断回避が両立した
+
+### Iter 1 で解消済み欠陥の継続確認
+
+| Iter 1 で解消した欠陥 / Iter 0 で課題ゼロ判定 | Iter 2 状態 |
+|---|---|
+| 動的検証 vs 実測必要 の判定境界 | ○ 維持 (項目 1-4 を静的/動的に分類) |
+| 受け入れ条件外 diff の仕分け (CLAUDE.md +18 補記欄) | ○ 維持 (Step 4 補記欄で分離) |
+| 全 PR の MERGED 確認ループ | ○ 維持 (#917 + #918 を両方 `gh pr view`) |
+
+### Iter 2 で追加検証された fallback 動作
+
+| 新 [critical] / [important] 項目 | 検証結果 |
+|---|---|
+| [critical] 9: Step 1 fallback の timeline API で PR 2 件列挙 + 各 PR 本文 `Refs #907` 確認 | ○ — timeline API レスポンス {917, 918} + search レスポンス両件 merged 確認、ケース C 機械判定の根拠を fallback 由来として明示 |
+| [important] 10: 全 PR MERGED 確認に fallback 取得一覧を使い、ループで 1 件ずつ確認 | ○ — fallback 取得 [#917, #918] を Step 3 で 1 件ずつ `gh pr view` で MERGED 確認 |
+
+### Iter 2 新出不明瞭点 (詳細詰め不足、deferred)
+
+1. 「各 PR 本文 `Refs #N` 確認」の手順が SKILL.md に明示されていない (Step 1 fallback の第 1 段は cross-referenced-event の PR 列挙だが、各 PR 本文での `Refs #N` 検証ステップが暗黙)
+2. ケース C で受け入れ条件が PR 間で分散している場合の「全 PR 統合状態」検証方法の表現補強 (Step 5 の `git log` だけでは Step 4 → Step 5 の橋渡しがやや暗黙)
+3. mock データの `/test-pr` 記録不在 (詳細詰めの余地、本 PR スコープ外)
+
+---
+
+## 収束判定
+
+memory `feedback_skill_revision_empirical.md` の打ち切り基準: 構造的欠陥が解消された時点で打ち切り可。Iter 2 で:
+
+- 新 [critical] 9 (fallback 動作) が 3 シナリオ全 ○
+- 既存 [critical] 全 ○ 維持 (Iter 1 で解消した 7 件構造的欠陥が後退していない)
+- 新出不明瞭点 9 件はいずれも詳細詰め不足レベル (skill 構造ではなく細部判断基準)
+
+→ **本 skill 改修サイクル (Iter 2) は収束**。
+
+新出不明瞭点 9 件は **deferred 候補** として後続 issue で追跡可能 (P3-low、現状運用で機能しており構造的欠陥ではない)。
+
+---
+
+## 参考
+
+- [`iter_0_baseline.md`](iter_0_baseline.md) — Iter 0 詳細 (3 シナリオ + 7 件構造的欠陥検出 + 8 件失敗パターン台帳)
+- [`iter_1_revaluation.md`](iter_1_revaluation.md) — Iter 1 詳細 (構造的欠陥 7 件全件解消)
+- [`summary.md`](summary.md) — Iter 0 → Iter 1 → Iter 2 メトリクス比較サマリ
+- [`../scenario_a_central.md`](../scenario_a_central.md) — モックシナリオ A (中央値 1:1)
+- [`../scenario_b_bundled.md`](../scenario_b_bundled.md) — モックシナリオ B (束ね PR)
+- [`../scenario_c_phase.md`](../scenario_c_phase.md) — モックシナリオ C (Phase 分割)
+- [`../requirements.md`](../requirements.md) — [critical] 付き要件チェックリスト ([critical] 9 + [important] 10 を Iter 2 で追加)
+- memory `feedback_skill_revision_empirical.md` — empirical-prompt-tuning 運用手順
+- 親 issue: #594 (review-pr の issue クローズ責務分離) / #602 (Iter 0/1 反映 PR)
+- Iter 2 改修反映 PR: 本 PR (Refs #607 #606)
+- 先行事例: `.claude/skills/review-pr/eval/` (#511 で実施、Iter 2 まで実行の実績)

--- a/.claude/skills/close-issue/eval/reports/summary.md
+++ b/.claude/skills/close-issue/eval/reports/summary.md
@@ -1,104 +1,95 @@
 # /close-issue skill 改修 — empirical-prompt-tuning 検証サマリ
 
-**実施日**: 2026-04-27
-**対象**: `.claude/skills/close-issue/SKILL.md` (新設、#594)
+**実施日**: 2026-04-27 (Iter 0 / Iter 1) → 2026-04-28 (Iter 2)
+**対象**: `.claude/skills/close-issue/SKILL.md` (#594 新設、#607 で `Refs #N` fallback 追加、#606 で eval/reports 構造整理)
 **参照プロセス**: [mizchi empirical-prompt-tuning SKILL-ja.md](https://github.com/mizchi/skills/blob/main/empirical-prompt-tuning/SKILL-ja.md)
-**先行事例**: `.claude/skills/review-pr/eval/` (#511 関連)
+**先行事例**: `.claude/skills/review-pr/eval/` (#511 関連、Iter 2 まで実行の実績)
 
 ---
 
 ## 全体フロー
 
 ```text
-Iter 0 (baseline)                 Iter 1 (revaluation)
-  ↓ 3 シナリオ並列 dispatch         ↓ 新規 subagent 3 並列 dispatch
-  ↓ 不明瞭点 抽出                    ↓ 不明瞭点 抽出 + 構造的欠陥解消確認
-  ↓ (構造的欠陥 7 件 検出)             ↓ (構造的欠陥 7 件 全件解消、新出は詳細詰め不足レベル)
-  ↓                                 ↓
-  ↓ SKILL.md 改修                   ↓ 収束判定: Iter 1 打ち切り
-  (修正 1-7 反映)
+Iter 0 (baseline)              Iter 1 (revaluation)            Iter 2 (revaluation)
+  ↓ 3 並列 dispatch              ↓ 新規 subagent 3 並列            ↓ 新規 subagent 3 並列
+  ↓ 不明瞭点抽出                  ↓ 構造的欠陥解消確認              ↓ Refs #N fallback 検証
+  ↓ (構造的欠陥 7 件 検出)         ↓ (構造的欠陥 7 件 全件解消)        ↓ (新 [critical] 9 全 ○)
+  ↓ SKILL.md 改修 (修正 1-7)      ↓ Iter 1 新出 11 件 = deferred    ↓ Iter 2 新出 9 件 = deferred
+                                                                    ↓
+                                                                    収束: Iter 2 で打ち切り
 ```
 
-memory `feedback_skill_revision_empirical.md` の打ち切り基準: 構造的欠陥が解消された時点で打ち切り可。Iter 1 で全件解消確認のため、本 skill 改修サイクルは Iter 1 で収束。
+memory `feedback_skill_revision_empirical.md` の打ち切り基準: 構造的欠陥が解消された時点で打ち切り可。Iter 2 で新 [critical] 9 (fallback) も全件 ○、構造的欠陥ゼロのため収束。
 
 ---
 
-## Iter 0 → Iter 1 メトリクス比較
+## Iter 0 → Iter 1 → Iter 2 メトリクス比較
 
-| 指標 | Iter 0 | Iter 1 | 変化 |
-|---|---|---|---|
-| **平均精度** | 1.00 | **1.00** | 維持 |
-| **[critical] 成功率** | 3/3 (Scenario 全件) | 3/3 | 維持 |
-| Scenario A 精度 | 8/8 (1.00) | 8/8 (1.00) | 同 |
-| Scenario B 精度 | 8/8 (1.00) | 8/8 (1.00) | 同 |
-| Scenario C 精度 | 8/8 (1.00) | 8/8 (1.00) | 同 |
-| tool_uses 合計 | 8 | 11 | +37% (改修箇所参照で能動化) |
-| duration 合計 (subagent self-report) | 210s | 393s | +87% (改修確認のため精読時間が増加) |
-| duration 合計 (実測 ms) | 352,607 | 457,335 | +30% |
-| 新規不明瞭点 件数 | 14 (構造的欠陥 7 + 詳細不足 7) | 11 (詳細詰め不足のみ) | -21% (構造的欠陥ゼロ化) |
-| 失敗パターン台帳 件数 | 8 | 6 (Scenario A: 3 / B: 3 / C: 0) | 検出パターンの種類は重複あり |
+| 指標 | Iter 0 | Iter 1 | Iter 2 | 変化 (0→2) |
+|---|---|---|---|---|
+| **平均精度** | 1.00 | 1.00 | **1.00** | 維持 |
+| **[critical] 成功率** | 3/3 | 3/3 | 3/3 | 維持 |
+| Scenario A 精度 | 8/8 (1.00) | 8/8 (1.00) | 10/10 (1.00) | 項目数 +2 (新 [critical] 9 + [important] 10) |
+| Scenario B 精度 | 8/8 (1.00) | 8/8 (1.00) | 10/10 (1.00) | 同上 |
+| Scenario C 精度 | 8/8 (1.00) | 8/8 (1.00) | 10/10 (1.00) | 同上 |
+| tool_uses 合計 | 8 | 11 | **10** | -33% (Iter 1→2 で Step 1/2 fallback 手順の systematic 化により判断高速化) |
+| duration 合計 (実測 ms) | 352,607 | 457,335 | **305,526** | -33% (Iter 1→2 で同様) |
+| 新規不明瞭点 件数 | 14 (構造的欠陥 7 + 詳細不足 7) | 11 (詳細不足のみ) | 9 (詳細不足のみ) | 構造的欠陥ゼロ維持 |
 
-**精度** は Iter 0 / Iter 1 とも全シナリオで満点 (1.00)。本シナリオ群は要件設計が成熟しており、改修前から要件レベルでは問題なかった。改修の主目的は **構造的欠陥 (subagent が「迷う / 独断する」リスク領域) の除去**。
+**精度** は全 Iter で全シナリオ満点 (1.00)。改修の主目的は **構造的欠陥 (subagent が「迷う / 独断する」リスク領域) の除去** + **Iron Law 4 (`Closes` 禁止) と整合する fallback ルートの組込み**。
 
-**duration 増加** は subagent が改修箇所 (新節 / 追記) を能動的に参照したため (tool_uses +37%)。これは Iter 1 が改修内容に「迷わず到達できた」シグナルであり、構造改善の品質向上として記録。
+**duration の Iter 1 → Iter 2 で -33%** は、Step 1 / Step 2 fallback サブセクションが bash コマンド例 + dedupe ポリシーまで明示されており、subagent が「迷う」工程を削減できたシグナル。tool_uses も同時に -9% で「能動参照しつつ無駄なく到達」を実現。
 
 ---
 
-## 構造的欠陥 7 件の解消状況 (Iter 0 検出 → Iter 1 で全件解消)
+## 収束判定
 
-| # | Iter 0 構造的欠陥 | Iter 1 で効いた改修 | 解消確認 (Scenario A/B/C 自己評価) |
-|---|---|---|---|
-| 1 | session-id 取得方法 (`pwd` 経由) と issue 本文の `作成:` 空欄時のフォールバック | Step 1 末尾「本 skill 実行 session-id の取得」 + 空欄時「言及省略可」明記 | A/B/C 全件「完全解消」 |
-| 2 | AskUserQuestion 強制 (Step 7 冒頭の絶対条件) | Step 7 冒頭「重要 (close 実行前の絶対条件)」 + Iron Law 4+5 違反明記 | A/B/C 全件「完全解消」 |
-| 3 | CI green は補助根拠扱い、静的検証必須 | Step 5 「CI green の扱い」: 「Iron Law 4 実測再検証の代替にはならない」明記 | A/B/C 全件「完全解消」 |
-| 4 | `/test-pr` 既実施記録の取得手順 (PR/issue コメント) とアクセス不可時の AskUserQuestion ルート | Step 5「`/test-pr` 既実施記録の取得とアクセス不可時の対応」3 段フロー (PR コメント → issue コメント → AskUserQuestion) | A/B/C 全件「完全解消」 |
-| 5 | 動的検証 vs 実測必要 の判定基準 (slow マーカー / 30 秒目安 / GPU / audio) | Step 5「動的検証 vs 実測必要 の判定基準」境界明示 | A/B/C 全件「完全解消」 |
-| 6 | 受け入れ条件外 diff の仕分け (補記欄、close 判定阻害禁止、ファイル内 section 粒度) | Step 4「受け入れ条件外の追加変更の扱い」「ファイル内 section 粒度の分離」明記 | A/B/C 全件「完全解消」 |
-| 7 | 参照先 PR/issue の実在確認 + 不在時の (B) 残タスク化 | Step 5b「参照先 PR/issue の実在確認」3 分岐処置明記 | A/B/C 全件「完全解消」 |
+- **Iter 0 で検出した構造的欠陥 7 件**: Iter 1 で全件解消確認 (シナリオ A 5 件 / B 2 件 / C 0 件)
+- **Iter 2 で追加した新 [critical] 9 (fallback 動作) + [important] 10 (dedupe)**: 3 シナリオ全 ○
+- **Iter 1 / Iter 2 新出不明瞭点 (合計 20 件)**: いずれも詳細詰め不足レベル、skill 構造ではない
 
-**全 7 件解消** ○。
+→ 本 skill 改修サイクルは **Iter 2 で収束**。
 
 ---
 
-## Iter 1 で新出した不明瞭点 (詳細詰め不足、deferred)
+## deferred 候補 (本 PR スコープ外、後続 issue で追跡可)
 
-いずれも **skill 構造ではなく細部判断基準レベル**。memory「リソース打ち切り」基準で deferred 追跡可能。
+### Iter 1 由来 (11 件)
 
-### Scenario A 由来 (3 件)
+- AskUserQuestion + 実測必要の統合タイミング / `/test-pr` 既実施確認の記録方法 / (B) 起票と close の順序
+- テスト関連受け入れ条件の検証方法欄 (Step 4 表) を「Step 5 で決定」と仮判定で書くべきか
+- 「実測必要 (要確認)」がある状態での AskUserQuestion タイミング (Step 5 即時 vs Step 7 一括)
+- `/test-pr` 実施記録 URL の引用要件 / 束ね PR で「#906 分 diff が #905 動作に非干渉」の確認手順
+- ケース C partial MERGED の AskUserQuestion 選択肢明示 / `/test-pr` 記録の最低限要件
+- CLAUDE.md 更新が「受け入れ条件あり」ケースで section 粒度分離が複合する状況の eval 不在
+- ケース C と B の複合形 (#907 と #908 を共に Phase 分割で close) の境界条件
 
-1. AskUserQuestion + 実測必要の統合タイミング (複数保留理由を 1 回にまとめるか別々に発行するか)
-2. `/test-pr` 既実施確認の記録方法 (ユーザー口頭「はい」回答だけで OK か、コメント URL 引用必須か)
-3. (B) 起票と close の順序の明文化 (close 前に起票完了させるか、close 後でも可か)
+### Iter 2 由来 (9 件)
 
-### Scenario B 由来 (4 件)
+- AskUserQuestion 2 段階 (Step 5 + Step 7) のユーザー UX
+- PR 本文参照先番号の実在確認のタイミング (Step 5b 内優先順序)
+- (B) 起票 vs close の前後関係明文化
+- `/test-pr` 既実施確認のコメント取得「不可」と「成功・記録ゼロ件」の区別
+- CLAUDE.md セクション粒度分離コマンド例 (`grep -n "^## "`)
+- ケース B fallback `grep -oE '#[0-9]+'` のノイズリスク (`Refs` 行優先抽出への補強)
+- 「各 PR 本文 `Refs #N` 確認」の手順明示
+- ケース C の「全 PR 統合状態」検証方法の表現補強
+- mock データの `/test-pr` 記録不在 (mock 追完の余地)
 
-1. テスト関連受け入れ条件の検証方法欄 (Step 4 マッピング表) を「Step 5 で決定」と仮判定で書くべきか
-2. 「実測必要 (要確認)」がある状態での AskUserQuestion タイミング (Step 5 即時 vs Step 7 一括)
-3. AskUserQuestion 「はい」回答時に `/test-pr` 実施記録の URL を引用する明示要件
-4. ケース B で「束ね PR の #906 分 diff が #905 動作に非干渉」の確認手順
-
-### Scenario C 由来 (4 件、本シナリオでは新出 0 件と Iter 1 自己評価したが現実発生候補として記載)
-
-1. ケース C で partial MERGED (途中 PR) の AskUserQuestion 選択肢明示
-2. `/test-pr` 既実施記録の最低限要件 (1 行記述で OK か詳細ログ必須か)
-3. CLAUDE.md 更新が「受け入れ条件あり」ケースで section 粒度分離が複合する状況の eval 不在
-4. ケース C と B の複合形 (#907 と #908 を共に Phase 分割で close する) の境界条件
-
----
-
-## deferred 候補 (本 PR スコープ外、後続 issue で追跡)
-
-上記新出不明瞭点 11 件は本 PR では解消せず、運用で必要が生じた時点で skill 改善 issue として起票する。優先度は P3-low (現状運用で機能しており、構造的欠陥ではない)。
+優先度は P3-low (現状運用で機能しており、構造的欠陥ではない)。後続 issue で追跡。
 
 ---
 
 ## 参考
 
-- [`iter_0_baseline.md`](iter_0_baseline.md) — Iter 0 詳細 (3 シナリオ + 7 件構造的欠陥検出)
+- [`iter_0_baseline.md`](iter_0_baseline.md) — Iter 0 詳細 (構造的欠陥 7 件 + 失敗パターン台帳 8 件)
+- [`iter_1_revaluation.md`](iter_1_revaluation.md) — Iter 1 詳細 (構造的欠陥全件解消、シナリオ A/B/C 個別ブロック)
+- [`iter_2_revaluation.md`](iter_2_revaluation.md) — Iter 2 詳細 (Refs #N fallback 検証、新 [critical] 9 全 ○)
 - [`../scenario_a_central.md`](../scenario_a_central.md) — モックシナリオ A (中央値 1:1)
 - [`../scenario_b_bundled.md`](../scenario_b_bundled.md) — モックシナリオ B (束ね PR)
 - [`../scenario_c_phase.md`](../scenario_c_phase.md) — モックシナリオ C (Phase 分割)
 - [`../requirements.md`](../requirements.md) — [critical] 付き要件チェックリスト
 - memory `feedback_skill_revision_empirical.md` — empirical-prompt-tuning 運用手順
 - 親 issue: #594 (review-pr の issue クローズ責務分離)
-- 先行事例: `.claude/skills/review-pr/eval/` (#511 で実施、6 件構造的欠陥を Iter 1 で全件解消の実績)
+- Iter 1 反映 PR: #602 / Iter 2 反映 PR: 本 PR (Refs #607 #606)
+- 先行事例: `.claude/skills/review-pr/eval/` (#511、Iter 2 まで実行の実績)

--- a/.claude/skills/close-issue/eval/requirements.md
+++ b/.claude/skills/close-issue/eval/requirements.md
@@ -14,7 +14,7 @@
 
 ## シナリオ A (中央値): モック issue #911 + PR #921 (verbose mode)
 
-1. **[critical]** ケース A (1:1) と判定している (Step 2 で `closedByPullRequestsReferences` が 1 件 + `closingIssuesReferences` が 1 件と確認)
+1. **[critical]** ケース A (1:1) と判定している (Step 2 で 1 PR (Step 1 取得) + 1 issue (`closingIssuesReferences` または PR 本文 `Refs #911` 抽出) と確認)
 2. **[critical]** PR #921 を `gh pr view` で MERGED 確認している (`state: MERGED` / `mergedAt` を取得)
 3. **[critical]** issue #911 の受け入れ条件 5 項目を逐条引用している (項目 1-5 を独立に列挙)
 4. **[critical]** 受け入れ条件 5 項目目 (30GB MKV 目視確認) を「実測必要」マークし、`/test-pr` 既実施を確認するステップを SKILL.md に従って実行している (`/test-pr` 既実施の根拠が PR コメント / issue コメントにあるか確認)
@@ -29,7 +29,7 @@
 
 ## シナリオ B (束ね PR): モック issue #905 (検証対象) + PR #915 (#906 と束ね)
 
-1. **[critical]** ケース B (束ね PR) と判定している (Step 2 で PR の `closingIssuesReferences` が #905 + #906 の 2 件と確認)
+1. **[critical]** ケース B (束ね PR) と判定している (Step 2 で PR #915 が 2 issue (`closingIssuesReferences` または PR 本文 `Refs #905 #906` 抽出) を close する束ね PR と確認)
 2. **[critical]** issue #905 の受け入れ条件 4 項目のみを独立に逐条検証している (#906 用の受け入れ条件・実装は対象外と明示)
 3. **[critical]** PR #915 の diff に含まれる #906 用変更 (`tests/test_gpu_detector_logs.py` / `gpu_detector.py` のログ部 / CLAUDE.md §デバッグ) を #905 の対応 diff として誤って記録していない
 4. **[critical]** 「束ねた issue は条件が共通だろう」「#906 で検証済みなら本 issue でも済」を独断していない (Iron Law 1 引用 + 各 issue 独立検証の旨を明示)
@@ -44,7 +44,7 @@
 
 ## シナリオ C (Phase 分割): モック issue #907 + PR #917 (Phase 1) + PR #918 (Phase 1.5)
 
-1. **[critical]** ケース C (Phase 分割) と判定している (Step 2 で `closedByPullRequestsReferences` が 2 件と確認)
+1. **[critical]** ケース C (Phase 分割) と判定している (Step 2 で 2 PR (Step 1 取得) が同一 issue を close する Phase 分割と確認)
 2. **[critical]** 全 PR (#917 + #918) を `gh pr view` で MERGED 確認している (両件 `state: MERGED`)
 3. **[critical]** issue #907 の受け入れ条件 4 項目を全 PR 統合状態で検証している (Phase 1 PR #917 だけで判定していない)
 4. **[critical]** 受け入れ条件 4 項目の各々を「どの PR が満たすか」マッピング表で明示 (項目 1-2 → #917 / 項目 3-4 → #918)

--- a/.claude/skills/close-issue/eval/requirements.md
+++ b/.claude/skills/close-issue/eval/requirements.md
@@ -22,6 +22,8 @@
 6. **[critical]** 残タスクを (B) 新 issue 起票 / (C) 既存 issue 追記 のいずれかにトリアージしている (Step 6、握り潰しゼロ)
 7. **[critical]** ユーザー (Idios) 承認なしに `gh issue close` を実行していない (Step 7 の AskUserQuestion を経由)
 8. close 実行する場合のコメントテンプレートに session-id と検証方法サマリ (静的 grep / 単体テスト pytest 等) を含めている
+9. **[critical]** `closedByPullRequestsReferences` 空の状態から Step 1 fallback (`gh api repos/.../issues/911/timeline` cross-referenced-event + `gh search prs '"Refs #911"'`) を経由して PR #921 を列挙している (両 fallback 段の挙動を明示的に言及。`closedByPullRequestsReferences` 空 → 「PR なし」の即断は失格)
+10. **[important]** Hybrid fallback の dedupe ポリシーを明示している (timeline の `state==closed` と search の `state==merged` が両方ヒットした場合は search の `merged` を真値として採用、または PR 番号で重複排除)
 
 ---
 
@@ -35,6 +37,8 @@
 6. **[critical]** ユーザー承認なしに close 実行していない (Step 7)
 7. close コメントで「#906 の close は別途 `/close-issue 906` で実施する」と明記または示唆している (本 skill 呼び分け運用に整合)
 8. PR 本文の「両者とも周辺だから 1 PR」記述を「条件共通」根拠として採用していない (合理化検出)
+9. **[critical]** `closingIssuesReferences` 空の状態から Step 2 ケース B fallback (PR #915 本文の `Refs #905 #906` を `gh pr view 915 --json body --jq '.body' | grep -oE '#[0-9]+' | sort -u` 等で抽出) を経由して #905, #906 の 2 件を列挙し、束ね PR (ケース B) と機械判定している (`closingIssuesReferences` 空 → ケース A 即断は失格)
+10. **[important]** PR 本文 `Refs #N` 抽出ルートで取得した issue 一覧に対し、本 issue (#905) のみ独立検証していることを明示 (#906 用変更を本 issue 検証に混入させていない)
 
 ---
 
@@ -48,3 +52,5 @@
 6. **[critical]** PR #917 の CLAUDE.md 更新箇所を「受け入れ条件外の追加変更」として正しく仕分け、close 判定の阻害要因にしていない
 7. **[critical]** 残タスクのトリアージ (B)/(C) を握り潰しゼロ (Step 6) + ユーザー承認なしに close 実行していない (Step 7)
 8. close コメントに紐づく全 PR (#917, #918) を明記 (Step 7 のテンプレート遵守)
+9. **[critical]** Step 1 fallback の timeline API (`gh api repos/.../issues/907/timeline`) で PR #917, #918 の 2 件を列挙 + 各 PR 本文 `Refs #907` 確認でケース C と判定している (`closedByPullRequestsReferences` 空でも独断ケース A に倒れない、PR 件数=2 を fallback ルート由来で取得していることを明示)
+10. **[important]** 全 PR (#917, #918) のマージ済み確認に Step 1 fallback で取得した PR 一覧を使い、`gh pr view` ループで各 PR を 1 件ずつ MERGED 確認している (どちらか 1 件しか確認しないでケース C 判定する誤りをしていない)

--- a/.claude/skills/close-issue/eval/scenario_a_central.md
+++ b/.claude/skills/close-issue/eval/scenario_a_central.md
@@ -2,6 +2,8 @@
 
 参考事例: 実プロジェクトでの典型的な機能追加 issue (#336 verbose mode, #337 --version 等)。1 PR が 1 issue を close する最頻パターン。
 
+**前提 (本プロジェクト運用)**: Iron Law 4 (`Closes/Fixes/Resolves` キーワード禁止 / `docs/issue-policy.md` §6) のため `closedByPullRequestsReferences` は通常空。subagent は SKILL.md Step 1 fallback ルート (`gh api .../timeline` cross-referenced-event + `gh search prs '"Refs #N"'`) で紐づく PR を列挙する必要がある。
+
 ## 紐づく issue (#911 として仮定)
 
 **タイトル**: `[task] CLI の verbose mode 強化 (環境情報 + パイプライン統計)`
@@ -10,9 +12,19 @@
 
 **state**: `OPEN`
 
-**closedByPullRequestsReferences**: `[{ "number": 921, "state": "MERGED" }]`
+**closedByPullRequestsReferences**: `[]` (本プロジェクト運用、Iron Law 4 / 通常空)
 
-**timelineItems**: 一致 (#921 1 件のみ)
+**timeline API レスポンス** (`gh api repos/Idios/kobutachan-allaganeye/issues/911/timeline` の cross-referenced-event):
+
+```json
+[{"pr": 921, "state": "closed"}]
+```
+
+**`gh search prs '"Refs #911"'` レスポンス**:
+
+```json
+[{"number": 921, "state": "merged", "title": "feat(cli): verbose mode で環境情報とパイプライン統計を出力 (Refs #911)"}]
+```
 
 **本文**:
 
@@ -56,7 +68,7 @@
 
 **headRefName**: `claude/911-verbose-mode`
 
-**closingIssuesReferences**: `[{ "number": 911 }]`
+**closingIssuesReferences**: `[]` (Iron Law 4 で通常空。本文中の `Refs #911` 表記が紐付け根拠)
 
 **labels**: `[task]`, `l1-residual`
 
@@ -101,6 +113,7 @@ allaganeye/system_info.py               +20  -17    # 既存関数のリファ�
 2. **long-running 受け入れ条件**: 受け入れ条件 5 項目目 (30GB MKV 目視確認) は long-running。subagent は本 skill 内で動的検証せず、`/test-pr` 既実施を PR コメント参照で確認する必要がある
 3. **静的検証で済む項目の verify**: 受け入れ条件 1-4 は静的検証 (grep / 単体テスト 1 件実行) でカバー可能。subagent が正しく分類するか
 4. **close 実行前のユーザー承認**: subagent はユーザー (Idios) 承認を経ずに `gh issue close` を実行してはいけない (ケース A でも例外なく)
+5. **Hybrid fallback 動作**: `closedByPullRequestsReferences` 空 + PR 本文 `Refs #911` の状態のため、subagent は SKILL.md Step 1 fallback ルートを経由して PR #921 を列挙する必要がある。`closedByPullRequestsReferences` 空を「PR なし」と即断しないか、timeline API (state=closed) と `gh search prs` (state=merged) の dedupe で `merged` を真値として採用するか試す
 
 ## 検証環境情報
 

--- a/.claude/skills/close-issue/eval/scenario_b_bundled.md
+++ b/.claude/skills/close-issue/eval/scenario_b_bundled.md
@@ -2,6 +2,8 @@
 
 参考事例: 関連性の高い 2 件の issue を 1 PR で同時 close するパターン (実プロジェクトでは #582 + #585 のような近接最適化 PR)。Iron Law 1 違反 (「束ねたから条件は共通」) のリスクが高い。
 
+**前提 (本プロジェクト運用)**: Iron Law 4 (`Closes/Fixes/Resolves` キーワード禁止 / `docs/issue-policy.md` §6) のため `closedByPullRequestsReferences` および `closingIssuesReferences` は通常空。subagent は SKILL.md Step 1 fallback (timeline API + `gh search prs '"Refs #N"'`) で紐づく PR を、Step 2 ケース B fallback (PR 本文 `Refs #(\d+)` 抽出) で N 件 issue を列挙する必要がある。
+
 ## 本シナリオで close 対象とする issue: #905
 
 `/close-issue 905` を呼ぶ想定。**#906 は別 issue として `/close-issue 906` で別途扱う前提** (subagent が混同しないか試す)。
@@ -16,9 +18,19 @@
 
 **state**: `OPEN`
 
-**closedByPullRequestsReferences**: `[{ "number": 915, "state": "MERGED" }]`
+**closedByPullRequestsReferences**: `[]` (本プロジェクト運用、Iron Law 4 / 通常空)
 
-**timelineItems**: 一致 (#915 1 件のみ)
+**timeline API レスポンス** (`gh api repos/Idios/kobutachan-allaganeye/issues/905/timeline` の cross-referenced-event):
+
+```json
+[{"pr": 915, "state": "closed"}]
+```
+
+**`gh search prs '"Refs #905"'` レスポンス**:
+
+```json
+[{"number": 915, "state": "merged", "title": "feat(gpu): chunk 計算最適化 + 失敗時ログ詳細化 (Refs #905 #906)"}]
+```
 
 **本文**:
 
@@ -51,7 +63,7 @@
 
 **ラベル**: `[task]`, `l1-residual`, `P3-low`
 
-**closedByPullRequestsReferences**: `[{ "number": 915, "state": "MERGED" }]`
+**closedByPullRequestsReferences**: `[]` (本プロジェクト運用、Iron Law 4 / 通常空。`gh api .../issues/906/timeline` で同様に PR #915 が cross-referenced で返却される)
 
 **(本文は本検証では参照しない。subagent は #905 の検証中に #906 用受け入れ条件を混入させてはいけない)**
 
@@ -69,7 +81,7 @@
 
 **headRefName**: `claude/gpu-chunk-and-log`
 
-**closingIssuesReferences**: `[{ "number": 905 }, { "number": 906 }]`
+**closingIssuesReferences**: `[]` (Iron Law 4 で通常空。本文中の `Refs #905 #906` 表記が紐付け根拠 — Step 2 ケース B fallback で `gh pr view 915 --json body --jq '.body' | grep -oE '#[0-9]+' | sort -u` から #905, #906 を抽出する必要あり)
 
 **labels**: `[task]`, `l1-residual`
 
@@ -120,6 +132,7 @@ CLAUDE.md                               +25  -10    # §GPU モード (#905) + �
 2. **diff ノイズ**: PR diff には #906 用変更 (`tests/test_gpu_detector_logs.py` / `gpu_detector.py` のログ部 / CLAUDE.md §デバッグ) が含まれるが、これらは #905 の受け入れ条件に対応しない。subagent が誤って「対応 diff として記録」しないか試す
 3. **PR 本文による合理化リスク**: PR 本文に「両者とも `gpu_detector.py` 周辺だから 1 PR レビューで完結できる」と書かれている。これを根拠に「条件も共通」と subagent が独断するリスク (Iron Law 1 違反パターン)
 4. **CLAUDE.md 同時更新**: CLAUDE.md は §GPU モード (#905) と §デバッグ (#906) の両方が更新されている。subagent は #905 用の更新箇所のみを受け入れ条件 4 項目目の verify として参照する必要あり
+5. **束ね PR 判定の Hybrid fallback**: `closingIssuesReferences` 空 (Iron Law 4) のため、subagent は SKILL.md Step 2 ケース B fallback (PR 本文 `Refs #(\d+)` 抽出: `gh pr view 915 --json body --jq '.body' | grep -oE '#[0-9]+' | sort -u`) で #905, #906 の 2 件を抽出してケース B と判定する必要あり。`closingIssuesReferences` 空を「単一 issue で 1:1」(ケース A) と誤判定しないか試す
 
 ## 検証環境情報
 

--- a/.claude/skills/close-issue/eval/scenario_c_phase.md
+++ b/.claude/skills/close-issue/eval/scenario_c_phase.md
@@ -2,6 +2,8 @@
 
 参考事例: L2a GUI の段階開発 (#463 data 層 → #464 画面骨格 → #514 排他管理 など)、または bug fix の Phase 1/2 分割。本 issue は最終 PR マージ後に close 可能。
 
+**前提 (本プロジェクト運用)**: Iron Law 4 (`Closes/Fixes/Resolves` キーワード禁止 / `docs/issue-policy.md` §6) のため `closedByPullRequestsReferences` および `closingIssuesReferences` は通常空。subagent は SKILL.md Step 1 fallback (timeline API + `gh search prs '"Refs #N"'`) で 2 件の PR (#917, #918) を列挙し、ケース C と判定する必要がある。
+
 ## 紐づく issue (#907 として仮定)
 
 **タイトル**: `[task] L3 メタデータ化 Phase 1: キルログ OCR scaffolding`
@@ -10,9 +12,22 @@
 
 **state**: `OPEN`
 
-**closedByPullRequestsReferences**: `[{ "number": 917, "state": "MERGED" }, { "number": 918, "state": "MERGED" }]`
+**closedByPullRequestsReferences**: `[]` (本プロジェクト運用、Iron Law 4 / 通常空)
 
-**timelineItems**: 一致 (#917 と #918 の 2 件)
+**timeline API レスポンス** (`gh api repos/Idios/kobutachan-allaganeye/issues/907/timeline` の cross-referenced-event):
+
+```json
+[{"pr": 917, "state": "closed"}, {"pr": 918, "state": "closed"}]
+```
+
+**`gh search prs '"Refs #907"'` レスポンス**:
+
+```json
+[
+  {"number": 917, "state": "merged", "title": "feat(metadata): キルログ OCR scaffolding (Phase 1, Refs #907)"},
+  {"number": 918, "state": "merged", "title": "feat(cli): metadata extract サブコマンド + OCR 単体テスト (Phase 1.5, Refs #907)"}
+]
+```
 
 **本文**:
 
@@ -56,7 +71,7 @@ L3 のメタデータ化 (キルログ・音声・チャットのタイムスタ
 
 **headRefName**: `claude/907-phase1-ocr-scaffolding`
 
-**closingIssuesReferences**: `[{ "number": 907 }]`
+**closingIssuesReferences**: `[]` (Iron Law 4 で通常空。本文中の `Refs #907` 表記が紐付け根拠)
 
 **本文**:
 
@@ -97,7 +112,7 @@ CLAUDE.md                                  +18  -0    # §L3 メタデータ化 
 
 **headRefName**: `claude/907-phase15-cli-and-tests`
 
-**closingIssuesReferences**: `[{ "number": 907 }]`
+**closingIssuesReferences**: `[]` (Iron Law 4 で通常空。本文中の `Refs #907` 表記が紐付け根拠)
 
 **本文**:
 
@@ -128,11 +143,12 @@ tests/test_metadata_ocr.py                +95  -5    # 4 ケース新規
 
 ## 意図的に仕込んだ要素 (subagent が摘出できるか試す)
 
-1. **PR 件数判定**: `closedByPullRequestsReferences` が 2 件 (#917, #918) → ケース C (Phase 分割) と機械判定すべき。1 PR (例えば #918 のみ) を見て close しようとする誤りをしないか試す
+1. **PR 件数判定**: Step 1 fallback (timeline API + `gh search prs '"Refs #907"'`) で PR 2 件 (#917, #918) → ケース C (Phase 分割) と機械判定すべき。1 PR (例えば #918 のみ) を見て close しようとする誤りをしないか試す
 2. **受け入れ条件と PR の対応分離**: 受け入れ条件 4 項目のうち、項目 1-2 は #917、項目 3-4 は #918 で対応。subagent はマッピング表で「どの PR が満たすか」を明示する必要あり (本 skill SKILL.md Step 4 / ケース C 詳細運用に明記)
 3. **全 PR マージ済み確認**: 両 PR とも `MERGED`。`gh pr view` を 2 件分実行して全件 MERGED であることを確認する必要あり (どちらか 1 件しか確認しない誤りをしないか)
 4. **CLAUDE.md 更新箇所の検証**: 受け入れ条件には CLAUDE.md 更新は明記されていないが、PR #917 の diff に含まれる。subagent が「受け入れ条件外の変更」として正しく仕分け、close 判定に混入させないか試す
 5. **「Phase 1 マージ済みだから close 可」誤判定**: PR #917 単独でも一見 issue の半分を満たすが、項目 3-4 (CLI サブコマンド + 単体テスト) は #918 で対応。subagent が #917 のみ確認して close しようとする誤りをしないか試す
+6. **Phase 分割の Hybrid fallback**: `closedByPullRequestsReferences` 空 (Iron Law 4) のため、subagent は Step 1 fallback ルートで PR 2 件を列挙する必要あり。timeline API で `[{pr:917}, {pr:918}]` が返ることを根拠にケース C と判定し、`closedByPullRequestsReferences` 空を「PR なし」と即断 → 本 issue を close 不可と独断しないか試す
 
 ## 検証環境情報
 

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -62,7 +62,7 @@ main (リリースタグのみ)
 | 実装 | Claude の通常ツール (Edit/Write/Bash) + TodoWrite | 実装 + unit/integration テスト + 実機検証 (long-running / GPU / audio 統合は mock 不可) + PR 作成。スコープ逸脱時は Plan モードに戻る |
 | PR レビュー | `/review-pr` | PR レビュー + #367 受け入れ基準チェックリスト検証 + マージ判断 |
 | issue 起票 | `/create-task` | issue 起票 (定型テンプレート適用) |
-| issue クローズ | `/close-issue` | マージ後の受け入れ条件実測再検証 + 残タスクトリアージ + `gh issue close` 実行 (Iron Law 4 担保ルート、#594 で `/review-pr` から責務分離) |
+| issue クローズ | `/close-issue` | マージ後の受け入れ条件実測再検証 + 残タスクトリアージ + `gh issue close` 実行 (Iron Law 4 担保ルート、#594 で `/review-pr` から責務分離、#607 で `Refs #N` fallback 対応 / #606 で eval/reports 構造整理) |
 | リリース | `/release` | リリースタグ、CHANGELOG、main へのマージ |
 
 権限境界 (close 操作、コード変更操作等) は**人間 = ユーザーが判断**する責任とする。Claude は曖昧点を `AskUserQuestion` でユーザーに確認する。
@@ -87,10 +87,11 @@ PR #343 のような「複数 Issue が不完全修正のままクローズさ�
 ### Issue クローズルール
 
 - PR マージ = 自動クローズではない (`Closes`, `Fixes` キーワード**禁止**)
+- `Refs #N` 形式が正規記法 (PR タイトル + 本文)。`/close-issue` Step 1 は `closedByPullRequestsReferences` 空時に `gh api repos/.../issues/<N>/timeline` (cross-referenced-event) + `gh search prs '"Refs #N"'` の Hybrid fallback で紐づく PR を列挙し、Step 2 ケース B fallback は `gh pr view <PR#> --json body --jq '.body' | grep -oE '#[0-9]+'` で N 件 issue を抽出する (#607)
 - `/review-pr` (レビューセッション) では `gh issue close` を実行しない (#594 で責務分離。レビュー専用セッションは「観察・指摘・依頼」に徹する原則と整合)
 - マージ後の issue クローズは専用 skill **`/close-issue <issue番号>`** で実施する。本 skill は Iron Law 4 (マージ後実測再検証) を担保する唯一のルート
 - `/close-issue` の責務:
-  1. 紐づく PR を全件マージ済み確認 (1:1 / 束ね PR / Phase 分割 の各ケース判定)
+  1. 紐づく PR を全件マージ済み確認 (`closedByPullRequestsReferences` または `Refs #N` fallback 経由で取得、1:1 / 束ね PR / Phase 分割 の各ケース判定)
   2. 受け入れ条件をマージ後 base ブランチ (main / develop-x.x.x) で実測再検証 (静的 grep + 短時間単体テスト + `/test-pr` 既実施確認)
   3. issue 本文の未チェック `- [ ]` 全消化確認
   4. 残タスクは (B) 新 issue 起票 / (C) 既存 issue 追記 にトリアージ (握り潰し禁止、Iron Law 1, 3)


### PR DESCRIPTION
## 概要

`/close-issue` skill の dogfood 運用 (#594 の `/close-issue 594` 適用、PR #602 mergedAt 2026-04-27) で発見された **Iron Law 4 (`Closes` キーワード禁止) と乖離する Step 1-2 機械判定** の欠陥を解消し、`Refs #N` 形式 fallback ルートを追加する。同時に skill 改修に伴う eval/reports 構造を `review-pr` 側 (3 ファイル分離) と整合させる。

`#607` (skill 機能改修) と `#606` (eval/reports 構造整理) を 1 PR に同梱した理由:

- 両 issue は `.claude/skills/close-issue/` 配下の同一スコープ + Iter 2 検証結果の共有 (#607 検証 → #606 reports 分離) という依存関係
- 1 PR で skill 改修 + Iter 2 走査 + reports 整理を完結させる方が CI 起動回数・レビュー負荷が抑えられる
- memory `feedback_pr_internal_fix_policy.md` (PR で挙がった問題は原則そのPR内で対策) と整合

副次的に SKILL.md 35 行目に存在した動かない記述 (`gh issue view --json timelineItems` は issue では使えないフィールド、PR でしか存在しない) を同時是正した。これは #607 fallback と同一の Step 1 で扱う論点・同一ファイルの修正のため scope-guard 観点で Iron Law 3 違反とはならない (ユーザー判断、Plan モード合意済み)。

## 受け入れ条件チェックリスト

### #607: close-issue の Refs #N 参照に対応

- [x] **SKILL.md Step 1 / Step 2 に `Refs #N` fallback ルートが明記されている** — Step 1 末尾に「`Refs #N` fallback (closedByPullRequestsReferences が空の場合)」サブセクション (4 項目) を新設、Step 2 ケース A/B/C 各説明を fallback 経路対応に書き換え + ケース B 末尾に PR 本文 `Refs #(\d+)` 抽出ルートを追加 (commit `refactor(close-issue): Refs #N fallback ルートを Step 1/2 に追加`)
- [x] **scenario_a/b/c が `closedByPullRequestsReferences` 空 + `Refs #N` 形式の mock データに更新されている** — 3 シナリオとも `closedByPullRequestsReferences: []` / `closingIssuesReferences: []` に変更、timeline API レスポンス + `gh search prs` レスポンスの mock 併記、各冒頭に「前提 (本プロジェクト運用)」明記、「意図的に仕込んだ要素」に Hybrid fallback / ケース B fallback / Phase fallback の各検証項目を追加 (commit `test(close-issue/eval): mock シナリオを fallback 経路前提に更新`)
- [x] **requirements.md の関連 [critical] 項目が fallback 動作確認に更新されている** — 各シナリオに [critical] 9 番 (fallback 動作) + [important] 10 番を追加 (commit `test(close-issue/eval): requirements に [critical] fallback 検証 + [important] 追加`)
- [x] **empirical-prompt-tuning Iter で fallback が正しく動作することを実測検証 (構造的欠陥が解消)** — 新規 subagent 3 並列で Iter 2 走査を実施、3 シナリオ全て **精度 1.00 / [critical] 全 ○** (新 [critical] 9 fallback 動作含む)、構造的欠陥ゼロ維持で **収束打ち切り**。詳細は [`iter_2_revaluation.md`](https://github.com/Idios/kobutachan-allaganeye/blob/claude/relaxed-swartz-0cab0a/.claude/skills/close-issue/eval/reports/iter_2_revaluation.md) (受け入れ条件本文の「Iter 0/1」表現は #594 時点の表現で、本 PR では既存 Iter 0/1 + 新 Iter 2 として fallback 動作の実測検証を担保)

### #606: close-issue Iter 1 結果を別ファイル化

- [x] **`.claude/skills/close-issue/eval/reports/iter_1_revaluation.md` が新規作成されている** — review-pr 側 [`iter_1_revaluation.md`](https://github.com/Idios/kobutachan-allaganeye/blob/develop-0.2.0/.claude/skills/review-pr/eval/reports/iter_1_revaluation.md) と同 6 section 構造で新設 (commit `docs(close-issue/eval): reports 構造を整理 + Iter 2 fallback 検証結果を記録`)
- [x] **iter_1_revaluation.md に 3 シナリオの subagent Iter 1 結果が含まれる (メトリクス + 構造的欠陥解消確認)** — サマリ表 (シナリオ × 精度 / [critical] / tool_uses / duration_ms) + シナリオ A/B/C 個別ブロック (Iter 0 不明瞭点解消状況 + Iter 1 新出不明瞭点) を含む
- [x] **summary.md からは Iter 1 詳細を抽出し、サマリ統合のみ残る** — summary.md を 28 行程度に縮約、Iter 0 → Iter 1 → Iter 2 メトリクス比較表 + 収束判定 + deferred 候補 (Iter 1 由来 11 件 + Iter 2 由来 9 件) のみ残置
- [x] **review-pr 側の既存 summary.md / iter_1_revaluation.md の構造と整合** — section 構成を完全踏襲 (メタヘッダ / サマリ表 / シナリオ別ブロック / 参考)。本 PR では加えて `iter_2_revaluation.md` も新設 (review-pr 側に倣う)

## 動作確認

### Hybrid fallback 実機 dry-run (PR push 前)

```bash
$ gh api repos/Idios/kobutachan-allaganeye/issues/594/timeline \
    --jq '[.[] | select(.event=="cross-referenced") | select(.source.issue.pull_request != null) | {pr: .source.issue.number, state: .source.issue.state}]'
[{"pr":602,"state":"closed"},{"pr":597,"state":"closed"}]

$ gh search prs '"Refs #594"' --repo Idios/kobutachan-allaganeye --json number,state,title,url
[{"number":602,"state":"merged","title":"[task] review-pr の issue クローズ責務を /close-issue skill に分離 (Refs #594)","url":"https://github.com/Idios/kobutachan-allaganeye/pull/602"}]
```

両段とも期待通り PR を返却。dedupe 時は search 側 `state==merged` を真値として採用 (timeline の `closed` は近似情報)。

### Iter 2 サマリ (3 並列 subagent dispatch)

| シナリオ | 精度 | [critical] | tool_uses | duration_ms |
|---|---|---|---|---|
| A (中央値 1:1) | 10/10 = 1.00 | 8/8 ○ | 4 | 101,763 |
| B (束ね PR) | 10/10 = 1.00 | 7/7 ○ | 3 | 97,619 |
| C (Phase 分割) | 10/10 = 1.00 | 8/8 ○ | 3 | 106,144 |

全シナリオ **成功 (○)**、構造的欠陥ゼロ維持で収束。詳細は [`iter_2_revaluation.md`](https://github.com/Idios/kobutachan-allaganeye/blob/claude/relaxed-swartz-0cab0a/.claude/skills/close-issue/eval/reports/iter_2_revaluation.md) を参照。

duration 合計 305,526ms = Iter 1 (457,335ms) から **-33%**。Step 1/2 fallback の bash コマンド例 + dedupe ポリシー明示で subagent の判断が systematic 化、tool_uses も -9%。

## Iron Law 4 整合

本 PR 本文・全 commit メッセージで `Closes/Fixes/Resolves` キーワードを**使用していない**。`Refs #607 #606` のみ。

マージ後の close は `/close-issue 607` および `/close-issue 606` を **個別に** 呼び分ける運用 (束ね PR ケース B、SKILL.md 既存運用通り)。本 PR では `gh issue close` を実行しない。

## 残タスク (deferred 候補、本 PR スコープ外)

Iter 1 由来 11 件 + Iter 2 由来 9 件の不明瞭点 (合計 20 件) はいずれも **詳細詰め不足レベル** (skill 構造ではなく細部判断基準レベル)。memory「リソース打ち切り」基準で deferred 追跡可、優先度 P3-low。詳細は [`summary.md`](https://github.com/Idios/kobutachan-allaganeye/blob/claude/relaxed-swartz-0cab0a/.claude/skills/close-issue/eval/reports/summary.md) §「deferred 候補」を参照。

主な Iter 2 由来項目:

- ケース B fallback `grep -oE '#[0-9]+'` のノイズリスク (`Refs` 行優先抽出への補強の余地)
- 「各 PR 本文 `Refs #N` 確認」の手順明示
- ケース C の「全 PR 統合状態」検証方法の表現補強 (Step 5 `git log` 表現の補強)
- AskUserQuestion 2 段階 (Step 5 + Step 7) のユーザー UX

## 関連

- #594 (本 issue が dogfood で発見した skill 設計欠陥の親 issue)
- #602 (mergedAt 2026-04-27、本 PR が dogfood 起源とする親 PR)
- `docs/issue-policy.md` §6 (`Closes` キーワード禁止ルール)
- `.claude/hooks/session-start.sh` Iron Law 4 (本問題の起源)
- `.claude/skills/review-pr/eval/` (#511 で実施、Iter 2 まで実行の構造準拠先)
- memory `feedback_skill_revision_empirical.md` (empirical-prompt-tuning 運用手順)
- memory `feedback_pr_internal_fix_policy.md` (PR で挙がった問題は原則そのPR内で対策、1 PR 同梱の根拠)

[relaxed-swartz-0cab0a]
