### PR TITLE
fix: single-dash long-option 入力時に --<name> ヒントを表示 (Refs #440)

### DIFF
--- a/allaganeye/__main__.py
+++ b/allaganeye/__main__.py
@@ -1,5 +1,5 @@
 """Enable ``python -m allaganeye`` invocation."""
 
-from allaganeye.cli import app
+from allaganeye.cli import main
 
-app()
+main()

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -5,6 +5,7 @@ import traceback
 from pathlib import Path
 from typing import Annotated
 
+import click
 import typer
 
 from allaganeye import __version__
@@ -31,7 +32,7 @@ def version_callback(value: bool) -> None:
 
 
 @app.callback()
-def main(
+def _root_callback(
     version: Annotated[
         bool | None,
         typer.Option(
@@ -494,3 +495,80 @@ def _report_unexpected_error(
 
     if show_hint:
         typer.echo(_VERBOSE_HINT, err=True)
+
+
+def _suggest_long_option_hint(argv: list[str]) -> str | None:
+    """Return ``--<name>`` candidate when argv has a single-dash long-option typo (#440).
+
+    typer / click parses ``-version`` as the short-option cluster
+    ``-v -e -r -s -i -o -n`` and raises ``NoSuchOption`` for the first
+    char.  We scan argv for a single-dash token of length >= 2 (e.g.
+    ``-version``) that, with the leading dash doubled, matches a known
+    long option of the typer app or any subcommand.  Returns ``None``
+    when no suitable candidate exists so we don't volunteer misleading
+    hints for unrelated typos.
+    """
+    cmd = typer.main.get_command(app)
+    # ``--help`` is added by click at parse time (``add_help_option=True``)
+    # so it is NOT in ``cmd.params``; seed the set so ``-help`` typos still
+    # get a hint.
+    known: set[str] = {"help"}
+    for param in cmd.params:
+        for opt in param.opts:
+            if opt.startswith("--"):
+                known.add(opt[2:])
+    if isinstance(cmd, click.Group):
+        for sub_cmd in cmd.commands.values():
+            for param in sub_cmd.params:
+                for opt in param.opts:
+                    if opt.startswith("--"):
+                        known.add(opt[2:])
+
+    for token in argv:
+        if not token.startswith("-") or token.startswith("--"):
+            continue
+        name = token.lstrip("-").split("=", 1)[0]
+        if len(name) >= 2 and name in known:
+            return f"--{name}"
+
+    return None
+
+
+def main() -> None:
+    """Console-script entry point that adds a hint for single-dash long-option typos (#440).
+
+    ``allaganeye -version`` parses as the cluster ``-v -e -r -s -i -o -n``
+    and click raises ``NoSuchOption`` for the first char.  Without
+    context the message ("No such option: -v") doesn't reveal that the
+    user typed ``-version``; we catch the error, let click print its
+    usual usage / boxed message via ``exc.show()``, and append a
+    ``Did you mean --version?`` line when the pattern matches a real
+    long option.
+
+    Uses ``standalone_mode=False`` so click re-raises ``ClickException``
+    subclasses for us to inspect (and converts ``Exit`` into a return
+    value containing its exit code).  Always finishes with ``sys.exit``
+    so the caller gets the same SystemExit semantics as the original
+    ``app()`` entry point.
+    """
+    rv: int = 0
+    try:
+        result = app(standalone_mode=False)
+        if isinstance(result, int):
+            rv = result
+    except click.exceptions.NoSuchOption as exc:
+        exc.show()
+        hint = _suggest_long_option_hint(sys.argv[1:])
+        if hint:
+            click.echo(f"Did you mean {hint}?", err=True)
+        rv = exc.exit_code
+    except click.exceptions.UsageError as exc:
+        exc.show()
+        rv = exc.exit_code
+    except click.exceptions.ClickException as exc:
+        exc.show()
+        rv = exc.exit_code
+    except click.exceptions.Abort:
+        click.echo("Aborted!", err=True)
+        rv = 1
+    sys.exit(rv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.scripts]
-allaganeye = "allaganeye.cli:app"
+allaganeye = "allaganeye.cli:main"
 
 [tool.setuptools.packages.find]
 include = ["allaganeye*"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1053,3 +1053,120 @@ def test_split_from_metadata_missing_file_exits_with_input_file_error(tmp_path):
         app, ["split", "--from-metadata", str(tmp_path / "nope.json")]
     )
     assert result.exit_code == 2  # InputFileError
+
+
+# --- single-dash long-option hint (#440) ---
+
+
+def test_suggest_long_option_hint_matches_top_level():
+    """``-version`` argv -> suggest ``--version`` (top-level option, #440)."""
+    from allaganeye.cli import _suggest_long_option_hint
+
+    assert _suggest_long_option_hint(["-version"]) == "--version"
+
+
+def test_suggest_long_option_hint_matches_subcommand_option():
+    """``-gpu`` argv -> suggest ``--gpu`` (subcommand-only option, #440).
+
+    Subcommand options like ``--gpu`` belong to ``split`` / ``detect``,
+    not the top-level group, so the helper must walk subcommands too.
+    """
+    from allaganeye.cli import _suggest_long_option_hint
+
+    assert _suggest_long_option_hint(["split", "-gpu"]) == "--gpu"
+
+
+def test_suggest_long_option_hint_skips_real_short_flag():
+    """``-V`` (real short alias, len 1) must NOT be treated as a typo (#440)."""
+    from allaganeye.cli import _suggest_long_option_hint
+
+    assert _suggest_long_option_hint(["-V"]) is None
+    assert _suggest_long_option_hint(["-v"]) is None
+
+
+def test_suggest_long_option_hint_skips_double_dash():
+    """``--version`` is already correct, return ``None`` (#440)."""
+    from allaganeye.cli import _suggest_long_option_hint
+
+    assert _suggest_long_option_hint(["--version"]) is None
+
+
+def test_suggest_long_option_hint_skips_unknown_token():
+    """``-xyz`` where ``--xyz`` isn't a real option -> no misleading hint (#440)."""
+    from allaganeye.cli import _suggest_long_option_hint
+
+    assert _suggest_long_option_hint(["-xyz"]) is None
+
+
+def test_suggest_long_option_hint_empty_argv():
+    """Empty argv -> ``None`` (defensive, #440)."""
+    from allaganeye.cli import _suggest_long_option_hint
+
+    assert _suggest_long_option_hint([]) is None
+
+
+def test_main_emits_hint_for_single_dash_version(monkeypatch, capsys):
+    """``allaganeye -version`` triggers ``Did you mean --version?`` (#440)."""
+    from allaganeye.cli import main
+
+    monkeypatch.setattr("sys.argv", ["allaganeye", "-version"])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Did you mean --version?" in combined
+
+
+def test_main_emits_hint_for_single_dash_help(monkeypatch, capsys):
+    """``allaganeye -help`` triggers ``Did you mean --help?`` (#440)."""
+    from allaganeye.cli import main
+
+    monkeypatch.setattr("sys.argv", ["allaganeye", "-help"])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Did you mean --help?" in combined
+
+
+def test_main_no_hint_when_double_dash_correct(monkeypatch, capsys):
+    """``--version`` works normally without spurious hint (#440 regression guard)."""
+    from allaganeye.cli import main
+
+    monkeypatch.setattr("sys.argv", ["allaganeye", "--version"])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Did you mean" not in combined
+    assert "allaganeye" in combined  # version output present
+
+
+def test_main_short_alias_unchanged(monkeypatch, capsys):
+    """``-V`` short alias still prints version, no hint emitted (#440 regression guard)."""
+    from allaganeye.cli import main
+
+    monkeypatch.setattr("sys.argv", ["allaganeye", "-V"])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Did you mean" not in combined
+    assert "allaganeye" in combined
+
+
+def test_main_no_misleading_hint_for_unrelated_typo(monkeypatch, capsys):
+    """``-xyz`` (no matching long option) prints click error WITHOUT a hint (#440)."""
+    from allaganeye.cli import main
+
+    monkeypatch.setattr("sys.argv", ["allaganeye", "-xyz"])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Did you mean" not in combined


### PR DESCRIPTION
## Summary

`allaganeye -version` (single dash) を typer/click が short option cluster として解釈し "No such option: -v" を出していた問題を修正 (#440)。`NoSuchOption` をエラーハンドラで補足し、`-<長い名前>` パターンに該当する long option があれば `Did you mean --<name>?` ヒントを stderr 末尾に追記する。

## 受け入れ条件 (#440)

- [x] `-version` 等の typo に `--version` ヒントが表示される (案 a 採用)
  - 実機検証: `python -m allaganeye -version` で `Did you mean --version?` 出力確認
  - 実機検証: `python -m allaganeye -help` で `Did you mean --help?` 出力確認
- [x] 既存正常系オプションの挙動が破壊されない
  - 実機検証: `python -m allaganeye --version` / `-V` ともに `allaganeye 0.2.0` 出力 (#376 の short alias 維持)
  - 回帰テスト 5 件 (`test_main_no_hint_when_double_dash_correct` / `test_main_short_alias_unchanged` / `test_main_no_misleading_hint_for_unrelated_typo` 他)
- [x] (案 a / b 採用前提なので) docs ガイダンスは更新不要

## 実装方針: 案 a (エラーハンドラ override + prefix match)

ユーザー入力 (`sys.argv`) は補正せず、click の usage / boxed error 表示を温存したうえで stderr に 1 行追加する非破壊的アプローチ。

- 新規 `_suggest_long_option_hint(argv)`: typer app + 全 subcommand の long-option 名を集めた `known` set を構築し、argv 中の `-<2 文字以上>` トークンが `known` にあれば `--<name>` を返す。`--help` は click が parse 時に動的追加するため `cmd.params` に出ないので `{"help"}` で seed
- 新規 `main()` console-script wrapper: `app(standalone_mode=False)` を呼んで click の例外を捕捉。`NoSuchOption` のときは `exc.show()` のあと `_suggest_long_option_hint(sys.argv[1:])` を実行してヒント追記。click が `Exit` を return value に変換するため最後に `sys.exit(rv)` でラップして既存 `app()` の SystemExit セマンティクスを維持
- 既存 `@app.callback()` 関数 (元 `def main()`) は名前衝突回避のため `_root_callback` に rename (typer の表示・挙動に影響なし、関数名のみ変更)
- `__main__.py` / `pyproject.toml` の entry point を `app` から `main` に切り替え

## 変更ファイル

- `allaganeye/cli.py`: `import click` 追加、`_suggest_long_option_hint()` / `main()` 新設、既存 callback rename
- `allaganeye/__main__.py`: `app()` -> `main()` 呼び出し変更
- `pyproject.toml`: console_scripts entry を `allaganeye.cli:app` -> `allaganeye.cli:main`
- `tests/test_cli.py`: 11 件の新規テスト追加

## 新規テスト内訳

- Helper 単体 6 件: top-level / subcommand option 認識、real short flag (`-V`) 除外、double-dash 除外、unknown token 除外、empty argv 防御
- main() 経由 5 件: `-version` / `-help` ヒント表示、`--version` / `-V` 正常動作 (regression guard)、`-xyz` 誤誘導防止

## Test plan

- [x] `python -m ruff check .` pass
- [x] `python -m ruff format --check .` pass
- [x] `python -m pyright` (changed files) pass
- [x] `python -m pytest` 825 passed / 1 skipped / 37 deselected (slow) — 既存 814 から 11 増、回帰なし
- [x] 実機検証 5 シナリオ (`-version` / `-help` / `--version` / `-V` / `-xyz`) すべて期待通り

## Refs

- Refs #440
- 関連: #376 (`-V` を `--version` short alias として追加、本 PR で hint 対象 `known` set にも自動取り込み)

## Note

- `Closes` / `Fixes` / `Resolves` キーワードは使用していません (Iron Law 4 / `docs/l2-workflow.md`)。マージ後 `/close-issue 440` で受け入れ条件を実測再検証してから手動 close します。
