### PR TITLE
feat(workflow): Iron Law 6 新設で PR 作成前ゲートを強制 (Refs #636)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -30,6 +30,11 @@ cat <<'EOF'
    - 曖昧と認識している判断点は独断で prescribe せず AskUserQuestion で多肢選択
    - 「Recommended 付き 2-4 択」が標準
 
+6. **NO PR CREATION WITHOUT VERIFIED CHECKS**
+   - PR 作成前に変更ファイル path に応じた自動チェック (Python: `ruff check .` / `ruff format --check .` / `pyright` / `pytest`、GUI: `npm run lint` / `typecheck` / `test` / `build` / `cargo check`) を全 pass させる。「軽微だから skip」「Python のみだから GUI 側不要」は Red Flag (失敗パターン A 再発)
+   - ロジック変更 (`gpu_detector.py` / `audio/*.py` / `video/detector.py` / `gui/src-tauri/**` 等) を含む場合は、ユーザー (Idios) に実機検証 (GPU / audio / 長時間動画 / GUI Tauri 起動) を `AskUserQuestion` で依頼する。「mock テスト pass = 実機検証不要」は Red Flag (失敗パターン B 再発)
+   - PR 本文には machine-verified を `[x]` で、machine-unverifiable を plain bullet `-` で書き分ける (`feedback_pr_validate_checklist.md` 規約)。詳細手順は `feedback_pr_pre_creation_checks.md` / `feedback_user_realmachine_test_request.md` 参照
+
 ## Red Flags (この思考が浮かんだら STOP)
 
 | 浮かんだ思考 | 現実 |
@@ -40,6 +45,8 @@ cat <<'EOF'
 | 「受け入れ条件は大体満たしてる」 | Iron Law 1 違反。「大体」は NG。逐条検証必須 |
 | 「Closes を付ければ自動で閉じて便利」 | Iron Law 4 違反。手動クローズ厳守 |
 | 「観察 (修正不要) とコメントしておこう」 | #399 B 違反。別 issue 起票 or escalate |
+| 「ローカル lint 通ったから PR 出して大丈夫」 | Iron Law 6 違反。変更 path から必要 job を判定 (Python / GUI / installer / docs)。GUI 変更を含むなら `npm run lint` / `typecheck` / `test` / `build` / `cargo check` も実行 |
+| 「mock テスト pass = 実機検証不要」 | Iron Law 6 違反。GPU / audio / 長時間動画 / GUI Tauri は mock 不可。該当 path 変更時は `AskUserQuestion` で依頼 |
 
 詳細は `docs/l2-workflow.md` を参照。Iron Law が不明確な場合は先に l2-workflow.md を読むこと。
 </EXTREMELY_IMPORTANT>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,15 +33,46 @@
 
 - [ ] 本文・コミットメッセージに `Closes` / `Fixes` / `Resolves` キーワードが含まれていない (issue クローズは手動)
 
-### 品質ゲート
+### Iron Law 6: PR 作成前検証
 
-- [ ] 全テスト通過 (`pytest`)
-- [ ] Lint 通過 (`ruff check .` + `ruff format --check .`)
-- [ ] 型チェック通過 (`pyright`)
+#### Self-Test Report (machine-verified — 全件 `[x]` で validate-checklist 通過)
+
+<!--
+変更ファイル path に応じて該当する job のみ `[x]` 必須。
+該当しない場合は `[x]` + 「N/A: <理由>」 を付記 (例: `[x] cargo check — N/A: gui/src-tauri/ 変更なし`)。
+未実施の場合は `[ ]` のままで CI fail させる (Iron Law 6 違反として明示)。
+-->
+
+- [ ] `ruff check .` (python-core 変更時)
+- [ ] `ruff format --check .` (python-core 変更時)
+- [ ] `pyright` (python-core 変更時)
+- [ ] `pytest` (python-core 変更時、slow 除外)
+- [ ] `cd gui && npm run lint` (gui-frontend 変更時)
+- [ ] `cd gui && npm run typecheck` (gui-frontend 変更時)
+- [ ] `cd gui && npm test` (gui-frontend 変更時)
+- [ ] `cd gui && npm run build` (gui-frontend 変更時)
+- [ ] `cargo check --manifest-path gui/src-tauri/Cargo.toml` (gui-rust 変更時)
+- [ ] `Invoke-Pester -Path scripts/tests/` (installer-pester 変更時、Windows 上で)
+
+#### 関連ドキュメント / マトリクス更新
+
 - [ ] 関連ドキュメント更新 (`docs/cli-spec.md` / `docs/design-overview.md` / `README.md` 等) — 該当なしなら `[x]` + 理由付記
 - [ ] **新規 CLI オプション追加時**: [`docs/output-spec.md`](../docs/output-spec.md) のマトリクス更新 (#405) — 該当なしなら `[x]` + 理由付記
 - [ ] CLAUDE.md / `docs/l2-workflow.md` の更新要否確認 — 不要なら `[x]` + 理由付記
 - [ ] 出力書式を変更した場合、`docs/cli-spec.md` の該当出力例も更新 (再発防止: #343 系)
+- [ ] docs / 識別子のリネーム時は `feedback_doc_section_ref_check.md` 規約で §「<旧名>」grep し残骸ゼロ確認
+
+#### 実機検証 (machine-unverifiable — plain bullet で書く)
+
+<!--
+validate-checklist は plain bullet `-` を無視するため未実施でもブロックしない。
+ただし「未実施」を握り潰しせず明示する: 「PR 提出時点では未実施 / レビュー時に実機確認」と書く。
+該当 path 変更がない場合: 「- 該当なし (gpu_detector.py / audio/ / video/detector.py / gui/ 変更なし)」を 1 行書く。
+-->
+
+- (例) `pytest -m slow_gpu tests/test_gpu_detector.py` — PR 提出時点で実施済 (Windows + NVIDIA RTX 4070, ffmpeg 8.1, NVENC 動作確認)
+- (例) `npm run tauri dev` で export 画面の H.264 再エンコード目視確認 — PR 提出時点では未実施 (レビュー時にユーザー確認依頼)
+- (例) 該当なし (gpu_detector.py / audio/ / video/detector.py / gui/ 変更なし)
 
 ## 関連
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,9 +251,24 @@ L2 からは**単一ワークツリー + skill ベースディスパッチ**を�
 
 ## PR 作成ルール
 
-詳細は `docs/l2-workflow.md` を参照。要約:
+詳細は `docs/l2-workflow.md` を参照。Iron Law 6 (`.claude/hooks/session-start.sh`) と `feedback_pr_pre_creation_checks.md` / `feedback_user_realmachine_test_request.md` も参照。要約:
 
-- **PR 作成前**: ベースブランチをリベースし、Python 側は `ruff check .` / `ruff format --check .` / `pytest`、GUI (gui/) 変更を含む場合は追加で `npm run lint` / `npm run typecheck` / `npm test` / `cargo check` (src-tauri/) を通すこと。加えてロジック変更を含む場合は実機検証 (long-running / GPU / audio 統合等は mock 不可) を実施
+- **PR 作成前 (Iron Law 6)**: 変更ファイル path から必要な自動チェックを判定して全 pass させる:
+  - **python-core** (`allaganeye/**/*.py`, `tests/**/*.py`, `pyproject.toml`): `ruff check .` / `ruff format --check .` / `pyright` / `pytest`
+  - **gui-frontend** (`gui/src/**`, `gui/package.json`, `gui/tsconfig.json` 等): `cd gui && npm run lint` / `npm run typecheck` / `npm test` / `npm run build`
+  - **gui-rust** (`gui/src-tauri/**`): `cargo check --manifest-path gui/src-tauri/Cargo.toml`
+  - **installer-pester** (`scripts/**/*.ps1`, `scripts/tests/**`): `Invoke-Pester -Path scripts/tests/`
+  - **docs-only** (`docs/**/*.md`, `README.md`, `CLAUDE.md` のみ): `feedback_doc_section_ref_check.md` 規約 §「<旧名>」grep で残骸ゼロ確認
+  - 複数種別にまたがれば全部実行。「軽微だから skip」「Python のみだから GUI 側不要」は **Iron Law 6 違反 / 失敗パターン A 再発**
+- **ロジック変更時の実機検証 (Iron Law 6)**: 以下に該当する path 変更があれば `AskUserQuestion` で実機検証をユーザー (Idios) に依頼。「mock テスト pass = 実機検証不要」は **Iron Law 6 違反 / 失敗パターン B 再発**:
+  - `allaganeye/video/gpu_detector.py`, `system_info.py` → `pytest -m slow_gpu` (NVIDIA GPU 必須)
+  - `allaganeye/audio/scan.py`, `audio/matcher.py`, `audio/features.py` → `pytest -m slow tests/test_audio_integration.py` (`ALLAGANEYE_AUDIO_TEST_VIDEO` 必須)
+  - `allaganeye/video/detector.py` Pass 1 / scorebar 変更 → `pytest -m slow_detect` または `pytest -m "slow or baseline_regen"`
+  - `allaganeye/commands/split_matches.py` パイプライン変更 → `pytest -m slow_pipeline`
+  - `gui/src-tauri/**` Tauri command → `cd gui && npm run tauri dev` で手動 GUI 起動 + 該当 command 操作確認
+  - `gui/src/screens/**` UI 変更 → `npm run tauri dev` + 5 画面 (drop / detecting / complete / preview / export) 目視 + スクショ
+  - `gui/src-tauri/src/commands/export*.rs` H.264 エンコーダ → 実機 export (NVENC / QSV / AMF / libx264) 確認
+- **PR 本文の Self-Test Report**: machine-verified を `[x]` (validate-checklist が pass 判定)、machine-unverifiable を plain bullet `-` で書き分ける (`feedback_pr_validate_checklist.md` 規約)。「PR 提出時点では未実施 / レビュー時に実機確認」も plain bullet で明記すれば許容 (握り潰しではない)
 - ベースブランチ: `develop-x.x.x`（`main` ではない）
 - 作業ブランチ命名: `claude/<scope>-<short-description>` または `claude/<issue-N>-<slug>`
 - マージ方法: `gh pr merge <番号> --squash` (ユーザーが実行)


### PR DESCRIPTION
## 概要

PR レビュー時の手戻り (CI エラー / ユーザー実機検証依頼漏れ) を防ぐため、Iron Law 6「NO PR CREATION WITHOUT VERIFIED CHECKS」を新設し、PR 作成前ゲートを強制する。

## 変更点

- `.claude/hooks/session-start.sh`: Iron Law 6 追加 + Red Flags 表に 2 行追加
- `CLAUDE.md`: § PR 作成ルールに path 分類表 (python-core / gui-frontend / gui-rust / installer-pester / docs-only) + 実機検証 trigger 表 (gpu_detector / audio / detector / split_matches / gui/) を追加
- `.github/pull_request_template.md`: 「品質ゲート」節を削除し「Iron Law 6: PR 作成前検証」節を新設 (Self-Test Report 10 項目 + 関連ドキュメント + 実機検証 plain bullet 構造)
- memory `feedback_pr_pre_creation_checks.md` (失敗パターン A 対応) 新規 [worktree 外、user-level memory]
- memory `feedback_user_realmachine_test_request.md` (失敗パターン B 対応) 新規 [worktree 外、user-level memory]
- memory `MEMORY.md` に上記 2 件のインデックス行追加 [worktree 外、user-level memory]

## 受け入れ基準 / 確認項目 (Iron Law 1: 逐条検証)

- [x] `.claude/hooks/session-start.sh` に Iron Law 6 追加 + Red Flags 表 2 行追加 — 対応 diff: `.claude/hooks/session-start.sh:33-37` (Iron Law 6 本体), `:48-49` (Red Flags 2 行)
- [x] `CLAUDE.md` § PR 作成ルールに path 分類表 + 実機検証 trigger 表 — 対応 diff: `CLAUDE.md:254-274` (path 分類表 5 種別 + 実機検証 trigger 7 行)
- [x] `.github/pull_request_template.md` 「品質ゲート」節削除 + Iron Law 6 節新設 — 対応 diff: `.github/pull_request_template.md:36-79` (Self-Test Report 10 項目 + 関連ドキュメント 5 項目 + 実機検証 plain bullet)
- [x] memory `feedback_pr_pre_creation_checks.md` 新規 (失敗パターン A 対応) — 対応: `~/.claude/projects/E--projects-kobutachan-tools-kobutachan-allaganeye/memory/feedback_pr_pre_creation_checks.md` (worktree 外、user-level)
- [x] memory `feedback_user_realmachine_test_request.md` 新規 (失敗パターン B 対応) — 同上
- [x] memory `MEMORY.md` 索引追記 — 同上
- [x] session-start hook 出力に Iron Law 6 が含まれることを確認 — `bash .claude/hooks/session-start.sh` 実行で Iron Law 6 + Red Flags 2 行追加が出力されることを確認済 (本 PR コミット作成前)

## PR チェックリスト (Iron Law 遵守確認)

### Iron Law 1: 受け入れ条件検証

- [x] 元 issue (#636) の `## 受け入れ条件` を上記で逐条検証した
- [x] UI/出力変更の場合、実サンプル添付 — N/A: UI 変更なし

### Iron Law 3: スコープ遵守 (scope-guard)

- [x] 変更ファイルがすべて元 issue (#636) のスコープ内であることを確認した
- [x] スコープ外変更がある場合の理由と子 issue 番号 — N/A: スコープ外変更なし

### Iron Law 4: クローズキーワード禁止

- [x] 本文・コミットメッセージに `Closes` / `Fixes` / `Resolves` キーワードが含まれていない (issue クローズは手動)

### Iron Law 6: PR 作成前検証

#### Self-Test Report (machine-verified — 全件 `[x]` で validate-checklist 通過)

- [x] `ruff check .` — N/A: python-core 変更なし (`allaganeye/**/*.py` / `tests/**/*.py` / `pyproject.toml` いずれも未変更)
- [x] `ruff format --check .` — N/A: python-core 変更なし
- [x] `pyright` — N/A: python-core 変更なし
- [x] `pytest` — N/A: python-core 変更なし
- [x] `cd gui && npm run lint` — N/A: gui-frontend 変更なし
- [x] `cd gui && npm run typecheck` — N/A: gui-frontend 変更なし
- [x] `cd gui && npm test` — N/A: gui-frontend 変更なし
- [x] `cd gui && npm run build` — N/A: gui-frontend 変更なし
- [x] `cargo check --manifest-path gui/src-tauri/Cargo.toml` — N/A: gui-rust 変更なし
- [x] `Invoke-Pester -Path scripts/tests/` — N/A: installer-pester 変更なし

#### 関連ドキュメント / マトリクス更新

- [x] 関連ドキュメント更新 — 本 PR 自身が CLAUDE.md / PR template 更新を含む
- [x] **新規 CLI オプション追加時** — N/A: CLI オプション変更なし
- [x] CLAUDE.md / `docs/l2-workflow.md` の更新要否確認 — CLAUDE.md は本 PR で更新済。`docs/l2-workflow.md` は別 issue で対応 (本 PR の「残スコープ」)
- [x] 出力書式変更時の `docs/cli-spec.md` 更新 — N/A: 出力書式変更なし
- [x] docs / 識別子のリネーム時は `feedback_doc_section_ref_check.md` 規約で §「<旧名>」grep し残骸ゼロ確認 — `git grep "品質ゲート"` ヒット 0 件、PR template から削除した節名の残骸ゼロ確認済

#### 実機検証 (machine-unverifiable — plain bullet で書く)

- 該当なし (gpu_detector.py / audio/ / video/detector.py / commands/split_matches.py / gui/src-tauri/ / gui/src/screens/ / export*.rs いずれも変更なし)
- session-start hook 動作確認: `bash .claude/hooks/session-start.sh` 実行で Iron Law 6 + Red Flags 2 行が出力されることを確認済 (PR 提出前、worktree 内で実行)

## 関連

- Refs #636
- Base branch: `develop-0.2.0`
- Session: pensive-mcnulty-52fa0c

## 備考

- 本 PR は Iron Law 6 自身を導入する初回 PR のため、Self-Test Report の構造を本 PR で実証している (path 分類で「該当なし」が中心、実機検証も「該当なし」だが明示的に記載)
- memory ファイル (worktree 外) は user-level (`C:\Users\idios\.claude\projects\E--projects-kobutachan-tools-kobutachan-allaganeye\memory\`) に配置されているため git diff には現れない。これは既存の memory 運用と整合
- 残スコープ (`/test-pr` 参照整理 / `docs/l2-workflow.md` §強制メカニズム表更新 / `gh pr create` PreToolUse hook 化) は本 PR では扱わず、効果計測 (5-10 PR) 後に別 issue で対応する想定
