### PR TITLE
fix: verbose Filter 行に unknown match 件数の別行を追加 (Refs #433)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -1355,6 +1355,16 @@ def _print_detection_stats(stats: DetectionStats) -> None:
         if drops.get("other", 0) > 0:
             typer.echo(f"    {drops['other']} dropped (other)")
 
+    # Unknown match accounting (#433): recordings starting / ending mid-match
+    # produce ``type=unknown`` segments at the timeline edges. They are part
+    # of Detected count but not of the Filter "kept" formula (candidates
+    # counts blackout boundaries, not edge segments), so without this line
+    # users see Filter=N / Detected=N+1 and assume a counting bug.
+    unknown_count = stats.get("filter_unknown", 0)
+    if unknown_count > 0:
+        label = "match" if unknown_count == 1 else "matches"
+        typer.echo(f"  + {unknown_count} unknown {label} (録画途中試合)")
+
 
 def _format_timestamp(seconds: float) -> str:
     """Format seconds as MM:SS or H:MM:SS."""

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -49,6 +49,11 @@ class DetectionStats(TypedDict, total=False):
     # ``<candidates> -> <final matches>`` with breakdown.
     filter_candidates: int
     filter_drops: dict[str, int]  # keys: below_min_match_duration, other
+    # Count of segments returned with type=="unknown" (#433). Used by the
+    # verbose ``+ N unknown match`` line so the user can reconcile
+    # Filter "kept" with the larger Detected count when a recording
+    # starts / ends mid-match.
+    filter_unknown: int
 
 
 logger = logging.getLogger(__name__)
@@ -1351,13 +1356,20 @@ def _filter_and_extract_segments(
         if stats is not None:
             stats["filter_drops"][key] = stats["filter_drops"].get(key, 0) + 1
 
+    def _finalize(segments: list[MatchBoundary]) -> list[MatchBoundary]:
+        # Track unknown-typed segments so the verbose Filter section can
+        # explain the ``Detected = kept + unknown`` discrepancy (#433).
+        if stats is not None:
+            stats["filter_unknown"] = sum(1 for s in segments if s["type"] == "unknown")
+        return segments
+
     if not blackout_regions:
         if total_duration >= min_match_duration:
-            return [{"start": 0.0, "end": total_duration, "type": "unknown"}]
+            return _finalize([{"start": 0.0, "end": total_duration, "type": "unknown"}])
         # Whole video was shorter than min_match_duration -- count the
         # implicit whole-video candidate as dropped.
         _record_drop("other")
-        return []
+        return _finalize([])
 
     # Filter out short blackout regions (e.g. respawn blackouts 1-2s)
     if classifications is not None:
@@ -1381,9 +1393,9 @@ def _filter_and_extract_segments(
 
     if not blackout_regions:
         if total_duration >= min_match_duration:
-            return [{"start": 0.0, "end": total_duration, "type": "unknown"}]
+            return _finalize([{"start": 0.0, "end": total_duration, "type": "unknown"}])
         _record_drop("other")
-        return []
+        return _finalize([])
 
     # Extract segments between blackout regions
     segments: list[MatchBoundary] = []
@@ -1440,7 +1452,7 @@ def _filter_and_extract_segments(
     else:
         _record_drop("below_min_match_duration")
 
-    return segments
+    return _finalize(segments)
 
 
 def _padded_end(region: tuple[float, float]) -> float:

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -168,7 +168,8 @@ verbose モードの UX 目的 (= 情報取得) を優先する設計。silent r
   Filter: 15 candidates -> 8 matches
     6 dropped (below min_match_duration)
     1 dropped (other)
-  Splitting: 8 matches, 1m02s
+  + 1 unknown match (録画途中試合)
+  Splitting: 9 matches, 1m02s
 ```
 
 | 行 | 内容 |
@@ -176,7 +177,7 @@ verbose モードの UX 目的 (= 情報取得) を優先する設計。silent r
 | `Pass 1` | Pass 1 のサンプル数・暗転フレーム数・所要時間 |
 | `Pass 2` | Pass 2 精密計測の region 数・所要時間 (#366) |
 | `Scorebar` | Scorebar 分類 (match_boundary / in_match / non_fl / unknown) のカウントと所要時間 (#386) |
-| `Filter` | Scorebar 通過後の候補数 → 最終 match 数。`below_min_match_duration` / `other` が 0 より大きい場合のみ内訳を追加出力 (#388) |
+| `Filter` | Scorebar 通過後の候補数 → 最終 match 数。`below_min_match_duration` / `other` が 0 より大きい場合のみ内訳を追加出力 (#388)。録画途中で開始 / 終了する `unknown` 試合 (Detected には含まれるが Filter "kept" には含まれない) がある場合、内訳の直下に `+ N unknown match (録画途中試合)` 行を出力 (#433) |
 | `Splitting` | 分割フェーズの match 数・所要時間 (#387) |
 
 `Filter` セクションは候補数がゼロかつドロップがゼロの場合 (whole-video fallback により match が生成されたケース) は出力を省略する。`dropped (below min_match_duration)` は **セグメント長が `min_match_duration` に満たなかった数**、`dropped (other)` は短尺動画の whole-video 候補不適合等の残余カウント。`in_match` / `non_fl` はここに含まれず、上の Scorebar 行がそのカウントを担う (重複防止)。

--- a/docs/output-spec.md
+++ b/docs/output-spec.md
@@ -60,7 +60,7 @@ Error: --quiet and --verbose are mutually exclusive
 | 9 | 検知パラメータ summary (`interval=..., threshold=..., workers=auto(N), audio=frozen`) | [#384](https://github.com/Idios/kobutachan-allaganeye/issues/384), [#389](https://github.com/Idios/kobutachan-allaganeye/issues/389) | × | ◯ | × | × | ◯ | × | ❌ |
 | 10 | 進捗バー `Detecting` / `Refining` / `Scorebar` | [#368](https://github.com/Idios/kobutachan-allaganeye/issues/368), [#393](https://github.com/Idios/kobutachan-allaganeye/issues/393) | ◯ | ◯ | × | ◯ | ◯ | × | ❌ |
 | 11 | 検知統計 (`Pass 1`, `Pass 2`, `Scorebar`, `Splitting` elapsed 含) | [#386](https://github.com/Idios/kobutachan-allaganeye/issues/386), [#387](https://github.com/Idios/kobutachan-allaganeye/issues/387) | × | ◯ | × | × | ◯ | × | ❌ |
-| 12 | Filter drop 内訳 (`Filter: N candidates -> M matches`) | [#388](https://github.com/Idios/kobutachan-allaganeye/issues/388) | × | ◯ | × | × | ◯ | × | ❌ |
+| 12 | Filter drop 内訳 + unknown match 行 (`Filter: N candidates -> M matches` + `+ N unknown match (録画途中試合)`) | [#388](https://github.com/Idios/kobutachan-allaganeye/issues/388), [#433](https://github.com/Idios/kobutachan-allaganeye/issues/433) | × | ◯ | × | × | ◯ | × | ❌ |
 | 13 | `Detected N match(es) ... (cached)` サフィックス含 | [#418](https://github.com/Idios/kobutachan-allaganeye/issues/418) (M) | ◯ | ◯ | × | ◯ | ◯ | × | ❌ |
 | 14 | Match 一覧 (`[unknown]` / `[fl_match]` マーカー含) | [#382](https://github.com/Idios/kobutachan-allaganeye/issues/382) | ◯ | ◯ | × | ◯ | ◯ | × | ❌ |
 | 15 | Gap 一覧 | - | × | ◯ | × | × | ◯ | × | ❌ |

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -808,6 +808,96 @@ class TestFilterDropsStats:
 
 
 # ============================================================
+# _filter_and_extract_segments: filter_unknown stat (#433)
+# ============================================================
+
+
+class TestFilterUnknownStats:
+    """Verify the stats param tracks unknown segment count (#433).
+
+    Recordings starting / ending mid-match produce ``type=unknown``
+    edge segments. Without a counter the verbose Filter "kept" formula
+    is structurally smaller than the Detected count and users assume a
+    counting bug.  ``stats["filter_unknown"]`` lets the caller emit a
+    ``+ N unknown match`` reconciliation line.
+    """
+
+    def test_zero_when_all_segments_are_fl_match(self):
+        """fl_match-only result -> filter_unknown == 0.
+
+        Two blackouts framed by classifications produce one between-segment
+        typed fl_match. before-first / after-last are absent because the
+        outer regions hug 0s and total_duration.
+        """
+        stats: dict = {}
+        regions = [(0.0, 5.0), (1500.0, 1505.0)]
+        classifications = ["match_boundary", "match_boundary"]
+        result = _filter_and_extract_segments(
+            regions,
+            1505.0,
+            300.0,
+            3.0,
+            classifications=classifications,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert all(s["type"] == "fl_match" for s in result)
+        assert stats["filter_unknown"] == 0
+
+    def test_counts_before_first_unknown_edge(self):
+        """Recording started mid-match -> 1 unknown before first blackout."""
+        stats: dict = {}
+        # First blackout at 1000s leaves a 0-1000 unknown edge segment.
+        regions = [(1000.0, 1005.0), (1500.0, 1505.0)]
+        classifications = ["match_boundary", "match_boundary"]
+        result = _filter_and_extract_segments(
+            regions,
+            1800.0,
+            300.0,
+            3.0,
+            classifications=classifications,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        unknowns = [s for s in result if s["type"] == "unknown"]
+        assert len(unknowns) == 1
+        assert stats["filter_unknown"] == 1
+
+    def test_counts_whole_video_fallback_unknown(self):
+        """No blackouts but video >= min_match -> 1 unknown whole-video segment."""
+        stats: dict = {}
+        result = _filter_and_extract_segments(
+            [],
+            1800.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert len(result) == 1
+        assert result[0]["type"] == "unknown"
+        assert stats["filter_unknown"] == 1
+
+    def test_zero_on_empty_drop_path(self):
+        """No segments returned -> filter_unknown == 0 (defensive)."""
+        stats: dict = {}
+        # Whole-video shorter than min_match -> [] returned via 'other' drop.
+        result = _filter_and_extract_segments(
+            [],
+            100.0,
+            300.0,
+            3.0,
+            stats=stats,  # type: ignore[arg-type]
+        )
+        assert result == []
+        assert stats["filter_unknown"] == 0
+
+    def test_stats_none_runs_without_raising(self):
+        """When stats is None the unknown counter is silently skipped."""
+        # Backwards-compat with callers that don't pass stats.
+        result = _filter_and_extract_segments([(100.0, 105.0)], 1800.0, 300.0, 3.0)
+        # Result still contains unknown edges; just the stat isn't recorded.
+        assert any(s["type"] == "unknown" for s in result)
+
+
+# ============================================================
 # TestInferSegmentType
 # ============================================================
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -2635,6 +2635,164 @@ def test_verbose_filter_breakdown_absent_when_stats_missing_keys(
     assert "Filter:" not in out
 
 
+# --- unknown match accounting (#433) ---
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_emits_unknown_match_line_singular(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """1 unknown segment -> ``+ 1 unknown match`` reconciliation line (#433).
+
+    Reproduces the user-test scenario: ``Filter: 8 candidates -> 7 matches``
+    with ``Detected 8 match(es)`` due to a recording starting mid-match.
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 3
+            stats["pass1_elapsed_s"] = 5.0
+            stats["pass2_regions"] = 8
+            stats["pass2_elapsed_s"] = 1.0
+            stats["filter_candidates"] = 8
+            stats["filter_drops"] = {
+                "below_min_match_duration": 1,
+                "other": 0,
+            }
+            stats["filter_unknown"] = 1
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=300.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    assert "Filter: 8 candidates -> 7 matches" in out
+    # Singular form for count==1.
+    assert "+ 1 unknown match" in out
+    assert "+ 1 unknown matches" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_emits_unknown_matches_line_plural(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """2+ unknown segments -> ``+ N unknown matches`` plural form (#433)."""
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 3
+            stats["pass1_elapsed_s"] = 5.0
+            stats["pass2_regions"] = 5
+            stats["pass2_elapsed_s"] = 1.0
+            stats["filter_candidates"] = 5
+            stats["filter_drops"] = {
+                "below_min_match_duration": 0,
+                "other": 0,
+            }
+            stats["filter_unknown"] = 2
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=300.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    assert "+ 2 unknown matches" in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_omits_unknown_line_when_zero(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """filter_unknown == 0 -> no unknown line (terse output, #433)."""
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 3
+            stats["pass1_elapsed_s"] = 5.0
+            stats["pass2_regions"] = 3
+            stats["pass2_elapsed_s"] = 1.0
+            stats["filter_candidates"] = 3
+            stats["filter_drops"] = {
+                "below_min_match_duration": 0,
+                "other": 0,
+            }
+            stats["filter_unknown"] = 0
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=300.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    assert "unknown match" not in out
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_unknown_line_absent_when_stat_missing(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Legacy stats without filter_unknown render without unknown line (#433).
+
+    Backwards-compat: older detect fixtures may not populate the new key
+    (the verbose Filter section was added in #388, this counter in #433).
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def populate_stats(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats["mode"] = "CPU"
+            stats["pass1_samples"] = 100
+            stats["pass1_blackout_frames"] = 3
+            stats["pass1_elapsed_s"] = 5.0
+            stats["pass2_regions"] = 3
+            stats["pass2_elapsed_s"] = 1.0
+            stats["filter_candidates"] = 3
+            stats["filter_drops"] = {
+                "below_min_match_duration": 0,
+                "other": 0,
+            }
+            # intentionally NOT setting filter_unknown
+        return BOUNDARIES
+
+    mock_detect.side_effect = populate_stats
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=300.0)
+
+    run_split(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+
+    assert "unknown match" not in out
+
+
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")


### PR DESCRIPTION
## Summary

verbose dry-run で `Filter: 8 candidates -> 7 matches` の直下に Detected が `8 match(es)` を返し、ユーザーが Filter / Detected の数字の差分を計算ミスと誤認していた問題を修正 (#433)。Filter 行直下に `+ N unknown match (録画途中試合)` を追加し、Detected = kept + unknown の整合を可視化する。

## 受け入れ基準 (#433)

- [x] Filter 内訳と Detected 数が整合する表示になっている
  - 実機検証相当: `verbose=True` + `filter_unknown=1` の `_print_detection_stats` 経路で `Filter: 8 candidates -> 7 matches` + `+ 1 unknown match (録画途中試合)` が emit され Detected `8 match(es)` と整合 (test `test_verbose_emits_unknown_match_line_singular`)
- [x] unknown 試合の bypass 挙動がユーザーにわかる形になっている
  - `(録画途中試合)` ラベル付きで before-first / after-last 経路の unknown を明示

## 採用方針: 案 c (unknown を別行で扱う)

AskUserQuestion で確定。Filter 行は現状維持 (`8 candidates -> 7 matches`) のまま、その直下に `+ N unknown match (録画途中試合)` を追加する非破壊アプローチ。L1 タクソノミー上 unknown を「録画途中試合 = fl_match と別 class」として位置づける明示的な表現。

## 変更ファイル

- `allaganeye/video/detector.py`:
  - `DetectionStats` TypedDict に `filter_unknown: int` を追加
  - `_filter_and_extract_segments` 内に `_finalize` ヘルパを追加し、全 return 経路で `stats["filter_unknown"] = sum(1 for s in segments if s["type"] == "unknown")` を populate
- `allaganeye/commands/split_matches.py`:
  - `_print_detection_stats` で Filter 内訳の直下に `+ N unknown match (録画途中試合)` を emit
  - 1 件のとき `match` / 2+ 件のとき `matches` の単複切替
  - 0 件 / stat 未設定経路では行を抑制 (backwards-compat)
- `tests/test_detector.py`: `TestFilterUnknownStats` 新設 (5 件)
- `tests/test_split_matches.py`: 4 件追加 (singular / plural / 0 件 / 未設定)

## 新規テスト内訳 (9 件)

- detector 5 件: 全 fl_match (`filter_unknown=0`) / before-first edge unknown / whole-video fallback / empty drop path / stats=None backwards-compat
- split_matches 4 件: singular emit (1 件 → "match") / plural emit (2 件 → "matches") / 0 件で行抑制 / stat 未設定 backwards-compat

## Test plan

- [x] `python -m ruff check .` pass
- [x] `python -m ruff format --check .` pass
- [x] `python -m pyright allaganeye/video/detector.py allaganeye/commands/split_matches.py tests/test_detector.py tests/test_split_matches.py` pass
- [x] `python -m pytest` 850 passed / 1 skipped / 37 deselected (slow) — 既存 841 から 9 増、回帰なし

## Refs

- Refs #433
- 関連: #388 (Filter drop 内訳追加、本 PR の上に乗る) / #382 (Match 一覧の `[unknown]` マーカー、本 PR と統一表現)

## Note

- `Closes` / `Fixes` / `Resolves` キーワードは使用していません (Iron Law 4 / `docs/l2-workflow.md`)。マージ後 `/close-issue 433` で受け入れ条件を実測再検証してから手動 close します。
