### PR TITLE
feat(gui): DropScreen 詳細設定パネル (3 検知パラメータ調整 UI) を追加 (Refs #613)

### DIFF
--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -71,10 +71,12 @@ stateDiagram-v2
 - `drop_idle` 初期 — [参照...] と D&D エリア表示
 - `drop_selecting` file dialog 起動中 (`@tauri-apps/plugin-dialog.open`)
 - `drop_probing` ffprobe 実行中 (Phase 2 は dummy)
-- `drop_selected` 成功 — ファイル情報 + [OK]/[キャンセル]
+- `drop_selected` 成功 — ファイル情報 + 詳細設定パネル ([DetectionParamsPanel](../gui/src/screens/DetectionParamsPanel.tsx)、collapsible、#613) + [OK]/[キャンセル]
 - `drop_probeError` 失敗 — error + [再試行]
 
 Phase 3 での差し替え: `dummyProbeVideo(path)` → Rust `invoke('probe_video', { path })`。
+
+詳細設定パネル (#613) で調整した値は `appStateStore.detectionParams` に保持され、`[OK]` 後の `DetectingScreen` 起動時に `toStartDetectParams` ([utils/detection.ts](../gui/src/utils/detection.ts)) で Rust `start_detect` (#569) の `params` 引数に変換されて渡る。reset() でデフォルト復帰、永続化なし (in-memory のみ)。
 
 ### detecting (Phase 2 は dummy)
 
@@ -214,7 +216,7 @@ Windows title bar に一本化。`tauri.conf.json` の `title: "Allagan Eye"` �
 表示される)。
 
 state/
-├── appStateStore.ts  — screen + selectedMatchIndex + selectedVideoPath
+├── appStateStore.ts  — screen + selectedMatchIndex + selectedVideoPath + detectionParams (#613)
 └── metadataStore.ts  — metadata + dirty + apply / restore / loadSample
 
 screens/reducers/

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -231,6 +231,8 @@
 
 **目的**: `start_detect` (#569) に渡す検知パラメータを GUI 上で調整。値は `appStateStore.detectionParams` に保存され、`reset()` まで session 中保持される (localStorage 永続化なし、再起動時は default に戻る)。
 
+**スコープ (3 パラメータ)**: `blackout_threshold` / `workers` / `gpu`。`--no-audio` は audio module frozen (#327、`split_matches.py:525`) のため UI 不公開、#327 解凍後に再追加する。
+
 | 項目 | 内容 |
 |---|---|
 | 種類 | collapsible panel (`<button aria-expanded={open} aria-controls={bodyId}>` header + 折り畳まれた body の `<div id={bodyId}>`) |
@@ -269,17 +271,7 @@
 | store mutation | `appStateStore.detectionParams.workers` |
 | 例外 / edge case | `0` は UI 上の auto sentinel。`toStartDetectParams` で `workers: 0` → `null` に変換され、Rust 側 `DetectParams.workers: None` で `--workers` flag が省略される ([detection.ts:23-29](../gui/src/utils/detection.ts#L23)) |
 
-##### §2.1.10.4 音声解析 toggle (noAudio)
-
-| 項目 | 内容 |
-|---|---|
-| 種類 | `<input type="checkbox">` + label (チェックは「音声有効」、chk=true → noAudio=false) |
-| 状態 | `default 有効` (noAudio=false、checked) / `無効 (--no-audio)` (noAudio=true、unchecked) |
-| 遷移トリガー | `onChange` → `setDetectionParams({ noAudio: !checked })` |
-| store mutation | `appStateStore.detectionParams.noAudio` |
-| 例外 / edge case | UI label は「音声解析」(英語 noAudio の二重否定を避けるため、checkbox=有効/無効 の自然な意味付け)。`noAudio: true` のときのみ Rust 側で `--no-audio` flag が emit される |
-
-##### §2.1.10.5 GPU tri-state 選択 (gpu)
+##### §2.1.10.4 GPU tri-state 選択 (gpu)
 
 | 項目 | 内容 |
 |---|---|
@@ -289,7 +281,7 @@
 | store mutation | `appStateStore.detectionParams.gpu` |
 | 例外 / edge case | radiogroup pattern (`aria-checked` で active state を表現)。Rust 側 `DetectParams.gpu` が 3 値 `Option<bool>` を解釈し排他 flag に変換 |
 
-##### §2.1.10.6 [リセット] button
+##### §2.1.10.5 [リセット] button
 
 | 項目 | 内容 |
 |---|---|
@@ -297,16 +289,17 @@
 | 状態 | params == default のとき `disabled` (押下不可) / それ以外で active |
 | 遷移トリガー | `onClick` → `resetDetectionParams()` (全 4 フィールドを `DEFAULT_DETECTION_PARAMS` に戻す) |
 | store mutation | `appStateStore.detectionParams` 全体を default に上書き (`selectedVideoPath` など他の state は触らない) |
-| 例外 / edge case | disabled 判定は `isDetectionParamsModified` ([utils/detection.ts:34-41](../gui/src/utils/detection.ts#L34)) が四フィールドを default と等値判定で行う。`aria-label` に default 値を含める (例: `"reset to defaults (blackout 15, workers auto, audio enabled, gpu auto)"`) |
+| 例外 / edge case | disabled 判定は `isDetectionParamsModified` ([utils/detection.ts](../gui/src/utils/detection.ts)) が三フィールドを default と等値判定で行う。`aria-label` に default 値を含める (例: `"reset to defaults (blackout 15, workers auto, gpu auto)"`) |
 
-##### §2.1.10.7 styling / a11y / Tab order
+##### §2.1.10.6 styling / a11y / Tab order
 
 - styling: 既存 ExportScreen の field/value pattern (`fieldLabel` + 入力要素) と同系統。色は token (`var(--ae-gold-dim)` / `var(--ae-cyan)` / `var(--ae-text)`) を再利用、新規追加なし
 - a11y:
   - header: `aria-expanded` / `aria-controls` で expand 状態を AT に通知
   - 各 input: `<label htmlFor>` (slider / numeric / toggle) で関連付け、tri-state は `aria-label="gpu mode"` + `role="radio"`
   - リセット button: `aria-label` で disabled 理由 (default 値) を明示
-- Tab order: header toggle → (展開時) blackout slider → workers numeric → audio toggle → gpu (auto/on/off の 3 button) → reset button → SelectedCard `[キャンセル]` → `[OK]`。drop flow 全体で natural forward tab を保つ
+- Tab order: header toggle → (展開時) blackout slider → workers numeric → gpu (auto/on/off の 3 button) → reset button → SelectedCard `[キャンセル]` → `[OK]`。drop flow 全体で natural forward tab を保つ
+- **`--no-audio` UI 不採用**: `allaganeye/commands/split_matches.py:525` で audio module は frozen 状態 (#327) のため `--no-audio` flag は実質 no-op。GUI 側でのみ控え (Rust `DetectParams.no_audio` field 自体は #569 で実装済み、#327 解凍時に再公開)
 
 ### §2.2 detecting
 

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -101,7 +101,7 @@
 
 | 節 | 画面 | 主要 UI 部品 | 進捗 |
 |---|---|---|---|
-| §2.1 | drop | D&D zone / [参照…] / 直近録画リスト / SelectedCard / probeError card | #598 で追加 |
+| §2.1 | drop | D&D zone / [参照…] / 直近録画リスト / SelectedCard (詳細設定パネル含む、#613) / probeError card | #598 で追加 |
 | §2.2 | detecting | AllaganSigil 回転 / Header / progressBadge / PhaseRow ×2 / live log / [中断] | #600 で追加 |
 | §2.3 | complete | statusDot / sourceBox / stats / [元に戻す] / [境界を調整] / [全試合書き出し] / [× 閉じる] / BrightnessTimeline / listItem / previewPane / emptyNote | #603 で追加 |
 | §2.4 | preview | [◀ 一覧へ] / match name input / type select / Pane (×2 IN/OUT) / Pane.video / Pane.tcInput / stepRow ×6 / keyHint / FrameStrip / [適用] / dirty indicator / applyError / [元に戻す] / [書き出し] / emptyNote | #605 で追加 |
@@ -224,6 +224,89 @@
 | 遷移トリガー | `onClick` → `pickAndProbe()` → reducer `BROWSE_CLICKED` (phase=`probeError → selecting`) |
 | store mutation | なし (probe 成功時の流れは §2.1.2 と同じ) |
 | 例外 / edge case | 連続失敗時も常に [閉じる] で `idle` に戻れる。`pickAndProbe()` 内で `setError(null)` するので前回 error は消える |
+
+#### §2.1.10 詳細設定パネル (DetectionParamsPanel、SelectedCard 内)
+
+[#613](https://github.com/Idios/kobutachan-allaganeye/issues/613) で追加。SelectedCard (phase=`selected`) の meta 表 と `[OK]/[キャンセル]` actions の間に collapsible で配置 ([DetectionParamsPanel.tsx](../gui/src/screens/DetectionParamsPanel.tsx))。
+
+**目的**: `start_detect` (#569) に渡す検知パラメータを GUI 上で調整。値は `appStateStore.detectionParams` に保存され、`reset()` まで session 中保持される (localStorage 永続化なし、再起動時は default に戻る)。
+
+| 項目 | 内容 |
+|---|---|
+| 種類 | collapsible panel (`<button aria-expanded={open} aria-controls={bodyId}>` header + 折り畳まれた body の `<div id={bodyId}>`) |
+| 状態 | `collapsed` (default、初期表示) / `expanded` (header click で toggle) |
+| 遷移トリガー | header `onClick` → local `setOpen` で toggle (store には影響なし) |
+| store mutation | 各 control が `setDetectionParams({...})` で patch、`[リセット]` で `resetDetectionParams()` |
+| 例外 / edge case | collapsed 時に default 以外の値があれば header 横に「(変更あり)」 hint を表示。`reset()` (アプリ全体の reset) からも default に戻る |
+
+##### §2.1.10.1 [▶ 詳細設定] / [▼ 詳細設定] header toggle
+
+| 項目 | 内容 |
+|---|---|
+| 種類 | button (`aria-expanded` / `aria-controls` 属性付き) |
+| 状態 | `collapsed` (▶) / `expanded` (▼) |
+| 遷移トリガー | `onClick` → local `setOpen((v) => !v)` |
+| store mutation | なし |
+| 例外 / edge case | collapsed + 値が default と異なる場合のみ `(変更あり)` chip を表示 (`<span aria-label="変更あり">`) |
+
+##### §2.1.10.2 検知しきい値 slider (blackoutThreshold)
+
+| 項目 | 内容 |
+|---|---|
+| 種類 | `<input type="range" min={0} max={50} step={1}>` + 値表示 |
+| 状態 | 0-50 (CLI 仕様は 0-255 だが UI では実用域 0-50 に絞る、default 15) |
+| 遷移トリガー | `onChange` → `setDetectionParams({ blackoutThreshold: number })` |
+| store mutation | `appStateStore.detectionParams.blackoutThreshold` |
+| 例外 / edge case | スライダ値はそのまま `start_detect` の `params.blackoutThreshold` として渡る (default 値 15 でも CLI は `--blackout-threshold 15` flag を構築する。実害なし) |
+
+##### §2.1.10.3 ワーカー数 numeric input (workers)
+
+| 項目 | 内容 |
+|---|---|
+| 種類 | `<input type="number" min={0} max={32} step={1}>` + `(自動)` hint (workers===0 のみ) |
+| 状態 | 0 (auto) / 1-32 (explicit) |
+| 遷移トリガー | `onChange` → `setDetectionParams({ workers: number })` (`Number.isFinite` ガード付き) |
+| store mutation | `appStateStore.detectionParams.workers` |
+| 例外 / edge case | `0` は UI 上の auto sentinel。`toStartDetectParams` で `workers: 0` → `null` に変換され、Rust 側 `DetectParams.workers: None` で `--workers` flag が省略される ([detection.ts:23-29](../gui/src/utils/detection.ts#L23)) |
+
+##### §2.1.10.4 音声解析 toggle (noAudio)
+
+| 項目 | 内容 |
+|---|---|
+| 種類 | `<input type="checkbox">` + label (チェックは「音声有効」、chk=true → noAudio=false) |
+| 状態 | `default 有効` (noAudio=false、checked) / `無効 (--no-audio)` (noAudio=true、unchecked) |
+| 遷移トリガー | `onChange` → `setDetectionParams({ noAudio: !checked })` |
+| store mutation | `appStateStore.detectionParams.noAudio` |
+| 例外 / edge case | UI label は「音声解析」(英語 noAudio の二重否定を避けるため、checkbox=有効/無効 の自然な意味付け)。`noAudio: true` のときのみ Rust 側で `--no-audio` flag が emit される |
+
+##### §2.1.10.5 GPU tri-state 選択 (gpu)
+
+| 項目 | 内容 |
+|---|---|
+| 種類 | button group (`role="radiogroup"` + 3 つの `role="radio"`) |
+| 状態 | `自動` (gpu=null、CLI omit) / `ON` (gpu=true、`--gpu`) / `OFF` (gpu=false、`--no-gpu`) |
+| 遷移トリガー | 各 button `onClick` → `setDetectionParams({ gpu: null \| true \| false })` |
+| store mutation | `appStateStore.detectionParams.gpu` |
+| 例外 / edge case | radiogroup pattern (`aria-checked` で active state を表現)。Rust 側 `DetectParams.gpu` が 3 値 `Option<bool>` を解釈し排他 flag に変換 |
+
+##### §2.1.10.6 [リセット] button
+
+| 項目 | 内容 |
+|---|---|
+| 種類 | button (panel body 末尾、右寄せ) |
+| 状態 | params == default のとき `disabled` (押下不可) / それ以外で active |
+| 遷移トリガー | `onClick` → `resetDetectionParams()` (全 4 フィールドを `DEFAULT_DETECTION_PARAMS` に戻す) |
+| store mutation | `appStateStore.detectionParams` 全体を default に上書き (`selectedVideoPath` など他の state は触らない) |
+| 例外 / edge case | disabled 判定は `isDetectionParamsModified` ([utils/detection.ts:34-41](../gui/src/utils/detection.ts#L34)) が四フィールドを default と等値判定で行う。`aria-label` に default 値を含める (例: `"reset to defaults (blackout 15, workers auto, audio enabled, gpu auto)"`) |
+
+##### §2.1.10.7 styling / a11y / Tab order
+
+- styling: 既存 ExportScreen の field/value pattern (`fieldLabel` + 入力要素) と同系統。色は token (`var(--ae-gold-dim)` / `var(--ae-cyan)` / `var(--ae-text)`) を再利用、新規追加なし
+- a11y:
+  - header: `aria-expanded` / `aria-controls` で expand 状態を AT に通知
+  - 各 input: `<label htmlFor>` (slider / numeric / toggle) で関連付け、tri-state は `aria-label="gpu mode"` + `role="radio"`
+  - リセット button: `aria-label` で disabled 理由 (default 値) を明示
+- Tab order: header toggle → (展開時) blackout slider → workers numeric → audio toggle → gpu (auto/on/off の 3 button) → reset button → SelectedCard `[キャンセル]` → `[OK]`。drop flow 全体で natural forward tab を保つ
 
 ### §2.2 detecting
 

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -287,7 +287,7 @@
 |---|---|
 | 種類 | button (panel body 末尾、右寄せ) |
 | 状態 | params == default のとき `disabled` (押下不可) / それ以外で active |
-| 遷移トリガー | `onClick` → `resetDetectionParams()` (全 4 フィールドを `DEFAULT_DETECTION_PARAMS` に戻す) |
+| 遷移トリガー | `onClick` → `resetDetectionParams()` (全 3 フィールドを `DEFAULT_DETECTION_PARAMS` に戻す) |
 | store mutation | `appStateStore.detectionParams` 全体を default に上書き (`selectedVideoPath` など他の state は触らない) |
 | 例外 / edge case | disabled 判定は `isDetectionParamsModified` ([utils/detection.ts](../gui/src/utils/detection.ts)) が三フィールドを default と等値判定で行う。`aria-label` に default 値を含める (例: `"reset to defaults (blackout 15, workers auto, gpu auto)"`) |
 
@@ -296,7 +296,7 @@
 - styling: 既存 ExportScreen の field/value pattern (`fieldLabel` + 入力要素) と同系統。色は token (`var(--ae-gold-dim)` / `var(--ae-cyan)` / `var(--ae-text)`) を再利用、新規追加なし
 - a11y:
   - header: `aria-expanded` / `aria-controls` で expand 状態を AT に通知
-  - 各 input: `<label htmlFor>` (slider / numeric / toggle) で関連付け、tri-state は `aria-label="gpu mode"` + `role="radio"`
+  - 各 input: `<label htmlFor>` (slider / numeric) で関連付け、tri-state は `aria-label="gpu mode"` + `role="radio"`
   - リセット button: `aria-label` で disabled 理由 (default 値) を明示
 - Tab order: header toggle → (展開時) blackout slider → workers numeric → gpu (auto/on/off の 3 button) → reset button → SelectedCard `[キャンセル]` → `[OK]`。drop flow 全体で natural forward tab を保つ
 - **`--no-audio` UI 不採用**: `allaganeye/commands/split_matches.py:525` で audio module は frozen 状態 (#327) のため `--no-audio` flag は実質 no-op。GUI 側でのみ控え (Rust `DetectParams.no_audio` field 自体は #569 で実装済み、#327 解凍時に再公開)

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -148,7 +148,6 @@ describe('DetectingScreen', () => {
     useAppStateStore.getState().setDetectionParams({
       blackoutThreshold: 22,
       workers: 8,
-      noAudio: true,
       gpu: false,
     });
     render(<DetectingScreen />);
@@ -159,7 +158,6 @@ describe('DetectingScreen', () => {
           params: {
             blackoutThreshold: 22,
             workers: 8,
-            noAudio: true,
             gpu: false,
           },
         }),

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -143,6 +143,44 @@ describe('DetectingScreen', () => {
     });
   });
 
+  // #613: detectionParams set on the drop screen are forwarded to start_detect.
+  it('forwards detectionParams from the store as start_detect params (#613)', async () => {
+    useAppStateStore.getState().setDetectionParams({
+      blackoutThreshold: 22,
+      workers: 8,
+      noAudio: true,
+      gpu: false,
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'start_detect',
+        expect.objectContaining({
+          params: {
+            blackoutThreshold: 22,
+            workers: 8,
+            noAudio: true,
+            gpu: false,
+          },
+        }),
+      );
+    });
+  });
+
+  // #613: workers=0 (auto sentinel) maps to null in the wire payload.
+  it('translates workers=0 (auto) to null in start_detect params (#613)', async () => {
+    useAppStateStore.getState().setDetectionParams({ workers: 0 });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'start_detect',
+        expect.objectContaining({
+          params: expect.objectContaining({ workers: null }),
+        }),
+      );
+    });
+  });
+
   it('subscribes to detect-progress events on mount', async () => {
     render(<DetectingScreen />);
     await waitFor(() => {

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -6,6 +6,7 @@ import { AllaganSigil } from '../components/AllaganSigil';
 import { DisabledTooltip } from '../components/DisabledTooltip';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
+import { toStartDetectParams } from '../utils/detection';
 import {
   deriveDetectOutputDir,
   metadataPathFor,
@@ -262,6 +263,7 @@ function computeEta(percent: number, elapsed: number): number | null {
 export function DetectingScreen() {
   const navigate = useAppStateStore((s) => s.navigate);
   const selectedVideoPath = useAppStateStore((s) => s.selectedVideoPath);
+  const detectionParams = useAppStateStore((s) => s.detectionParams);
   const loadMetadata = useMetadataStore((s) => s.load);
   const loadSample = useMetadataStore((s) => s.loadSample);
 
@@ -362,7 +364,7 @@ export function DetectingScreen() {
         const result = await invoke<DetectResult>('start_detect', {
           videoPath: selectedVideoPath,
           outputDir,
-          params: {},
+          params: toStartDetectParams(detectionParams),
         });
         if (cancelled) return;
 

--- a/gui/src/screens/DetectionParamsPanel.module.css
+++ b/gui/src/screens/DetectionParamsPanel.module.css
@@ -1,0 +1,228 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px solid rgba(var(--ae-gold-rgb), 0.18);
+  padding-top: 10px;
+  margin-top: 4px;
+}
+
+.panelHeaderToggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  padding: 4px 0;
+  margin: 0;
+  cursor: pointer;
+  font-family: var(--ae-font-ui);
+  font-size: 10px;
+  letter-spacing: 3px;
+  color: var(--ae-gold-dim);
+  text-transform: uppercase;
+  text-align: left;
+}
+
+.panelHeaderToggle:hover,
+.panelHeaderToggle:focus-visible {
+  color: var(--ae-gold);
+  outline: none;
+}
+
+.panelHeaderChevron {
+  display: inline-block;
+  width: 10px;
+  font-family: var(--ae-font-mono);
+  color: var(--ae-gold-dim);
+}
+
+.panelHeaderToggle:hover .panelHeaderChevron,
+.panelHeaderToggle:focus-visible .panelHeaderChevron {
+  color: var(--ae-gold);
+}
+
+.panelHeaderModified {
+  font-family: var(--ae-font-mono);
+  font-size: 10px;
+  color: var(--ae-cyan);
+  margin-left: 6px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.panelBody {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  column-gap: 12px;
+  row-gap: 10px;
+  align-items: center;
+  padding: 6px 4px 0 4px;
+}
+
+.fieldLabel {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  color: var(--ae-text-dim);
+  text-align: right;
+}
+
+.sliderRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.slider {
+  flex: 1;
+  appearance: none;
+  height: 2px;
+  background: rgba(var(--ae-gold-rgb), 0.3);
+  border: none;
+  cursor: pointer;
+  margin: 0;
+}
+
+.slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  background: var(--ae-gold);
+  border: 1px solid var(--ae-gold-bright);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  background: var(--ae-gold);
+  border: 1px solid var(--ae-gold-bright);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.slider:focus-visible {
+  outline: 1px solid var(--ae-cyan);
+  outline-offset: 4px;
+}
+
+.sliderValue {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  color: var(--ae-text);
+  width: 38px;
+  text-align: right;
+}
+
+.numericRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.numericInput {
+  width: 60px;
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  color: var(--ae-text);
+  background: var(--ae-bg-deep);
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.3);
+  padding: 3px 6px;
+  outline: none;
+}
+
+.numericInput:focus-visible {
+  border-color: var(--ae-cyan);
+}
+
+.numericHint {
+  font-family: var(--ae-font-mono);
+  font-size: 10px;
+  color: var(--ae-text-dim);
+}
+
+.toggleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.toggle {
+  appearance: auto;
+  cursor: pointer;
+  margin: 0;
+  accent-color: var(--ae-gold);
+}
+
+.toggleLabel {
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  color: var(--ae-text);
+}
+
+.triStateRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.triStateButton {
+  font-family: var(--ae-font-ui);
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  color: var(--ae-gold-dim);
+  background: transparent;
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.3);
+  padding: 4px 10px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.triStateButton:hover,
+.triStateButton:focus-visible {
+  color: var(--ae-gold);
+  border-color: var(--ae-gold);
+  outline: none;
+}
+
+.triStateButtonActive {
+  color: var(--ae-bg);
+  background: linear-gradient(180deg, var(--ae-gold), var(--ae-gold-dim));
+  border-color: var(--ae-gold);
+}
+
+.triStateButtonActive:hover,
+.triStateButtonActive:focus-visible {
+  color: var(--ae-bg);
+}
+
+.resetRow {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.resetButton {
+  font-family: var(--ae-font-ui);
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: var(--ae-gold);
+  background: transparent;
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.33);
+  padding: 6px 14px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.resetButton:hover,
+.resetButton:focus-visible {
+  color: var(--ae-gold-bright);
+  border-color: var(--ae-gold-bright);
+  outline: none;
+}
+
+.resetButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}

--- a/gui/src/screens/DetectionParamsPanel.test.tsx
+++ b/gui/src/screens/DetectionParamsPanel.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DETECTION_PARAMS,
+  useAppStateStore,
+} from '../state/appStateStore';
+import { DetectionParamsPanel } from './DetectionParamsPanel';
+
+beforeEach(() => {
+  useAppStateStore.getState().reset();
+});
+
+describe('DetectionParamsPanel (#613)', () => {
+  it('starts collapsed: body is not rendered', () => {
+    render(<DetectionParamsPanel />);
+    const toggle = screen.getByTestId('detection-params-toggle');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('detection-params-body')).toBeNull();
+  });
+
+  it('expands when the header toggle is clicked', async () => {
+    render(<DetectionParamsPanel />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('detection-params-toggle'));
+    expect(screen.getByTestId('detection-params-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByTestId('detection-params-body')).toBeInTheDocument();
+  });
+
+  it('collapses again on a second click', async () => {
+    render(<DetectionParamsPanel />);
+    const user = userEvent.setup();
+    const toggle = screen.getByTestId('detection-params-toggle');
+    await user.click(toggle);
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('detection-params-body')).toBeNull();
+  });
+
+  it('shows a "(変更あり)" hint while collapsed when params differ from defaults', async () => {
+    useAppStateStore.getState().setDetectionParams({ gpu: false });
+    render(<DetectionParamsPanel />);
+    expect(screen.getByLabelText('変更あり')).toBeInTheDocument();
+  });
+
+  it('blackout slider mutates the store and reflects in the value display', async () => {
+    render(<DetectionParamsPanel />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('detection-params-toggle'));
+    const slider = screen.getByTestId(
+      'detection-params-blackout',
+    ) as HTMLInputElement;
+    // jsdom does not interpret arrow keys on type=range as value changes,
+    // so drive the change handler directly via fireEvent (the canonical
+    // pattern for range inputs in @testing-library/react).
+    fireEvent.change(slider, { target: { value: '22' } });
+    expect(useAppStateStore.getState().detectionParams.blackoutThreshold).toBe(
+      22,
+    );
+    expect(screen.getByText('22')).toBeInTheDocument();
+  });
+
+  it('workers numeric input mutates the store', async () => {
+    render(<DetectionParamsPanel />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('detection-params-toggle'));
+    const input = screen.getByTestId(
+      'detection-params-workers',
+    ) as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, '8');
+    expect(useAppStateStore.getState().detectionParams.workers).toBe(8);
+  });
+
+  it('audio toggle (un)checks and flips the noAudio flag', async () => {
+    render(<DetectionParamsPanel />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('detection-params-toggle'));
+    // Default: audio enabled (noAudio = false), so checkbox is checked.
+    const cb = screen.getByTestId(
+      'detection-params-no-audio',
+    ) as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+    await user.click(cb);
+    expect(useAppStateStore.getState().detectionParams.noAudio).toBe(true);
+    expect(cb.checked).toBe(false);
+  });
+
+  it.each([
+    {
+      testid: 'detection-params-gpu-on',
+      expected: true as boolean | null,
+    },
+    {
+      testid: 'detection-params-gpu-off',
+      expected: false as boolean | null,
+    },
+    {
+      testid: 'detection-params-gpu-auto',
+      expected: null as boolean | null,
+    },
+  ])('GPU tri-state $testid sets gpu=$expected', async ({ testid, expected }) => {
+    render(<DetectionParamsPanel />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('detection-params-toggle'));
+    // First flip away from auto so the auto button click is observable.
+    if (expected === null) {
+      useAppStateStore.getState().setDetectionParams({ gpu: true });
+    }
+    await user.click(screen.getByTestId(testid));
+    expect(useAppStateStore.getState().detectionParams.gpu).toBe(expected);
+  });
+
+  it('reset button is disabled while params equal defaults', async () => {
+    render(<DetectionParamsPanel />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('detection-params-toggle'));
+    expect(screen.getByTestId('detection-params-reset')).toBeDisabled();
+  });
+
+  it('reset button restores defaults when clicked', async () => {
+    useAppStateStore.getState().setDetectionParams({
+      blackoutThreshold: 30,
+      workers: 8,
+      noAudio: true,
+      gpu: false,
+    });
+    render(<DetectionParamsPanel />);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('detection-params-toggle'));
+    const reset = screen.getByTestId('detection-params-reset');
+    expect(reset).not.toBeDisabled();
+    await user.click(reset);
+    expect(useAppStateStore.getState().detectionParams).toEqual(
+      DEFAULT_DETECTION_PARAMS,
+    );
+  });
+});

--- a/gui/src/screens/DetectionParamsPanel.test.tsx
+++ b/gui/src/screens/DetectionParamsPanel.test.tsx
@@ -76,20 +76,6 @@ describe('DetectionParamsPanel (#613)', () => {
     expect(useAppStateStore.getState().detectionParams.workers).toBe(8);
   });
 
-  it('audio toggle (un)checks and flips the noAudio flag', async () => {
-    render(<DetectionParamsPanel />);
-    const user = userEvent.setup();
-    await user.click(screen.getByTestId('detection-params-toggle'));
-    // Default: audio enabled (noAudio = false), so checkbox is checked.
-    const cb = screen.getByTestId(
-      'detection-params-no-audio',
-    ) as HTMLInputElement;
-    expect(cb.checked).toBe(true);
-    await user.click(cb);
-    expect(useAppStateStore.getState().detectionParams.noAudio).toBe(true);
-    expect(cb.checked).toBe(false);
-  });
-
   it.each([
     {
       testid: 'detection-params-gpu-on',
@@ -126,7 +112,6 @@ describe('DetectionParamsPanel (#613)', () => {
     useAppStateStore.getState().setDetectionParams({
       blackoutThreshold: 30,
       workers: 8,
-      noAudio: true,
       gpu: false,
     });
     render(<DetectionParamsPanel />);

--- a/gui/src/screens/DetectionParamsPanel.tsx
+++ b/gui/src/screens/DetectionParamsPanel.tsx
@@ -23,7 +23,6 @@ export function DetectionParamsPanel() {
   const panelBodyId = useId();
   const blackoutId = useId();
   const workersId = useId();
-  const noAudioId = useId();
 
   const modified = isDetectionParamsModified(detectionParams);
 
@@ -105,26 +104,6 @@ export function DetectionParamsPanel() {
             </span>
           </div>
 
-          <span className={styles.fieldLabel}>音声解析</span>
-          <div className={styles.toggleRow}>
-            <input
-              id={noAudioId}
-              type="checkbox"
-              checked={!detectionParams.noAudio}
-              onChange={(e) =>
-                setDetectionParams({ noAudio: !e.target.checked })
-              }
-              className={styles.toggle}
-              aria-label="audio enabled"
-              data-testid="detection-params-no-audio"
-            />
-            <label htmlFor={noAudioId} className={styles.toggleLabel}>
-              {detectionParams.noAudio
-                ? '無効 (--no-audio)'
-                : '有効 (default)'}
-            </label>
-          </div>
-
           <span className={styles.fieldLabel}>GPU</span>
           <div
             className={styles.triStateRow}
@@ -170,7 +149,7 @@ export function DetectionParamsPanel() {
               className={styles.resetButton}
               onClick={resetDetectionParams}
               disabled={!modified}
-              aria-label={`reset to defaults (blackout ${DEFAULT_DETECTION_PARAMS.blackoutThreshold}, workers auto, audio enabled, gpu auto)`}
+              aria-label={`reset to defaults (blackout ${DEFAULT_DETECTION_PARAMS.blackoutThreshold}, workers auto, gpu auto)`}
               data-testid="detection-params-reset"
             >
               リセット

--- a/gui/src/screens/DetectionParamsPanel.tsx
+++ b/gui/src/screens/DetectionParamsPanel.tsx
@@ -1,0 +1,183 @@
+import { useId, useState } from 'react';
+
+import {
+  DEFAULT_DETECTION_PARAMS,
+  useAppStateStore,
+} from '../state/appStateStore';
+import { isDetectionParamsModified } from '../utils/detection';
+import styles from './DetectionParamsPanel.module.css';
+
+/**
+ * #613: 詳細設定パネル — DropScreen の SelectedCard 内に collapsible で
+ * 配置され、`detectionParams` (appStateStore) を直接 mutate する。
+ *
+ * Default は折り畳み (panelOpen=false)。展開時に 4 controls + [リセット]
+ * を表示する。各 control の挙動は `docs/ui-interaction-spec.md` §2.1.10。
+ */
+export function DetectionParamsPanel() {
+  const detectionParams = useAppStateStore((s) => s.detectionParams);
+  const setDetectionParams = useAppStateStore((s) => s.setDetectionParams);
+  const resetDetectionParams = useAppStateStore((s) => s.resetDetectionParams);
+
+  const [open, setOpen] = useState(false);
+  const panelBodyId = useId();
+  const blackoutId = useId();
+  const workersId = useId();
+  const noAudioId = useId();
+
+  const modified = isDetectionParamsModified(detectionParams);
+
+  return (
+    <div className={styles.panel} data-testid="detection-params-panel">
+      <button
+        type="button"
+        className={styles.panelHeaderToggle}
+        aria-expanded={open}
+        aria-controls={panelBodyId}
+        onClick={() => setOpen((v) => !v)}
+        data-testid="detection-params-toggle"
+      >
+        <span className={styles.panelHeaderChevron} aria-hidden>
+          {open ? '▼' : '▶'}
+        </span>
+        詳細設定
+        {!open && modified && (
+          <span className={styles.panelHeaderModified} aria-label="変更あり">
+            (変更あり)
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          id={panelBodyId}
+          className={styles.panelBody}
+          data-testid="detection-params-body"
+        >
+          <label htmlFor={blackoutId} className={styles.fieldLabel}>
+            検知しきい値
+          </label>
+          <div className={styles.sliderRow}>
+            <input
+              id={blackoutId}
+              type="range"
+              min={0}
+              max={50}
+              step={1}
+              value={detectionParams.blackoutThreshold}
+              onChange={(e) =>
+                setDetectionParams({
+                  blackoutThreshold: Number.parseFloat(e.target.value),
+                })
+              }
+              className={styles.slider}
+              aria-label="blackout threshold"
+              data-testid="detection-params-blackout"
+            />
+            <span className={styles.sliderValue}>
+              {detectionParams.blackoutThreshold.toFixed(0)}
+            </span>
+          </div>
+
+          <label htmlFor={workersId} className={styles.fieldLabel}>
+            ワーカー数
+          </label>
+          <div className={styles.numericRow}>
+            <input
+              id={workersId}
+              type="number"
+              min={0}
+              max={32}
+              step={1}
+              value={detectionParams.workers}
+              onChange={(e) => {
+                const n = Number.parseInt(e.target.value, 10);
+                setDetectionParams({
+                  workers: Number.isFinite(n) && n >= 0 ? n : 0,
+                });
+              }}
+              className={styles.numericInput}
+              aria-label="workers"
+              data-testid="detection-params-workers"
+            />
+            <span className={styles.numericHint}>
+              {detectionParams.workers === 0 ? '(自動)' : ''}
+            </span>
+          </div>
+
+          <span className={styles.fieldLabel}>音声解析</span>
+          <div className={styles.toggleRow}>
+            <input
+              id={noAudioId}
+              type="checkbox"
+              checked={!detectionParams.noAudio}
+              onChange={(e) =>
+                setDetectionParams({ noAudio: !e.target.checked })
+              }
+              className={styles.toggle}
+              aria-label="audio enabled"
+              data-testid="detection-params-no-audio"
+            />
+            <label htmlFor={noAudioId} className={styles.toggleLabel}>
+              {detectionParams.noAudio
+                ? '無効 (--no-audio)'
+                : '有効 (default)'}
+            </label>
+          </div>
+
+          <span className={styles.fieldLabel}>GPU</span>
+          <div
+            className={styles.triStateRow}
+            role="radiogroup"
+            aria-label="gpu mode"
+            data-testid="detection-params-gpu"
+          >
+            <button
+              type="button"
+              className={`${styles.triStateButton}${detectionParams.gpu === null ? ` ${styles.triStateButtonActive}` : ''}`}
+              role="radio"
+              aria-checked={detectionParams.gpu === null}
+              onClick={() => setDetectionParams({ gpu: null })}
+              data-testid="detection-params-gpu-auto"
+            >
+              自動
+            </button>
+            <button
+              type="button"
+              className={`${styles.triStateButton}${detectionParams.gpu === true ? ` ${styles.triStateButtonActive}` : ''}`}
+              role="radio"
+              aria-checked={detectionParams.gpu === true}
+              onClick={() => setDetectionParams({ gpu: true })}
+              data-testid="detection-params-gpu-on"
+            >
+              ON
+            </button>
+            <button
+              type="button"
+              className={`${styles.triStateButton}${detectionParams.gpu === false ? ` ${styles.triStateButtonActive}` : ''}`}
+              role="radio"
+              aria-checked={detectionParams.gpu === false}
+              onClick={() => setDetectionParams({ gpu: false })}
+              data-testid="detection-params-gpu-off"
+            >
+              OFF
+            </button>
+          </div>
+
+          <div className={styles.resetRow}>
+            <button
+              type="button"
+              className={styles.resetButton}
+              onClick={resetDetectionParams}
+              disabled={!modified}
+              aria-label={`reset to defaults (blackout ${DEFAULT_DETECTION_PARAMS.blackoutThreshold}, workers auto, audio enabled, gpu auto)`}
+              data-testid="detection-params-reset"
+            >
+              リセット
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gui/src/screens/DropScreen.tsx
+++ b/gui/src/screens/DropScreen.tsx
@@ -10,6 +10,7 @@ import { LoadingSpinner } from '../components/LoadingSpinner';
 import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useAppStateStore } from '../state/appStateStore';
+import { DetectionParamsPanel } from './DetectionParamsPanel';
 import { dropReducer } from './reducers/drop';
 import type { DropPhase, VideoProbeInfo } from './types';
 import styles from './DropScreen.module.css';
@@ -376,6 +377,7 @@ function SelectedCard({ info, onConfirm, onCancel }: SelectedCardProps) {
         <span className={styles.selectedMetaLabel}>コーデック</span>
         <span>{info.codec}</span>
       </div>
+      <DetectionParamsPanel />
       <div className={styles.actions}>
         <button type="button" className={styles.cancelButton} onClick={onCancel}>
           キャンセル

--- a/gui/src/state/appStateStore.test.ts
+++ b/gui/src/state/appStateStore.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { useAppStateStore } from './appStateStore';
+import { DEFAULT_DETECTION_PARAMS, useAppStateStore } from './appStateStore';
 
 beforeEach(() => {
   useAppStateStore.getState().reset();
@@ -93,5 +93,56 @@ describe('useAppStateStore.reset', () => {
     expect(state.screen).toBe('drop');
     expect(state.selectedMatchIndex).toBeNull();
     expect(state.selectedVideoPath).toBeNull();
+  });
+
+  // #613: detect parameters tuned on the drop screen reset back to defaults.
+  it('resets detectionParams back to defaults', () => {
+    useAppStateStore
+      .getState()
+      .setDetectionParams({ blackoutThreshold: 30, gpu: false });
+    useAppStateStore.getState().reset();
+    expect(useAppStateStore.getState().detectionParams).toEqual(
+      DEFAULT_DETECTION_PARAMS,
+    );
+  });
+});
+
+// #613
+describe('useAppStateStore.detectionParams', () => {
+  it('starts at the default values', () => {
+    expect(useAppStateStore.getState().detectionParams).toEqual(
+      DEFAULT_DETECTION_PARAMS,
+    );
+  });
+
+  it('setDetectionParams patches a single field without touching others', () => {
+    useAppStateStore.getState().setDetectionParams({ blackoutThreshold: 22 });
+    const dp = useAppStateStore.getState().detectionParams;
+    expect(dp.blackoutThreshold).toBe(22);
+    expect(dp.workers).toBe(DEFAULT_DETECTION_PARAMS.workers);
+    expect(dp.noAudio).toBe(DEFAULT_DETECTION_PARAMS.noAudio);
+    expect(dp.gpu).toBe(DEFAULT_DETECTION_PARAMS.gpu);
+  });
+
+  it('setDetectionParams supports multiple fields in one call', () => {
+    useAppStateStore
+      .getState()
+      .setDetectionParams({ workers: 8, noAudio: true, gpu: true });
+    const dp = useAppStateStore.getState().detectionParams;
+    expect(dp.workers).toBe(8);
+    expect(dp.noAudio).toBe(true);
+    expect(dp.gpu).toBe(true);
+  });
+
+  it('resetDetectionParams restores defaults without touching the rest of state', () => {
+    useAppStateStore.getState().setSelectedVideoPath('C:/video.mkv');
+    useAppStateStore
+      .getState()
+      .setDetectionParams({ blackoutThreshold: 30, gpu: false });
+    useAppStateStore.getState().resetDetectionParams();
+    const state = useAppStateStore.getState();
+    expect(state.detectionParams).toEqual(DEFAULT_DETECTION_PARAMS);
+    // selectedVideoPath must NOT be cleared by resetDetectionParams.
+    expect(state.selectedVideoPath).toBe('C:/video.mkv');
   });
 });

--- a/gui/src/state/appStateStore.test.ts
+++ b/gui/src/state/appStateStore.test.ts
@@ -120,17 +120,15 @@ describe('useAppStateStore.detectionParams', () => {
     const dp = useAppStateStore.getState().detectionParams;
     expect(dp.blackoutThreshold).toBe(22);
     expect(dp.workers).toBe(DEFAULT_DETECTION_PARAMS.workers);
-    expect(dp.noAudio).toBe(DEFAULT_DETECTION_PARAMS.noAudio);
     expect(dp.gpu).toBe(DEFAULT_DETECTION_PARAMS.gpu);
   });
 
   it('setDetectionParams supports multiple fields in one call', () => {
     useAppStateStore
       .getState()
-      .setDetectionParams({ workers: 8, noAudio: true, gpu: true });
+      .setDetectionParams({ workers: 8, gpu: true });
     const dp = useAppStateStore.getState().detectionParams;
     expect(dp.workers).toBe(8);
-    expect(dp.noAudio).toBe(true);
     expect(dp.gpu).toBe(true);
   });
 

--- a/gui/src/state/appStateStore.ts
+++ b/gui/src/state/appStateStore.ts
@@ -16,6 +16,37 @@ export type AppScreen =
   | 'preview'
   | 'export';
 
+/**
+ * #613: User-tunable detect parameters surfaced from the DropScreen "詳細設定"
+ * panel and forwarded to `start_detect` (Rust Tauri command, #569). All
+ * fields are optional in the sense that a value matching the default leaves
+ * the corresponding CLI flag off the argv (see `detect_command_args` in
+ * `gui/src-tauri/src/lib.rs`).
+ *
+ * Held in-memory only — `reset()` returns these to defaults; there is no
+ * localStorage persistence in #613 (deliberately deferred to a follow-up).
+ */
+export interface DetectionParams {
+  /** `--blackout-threshold {x}`. CLI default 15.0, valid range 0-255. */
+  blackoutThreshold: number;
+  /** `--workers {n}` when > 0; 0 means "auto" (omit flag, CLI picks). */
+  workers: number;
+  /** `--no-audio` when true. CLI default false (audio enabled). */
+  noAudio: boolean;
+  /**
+   * `--gpu` when `true`, `--no-gpu` when `false`, omit flag for `null` (auto
+   * — Rust side picks vendor by preference order).
+   */
+  gpu: boolean | null;
+}
+
+export const DEFAULT_DETECTION_PARAMS: DetectionParams = {
+  blackoutThreshold: 15.0,
+  workers: 0,
+  noAudio: false,
+  gpu: null,
+};
+
 export interface AppState {
   /** Currently rendered screen. */
   screen: AppScreen;
@@ -27,6 +58,11 @@ export interface AppState {
    * (#465) will implement.
    */
   selectedVideoPath: string | null;
+  /**
+   * #613: detect parameters tuned on the drop screen and forwarded to
+   * `start_detect`. In-memory only; `reset()` restores defaults.
+   */
+  detectionParams: DetectionParams;
 
   /** Switch to a different screen. */
   navigate: (screen: AppScreen) => void;
@@ -36,6 +72,10 @@ export interface AppState {
   openPreviewFor: (index: number) => void;
   /** Record / clear the in-flight video path that drop picked. */
   setSelectedVideoPath: (path: string | null) => void;
+  /** Patch one or more detect parameters. */
+  setDetectionParams: (patch: Partial<DetectionParams>) => void;
+  /** Restore detect parameters to defaults. */
+  resetDetectionParams: () => void;
   /** Reset everything back to a freshly launched state (screen = 'drop'). */
   reset: () => void;
 }
@@ -44,6 +84,7 @@ export const useAppStateStore = create<AppState>((set) => ({
   screen: 'drop',
   selectedMatchIndex: null,
   selectedVideoPath: null,
+  detectionParams: { ...DEFAULT_DETECTION_PARAMS },
 
   navigate: (screen) => set({ screen }),
   selectMatch: (selectedMatchIndex) => set({ selectedMatchIndex }),
@@ -61,10 +102,15 @@ export const useAppStateStore = create<AppState>((set) => ({
           ? null
           : stripExtendedPathPrefix(selectedVideoPath),
     }),
+  setDetectionParams: (patch) =>
+    set((s) => ({ detectionParams: { ...s.detectionParams, ...patch } })),
+  resetDetectionParams: () =>
+    set({ detectionParams: { ...DEFAULT_DETECTION_PARAMS } }),
   reset: () =>
     set({
       screen: 'drop',
       selectedMatchIndex: null,
       selectedVideoPath: null,
+      detectionParams: { ...DEFAULT_DETECTION_PARAMS },
     }),
 }));

--- a/gui/src/state/appStateStore.ts
+++ b/gui/src/state/appStateStore.ts
@@ -25,14 +25,17 @@ export type AppScreen =
  *
  * Held in-memory only — `reset()` returns these to defaults; there is no
  * localStorage persistence in #613 (deliberately deferred to a follow-up).
+ *
+ * NOTE: `--no-audio` is intentionally NOT exposed here. The audio module is
+ * frozen (`AUDIO_FROZEN` in `allaganeye/commands/split_matches.py:525`,
+ * #327), so the flag is a no-op until Fanfare scan ships. Re-add when
+ * #327 lands.
  */
 export interface DetectionParams {
   /** `--blackout-threshold {x}`. CLI default 15.0, valid range 0-255. */
   blackoutThreshold: number;
   /** `--workers {n}` when > 0; 0 means "auto" (omit flag, CLI picks). */
   workers: number;
-  /** `--no-audio` when true. CLI default false (audio enabled). */
-  noAudio: boolean;
   /**
    * `--gpu` when `true`, `--no-gpu` when `false`, omit flag for `null` (auto
    * — Rust side picks vendor by preference order).
@@ -43,7 +46,6 @@ export interface DetectionParams {
 export const DEFAULT_DETECTION_PARAMS: DetectionParams = {
   blackoutThreshold: 15.0,
   workers: 0,
-  noAudio: false,
   gpu: null,
 };
 

--- a/gui/src/utils/detection.test.ts
+++ b/gui/src/utils/detection.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DETECTION_PARAMS,
+  type DetectionParams,
+} from '../state/appStateStore';
+import { isDetectionParamsModified, toStartDetectParams } from './detection';
+
+describe('toStartDetectParams (#613)', () => {
+  it('passes blackoutThreshold through verbatim', () => {
+    const args = toStartDetectParams({
+      ...DEFAULT_DETECTION_PARAMS,
+      blackoutThreshold: 22,
+    });
+    expect(args.blackoutThreshold).toBe(22);
+  });
+
+  it('translates workers=0 (auto sentinel) to null', () => {
+    const args = toStartDetectParams({
+      ...DEFAULT_DETECTION_PARAMS,
+      workers: 0,
+    });
+    expect(args.workers).toBeNull();
+  });
+
+  it('passes workers > 0 through verbatim', () => {
+    const args = toStartDetectParams({
+      ...DEFAULT_DETECTION_PARAMS,
+      workers: 8,
+    });
+    expect(args.workers).toBe(8);
+  });
+
+  it('forwards noAudio boolean as-is', () => {
+    expect(
+      toStartDetectParams({ ...DEFAULT_DETECTION_PARAMS, noAudio: true })
+        .noAudio,
+    ).toBe(true);
+    expect(
+      toStartDetectParams({ ...DEFAULT_DETECTION_PARAMS, noAudio: false })
+        .noAudio,
+    ).toBe(false);
+  });
+
+  it.each([
+    { gpu: null as boolean | null, expected: null },
+    { gpu: true as boolean | null, expected: true },
+    { gpu: false as boolean | null, expected: false },
+  ])('forwards gpu tri-state $gpu unchanged', ({ gpu, expected }) => {
+    const args = toStartDetectParams({ ...DEFAULT_DETECTION_PARAMS, gpu });
+    expect(args.gpu).toBe(expected);
+  });
+
+  it('produces all four expected keys', () => {
+    const args = toStartDetectParams(DEFAULT_DETECTION_PARAMS);
+    expect(Object.keys(args).sort()).toEqual([
+      'blackoutThreshold',
+      'gpu',
+      'noAudio',
+      'workers',
+    ]);
+  });
+});
+
+describe('isDetectionParamsModified (#613)', () => {
+  it('returns false for the default params', () => {
+    expect(isDetectionParamsModified(DEFAULT_DETECTION_PARAMS)).toBe(false);
+  });
+
+  it.each<[string, Partial<DetectionParams>]>([
+    ['blackoutThreshold', { blackoutThreshold: 14 }],
+    ['workers', { workers: 8 }],
+    ['noAudio', { noAudio: true }],
+    ['gpu (true)', { gpu: true }],
+    ['gpu (false)', { gpu: false }],
+  ])('returns true when only %s differs', (_label, patch) => {
+    expect(
+      isDetectionParamsModified({ ...DEFAULT_DETECTION_PARAMS, ...patch }),
+    ).toBe(true);
+  });
+});

--- a/gui/src/utils/detection.test.ts
+++ b/gui/src/utils/detection.test.ts
@@ -31,17 +31,6 @@ describe('toStartDetectParams (#613)', () => {
     expect(args.workers).toBe(8);
   });
 
-  it('forwards noAudio boolean as-is', () => {
-    expect(
-      toStartDetectParams({ ...DEFAULT_DETECTION_PARAMS, noAudio: true })
-        .noAudio,
-    ).toBe(true);
-    expect(
-      toStartDetectParams({ ...DEFAULT_DETECTION_PARAMS, noAudio: false })
-        .noAudio,
-    ).toBe(false);
-  });
-
   it.each([
     { gpu: null as boolean | null, expected: null },
     { gpu: true as boolean | null, expected: true },
@@ -51,12 +40,11 @@ describe('toStartDetectParams (#613)', () => {
     expect(args.gpu).toBe(expected);
   });
 
-  it('produces all four expected keys', () => {
+  it('produces the three expected keys (noAudio omitted while audio module frozen, #327)', () => {
     const args = toStartDetectParams(DEFAULT_DETECTION_PARAMS);
     expect(Object.keys(args).sort()).toEqual([
       'blackoutThreshold',
       'gpu',
-      'noAudio',
       'workers',
     ]);
   });
@@ -70,7 +58,6 @@ describe('isDetectionParamsModified (#613)', () => {
   it.each<[string, Partial<DetectionParams>]>([
     ['blackoutThreshold', { blackoutThreshold: 14 }],
     ['workers', { workers: 8 }],
-    ['noAudio', { noAudio: true }],
     ['gpu (true)', { gpu: true }],
     ['gpu (false)', { gpu: false }],
   ])('returns true when only %s differs', (_label, patch) => {

--- a/gui/src/utils/detection.ts
+++ b/gui/src/utils/detection.ts
@@ -18,14 +18,15 @@ import {
  * - `blackoutThreshold` is always sent — the user always sees a concrete
  *   value on the slider, and the CLI default (15.0) is harmless when
  *   echoed back.
- * - `noAudio` is always sent — it is a plain boolean and the Rust side
- *   only emits `--no-audio` when `Some(true)`.
+ *
+ * NOTE: `noAudio` is intentionally not in `DetectionParams` (audio module
+ * frozen, #327 / split_matches.py:525). When #327 ships, re-add the flag
+ * here and to the panel UI.
  */
 export function toStartDetectParams(p: DetectionParams): Record<string, unknown> {
   return {
     blackoutThreshold: p.blackoutThreshold,
     workers: p.workers > 0 ? p.workers : null,
-    noAudio: p.noAudio,
     gpu: p.gpu,
   };
 }
@@ -38,7 +39,6 @@ export function isDetectionParamsModified(p: DetectionParams): boolean {
   return (
     p.blackoutThreshold !== DEFAULT_DETECTION_PARAMS.blackoutThreshold ||
     p.workers !== DEFAULT_DETECTION_PARAMS.workers ||
-    p.noAudio !== DEFAULT_DETECTION_PARAMS.noAudio ||
     p.gpu !== DEFAULT_DETECTION_PARAMS.gpu
   );
 }

--- a/gui/src/utils/detection.ts
+++ b/gui/src/utils/detection.ts
@@ -1,0 +1,44 @@
+import {
+  DEFAULT_DETECTION_PARAMS,
+  type DetectionParams,
+} from '../state/appStateStore';
+
+/**
+ * #613: Convert the DropScreen-tuned `DetectionParams` to the args object
+ * passed to the Rust `start_detect` Tauri command (#569).
+ *
+ * Rust side `DetectParams` fields are all `Option<T>` and any `None` simply
+ * leaves the corresponding `--flag` off the CLI argv. We adopt the same
+ * convention here:
+ *
+ * - `workers: 0` (the "auto" sentinel in our UI) maps to `null` so Rust
+ *   omits `--workers`; any positive int passes through.
+ * - `gpu: null` (the "auto" tri-state in our UI) maps to `null` for the
+ *   same reason; `true` -> `--gpu`, `false` -> `--no-gpu`.
+ * - `blackoutThreshold` is always sent — the user always sees a concrete
+ *   value on the slider, and the CLI default (15.0) is harmless when
+ *   echoed back.
+ * - `noAudio` is always sent — it is a plain boolean and the Rust side
+ *   only emits `--no-audio` when `Some(true)`.
+ */
+export function toStartDetectParams(p: DetectionParams): Record<string, unknown> {
+  return {
+    blackoutThreshold: p.blackoutThreshold,
+    workers: p.workers > 0 ? p.workers : null,
+    noAudio: p.noAudio,
+    gpu: p.gpu,
+  };
+}
+
+/**
+ * Returns true when the supplied params differ from {@link DEFAULT_DETECTION_PARAMS}.
+ * Used by the panel's [リセット] button to enable/disable itself.
+ */
+export function isDetectionParamsModified(p: DetectionParams): boolean {
+  return (
+    p.blackoutThreshold !== DEFAULT_DETECTION_PARAMS.blackoutThreshold ||
+    p.workers !== DEFAULT_DETECTION_PARAMS.workers ||
+    p.noAudio !== DEFAULT_DETECTION_PARAMS.noAudio ||
+    p.gpu !== DEFAULT_DETECTION_PARAMS.gpu
+  );
+}


### PR DESCRIPTION
## Summary

#569 (`start_detect` Tauri command) で土台が整った検知パラメータを、DropScreen の SelectedCard 内に **collapsible な詳細設定パネル**として GUI 化する。これまで `params: {}` 固定で起動していた `start_detect` を、ユーザーが drop 確定前に調整した値で起動できるようにする。

- パラメータ 3 種を UI 化: `blackout_threshold` / `workers` / `gpu`
- 値は `appStateStore.detectionParams` に in-memory 保持 (session 中、`reset()` で defaults 復帰)
- DetectingScreen が `toStartDetectParams(detectionParams)` で wire 形式に変換し `start_detect` に渡す
- パネルは default 折り畳み、collapsed 時は default 以外の値があれば「(変更あり)」 hint 表示

**`--no-audio` UI は不採用**: audio module は frozen 状態 (`split_matches.py:525`、#327) のため flag は no-op。GUI に non-functional control を出すと誤解を招くので、`--no-audio` UI は #327 解凍時に再追加する方針 (本 PR Round 1 ユーザー指摘で削除、commit `44de880`)。Rust 側 `DetectParams.no_audio` field は #569 で実装済みのため未変更。

## 受け入れ条件 (#613) と対応

| # | 受け入れ条件 | 実証 |
|---|---|---|
| 1 | 詳細設定パネルから 3 つのパラメータ調整可能 | [DetectionParamsPanel.tsx](gui/src/screens/DetectionParamsPanel.tsx) に slider (blackout 0-50) / numeric (workers 0-32, 0=auto) / tri-state radio (GPU 自動/ON/OFF)。`--no-audio` は #327 frozen のため UI 不公開 |
| 2 | パラメータ変更時に store が更新される | `setDetectionParams` 経由、appStateStore.test.ts に 4 ケース追加 |
| 3 | detect 起動時に CLI subprocess へパラメータが渡る (#569 連携) | DetectingScreen.test.tsx "forwards detectionParams from the store as start_detect params (#613)" + "translates workers=0 (auto) to null (#613)" |
| 4 | 「リセット」ボタンで default 値に戻る | DetectionParamsPanel.test.tsx "reset button restores defaults when clicked" + disabled 状態テスト |
| 5 | `docs/ui-architecture.md` / `docs/ui-interaction-spec.md` に新 UI 部品の挙動が記載 | ui-architecture.md drop 節に DetectionParamsPanel 言及追加、ui-interaction-spec.md §2.1.10 に DetectionParamsPanel 状態機械 + sub-section 5 つ (toggle / slider / numeric / tri-state radio / reset + styling/a11y/Tab order) |
| 6 | 他画面の同種 UI 部品との styling / aria / Tab order 一貫性 | ExportScreen の `fieldLabel` + `aria-pressed` / `aria-label` pattern を踏襲、tokens.css の既存 token (`--ae-gold-dim` / `--ae-cyan` / `--ae-text-dim` 等) を再利用 (新規 token 追加なし)。Tab order: header → slider → numeric → tri-state radio (3 button) → reset → SelectedCard `[キャンセル]` → `[OK]` |
| 7 | vitest: store mutation + CLI flag 変換ロジックの単体テスト | `utils/detection.test.ts` (10 ケース) + `appStateStore.test.ts` (4 ケース追加) + `DetectionParamsPanel.test.tsx` (11 ケース) + `DetectingScreen.test.tsx` (2 ケース追加) = 27 新規テスト |
| 8 | eslint / typecheck / vitest 全通過 | 414/414 PASS、`npm run lint` / `npm run typecheck` / `npm test` / `cargo check` / `npm run build` すべて green |

## 設計判断 (ユーザー確定済み)

- **state 場所**: appStateStore に `detectionParams` フィールド追加 (新規 store 作らず、既存 selectedVideoPath と同パターン)
- **panel 配置**: SelectedCard 内 collapsible (meta 表 と `[OK]/[キャンセル]` actions の間)
- **default 状態**: 折り畳み (panelOpen=false)、`[▶ 詳細設定]` toggle で展開
- **永続化**: なし (in-memory のみ、`reset()` で defaults 復帰、localStorage 不使用)
- **0 = auto sentinel** (workers): UI 上の `workers=0` は `toStartDetectParams` で `null` に変換され Rust 側で `--workers` flag が omit される (CLI default = `min(cpu_count, 24)`)
- **3-state GPU**: `null/true/false` の `Option<bool>` 形式で `--gpu` / `--no-gpu` / 省略 を使い分け
- **`(変更あり)` hint**: collapsed 時に default 以外の値があれば header 横に表示 (見落とし防止)
- **`--no-audio` 削除** (Round 1 修正): audio frozen (#327) のため UI 公開しない

## 変更ファイル

| ファイル | 変更概要 |
|---|---|
| `gui/src/state/appStateStore.ts` | `DetectionParams` interface (3 fields) + `DEFAULT_DETECTION_PARAMS` + `setDetectionParams` / `resetDetectionParams` action 追加。`reset()` も defaults 復帰に拡張。`noAudio` 不採用の理由は doc コメントで明記 |
| `gui/src/utils/detection.ts` (新規) | `toStartDetectParams` (wire 形式変換、workers=0 → null、3 keys) + `isDetectionParamsModified` |
| `gui/src/screens/DetectionParamsPanel.tsx` (新規) | collapsible パネル本体、3 controls + reset button、`useId` で a11y label 関連付け |
| `gui/src/screens/DetectionParamsPanel.module.css` (新規) | パネル + slider / numeric / tri-state / reset の styling、tokens.css の既存色を再利用 |
| `gui/src/screens/DropScreen.tsx` | SelectedCard 内に `<DetectionParamsPanel />` を配置 (meta 表 と actions の間) |
| `gui/src/screens/DetectingScreen.tsx` | `useAppStateStore((s) => s.detectionParams)` で読み取り、`start_detect` invoke 時に `toStartDetectParams` で変換して渡す |
| `gui/src/utils/detection.test.ts` (新規) | 10 ケース (toStartDetectParams + isDetectionParamsModified) |
| `gui/src/state/appStateStore.test.ts` | 4 ケース追加 (defaults / setDetectionParams patch / multi-field set / resetDetectionParams) |
| `gui/src/screens/DetectionParamsPanel.test.tsx` (新規) | 11 ケース (collapsed/expand toggle、各 control の mutation、変更あり hint、リセット button disable/enable) |
| `gui/src/screens/DetectingScreen.test.tsx` | 2 ケース追加 (params forward + workers=0 → null 変換) |
| `docs/ui-architecture.md` | drop 節 + state stores 一覧に detectionParams 追記 |
| `docs/ui-interaction-spec.md` | §2.1 表に「(詳細設定パネル含む、#613)」追記 + §2.1.10 + 5 sub-section 新規追加 (`--no-audio` 不採用の理由含む) |

## スコープから明示的に除外

- **`--no-audio` UI** → audio module frozen (#327)、#327 解凍時に再追加
- `gpu_vendor` 選択 UI → 3-state で当面十分、別 issue で追加検討
- `min_blackout_duration` / `min_match_duration` / `no_cache` の UI → CLI でのみ調整可能 (専門ユーザー向け、別 issue 候補)
- localStorage / TOML 永続化 → #613 は session 中保持で確定 (永続化は別 issue)
- 共通 UI コンポーネント (Slider / Toggle / TriState) の `gui/src/components/` 抽出 → 現状 DropScreen 専用、将来再利用要件出たら refactor

## Test plan (本 PR 提出前にローカルで実行済)

- [x] `npm run typecheck` (gui/, tsc --noEmit) PASS
- [x] `npm run lint` (gui/, eslint .) PASS
- [x] `npm test` (gui/, vitest) 414/414 PASS (新規 27 ケース、既存 387 維持)
- [x] `npm run build` (gui/, vite build) PASS
- [x] `cargo check` (gui/src-tauri/) PASS

## レビュー時の確認 (machine-unverifiable)

`npm run tauri dev` で起動して以下を逐条確認 (Iron Law 1 受け入れ条件 1, 2, 4 の実機ゲート):

- 動画 drop → SelectedCard に「▶ 詳細設定」 toggle 表示 (default 折り畳み)
- toggle click で展開、3 controls (検知しきい値 slider / ワーカー数 numeric / GPU tri-state radio) + [リセット] が表示。**音声解析行は無し** (Round 1 修正で削除)
- slider 移動 → 値表示更新 + store update (再展開しても保持)
- ワーカー数を 0 に戻すと「(自動)」 hint 表示
- GPU radio で 自動/ON/OFF 切替時に active styling が遷移
- いずれかを default から変更 → collapse 時に「(変更あり)」 hint 表示
- [リセット] click → 全 3 値が default に戻り button が disabled に
- `[OK — 検知開始]` → DetectingScreen で `start_detect` が変更後 params で起動
- `[キャンセル]` 後の再 drop で前回 params が保持されている (session 中保持の確認)
- `[参照…]` 経由フローも regression なし

## Group β 連鎖の進行状況

| W | issue | 状態 |
|---|---|---|
| W1-1 | #568 | merged (PR #625) |
| W2-1 | #613 | **本 PR** |
| W2-6 | #571 | 未着手 (独立、次セッション可) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
