### PR TITLE
fix(gui): detecting ログを overflow: auto + auto-scroll 化 (Refs #639)

### DIFF
--- a/gui/src/screens/DetectingScreen.module.css
+++ b/gui/src/screens/DetectingScreen.module.css
@@ -144,16 +144,45 @@
   box-shadow: none;
 }
 
+/*
+ * #639 — log pane は flex 子なので `min-height: 0` を明示しないと
+ * `overflow-y: auto` が無効化される (内容が parent を押し広げて
+ * しまい結局スクロールできない、#569 実機検証で発覚)。
+ * gold tint のスクロールバーは WebView2 (Chromium) 用の
+ * `-webkit-scrollbar*` を主軸にし、Firefox 用に
+ * `scrollbar-color` / `scrollbar-width` も指定する。
+ */
 .log {
   flex: 1;
+  min-height: 0;
   background: var(--ae-bg-deep);
   padding: 12px;
   font-family: var(--ae-font-mono);
   font-size: 10px;
   color: var(--ae-text-dim);
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   line-height: 1.6;
   border: 1px solid rgba(var(--ae-gold-rgb), 0.08);
+  scrollbar-color: rgba(var(--ae-gold-rgb), 0.4) transparent;
+  scrollbar-width: thin;
+}
+
+.log::-webkit-scrollbar {
+  width: 6px;
+}
+
+.log::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.log::-webkit-scrollbar-thumb {
+  background: rgba(var(--ae-gold-rgb), 0.3);
+  border-radius: 3px;
+}
+
+.log::-webkit-scrollbar-thumb:hover {
+  background: rgba(var(--ae-gold-rgb), 0.55);
 }
 
 .logTime {

--- a/gui/src/screens/DetectingScreen.module.css
+++ b/gui/src/screens/DetectingScreen.module.css
@@ -1,5 +1,13 @@
 .screen {
   flex: 1;
+  /*
+   * #639 review (実機検証 2 回目) — `.screen` 自身も flex 子
+   * (`App.module.css` の `.main > .screen`) なので `min-height: 0`
+   * を明示しないと内容に押し広げられて viewport を超え、子の
+   * `.log` の `overflow-y: auto` が機能しない。`.log` 単体修正で
+   * は不十分で、ここまで chain で伝播させる必要がある。
+   */
+  min-height: 0;
   display: flex;
   flex-direction: column;
   padding: 24px;

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -224,6 +224,54 @@ describe('DetectingScreen', () => {
     expect(meta.textContent).toContain('2:00:15');
   });
 
+  // #639 -- log viewport must auto-scroll to the bottom whenever a
+  // new entry arrives so the latest line is always visible without
+  // user interaction.
+  it('scrolls the log viewport to the bottom on new entries (#639)', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+
+    const log = screen.getByRole('log');
+    // jsdom doesn't lay out elements, so scrollHeight is always 0 by
+    // default. Stub the layout numbers so the auto-scroll effect has a
+    // non-trivial target to write into scrollTop.
+    Object.defineProperty(log, 'scrollHeight', {
+      configurable: true,
+      get: () => 1000,
+    });
+    Object.defineProperty(log, 'clientHeight', {
+      configurable: true,
+      get: () => 200,
+    });
+
+    // Drive a few events so the log array grows and the
+    // auto-scroll effect fires.
+    act(() => {
+      emitDetectProgress({ phase: 'start' });
+      emitDetectProgress({ phase: 'probing', duration_s: 600, codec: 'h264' });
+      emitDetectProgress({
+        phase: 'scan',
+        completed: 50,
+        total: 500,
+      });
+    });
+
+    // jsdom defaults scrollTop to 0; the effect should pull it to the
+    // current scrollHeight (1000) so the latest entry sits at the
+    // bottom of the visible viewport.
+    expect(log.scrollTop).toBe(1000);
+  });
+
   // #569 review Round 1 課題 2 -- log lines carry data-kind attribute
   // and apply the matching colour-coding class.
   it('renders log entries with kind-specific styling', async () => {

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -224,6 +224,74 @@ describe('DetectingScreen', () => {
     expect(meta.textContent).toContain('2:00:15');
   });
 
+  // #639 review (実機検証 3 回目) -- ResizeObserver で log pane の
+  // 縮小 (window resize / parent flex 変動) を検知して末尾に再追従
+  // させる。新エントリ追加経路と独立。
+  it('re-pins scrollTop to scrollHeight when log pane is resized (#639)', async () => {
+    let resizeCallback: ResizeObserverCallback | null = null;
+    const disconnect = vi.fn();
+    const originalRO = globalThis.ResizeObserver;
+    // jsdom does not implement ResizeObserver; install a minimal stub
+    // that captures the callback so the test can drive it.
+    class StubObserver {
+      constructor(cb: ResizeObserverCallback) {
+        resizeCallback = cb;
+      }
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {
+        disconnect();
+      }
+    }
+    globalThis.ResizeObserver =
+      StubObserver as unknown as typeof ResizeObserver;
+
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    try {
+      render(<DetectingScreen />);
+      await waitFor(() => {
+        expect(listenMock).toHaveBeenCalled();
+      });
+
+      const log = screen.getByRole('log');
+      // Stub layout numbers (jsdom default 0) so the resize handler
+      // has a non-trivial scrollHeight target.
+      Object.defineProperty(log, 'scrollHeight', {
+        configurable: true,
+        get: () => 1500,
+      });
+      // Place scrollTop at an outdated (mid) position simulating the
+      // "see-cut" state after resize before the observer fires.
+      log.scrollTop = 200;
+
+      // Trigger the observer's resize callback (jsdom doesn't lay
+      // anything out so we drive the callback synthetically; the
+      // assertion is about the handler logic, not jsdom layout).
+      expect(resizeCallback).not.toBeNull();
+      act(() => {
+        // ResizeObserver callback signature: (entries, observer)
+        resizeCallback!(
+          [] as unknown as ResizeObserverEntry[],
+          {} as unknown as ResizeObserver,
+        );
+      });
+
+      // Handler must pull scrollTop to the current scrollHeight so the
+      // most recent line lands inside the (now smaller) viewport.
+      expect(log.scrollTop).toBe(1500);
+    } finally {
+      globalThis.ResizeObserver = originalRO;
+    }
+  });
+
   // #639 -- log viewport must auto-scroll to the bottom whenever a
   // new entry arrives so the latest line is always visible without
   // user interaction.

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -312,6 +312,23 @@ export function DetectingScreen() {
     }
   }, [log]);
 
+  // #639 review (実機検証 3 回目) — window resize / 親 flex の高さ変動
+  // で log pane の viewport だけ縮んだ場合、`[log]` 依存の auto-scroll
+  // は再走しないため scrollTop が古い位置のまま残り「見切れ」が再発
+  // する。ResizeObserver で log 自身のサイズ変化を監視して都度末尾に
+  // 引き戻す。新エントリ追加経路と独立しているので 2 経路で末尾追従
+  // が担保される。
+  useEffect(() => {
+    const el = logRef.current;
+    if (!el) return;
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => {
+      el.scrollTop = el.scrollHeight;
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   // Subscribe to detect-progress, kick off start_detect.
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { useEffect, useReducer, useState } from 'react';
+import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { AllaganSigil } from '../components/AllaganSigil';
 import { DisabledTooltip } from '../components/DisabledTooltip';
@@ -284,6 +284,12 @@ export function DetectingScreen() {
   // screen). Avoids the react-hooks/set-state-in-effect lint warning
   // a setState-in-effect initialiser would trip.
   const [startedAt] = useState<number>(() => Date.now());
+  // #639 — pin the live-log scroll viewport so we can pull it back to
+  // the bottom whenever a new entry arrives. The DOM ref talks to an
+  // external system (scrollTop is browser state, not React state), so
+  // setting it inside an effect doesn't fall under the
+  // react-hooks/set-state-in-effect rule.
+  const logRef = useRef<HTMLDivElement | null>(null);
 
   // Wall-clock elapsed timer -- ticks once per second so the UI can
   // show "経過 00:42 / 残り ~01:30" without depending on event cadence.
@@ -294,6 +300,17 @@ export function DetectingScreen() {
     }, 1000);
     return () => clearInterval(id);
   }, [phase, startedAt]);
+
+  // #639 — auto-scroll the log viewport to the bottom whenever a new
+  // entry is appended so the most recent line is always visible. Scope
+  // out: pausing auto-scroll while the user is actively scrolling up
+  // (deferred per #639 §スコープ外).
+  useEffect(() => {
+    const el = logRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [log]);
 
   // Subscribe to detect-progress, kick off start_detect.
   useEffect(() => {
@@ -452,7 +469,12 @@ export function DetectingScreen() {
 
       <div className={styles.divider} />
 
-      <div className={styles.log} role="log" aria-label="detect log">
+      <div
+        ref={logRef}
+        className={styles.log}
+        role="log"
+        aria-label="detect log"
+      >
         {log.length === 0 && (
           <div>
             <span className={styles.logTime}>[--:--]</span> 起動中…

--- a/gui/src/screens/DropScreen.module.css
+++ b/gui/src/screens/DropScreen.module.css
@@ -1,5 +1,12 @@
 .screen {
   flex: 1;
+  /*
+   * #639 review (Round 2 波及) — flex 子 (`App.module.css` の
+   * `.main > .screen`) なので `min-height: 0` を明示しないと内容に
+   * 押し広げられて viewport を超え、`overflow: auto` が無効化される
+   * (DetectingScreen `.screen` と同パターン)。
+   */
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/gui/src/screens/ExportScreen.module.css
+++ b/gui/src/screens/ExportScreen.module.css
@@ -1,5 +1,13 @@
 .screen {
   flex: 1;
+  /*
+   * #639 review (Round 2 波及) — flex 子 (`App.module.css` の
+   * `.main > .screen`) なので `min-height: 0` を明示しないと内容に
+   * 押し広げられて viewport を超え、子 `.matchList` / `.summaryList`
+   * の `overflow: auto` が無効化される
+   * (DetectingScreen `.screen` と同パターン)。
+   */
+  min-height: 0;
   display: flex;
   flex-direction: column;
   padding: 24px;


### PR DESCRIPTION
## Summary

[#639](https://github.com/Idios/kobutachan-allaganeye/issues/639) (PR #623 実機検証で発覚): DetectingScreen ライブログが `overflow: hidden` のため viewport 外の行が見切れ、`MAX_LOG_LINES=80` で truncate しても履歴を遡れない問題を修正。

- **CSS**: `.log` を `overflow-y: auto` (横は hidden 維持) に変更、flex 子で auto が効くよう `min-height: 0` を明示。WebView2 / Firefox 両対応の gold tint スクロールバー。
- **TSX**: `useRef<HTMLDivElement>` + `useEffect` で log 更新時に `scrollTop = scrollHeight` 末尾追従。
- **Test**: vitest で scroll behaviour assertion (jsdom の scrollHeight stub 経由)。

## 受け入れ条件チェック ([#639](https://github.com/Idios/kobutachan-allaganeye/issues/639))

| # | 受け入れ条件 | 対応 diff / test |
|---|---|---|
| 1 | 80 行までのログが viewport 内でスクロールで読める (`overflow: auto`) | [DetectingScreen.module.css](gui/src/screens/DetectingScreen.module.css) `.log` の `overflow-y: auto` + `min-height: 0` |
| 2 | 新しい行が追加されたら最下部に自動スクロール | [DetectingScreen.tsx](gui/src/screens/DetectingScreen.tsx) `useRef` + `useEffect([log])` で `scrollTop = scrollHeight` |
| 3 | スクロールバーが gold tint で視認できる | [DetectingScreen.module.css](gui/src/screens/DetectingScreen.module.css) `.log::-webkit-scrollbar*` (6px 幅、`rgba(--ae-gold-rgb, 0.3)` thumb、hover で 0.55) + `scrollbar-color` / `scrollbar-width` (Firefox) |
| 4 | vitest で auto-scroll 挙動を assertion | [DetectingScreen.test.tsx](gui/src/screens/DetectingScreen.test.tsx) "scrolls the log viewport to the bottom on new entries (#639)" |
| 5 | eslint / typecheck / vitest 全通過 | 全通過 (test plan 参照) |

## スコープ外 (将来検討)

- 手動上スクロール中の auto-scroll 一時停止
- ログ retention の store 永続化

## Test plan

- [x] `cd gui && npm run lint`
- [x] `cd gui && npm run typecheck`
- [x] `cd gui && npm test -- --run` (385 passed、本 PR で +1)

GUI Tauri 統合での視認確認は本 PR マージ後の `/close-issue 639` 段階で `npm run tauri dev` 起動 → detecting 画面でログがスクロールできる + 末尾追従を Idios が実機検証する想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
