### PR TITLE
fix: verbose で 3 detect フェーズを最初から並べる多行 eager 表示 (Refs #434)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import shutil
+import sys
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -755,7 +756,7 @@ def _run_detection(
         total_duration = metadata["duration"]
         estimated_samples = max(1, int(total_duration / effective_interval))
 
-        # Three-bar progress design (#368 / #393):
+        # Three-bar progress design (#368 / #393 / #434):
         #
         # - Detecting (Pass 1 scan, known length = estimated_samples)
         # - Refining (Pass 2 probes, total published via first callback)
@@ -767,6 +768,30 @@ def _run_detection(
         # vanish, #368) and the Pass 2 -> Scorebar transition no longer
         # mixes units (100% -> 99% rollover, #393).  ``try/finally`` guards
         # against exceptions leaving a bar dangling on the TTY.
+        #
+        # #434 multi-line eager display: when stdout is a TTY we pre-print
+        # waiting placeholders for Refining / Scorebar BELOW the Detecting
+        # line so users see all three phases from the start.  Each
+        # placeholder is overwritten by its bar when the corresponding
+        # callback first fires.  Non-TTY (CI / redirected output) falls
+        # back to the historical sequential bars to avoid garbling logs
+        # with ANSI escapes.
+        eager_phases = _stdout_supports_eager_phases()
+        if eager_phases:
+            typer.echo("Detecting [starting...]".ljust(_PROGRESS_LABEL_WIDTH + 24))
+            typer.echo(
+                "Refining   [waiting for Pass 1 to finish]".ljust(
+                    _PROGRESS_LABEL_WIDTH + 30
+                )
+            )
+            typer.echo(
+                "Scorebar   [waiting for Pass 2 to finish]".ljust(
+                    _PROGRESS_LABEL_WIDTH + 30
+                )
+            )
+            sys.stdout.write("\033[3A")  # cursor up 3 lines back to Detecting
+            sys.stdout.flush()
+
         detecting_bar = _eta_progressbar(
             estimated_samples,
             "Detecting",
@@ -792,6 +817,16 @@ def _run_detection(
             if scorebar_state["bar"] is not None:
                 scorebar_state["bar"].__exit__(None, None, None)
                 scorebar_state["bar"] = None
+
+        def _erase_current_line() -> None:
+            """Clear the cursor's line so the next bar overwrites a placeholder.
+
+            No-op outside the eager-display path since there is no
+            placeholder to clear (#434).
+            """
+            if eager_phases:
+                sys.stdout.write("\033[2K")
+                sys.stdout.flush()
 
         def on_progress(completed: int, total: int, blackout_count: int) -> None:
             advance = completed - detecting_state["last_pos"]
@@ -828,6 +863,7 @@ def _run_detection(
             # open the Refining bar on a fresh line.
             if refine_state["bar"] is None:
                 _close_detecting_if_open()
+                _erase_current_line()  # erase ``Refining [waiting]`` placeholder
                 refine_state["bar"] = _eta_progressbar(total, "Refining")
                 refine_state["bar"].__enter__()
                 refine_state["last"] = 0
@@ -840,8 +876,16 @@ def _run_detection(
             # First scorebar callback: close Refining (or Detecting if
             # Pass 2 had no regions) and open the Scorebar bar fresh.
             if scorebar_state["bar"] is None:
+                refine_was_open = refine_state["bar"] is not None
                 _close_refine_if_open()
                 _close_detecting_if_open()
+                if eager_phases and not refine_was_open:
+                    # Pass 2 had no regions; cursor is on the Refining
+                    # placeholder. Replace it with a "skipped" marker and
+                    # advance one line to land on the Scorebar placeholder.
+                    sys.stdout.write("\033[2KRefining   [skipped: no regions]\n")
+                    sys.stdout.flush()
+                _erase_current_line()  # erase ``Scorebar [waiting]`` placeholder
                 scorebar_state["bar"] = _eta_progressbar(total, "Scorebar")
                 scorebar_state["bar"].__enter__()
                 scorebar_state["last"] = 0
@@ -962,6 +1006,17 @@ def _check_disk_space(
 
 _PROGRESS_LABEL_WIDTH = 11
 """Column width for progress bar labels (Detecting/Refining/Splitting)."""
+
+
+def _stdout_supports_eager_phases() -> bool:
+    """Whether stdout is a TTY suitable for the multi-line eager phase display (#434).
+
+    Centralizing the check lets tests substitute behaviour with
+    ``monkeypatch`` without touching ``sys.stdout`` directly (capsys
+    replaces stdout with a non-TTY buffer, so the production-mode
+    check would always be false during tests).
+    """
+    return sys.stdout.isatty()
 
 
 def _eta_progressbar(length: int, label: str, *, suppress_click_eta: bool = False):  # type: ignore[no-untyped-def]

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -799,8 +799,23 @@ def _run_detection(
         )
         detecting_bar.__enter__()
         detecting_state = {"last_pos": 0, "closed": False}
-        refine_state: dict = {"bar": None, "last": 0}
-        scorebar_state: dict = {"bar": None, "last": 0}
+        # ``placeholder_present`` tracks whether the ``[waiting...]`` line
+        # for that phase is still on screen.  Set ``True`` only when the
+        # eager pre-print actually ran; flipped to ``False`` when the bar
+        # opens (placeholder erased) or the Pass 2 skip path replaces it
+        # with ``[skipped: no regions]``.  Used by the ``finally`` cleanup
+        # so a Pass 1 / Pass 2 exception doesn't leave stale ``[waiting]``
+        # text dangling above the traceback (#434 error path).
+        refine_state: dict = {
+            "bar": None,
+            "last": 0,
+            "placeholder_present": eager_phases,
+        }
+        scorebar_state: dict = {
+            "bar": None,
+            "last": 0,
+            "placeholder_present": eager_phases,
+        }
 
         def _close_detecting_if_open() -> None:
             """Emit newline after Pass 1 so the next bar starts cleanly."""
@@ -864,6 +879,7 @@ def _run_detection(
             if refine_state["bar"] is None:
                 _close_detecting_if_open()
                 _erase_current_line()  # erase ``Refining [waiting]`` placeholder
+                refine_state["placeholder_present"] = False
                 refine_state["bar"] = _eta_progressbar(total, "Refining")
                 refine_state["bar"].__enter__()
                 refine_state["last"] = 0
@@ -885,7 +901,9 @@ def _run_detection(
                     # advance one line to land on the Scorebar placeholder.
                     sys.stdout.write("\033[2KRefining   [skipped: no regions]\n")
                     sys.stdout.flush()
+                    refine_state["placeholder_present"] = False
                 _erase_current_line()  # erase ``Scorebar [waiting]`` placeholder
+                scorebar_state["placeholder_present"] = False
                 scorebar_state["bar"] = _eta_progressbar(total, "Scorebar")
                 scorebar_state["bar"].__enter__()
                 scorebar_state["last"] = 0
@@ -910,6 +928,21 @@ def _run_detection(
             _close_scorebar_if_open()
             _close_refine_if_open()
             _close_detecting_if_open()
+            # Clean up any ``[waiting...]`` placeholder lines still on
+            # screen so a Pass 1 / Pass 2 exception's traceback isn't
+            # printed below stale "waiting" text (#434 error path).
+            # The ``_close_*_if_open`` calls above land the cursor on the
+            # next un-rendered phase line, so erasing in order matches
+            # the cursor's downward march.
+            if refine_state["placeholder_present"]:
+                sys.stdout.write("\033[2K\n")
+            if scorebar_state["placeholder_present"]:
+                sys.stdout.write("\033[2K\n")
+            if (
+                refine_state["placeholder_present"]
+                or scorebar_state["placeholder_present"]
+            ):
+                sys.stdout.flush()
 
         return result
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1603,6 +1603,89 @@ def test_eager_phases_marks_refining_skipped_when_pass2_empty(
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_eager_phases_clears_placeholders_on_pass1_exception(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys, monkeypatch
+):
+    """Pass 1 で例外発生時に Refining/Scorebar placeholder を ANSI clear する (#434 error path).
+
+    Without cleanup, an exception during Pass 1 leaves stale
+    ``[waiting...]`` lines hanging above the traceback because the
+    Refining / Scorebar bars never opened to overwrite their
+    placeholders.  Reviewer (#594) flagged this as an error-path UX
+    regression of the multi-line layout introduced for #434.
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    # Simulate a failure during Pass 1 before any refine / scorebar
+    # callback fires; the exception propagates out of run_split.
+    mock_detect.side_effect = VideoProcessingError("simulated Pass 1 failure")
+    monkeypatch.setattr(
+        f"{MODULE}._stdout_supports_eager_phases",
+        lambda: True,
+    )
+
+    with pytest.raises(VideoProcessingError):
+        run_split(Path("input.mp4"), config)
+    output = capsys.readouterr().out
+
+    # Both placeholders printed initially (sanity).
+    assert "[waiting for Pass 1 to finish]" in output
+    assert "[waiting for Pass 2 to finish]" in output
+    # Two cleanup escapes appended after the close calls so the
+    # waiting placeholders don't dangle above the traceback.
+    assert output.count("\x1b[2K\n") >= 2
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_eager_phases_clears_only_scorebar_placeholder_on_pass2_exception(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys, monkeypatch
+):
+    """Pass 2 中で例外発生時は Scorebar placeholder のみ cleanup する (#434 error path).
+
+    By the time Pass 2 raises, the Refining bar has already replaced
+    its waiting placeholder, so only the Scorebar placeholder needs
+    erasing.  Refining is closed by ``_close_refine_if_open`` which
+    advances the cursor onto the Scorebar waiting line.
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    def detect_side_effect(video_path, **kwargs):
+        ref_cb = kwargs.get("refine_progress_callback")
+        if ref_cb:
+            ref_cb(1, 4)
+        # Raise after Refining bar opened but before Scorebar fires.
+        raise VideoProcessingError("simulated Pass 2 failure")
+
+    mock_detect.side_effect = detect_side_effect
+    monkeypatch.setattr(
+        f"{MODULE}._stdout_supports_eager_phases",
+        lambda: True,
+    )
+
+    with pytest.raises(VideoProcessingError):
+        run_split(Path("input.mp4"), config)
+    output = capsys.readouterr().out
+
+    # Refining waiting placeholder was already replaced by the
+    # Refining bar before the exception fired -> no cleanup needed
+    # for it.  Scorebar waiting placeholder still on screen.
+    assert "[waiting for Pass 2 to finish]" in output
+    # Exactly one trailing cleanup escape (Scorebar).  ``output.count``
+    # is more flexible than equality because click may emit additional
+    # cursor controls during bar teardown; the regression we guard
+    # against is "zero cleanups", not "more than one".
+    assert output.count("\x1b[2K\n") >= 1
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_progress_bars_cleanup_on_exception(
     mock_probe, mock_detect, mock_split, tmp_path, capsys
 ):

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1507,6 +1507,99 @@ def test_refining_and_scorebar_bars_do_not_overlap(
     )
 
 
+# --- multi-line eager phase display (#434) ---
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_eager_phases_off_by_default_in_non_tty(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys
+):
+    """Non-TTY stdout (capsys default) skips eager placeholders (#434).
+
+    Backwards-compat / log hygiene: redirected output and CI logs must
+    not leak ANSI escape sequences or ``[waiting...]`` placeholder text.
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+
+    output = capsys.readouterr().out
+    assert "[waiting for Pass 1 to finish]" not in output
+    assert "[waiting for Pass 2 to finish]" not in output
+    # No ANSI cursor-up escape (\x1b[3A) when eager mode is off.
+    assert "\x1b[3A" not in output
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_eager_phases_prints_waiting_placeholders_in_tty_mode(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys, monkeypatch
+):
+    """TTY stdout pre-prints Refining / Scorebar [waiting] placeholders (#434).
+
+    User intent (issue body): "Detecting / Refining / Scorebar"
+    visible from the start so the appearance of Refining mid-pipeline
+    no longer feels like a phase materialising out of thin air.
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    monkeypatch.setattr(
+        f"{MODULE}._stdout_supports_eager_phases",
+        lambda: True,
+    )
+
+    run_split(Path("input.mp4"), config)
+    output = capsys.readouterr().out
+
+    assert "Refining" in output
+    assert "[waiting for Pass 1 to finish]" in output
+    assert "Scorebar" in output
+    assert "[waiting for Pass 2 to finish]" in output
+    # Cursor-up ANSI moves the next bar render onto the Detecting line.
+    assert "\x1b[3A" in output
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_eager_phases_marks_refining_skipped_when_pass2_empty(
+    mock_probe, mock_detect, mock_split, tmp_path, capsys, monkeypatch
+):
+    """Pass 2 with no regions -> Refining placeholder updated to ``[skipped: no regions]`` (#434)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    def detect_side_effect(video_path, **kwargs):
+        # Pass 2 yields zero callbacks (no regions to refine), but
+        # scorebar still classifies whatever survived from Pass 1.
+        sb_cb = kwargs.get("scorebar_progress_callback")
+        if sb_cb:
+            sb_cb(1, 2)
+            sb_cb(2, 2)
+        return BOUNDARIES
+
+    mock_detect.side_effect = detect_side_effect
+    monkeypatch.setattr(
+        f"{MODULE}._stdout_supports_eager_phases",
+        lambda: True,
+    )
+
+    run_split(Path("input.mp4"), config)
+    output = capsys.readouterr().out
+
+    assert "Refining   [skipped: no regions]" in output
+
+
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")


### PR DESCRIPTION
## Summary

verbose dry-run / split で Detecting 完了後に Refining / Scorebar バーが「突然出現」する UX を、TTY 検出時に 3 バー全部を最初から並べて表示する方式に変更 (#434)。進行中バーが進捗、待機中バーは `[waiting...]` ラベル、フェーズ開始で該当バーが進捗開始する。非 TTY (CI / redirected output) は ANSI 漏れを避けるため従来の sequential bars に fallback。Round 1 review (exciting-wu-090424) 指摘を受け error path placeholder cleanup を追加。

## 受け入れ基準 (#434)

- [x] 全フェーズが最初から認識可能な表示になっている
  - 実装: TTY 時に `Detecting [starting...]` / `Refining   [waiting for Pass 1 to finish]` / `Scorebar   [waiting for Pass 2 to finish]` を pre-print し ANSI `\x1b[3A` で cursor を Detecting 行に戻すことで、click.progressbar が pre-printed 行を上書きする形で 3 行レイアウトを実現
  - test `test_eager_phases_prints_waiting_placeholders_in_tty_mode` で `[waiting for Pass 1 to finish]` / `[waiting for Pass 2 to finish]` / `\x1b[3A` の出力を検証
- [x] 進行中バーは進捗を見せる
  - `_eta_progressbar` (click.progressbar) はそのままで、cursor 位置だけ多行レイアウトに合わせて制御
- [x] バー切替時の視覚的ジャンプが少ない
  - 行の出現タイミングが「最初から」に統一されたため、Detecting 完了直後の Refining 出現で視覚的ジャンプが発生しない (placeholder 行を `\x1b[2K` で消去してから新バーを `__enter__`)

## 採用方針: 案 a (Multi-line all-bars-visible)

AskUserQuestion で確定。3 バーを最初から並べて表示し、待機中は `[waiting...]` ラベルのみ表示、フェーズ開始で該当バーが進捗開始する。実装は ANSI cursor up (`\x1b[3A`) + erase line (`\x1b[2K`) を click.progressbar の `\r` rewrite と組み合わせる方式で、追加 dependency なし (tqdm 不要)。

## 変更ファイル

- `allaganeye/commands/split_matches.py`:
  - `import sys` 追加
  - `_stdout_supports_eager_phases()` ヘルパ新設 (テストから monkeypatch 可能)
  - `_run_detection` 内に eager_phases フラグ + placeholder pre-print + ANSI cursor up + `_erase_current_line` ヘルパを追加
  - on_refine / on_scorebar の first callback で `_erase_current_line` を呼んでから次バーを `__enter__`、placeholder を上書き
  - Pass 2 が空 (regions ゼロ) のとき Refining placeholder を `[skipped: no regions]` に書き換えてから Scorebar バーを開く
  - **Round 1 fix (commit 6b13475)**: `refine_state` / `scorebar_state` に `placeholder_present` フラグを追加し、`finally` block 末尾で残存 placeholder を `\x1b[2K\n` で消去 (error path UX cleanup)
- `tests/test_split_matches.py`: 5 件追加 (3 件 + Round 1 で 2 件)

## Non-TTY fallback

`sys.stdout.isatty()` が False (CI / redirected / capsys) のときは placeholder pre-print / ANSI escape を一切出さず、従来の sequential bars (Detecting -> Refining -> Scorebar) のまま。CI ログ / リダイレクト出力に ANSI 制御文字が混入する事故を防止。

## 新規テスト内訳 (5 件)

- `test_eager_phases_off_by_default_in_non_tty`: capsys (非 TTY) で `[waiting...]` / `\x1b[3A` を一切出力しないこと (backwards-compat / log hygiene)
- `test_eager_phases_prints_waiting_placeholders_in_tty_mode`: `monkeypatch` で TTY 化したとき `Refining` / `[waiting for Pass 1 to finish]` / `Scorebar` / `[waiting for Pass 2 to finish]` / `\x1b[3A` がすべて出力されること
- `test_eager_phases_marks_refining_skipped_when_pass2_empty`: Pass 2 callback ゼロで Scorebar に直行する場合 `Refining   [skipped: no regions]` 行が emit されること
- **`test_eager_phases_clears_placeholders_on_pass1_exception` (Round 1)**: Pass 1 中で例外発生時、未開始の Refining / Scorebar placeholder が `\x1b[2K\n` で cleanup されること
- **`test_eager_phases_clears_only_scorebar_placeholder_on_pass2_exception` (Round 1)**: Refining bar 開始後の Pass 2 中で例外発生時、Scorebar placeholder のみ cleanup されること

## Test plan

- [x] `python -m ruff check .` pass
- [x] `python -m ruff format --check .` pass
- [x] `python -m pyright tests/test_split_matches.py allaganeye/commands/split_matches.py` pass
- [x] `python -m pytest` 846 passed / 1 skipped / 37 deselected (slow) — 既存 841 から 5 増、回帰なし

## Refs

- Refs #434
- 関連: #368 / #393 (Detecting バー上書き / 表示崩れ問題、本 PR は同領域の UX 改善)

## Note (実機 TTY 動作確認のお願い)

実機 TTY 動作確認は CI 環境では困難なため、本 PR では実施していません。Idios の手元のローカル端末で `allaganeye split <video> --dry-run --verbose` を実行し、以下を目視確認していただけると助かります:

**正常系シナリオ (1 動画 / 30 秒程度):**

- Detecting / Refining / Scorebar の 3 行が最初から表示される
- Pass 1 進行中は Refining / Scorebar が `[waiting...]` 表示のまま
- Pass 1 完了 -> Refining バー開始時に `[waiting...]` placeholder が消えて Refining バーに切り替わる
- Pass 2 完了 -> Scorebar バー開始時に同様に切り替わる
- Pass 2 が空のケース (短い動画 / 区切り無し) では `Refining   [skipped: no regions]` に書き換わる

**Error path シナリオ (Round 1 fix の動作確認):**

- Pass 1 進行中で `Ctrl-C` (KeyboardInterrupt) -> Refining / Scorebar の `[waiting...]` placeholder が消去され traceback がクリーンに表示される
- Pass 2 進行中で `Ctrl-C` -> Scorebar の `[waiting...]` placeholder のみ消去され traceback がクリーンに表示される

## Note (Closes キーワード)

- `Closes` / `Fixes` / `Resolves` キーワードは使用していません (Iron Law 4 / `docs/l2-workflow.md`)。マージ後 `/close-issue 434` で受け入れ条件を実測再検証してから手動 close します。
