### PR TITLE
fix(gui): start_detect 失敗を可視化 + python -m フォールバック (Refs #646)

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1717,20 +1717,102 @@ fn parse_detect_progress_line(line: &str) -> Option<DetectProgress> {
     serde_json::from_str(line).ok()
 }
 
-/// #569 -- locate the `allaganeye` CLI executable.
+/// #646 -- how to invoke the `allaganeye` CLI from Rust.
+///
+/// Wraps the executable plus any prefix arguments (e.g. `-m allaganeye`
+/// when the executable is `python`) plus an optional working directory
+/// (e.g. the worktree root for the `python -m` fallback so the
+/// development checkout's `allaganeye/` package is on `sys.path`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllaganeyeCommand {
+    pub program: String,
+    pub prefix_args: Vec<String>,
+    pub cwd: Option<PathBuf>,
+}
+
+/// #569 / #646 -- resolve how to invoke the `allaganeye` CLI.
 ///
 /// Resolution order:
-/// 1. `ALLAGANEYE_BIN` environment variable (must point at a real file).
-/// 2. The bare name `"allaganeye"` -- relies on `tokio::process::Command`'s
-///    PATH search.  Portable ZIP layouts add the bundled `allaganeye.bat`
-///    location to PATH at install time.
-fn resolve_allaganeye_bin() -> String {
-    if let Ok(path) = std::env::var("ALLAGANEYE_BIN") {
-        if !path.is_empty() {
-            return path;
+/// 1. `ALLAGANEYE_BIN` env var (override / escape hatch). Single
+///    executable path, no prefix args, no cwd.
+/// 2. `<bundle_resource_dir>/allaganeye.bat` (Portable ZIP production
+///    path, #615). Resource dir is the directory the Tauri bundle
+///    extracted to; we look for the same `allaganeye.bat` the ZIP
+///    layout ships with.
+/// 3. `python -m allaganeye` fallback so `npm run tauri dev` works
+///    in a fresh worktree without `pip install -e .` and without
+///    setting `ALLAGANEYE_BIN`. `cwd` is the nearest ancestor of
+///    `current_dir()` that contains `pyproject.toml`, ensuring the
+///    worktree's `allaganeye/` package is the first match on
+///    `sys.path[0]` (cwd injected by Python `-m`).
+fn resolve_allaganeye_command(app: &tauri::AppHandle) -> AllaganeyeCommand {
+    if let Some(cmd) = resolve_from_env(std::env::var("ALLAGANEYE_BIN").ok()) {
+        return cmd;
+    }
+    if let Ok(resource_dir) = app.path().resource_dir() {
+        if let Some(cmd) = resolve_from_resource_dir(&resource_dir) {
+            return cmd;
         }
     }
-    "allaganeye".to_string()
+    resolve_python_fallback(find_worktree_root(std::env::current_dir().ok()))
+}
+
+/// Test helper: resolve from the `ALLAGANEYE_BIN` env var value (if any).
+/// Returns `None` for missing / empty env var so the caller can fall
+/// through to the next stage.
+fn resolve_from_env(env_value: Option<String>) -> Option<AllaganeyeCommand> {
+    let path = env_value?;
+    if path.is_empty() {
+        return None;
+    }
+    Some(AllaganeyeCommand {
+        program: path,
+        prefix_args: vec![],
+        cwd: None,
+    })
+}
+
+/// Test helper: resolve from a Tauri bundle resource directory by
+/// looking for `allaganeye.bat`. Returns `None` when the bat is
+/// absent so dev builds fall through to the python fallback.
+fn resolve_from_resource_dir(resource_dir: &Path) -> Option<AllaganeyeCommand> {
+    let bat = resource_dir.join("allaganeye.bat");
+    if bat.exists() {
+        Some(AllaganeyeCommand {
+            program: bat.to_string_lossy().to_string(),
+            prefix_args: vec![],
+            cwd: None,
+        })
+    } else {
+        None
+    }
+}
+
+/// Test helper: build the `python -m allaganeye` fallback command.
+/// `cwd` is whatever the caller decided is the worktree root (or
+/// `None` if no anchor was found, in which case Python's import
+/// machinery still finds globally-installed packages).
+fn resolve_python_fallback(cwd: Option<PathBuf>) -> AllaganeyeCommand {
+    AllaganeyeCommand {
+        program: "python".to_string(),
+        prefix_args: vec!["-m".to_string(), "allaganeye".to_string()],
+        cwd,
+    }
+}
+
+/// Test helper: walk the ancestors of `start` looking for the
+/// directory that holds `pyproject.toml`. Returns `None` for
+/// missing `start` or no anchor in the chain (e.g. when invoked
+/// outside the worktree, in which case the python fallback runs
+/// without `cwd` override).
+fn find_worktree_root(start: Option<PathBuf>) -> Option<PathBuf> {
+    let start = start?;
+    for ancestor in start.ancestors() {
+        if ancestor.join("pyproject.toml").exists() {
+            return Some(ancestor.to_path_buf());
+        }
+    }
+    None
 }
 
 /// #569 -- assemble argv for `allaganeye detect --progress-format json`.
@@ -1815,20 +1897,34 @@ async fn start_detect(
         ));
     }
 
-    let bin = resolve_allaganeye_bin();
-    let args = detect_command_args(&video_path, &output_dir, &params);
+    let cmd_spec = resolve_allaganeye_command(&app);
+    let detect_args = detect_command_args(&video_path, &output_dir, &params);
 
-    let mut cmd = tokio::process::Command::new(&bin);
-    for a in &args {
+    let mut cmd = tokio::process::Command::new(&cmd_spec.program);
+    for a in &cmd_spec.prefix_args {
         cmd.arg(a);
+    }
+    for a in &detect_args {
+        cmd.arg(a);
+    }
+    if let Some(cwd) = &cmd_spec.cwd {
+        cmd.current_dir(cwd);
     }
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
+    // #646 -- spawn failure messages need to surface the resolved
+    // program (e.g. "python -m allaganeye") so the GUI error display
+    // can hint at which stage of the resolution chain failed.
+    let resolved_label = if cmd_spec.prefix_args.is_empty() {
+        cmd_spec.program.clone()
+    } else {
+        format!("{} {}", cmd_spec.program, cmd_spec.prefix_args.join(" "))
+    };
     let mut child = cmd
         .spawn()
-        .map_err(|e| format!("spawn allaganeye failed ({}): {}", bin, e))?;
+        .map_err(|e| format!("spawn allaganeye failed ({}): {}", resolved_label, e))?;
     let stdout = child
         .stdout
         .take()
@@ -3527,32 +3623,97 @@ mod tests {
         assert!(!args.iter().any(|a| a == "--gpu-vendor"));
     }
 
-    /// `resolve_allaganeye_bin` reads `ALLAGANEYE_BIN`. cargo test is
-    /// multi-threaded by default and process env vars are shared across
-    /// threads, so split-out tests that all touch the same key would
-    /// race. Roll the three cases into one sequential test instead.
+    // -- #646 resolve_allaganeye_command parts -----------------------------
+
+    /// Custom path via env var wins.
     #[test]
-    fn resolve_allaganeye_bin_resolution_order() {
-        let key = "ALLAGANEYE_BIN";
-        let saved = std::env::var(key).ok();
+    fn resolve_from_env_returns_path_when_set() {
+        let cmd = resolve_from_env(Some("C:/custom/path/allaganeye.exe".to_string()))
+            .expect("non-empty env should resolve");
+        assert_eq!(cmd.program, "C:/custom/path/allaganeye.exe");
+        assert!(cmd.prefix_args.is_empty());
+        assert!(cmd.cwd.is_none());
+    }
 
-        // 1. Custom path wins when set.
-        std::env::set_var(key, "C:/custom/path/allaganeye.exe");
-        assert_eq!(resolve_allaganeye_bin(), "C:/custom/path/allaganeye.exe");
+    /// Empty / missing env var falls through (returns None) so the
+    /// caller can move on to the next resolution stage.
+    #[test]
+    fn resolve_from_env_returns_none_for_empty_or_missing() {
+        assert!(resolve_from_env(None).is_none());
+        assert!(resolve_from_env(Some(String::new())).is_none());
+    }
 
-        // 2. Empty value is treated as unset (PATH lookup fallback).
-        std::env::set_var(key, "");
-        assert_eq!(resolve_allaganeye_bin(), "allaganeye");
+    /// Bundle resource dir resolves to `<dir>/allaganeye.bat` when the
+    /// bat exists. Mirrors the Portable ZIP layout produced by #615.
+    #[test]
+    fn resolve_from_resource_dir_picks_bundled_bat() {
+        let tmp = TempDir::new().unwrap();
+        let bat = tmp.path().join("allaganeye.bat");
+        fs::write(&bat, "@echo off\r\n").unwrap();
 
-        // 3. Unset env -> bare name (relies on PATH search at spawn time).
-        std::env::remove_var(key);
-        assert_eq!(resolve_allaganeye_bin(), "allaganeye");
+        let cmd = resolve_from_resource_dir(tmp.path())
+            .expect("bat present should resolve");
+        assert_eq!(cmd.program, bat.to_string_lossy().to_string());
+        assert!(cmd.prefix_args.is_empty());
+        assert!(cmd.cwd.is_none());
+    }
 
-        // Restore prior env so other tests are unaffected.
-        match saved {
-            Some(v) => std::env::set_var(key, v),
-            None => std::env::remove_var(key),
-        }
+    /// Resource dir without the bat returns None (dev / non-bundled
+    /// build) so the python fallback runs.
+    #[test]
+    fn resolve_from_resource_dir_returns_none_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        assert!(resolve_from_resource_dir(tmp.path()).is_none());
+    }
+
+    /// Python fallback always builds `python -m allaganeye` regardless
+    /// of cwd.
+    #[test]
+    fn resolve_python_fallback_uses_minus_m_allaganeye() {
+        let cmd = resolve_python_fallback(None);
+        assert_eq!(cmd.program, "python");
+        assert_eq!(cmd.prefix_args, vec!["-m".to_string(), "allaganeye".to_string()]);
+        assert!(cmd.cwd.is_none());
+
+        let tmp = TempDir::new().unwrap();
+        let cmd = resolve_python_fallback(Some(tmp.path().to_path_buf()));
+        assert_eq!(cmd.cwd.as_deref(), Some(tmp.path()));
+    }
+
+    /// `find_worktree_root` walks ancestors looking for the directory
+    /// that holds `pyproject.toml`. The dev fallback uses this to
+    /// anchor `cwd` so `python -m allaganeye` finds the worktree's
+    /// `allaganeye/` package.
+    #[test]
+    fn find_worktree_root_locates_pyproject_anchor() {
+        let tmp = TempDir::new().unwrap();
+        // Layout: <root>/pyproject.toml + <root>/sub/<deeper>
+        fs::write(tmp.path().join("pyproject.toml"), b"").unwrap();
+        let deeper = tmp.path().join("sub").join("deeper");
+        fs::create_dir_all(&deeper).unwrap();
+
+        let canonical_root = fs::canonicalize(tmp.path()).unwrap();
+        let canonical_deeper = fs::canonicalize(&deeper).unwrap();
+
+        let found = find_worktree_root(Some(canonical_deeper))
+            .expect("anchor should be found");
+        let canonical_found = fs::canonicalize(&found).unwrap();
+        assert_eq!(canonical_found, canonical_root);
+    }
+
+    /// `find_worktree_root` returns None when no anchor exists in the
+    /// ancestor chain (callers fall back to a cwd-less command spec).
+    #[test]
+    fn find_worktree_root_returns_none_without_anchor() {
+        let tmp = TempDir::new().unwrap();
+        // Bare directory with no pyproject.toml at any ancestor.
+        let nested = tmp.path().join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+        // Note: the test process's parent ancestors might still contain
+        // a real `pyproject.toml` (e.g. when run from inside this repo)
+        // so we rely on the helper's None branch via Option::None
+        // input instead of trusting tmp ancestry.
+        assert!(find_worktree_root(None).is_none());
     }
 
     #[test]

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1907,6 +1907,15 @@ async fn start_detect(
     for a in &detect_args {
         cmd.arg(a);
     }
+    // #646 review Round 4 補足 #8 -- cwd は `python -m allaganeye`
+    // fallback のみで `Some(...)` になり、`find_worktree_root` で見つけた
+    // worktree root を anchor して `sys.path[0]` 経由で `allaganeye` パッケージ
+    // を import 可能にするためだけに設定する。Python 側 (allaganeye/ 配下)
+    // は video_path / output_dir を絶対 path で受けるため現状は cwd 非依存
+    // で動く。将来 Python 側で cwd-relative path 解決を追加する場合は、
+    // 本 fallback のときだけ cwd が worktree root になり挙動が静かに変わる
+    // 可能性があるので注意。env / bundle 経路では `cwd = None` なので
+    // OS デフォルト cwd で起動する。
     if let Some(cwd) = &cmd_spec.cwd {
         cmd.current_dir(cwd);
     }

--- a/gui/src/screens/DetectingScreen.module.css
+++ b/gui/src/screens/DetectingScreen.module.css
@@ -246,3 +246,48 @@
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/*
+ * #646 — start_detect Err 表示ビュー。Rust 側の失敗メッセージを
+ * `<pre>` で改行保持してそのまま見せる。ユーザーが [drop へ戻る]
+ * を明示操作するまで画面遷移しないので、ログから原因 (例:
+ * "spawn allaganeye failed (python -m allaganeye): ...") を読
+ * み取る時間を確保する。
+ */
+.errorScreen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 32px;
+  gap: 18px;
+}
+
+.errorHeading {
+  font-family: var(--ae-font-ui);
+  font-size: 16px;
+  letter-spacing: 2px;
+  color: var(--ae-danger);
+  text-transform: uppercase;
+}
+
+.errorFile {
+  font-family: var(--ae-font-body);
+  font-size: 13px;
+  color: var(--ae-text-bright);
+}
+
+.errorMessage {
+  flex: 1;
+  min-height: 0;
+  margin: 0;
+  padding: 14px 16px;
+  background: var(--ae-bg-deep);
+  border: 1px solid rgba(var(--ae-gold-rgb), 0.18);
+  font-family: var(--ae-font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--ae-text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-y: auto;
+}

--- a/gui/src/screens/DetectingScreen.module.css
+++ b/gui/src/screens/DetectingScreen.module.css
@@ -291,3 +291,27 @@
   word-break: break-word;
   overflow-y: auto;
 }
+
+/*
+ * #646 review Round 2 課題 2 — error view の [再試行] ボタン。
+ * gold tint で「次の操作を促す」プライマリ寄りに見せ、隣の
+ * `.cancelButton` (drop 復帰、`--ae-danger` 縁取り) と視覚的に
+ * 区別する。
+ */
+.retryButton {
+  padding: 8px 18px;
+  background: transparent;
+  border: 1px solid var(--ae-gold);
+  color: var(--ae-gold);
+  font-family: var(--ae-font-ui);
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.retryButton:hover {
+  background: rgba(var(--ae-gold-rgb), 0.08);
+  color: var(--ae-gold-bright);
+  border-color: var(--ae-gold-bright);
+}

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -478,6 +478,84 @@ describe('DetectingScreen', () => {
     expect(useAppStateStore.getState().screen).toBe('drop');
   });
 
+  // #646 review Round 2 課題 2 -- retry button restarts the detect
+  // run by clearing local state and bumping the run effect's dep
+  // counter so start_detect is invoked a second time.
+  it('retry button restarts detection after error (#646)', async () => {
+    let callCount = 0;
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.reject(new Error('spawn allaganeye failed'));
+        }
+        // Second call hangs so we can observe the retry transitioned
+        // back into detecting (running) without being immediately
+        // resolved into complete by the happy-path mock.
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-error')).toBeInTheDocument();
+    });
+    expect(callCount).toBe(1);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('detecting-error-retry'));
+    });
+
+    // After retry: error view replaced by the running detecting screen
+    // (the same data-testid='detecting-screen' container the running
+    // path uses) and start_detect invoked a second time.
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-screen')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(callCount).toBe(2);
+    });
+  });
+
+  // #646 review Round 2 課題 3 -- a11y: error view auto-focuses the
+  // back button so screen readers announce the error context and
+  // keyboard users land on a non-destructive action by default.
+  it('auto-focuses [drop へ戻る] when entering error view (#646)', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return Promise.reject(new Error('boom'));
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-error')).toBeInTheDocument();
+    });
+    const back = screen.getByTestId('detecting-error-back');
+    expect(document.activeElement).toBe(back);
+  });
+
+  // #646 review Round 2 課題 3 -- a11y: Escape key on the error view
+  // returns to drop without requiring mouse focus on the back button.
+  it('Escape on error view returns to drop (#646)', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return Promise.reject(new Error('boom'));
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-error')).toBeInTheDocument();
+    });
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    expect(useAppStateStore.getState().screen).toBe('drop');
+  });
+
   // #646 -- CLI が emit した phase=error event 経路でも同じ error UI
   // が表示され、ユーザーは Rust が emit した stderr tail を見ながら
   // 操作で drop に戻る。

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -436,7 +436,32 @@ describe('DetectingScreen', () => {
     });
   });
 
-  it('routes to drop when start_detect rejects', async () => {
+  // #646 -- start_detect reject から drop へは silent 復帰せず、error
+  // 表示 + 戻るボタンの明示操作で復帰する。Rust Err 内容が画面に出る。
+  it('shows error UI when start_detect rejects (#646)', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return Promise.reject(
+          new Error(
+            'spawn allaganeye failed (python -m allaganeye): not found',
+          ),
+        );
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-error')).toBeInTheDocument();
+    });
+    // detecting screen は unmount されない (drop へは行かない)
+    expect(useAppStateStore.getState().screen).toBe('detecting');
+    // Rust Err 内容が画面に出る
+    const msg = screen.getByTestId('detecting-error-message');
+    expect(msg.textContent).toContain('spawn allaganeye failed');
+    expect(msg.textContent).toContain('python -m allaganeye');
+  });
+
+  it('back button on error view returns to drop (#646)', async () => {
     invokeMock.mockImplementation((cmd) => {
       if (cmd === 'start_detect') {
         return Promise.reject(new Error('spawn allaganeye failed'));
@@ -445,12 +470,18 @@ describe('DetectingScreen', () => {
     });
     render(<DetectingScreen />);
     await waitFor(() => {
-      expect(useAppStateStore.getState().screen).toBe('drop');
+      expect(screen.getByTestId('detecting-error')).toBeInTheDocument();
     });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /drop へ戻る/ }));
+    });
+    expect(useAppStateStore.getState().screen).toBe('drop');
   });
 
-  it('routes to drop when CLI emits a phase=error event', async () => {
-    // Make start_detect hang so the only termination path is via error event.
+  // #646 -- CLI が emit した phase=error event 経路でも同じ error UI
+  // が表示され、ユーザーは Rust が emit した stderr tail を見ながら
+  // 操作で drop に戻る。
+  it('shows error UI when CLI emits a phase=error event (#646)', async () => {
     invokeMock.mockImplementation((cmd) => {
       if (cmd === 'start_detect') {
         return new Promise(() => {
@@ -470,8 +501,12 @@ describe('DetectingScreen', () => {
       });
     });
     await waitFor(() => {
-      expect(useAppStateStore.getState().screen).toBe('drop');
+      expect(screen.getByTestId('detecting-error')).toBeInTheDocument();
     });
+    expect(useAppStateStore.getState().screen).toBe('detecting');
+    expect(
+      screen.getByTestId('detecting-error-message').textContent,
+    ).toContain('No match boundaries detected.');
   });
 
   it('falls back to loadSample when no video is selected (StateSwitcher dev mode)', async () => {

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -519,6 +519,82 @@ describe('DetectingScreen', () => {
     });
   });
 
+  // #646 review Round 4 補足 #6 -- retry remounts the running view via
+  // `key={runCount}`. After retry the run-scoped state (progress / log
+  // / probeInfo / phaseLabel / elapsed) must be back at initial values
+  // so the user does not see leftover data from the failed run. Pin
+  // this contract so future state additions on the running view either
+  // ride the remount automatically or trip this test.
+  it('retry resets run-scoped state on remount (#646 補足 #6)', async () => {
+    let callCount = 0;
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        callCount += 1;
+        // Both calls hang so the lifecycle is driven by detect-progress
+        // events: probing + scan populate state, then phase=error trips
+        // the error UI without invoke ever resolving.
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(lastDetectProgressHandler).not.toBeNull();
+    });
+
+    // Populate run-scoped state on the first run.
+    act(() => {
+      emitDetectProgress({
+        phase: 'probing',
+        width: 1920,
+        height: 1080,
+        fps: 60,
+        codec: 'h264',
+        duration_s: 600,
+      });
+      emitDetectProgress({ phase: 'scan', completed: 50, total: 100 });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-meta').textContent).toContain(
+        '1920x1080',
+      );
+    });
+
+    // Drive into error UI via phase=error event.
+    act(() => {
+      emitDetectProgress({ phase: 'error', message: 'boom' });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-error')).toBeInTheDocument();
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('detecting-error-retry'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-screen')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(callCount).toBe(2);
+    });
+
+    // probeInfo cleared -> meta line falls back to "phase: start"
+    // (the phaseLabel initial value).
+    const meta = screen.getByTestId('detecting-meta');
+    expect(meta.textContent).toContain('phase: start');
+    expect(meta.textContent).not.toContain('1920x1080');
+    // progress badge + both PhaseRows display 0% on a fresh remount.
+    expect(screen.getAllByText('0%').length).toBeGreaterThan(0);
+    // log placeholder visible (log array empty).
+    expect(screen.getByText(/起動中…/)).toBeInTheDocument();
+    // elapsed back to 00:00 (timer reset on remount).
+    expect(screen.getByText(/経過 00:00/)).toBeInTheDocument();
+  });
+
   // #646 review Round 2 課題 3 -- a11y: error view auto-focuses the
   // back button so screen readers announce the error context and
   // keyboard users land on a non-destructive action by default.

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -279,13 +279,14 @@ export function DetectingScreen() {
   // #569 review Round 1 課題 1: probing event payload を保持して
   // header meta 行を実 ffprobe 結果で render する。
   const [probeInfo, setProbeInfo] = useState<ProbeInfo | null>(null);
-  // Captured once on first mount via lazy initialiser so log entries
-  // can compute their relative timestamp inside render. We never need
-  // to update this value -- the screen unmounts when navigating away,
-  // and a fresh detect run remounts the component (App.tsx routes by
-  // screen). Avoids the react-hooks/set-state-in-effect lint warning
-  // a setState-in-effect initialiser would trip.
-  const [startedAt] = useState<number>(() => Date.now());
+  // can compute their relative timestamp inside render. Updated only
+  // from the [再試行] handler so a retried detect resets its elapsed
+  // timer baseline to "now". The lazy initialiser sidesteps the
+  // react-hooks/set-state-in-effect rule for the initial assignment.
+  const [startedAt, setStartedAt] = useState<number>(() => Date.now());
+  // #646 review Round 2 課題 2 -- bumping `runCount` is the dep change
+  // that re-fires the start_detect / listen effect for [再試行].
+  const [runCount, setRunCount] = useState(0);
   // #639 — pin the live-log scroll viewport so we can pull it back to
   // the bottom whenever a new entry arrives. The DOM ref talks to an
   // external system (scrollTop is browser state, not React state), so
@@ -419,11 +420,11 @@ export function DetectingScreen() {
       if (unlisten) unlisten();
     };
     // selectedVideoPath / loadMetadata / loadSample / navigate are
-    // store-bound and stable; we re-run only if the user re-enters the
-    // screen with a different video, which already remounts via the
-    // App.tsx screen switch.
+    // store-bound and stable; we re-run only when `runCount` bumps from
+    // the [再試行] handler (#646 review Round 2 課題 2). Initial mount
+    // also goes through this effect (runCount = 0).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [runCount]);
 
   // completed → navigate to complete (load happened above)
   useEffect(() => {
@@ -466,30 +467,30 @@ export function DetectingScreen() {
   // #646 -- error phase は detect 進行 UI を捨てて専用 error view に
   // 切り替える。Rust Err 内容 (start_detect の failure message や
   // CLI が emit した phase=error event の message) を `<pre>` で
-  // 改行保持して表示し、ユーザーが [drop へ戻る] を明示操作する
-  // までは画面遷移しない。
+  // 改行保持して表示し、ユーザーが [再試行] / [drop へ戻る] を明示
+  // 操作するまでは画面遷移しない。
+  // Round 2 課題 2 / 課題 3: retry / auto-focus / Esc handler を
+  // 切り出した DetectingErrorView 内で実装する。
+  function handleRetry(): void {
+    setError(null);
+    setProgress(0);
+    setLog([]);
+    setProbeInfo(null);
+    setPhaseLabel('start');
+    setElapsed(0);
+    setStartedAt(Date.now());
+    dispatch({ type: 'RETRY' });
+    setRunCount((c) => c + 1);
+  }
+
   if (phase === 'error') {
     return (
-      <div
-        className={styles.errorScreen}
-        data-testid="detecting-error"
-        role="alert"
-      >
-        <div className={styles.errorHeading}>検知に失敗しました</div>
-        <div className={styles.errorFile}>{displayFile}</div>
-        <pre className={styles.errorMessage} data-testid="detecting-error-message">
-          {error ?? 'unknown error'}
-        </pre>
-        <div className={styles.actions}>
-          <button
-            type="button"
-            className={styles.cancelButton}
-            onClick={() => navigate('drop')}
-          >
-            ← drop へ戻る
-          </button>
-        </div>
-      </div>
+      <DetectingErrorView
+        error={error}
+        displayFile={displayFile}
+        onRetry={handleRetry}
+        onBack={() => navigate('drop')}
+      />
     );
   }
 
@@ -620,6 +621,84 @@ function PhaseRow({ name, jp, pct, sub }: PhaseRowProps) {
       </div>
       <div className={styles.bar}>
         <div className={fillClass} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * #646 review Round 2 課題 2 / 課題 3 -- error view extracted into
+ * its own component so we can attach focus management + an Escape
+ * keyboard handler local to the error state without leaking listeners
+ * into the running view.
+ *
+ * - Auto-focus the [drop へ戻る] button on mount so screen readers
+ *   announce the error context and keyboard users land on a non-
+ *   destructive action by default
+ * - Escape returns to drop (the canonical "get me out" key on this
+ *   terminal screen)
+ * - Retry button restarts the detect run via the parent's `onRetry`,
+ *   which clears local state and bumps the run effect's dep counter
+ */
+interface DetectingErrorViewProps {
+  error: string | null;
+  displayFile: string;
+  onRetry: () => void;
+  onBack: () => void;
+}
+
+function DetectingErrorView({
+  error,
+  displayFile,
+  onRetry,
+  onBack,
+}: DetectingErrorViewProps) {
+  const backButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    backButtonRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onBack();
+      }
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onBack]);
+
+  return (
+    <div
+      className={styles.errorScreen}
+      data-testid="detecting-error"
+      role="alert"
+    >
+      <div className={styles.errorHeading}>検知に失敗しました</div>
+      <div className={styles.errorFile}>{displayFile}</div>
+      <pre className={styles.errorMessage} data-testid="detecting-error-message">
+        {error ?? 'unknown error'}
+      </pre>
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.retryButton}
+          onClick={onRetry}
+          data-testid="detecting-error-retry"
+        >
+          ↻ 再試行
+        </button>
+        <button
+          ref={backButtonRef}
+          type="button"
+          className={styles.cancelButton}
+          onClick={onBack}
+          data-testid="detecting-error-back"
+        >
+          ← drop へ戻る
+        </button>
       </div>
     </div>
   );

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -271,22 +271,124 @@ export function DetectingScreen() {
     detectingReducer,
     'running' as DetectingPhase,
   );
+  const [error, setError] = useState<string | null>(null);
+  // #646 review Round 4 補足 #6 -- run-scoped state (progress / log /
+  // probeInfo / phaseLabel / elapsed / startedAt) は `DetectingRunningView`
+  // 内部に閉じ込め、retry 時は `key={runCount}` で remount して initial
+  // 値に戻す。親が個別 setState を列挙する旧設計だと「将来 state 追加
+  // で reset 漏れ」の visible regression を生むため、子 unmount で local
+  // state がまとめて捨てられる構造に変えた。
+  const [runCount, setRunCount] = useState(0);
+
+  const displayFile = selectedVideoPath?.split(/[/\\]/).pop() ?? '(video)';
+
+  // completed → navigate to complete (load happened in the running view)
+  useEffect(() => {
+    if (phase === 'completed') {
+      navigate('complete');
+    }
+  }, [phase, navigate]);
+
+  // #646 -- cancelled は即時 drop へ復帰、error は **手動操作** で復帰。
+  // 以前は error も即時 navigate('drop') していたため、Rust 側 Err
+  // (例: spawn allaganeye failed / video file not found) がユーザーに
+  // 見えず silent で drop 画面に戻る挙動だった。今は error phase で
+  // 専用 view を render し、ユーザーが [drop へ戻る] を押すまで画面
+  // 遷移しない。
+  useEffect(() => {
+    if (phase === 'cancelled') {
+      navigate('drop');
+    }
+  }, [phase, navigate]);
+
+  // Cancel button: phase transition only. Real ffmpeg kill ships in
+  // #523's PR via kill_tracked_processes; this PR keeps the issue's
+  // explicit scope ("UI phase transition only").
+  useEffect(() => {
+    if (phase === 'cancelling') {
+      dispatch({ type: 'CANCEL_CONFIRMED' });
+    }
+  }, [phase]);
+
+  // #646 -- error phase は detect 進行 UI を捨てて専用 error view に
+  // 切り替える。Rust Err 内容 (start_detect の failure message や
+  // CLI が emit した phase=error event の message) を `<pre>` で
+  // 改行保持して表示し、ユーザーが [再試行] / [drop へ戻る] を明示
+  // 操作するまでは画面遷移しない。
+  // Round 4 補足 #6: handleRetry は親 reducer の RETRY action と
+  // runCount bump のみ。run-scoped state の reset は `key={runCount}`
+  // による子 component remount で達成する。
+  function handleRetry(): void {
+    setError(null);
+    dispatch({ type: 'RETRY' });
+    setRunCount((c) => c + 1);
+  }
+
+  if (phase === 'error') {
+    return (
+      <DetectingErrorView
+        error={error}
+        displayFile={displayFile}
+        onRetry={handleRetry}
+        onBack={() => navigate('drop')}
+      />
+    );
+  }
+
+  return (
+    <DetectingRunningView
+      key={runCount}
+      phase={phase}
+      selectedVideoPath={selectedVideoPath}
+      detectionParams={detectionParams}
+      loadMetadata={loadMetadata}
+      loadSample={loadSample}
+      navigate={navigate}
+      onCancelClick={() => dispatch({ type: 'CANCEL_CLICKED' })}
+      onError={(msg) => {
+        setError(msg);
+        dispatch({ type: 'DETECT_ERROR' });
+      }}
+      onComplete={() => dispatch({ type: 'PROGRESS_COMPLETE' })}
+    />
+  );
+}
+
+interface DetectingRunningViewProps {
+  phase: DetectingPhase;
+  selectedVideoPath: string | null;
+  detectionParams: ReturnType<typeof useAppStateStore.getState>['detectionParams'];
+  loadMetadata: ReturnType<typeof useMetadataStore.getState>['load'];
+  loadSample: ReturnType<typeof useMetadataStore.getState>['loadSample'];
+  navigate: ReturnType<typeof useAppStateStore.getState>['navigate'];
+  onCancelClick: () => void;
+  onError: (message: string) => void;
+  onComplete: () => void;
+}
+
+function DetectingRunningView({
+  phase,
+  selectedVideoPath,
+  detectionParams,
+  loadMetadata,
+  loadSample,
+  navigate,
+  onCancelClick,
+  onError,
+  onComplete,
+}: DetectingRunningViewProps) {
   const [progress, setProgress] = useState(0);
   const [phaseLabel, setPhaseLabel] = useState<string>('start');
   const [log, setLog] = useState<LogEntry[]>([]);
   const [elapsed, setElapsed] = useState(0);
-  const [error, setError] = useState<string | null>(null);
   // #569 review Round 1 課題 1: probing event payload を保持して
   // header meta 行を実 ffprobe 結果で render する。
   const [probeInfo, setProbeInfo] = useState<ProbeInfo | null>(null);
-  // can compute their relative timestamp inside render. Updated only
-  // from the [再試行] handler so a retried detect resets its elapsed
-  // timer baseline to "now". The lazy initialiser sidesteps the
-  // react-hooks/set-state-in-effect rule for the initial assignment.
-  const [startedAt, setStartedAt] = useState<number>(() => Date.now());
-  // #646 review Round 2 課題 2 -- bumping `runCount` is the dep change
-  // that re-fires the start_detect / listen effect for [再試行].
-  const [runCount, setRunCount] = useState(0);
+  // Captured once on first mount via lazy initialiser so log entries
+  // can compute their relative timestamp inside render. The parent
+  // remounts this component (via `key={runCount}`) on retry, so a new
+  // run starts with a fresh `startedAt` baseline automatically.
+  const [startedAt] = useState<number>(() => Date.now());
   // #639 — pin the live-log scroll viewport so we can pull it back to
   // the bottom whenever a new entry arrives. The DOM ref talks to an
   // external system (scrollTop is browser state, not React state), so
@@ -333,6 +435,9 @@ export function DetectingScreen() {
   }, []);
 
   // Subscribe to detect-progress, kick off start_detect.
+  // Mount-once effect: the parent remounts this component on retry
+  // via `key={runCount}` so a new mount = a new detect run. No dep
+  // chasing needed for re-invocation.
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;
     let cancelled = false;
@@ -384,8 +489,7 @@ export function DetectingScreen() {
             }
 
             if (payload.phase === 'error') {
-              setError(payload.message ?? 'unknown error');
-              dispatch({ type: 'DETECT_ERROR' });
+              onError(payload.message ?? 'unknown error');
               return;
             }
 
@@ -406,11 +510,10 @@ export function DetectingScreen() {
         setProgress(100);
         const metaPath = result.metadata_path || metadataPathFor(outputDir);
         await loadMetadata(metaPath);
-        dispatch({ type: 'PROGRESS_COMPLETE' });
+        onComplete();
       } catch (e) {
         if (cancelled) return;
-        setError(e instanceof Error ? e.message : String(e));
-        dispatch({ type: 'DETECT_ERROR' });
+        onError(e instanceof Error ? e.message : String(e));
       }
     }
 
@@ -419,40 +522,10 @@ export function DetectingScreen() {
       cancelled = true;
       if (unlisten) unlisten();
     };
-    // selectedVideoPath / loadMetadata / loadSample / navigate are
-    // store-bound and stable; we re-run only when `runCount` bumps from
-    // the [再試行] handler (#646 review Round 2 課題 2). Initial mount
-    // also goes through this effect (runCount = 0).
+    // Mount-once: store-bound props are stable across the same mount
+    // and a retry remounts the component (via parent's `key={runCount}`).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runCount]);
-
-  // completed → navigate to complete (load happened above)
-  useEffect(() => {
-    if (phase === 'completed') {
-      navigate('complete');
-    }
-  }, [phase, navigate]);
-
-  // #646 -- cancelled は即時 drop へ復帰、error は **手動操作** で復帰。
-  // 以前は error も即時 navigate('drop') していたため、Rust 側 Err
-  // (例: spawn allaganeye failed / video file not found) がユーザーに
-  // 見えず silent で drop 画面に戻る挙動だった。今は error phase で
-  // 専用 view を render し、ユーザーが [drop へ戻る] を押すまで画面
-  // 遷移しない。
-  useEffect(() => {
-    if (phase === 'cancelled') {
-      navigate('drop');
-    }
-  }, [phase, navigate]);
-
-  // Cancel button: phase transition only. Real ffmpeg kill ships in
-  // #523's PR via kill_tracked_processes; this PR keeps the issue's
-  // explicit scope ("UI phase transition only").
-  useEffect(() => {
-    if (phase === 'cancelling') {
-      dispatch({ type: 'CANCEL_CONFIRMED' });
-    }
-  }, [phase]);
+  }, []);
 
   const pct1 = Math.min(100, progress * (100 / 70)); // scan finishes at 70%
   const pct2 = Math.max(0, Math.min(100, ((progress - 70) * 100) / 18)); // refine fills 70-88
@@ -464,36 +537,6 @@ export function DetectingScreen() {
   // 「meta 行が空」状態を回避する。
   const metaText = probeInfo ? formatProbeMeta(probeInfo) : `phase: ${phaseLabel}`;
 
-  // #646 -- error phase は detect 進行 UI を捨てて専用 error view に
-  // 切り替える。Rust Err 内容 (start_detect の failure message や
-  // CLI が emit した phase=error event の message) を `<pre>` で
-  // 改行保持して表示し、ユーザーが [再試行] / [drop へ戻る] を明示
-  // 操作するまでは画面遷移しない。
-  // Round 2 課題 2 / 課題 3: retry / auto-focus / Esc handler を
-  // 切り出した DetectingErrorView 内で実装する。
-  function handleRetry(): void {
-    setError(null);
-    setProgress(0);
-    setLog([]);
-    setProbeInfo(null);
-    setPhaseLabel('start');
-    setElapsed(0);
-    setStartedAt(Date.now());
-    dispatch({ type: 'RETRY' });
-    setRunCount((c) => c + 1);
-  }
-
-  if (phase === 'error') {
-    return (
-      <DetectingErrorView
-        error={error}
-        displayFile={displayFile}
-        onRetry={handleRetry}
-        onBack={() => navigate('drop')}
-      />
-    );
-  }
-
   return (
     <div className={styles.screen} data-testid="detecting-screen">
       <div className={styles.header}>
@@ -503,7 +546,6 @@ export function DetectingScreen() {
           <div className={styles.fileName}>{displayFile}</div>
           <div className={styles.meta} data-testid="detecting-meta">
             {metaText}
-            {error ? ` · error: ${error}` : ''}
           </div>
         </div>
         <div className={styles.progressBadge}>
@@ -582,7 +624,7 @@ export function DetectingScreen() {
               type="button"
               className={styles.cancelButton}
               disabled={phase !== 'running'}
-              onClick={() => dispatch({ type: 'CANCEL_CLICKED' })}
+              onClick={onCancelClick}
               {...p}
             >
               中断
@@ -662,7 +704,6 @@ function DetectingErrorView({
   useEffect(() => {
     function handler(e: KeyboardEvent) {
       if (e.key === 'Escape') {
-        e.preventDefault();
         onBack();
       }
     }

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -432,9 +432,14 @@ export function DetectingScreen() {
     }
   }, [phase, navigate]);
 
-  // cancelled / error → back to drop
+  // #646 -- cancelled は即時 drop へ復帰、error は **手動操作** で復帰。
+  // 以前は error も即時 navigate('drop') していたため、Rust 側 Err
+  // (例: spawn allaganeye failed / video file not found) がユーザーに
+  // 見えず silent で drop 画面に戻る挙動だった。今は error phase で
+  // 専用 view を render し、ユーザーが [drop へ戻る] を押すまで画面
+  // 遷移しない。
   useEffect(() => {
-    if (phase === 'cancelled' || phase === 'error') {
+    if (phase === 'cancelled') {
       navigate('drop');
     }
   }, [phase, navigate]);
@@ -457,6 +462,36 @@ export function DetectingScreen() {
   // 表示。受信前 (起動直後の数百 ms) は暫定で `phase: ...` を出して
   // 「meta 行が空」状態を回避する。
   const metaText = probeInfo ? formatProbeMeta(probeInfo) : `phase: ${phaseLabel}`;
+
+  // #646 -- error phase は detect 進行 UI を捨てて専用 error view に
+  // 切り替える。Rust Err 内容 (start_detect の failure message や
+  // CLI が emit した phase=error event の message) を `<pre>` で
+  // 改行保持して表示し、ユーザーが [drop へ戻る] を明示操作する
+  // までは画面遷移しない。
+  if (phase === 'error') {
+    return (
+      <div
+        className={styles.errorScreen}
+        data-testid="detecting-error"
+        role="alert"
+      >
+        <div className={styles.errorHeading}>検知に失敗しました</div>
+        <div className={styles.errorFile}>{displayFile}</div>
+        <pre className={styles.errorMessage} data-testid="detecting-error-message">
+          {error ?? 'unknown error'}
+        </pre>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.cancelButton}
+            onClick={() => navigate('drop')}
+          >
+            ← drop へ戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.screen} data-testid="detecting-screen">

--- a/gui/src/screens/reducers/detecting.test.ts
+++ b/gui/src/screens/reducers/detecting.test.ts
@@ -42,4 +42,18 @@ describe('detectingReducer', () => {
       detectingReducer('error', { type: 'CANCEL_CLICKED' }),
     ).toBe('error');
   });
+
+  // #646 review Round 2 課題 2 -- RETRY action transitions error → running.
+  it('goes error -> running on RETRY', () => {
+    expect(detectingReducer('error', { type: 'RETRY' })).toBe('running');
+  });
+
+  it('ignores RETRY in non-error states', () => {
+    // RETRY should be a no-op anywhere except error to avoid restarting
+    // detection from inside a running / cancelling / cancelled / completed flow.
+    expect(detectingReducer('running', { type: 'RETRY' })).toBe('running');
+    expect(detectingReducer('cancelling', { type: 'RETRY' })).toBe('cancelling');
+    expect(detectingReducer('cancelled', { type: 'RETRY' })).toBe('cancelled');
+    expect(detectingReducer('completed', { type: 'RETRY' })).toBe('completed');
+  });
 });

--- a/gui/src/screens/reducers/detecting.ts
+++ b/gui/src/screens/reducers/detecting.ts
@@ -11,7 +11,11 @@ export type DetectingEvent =
   | { type: 'CANCEL_CLICKED' }
   | { type: 'CANCEL_CONFIRMED' }
   | { type: 'PROGRESS_COMPLETE' }
-  | { type: 'DETECT_ERROR' };
+  | { type: 'DETECT_ERROR' }
+  // #646 review Round 2 課題 2 -- error view の [再試行] から発火。
+  // error → running の唯一の自動遷移経路で、ユーザー操作起因 (drop
+  // / refine 失敗 → 再試行 / done からの戻り等) のみ許可される。
+  | { type: 'RETRY' };
 
 export function detectingReducer(
   phase: DetectingPhase,
@@ -30,11 +34,16 @@ export function detectingReducer(
       if (event.type === 'DETECT_ERROR') return 'cancelled';
       return phase;
 
+    case 'error':
+      // #646 -- only RETRY transitions out of error; navigation to drop
+      // is the caller's responsibility (DetectingScreen back button).
+      if (event.type === 'RETRY') return 'running';
+      return phase;
+
     // Terminal-within-screen states — transitions out are handled by the caller
     // via navigate('drop') / navigate('complete').
     case 'cancelled':
     case 'completed':
-    case 'error':
       return phase;
   }
 }


### PR DESCRIPTION
## Summary

PR #641 実機検証で発覚した 2 問題に対応 ([#646](https://github.com/Idios/kobutachan-allaganeye/issues/646))。

- **問題 A (silent error)**: `start_detect` 失敗時に `phase=error` の `useEffect` 内 `navigate('drop')` で silent 復帰し、Rust Err 内容 (`spawn allaganeye failed: ...` 等) がユーザーに見えない。
- **問題 B (CLI 解決)**: `resolve_allaganeye_bin()` が env var + PATH lookup の 2 段階のみで、worktree 内 Python パッケージを直接呼ぶ経路が無く、開発時に `pip install -e .` + `ALLAGANEYE_BIN` 設定をユーザーに要求していた。

## 受け入れ条件チェック ([#646](https://github.com/Idios/kobutachan-allaganeye/issues/646))

| # | 受け入れ条件 | 対応 |
|---|---|---|
| A1 | `start_detect` 失敗時、DetectingScreen が drop へ navigate せず error message を画面表示する | [DetectingScreen.tsx](gui/src/screens/DetectingScreen.tsx) の `phase === 'error'` で専用 view を render (旧自動 navigate を削除) / `DetectingScreen.test.tsx` "shows error UI when start_detect rejects (#646)" |
| A2 | error 表示状態で `[戻る]` (or 同等) を押すと明示操作で drop 復帰 | error view 内 `← drop へ戻る` ボタン → `navigate('drop')` / `DetectingScreen.test.tsx` "back button on error view returns to drop (#646)" |
| A3 | error message に Rust 側 Err 内容が含まれる | `<pre data-testid="detecting-error-message">{error}</pre>` で改行保持表示 / DOM assertion で確認 |
| B1 | ALLAGANEYE_BIN 未設定 + `pip install -e .` 未実施で `npm run tauri dev` → drop → 動画選択 → detecting で start_detect が成功する | [lib.rs](gui/src-tauri/src/lib.rs) `resolve_python_fallback` + `find_worktree_root` で `cwd = <worktree>/pyproject.toml の親` に anchor、`python -m allaganeye` 起動で worktree 内 `allaganeye/` パッケージを `sys.path[0]` 経由で load (実機視認は本 PR マージ後の close-issue 時) |
| B2 | resolve 経路 (env > bundle > python -m fallback) を Rust unit test で pin | `resolve_from_env` / `resolve_from_resource_dir` / `resolve_python_fallback` / `find_worktree_root` 各 helper に分割し pure function として cargo test (7 ケース追加) |
| C1 | vitest + Rust unit test | vitest 460 passed (+4) / cargo test 120 passed (+7) |
| C2 | eslint / typecheck / cargo check / pyright 全通過 | 全通過 |

## 設計改修詳細 (問題 B)

`resolve_allaganeye_bin()` を `resolve_allaganeye_command(app: &AppHandle) -> AllaganeyeCommand` にリネーム。戻り値:

```rust
struct AllaganeyeCommand {
    program: String,      // 起動 exe (例: "python")
    prefix_args: Vec<String>,  // 例: ["-m", "allaganeye"]
    cwd: Option<PathBuf>,      // 例: worktree root
}
```

解決順:

1. `ALLAGANEYE_BIN` env var (escape hatch / override) → `(env_path, [], None)`
2. `<bundle_resource_dir>/allaganeye.bat` (Portable ZIP 配布、[#615](https://github.com/Idios/kobutachan-allaganeye/issues/615)) → `(bat_path, [], None)`
3. `python -m allaganeye` フォールバック → `("python", ["-m", "allaganeye"], Some(<worktree_root>))`

`worktree_root` は `current_dir().ancestors()` を walk して `pyproject.toml` を持つ祖先を探す (Tauri dev 時の cwd `gui/src-tauri` から `..` `..` で worktree root に到達)。

## ユーザー側の効果 (本 PR マージ後)

- `pip install -e .` **不要** (Python 環境に `allaganeye` をインストールする必要なし)
- `ALLAGANEYE_BIN` 環境変数の設定 **不要**
- 単に `cd gui && npm run tauri dev` で起動し、worktree 内のソースをそのまま実行できる
- production の Portable ZIP は同梱 `allaganeye.bat` を resource_dir 経由で resolve するので Pre-#646 と挙動同じ
- `ALLAGANEYE_BIN` を設定したい場合 (= 別 venv の allaganeye.exe を使う等) は escape hatch として残っている

## Test plan

- [x] `cd gui && npm run lint`
- [x] `cd gui && npm run typecheck`
- [x] `cd gui && npm test -- --run` (460 passed、本 PR で +4)
- [x] `cd gui/src-tauri && cargo check --tests`
- [x] `cd gui/src-tauri && cargo test --lib` (120 passed、本 PR で +7)
- [x] `python -m ruff check .` / `python -m pyright` (Python 変更なしだが回帰確認)

GUI Tauri 統合での動作確認は本 PR マージ後 → worktree を develop に rebase → ALLAGANEYE_BIN 未設定 + pip install 未実施の環境で `npm run tauri dev` → drop → 動画選択 → detecting で start_detect が成功するか視認 (Idios) 想定。

## 関連 PR

- [#641](https://github.com/Idios/kobutachan-allaganeye/pull/641) (#639 ログ overflow): 本 PR マージ後に develop rebase + 本 PR の resolve fallback 込みで実機検証可能になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

