### PR TITLE
feat: HW info verbose を multi-CPU / multi-GPU 対応 (Refs #435 #436)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -1344,7 +1344,7 @@ def _print_environment_header(
     from allaganeye.system_info import (
         get_cpu_info,
         get_disk_info,
-        get_gpu_info,
+        get_gpu_info_lines,
         get_memory_info,
     )
 
@@ -1356,7 +1356,15 @@ def _print_environment_header(
         f"{platform.system()} {platform.release()})"
     )
     typer.echo(f"  CPU: {get_cpu_info()}")
-    typer.echo(f"  GPU: {get_gpu_info()}")
+    gpus = get_gpu_info_lines()
+    if not gpus:
+        typer.echo("  GPU: (unavailable)")
+    elif len(gpus) == 1:
+        typer.echo(f"  GPU: {gpus[0]}")
+    else:
+        typer.echo("  GPU:")
+        for gpu in gpus:
+            typer.echo(f"    - {gpu}")
     typer.echo(f"  Memory: {get_memory_info()}")
     disk_target = output_dir if output_dir is not None else Path.cwd()
     typer.echo(f"  Disk: {get_disk_info(disk_target)}")

--- a/allaganeye/system_info.py
+++ b/allaganeye/system_info.py
@@ -51,18 +51,33 @@ def _run_text(cmd: list[str], *, timeout: float = _SUBPROCESS_TIMEOUT_S) -> str 
 def get_cpu_info() -> str:
     """Return CPU model + core/thread layout, e.g. ``"AMD Ryzen 9 (16C/32T)"``.
 
+    Multi-CPU (multi-socket) systems aggregate counts across all sockets and
+    use the following display heuristics (#435):
+
+    - Same model x N: ``"AMD EPYC 7763 x2 (128C/256T)"``
+    - Mixed models:   ``"Intel Xeon ... + AMD EPYC ... (128C/256T)"``
+    - Single socket:  unchanged (e.g. ``"AMD Ryzen 9 9950X3D (16C/32T)"``)
+
     Falls back to ``platform.processor()`` + ``os.cpu_count()`` when
     platform-specific probes fail.  Returns ``"(unavailable)"`` only when
     no useful information can be extracted at all.
     """
-    model = _detect_cpu_model()
+    models = _detect_cpu_models()
     logical = os.cpu_count()
     physical = _detect_physical_cores()
 
-    if model is None and logical is None:
+    if not models and logical is None:
         return _UNAVAILABLE
 
-    model_str = model or "(unknown CPU)"
+    if not models:
+        model_str = "(unknown CPU)"
+    elif len(models) == 1:
+        model_str = models[0]
+    elif all(m == models[0] for m in models):
+        model_str = f"{models[0]} x{len(models)}"
+    else:
+        model_str = " + ".join(models)
+
     if logical is None:
         return model_str
     if physical is not None and physical != logical:
@@ -70,51 +85,108 @@ def get_cpu_info() -> str:
     return f"{model_str} ({logical}T)"
 
 
-def _detect_cpu_model() -> str | None:
+def _detect_cpu_models() -> list[str] | None:
+    """Return CPU model names per socket (or single-element for one CPU).
+
+    Multi-socket Windows / Linux systems return one entry per physical CPU
+    package.  macOS is single-socket only (Apple silicon).  Returns ``None``
+    if no model name can be extracted at all.
+    """
     system = platform.system()
     if system == "Windows":
         stdout = _run_text(["wmic", "cpu", "get", "name"])
         if stdout:
             lines = [line.strip() for line in stdout.splitlines() if line.strip()]
-            # First line is the "Name" header; subsequent lines are values.
+            # First line is the "Name" header; subsequent lines are per-CPU.
             if len(lines) >= 2:
-                return lines[1]
+                return lines[1:]
         # Fall back to platform.processor() which on Windows returns
         # the CPU brand via registry lookup.
-        proc = platform.processor()
-        return proc.strip() or None
+        proc = platform.processor().strip()
+        return [proc] if proc else None
 
     if system == "Linux":
+        return _detect_cpu_models_linux()
+
+    if system == "Darwin":
+        stdout = _run_text(["sysctl", "-n", "machdep.cpu.brand_string"])
+        if stdout and stdout.strip():
+            return [stdout.strip()]
+        proc = platform.processor().strip()
+        return [proc] if proc else None
+
+    # Unknown platform: best-effort
+    proc = platform.processor().strip()
+    return [proc] if proc else None
+
+
+def _detect_cpu_models_linux() -> list[str] | None:
+    """Linux helper: extract one model name per physical socket.
+
+    /proc/cpuinfo blocks contain ``physical id`` + ``model name`` per logical
+    CPU; we deduplicate by ``physical id`` so dual-socket hosts return both
+    socket models even when both are identical.
+    """
+    models_by_socket: dict[str, str] = {}
+    current_phys = ""
+    current_model = ""
+    try:
+        with open("/proc/cpuinfo", encoding="utf-8") as fh:
+            for raw in fh:
+                if raw.startswith("physical id"):
+                    current_phys = raw.partition(":")[2].strip()
+                elif raw.startswith("model name"):
+                    current_model = raw.partition(":")[2].strip()
+                elif raw.strip() == "":
+                    if current_phys and current_model:
+                        models_by_socket.setdefault(current_phys, current_model)
+                    current_phys = ""
+                    current_model = ""
+            # Trailing block without final blank line.
+            if current_phys and current_model:
+                models_by_socket.setdefault(current_phys, current_model)
+    except OSError:
+        logger.debug("cannot read /proc/cpuinfo", exc_info=True)
+        proc = platform.processor().strip()
+        return [proc] if proc else None
+
+    if not models_by_socket:
+        # Single-socket containers / qemu often omit ``physical id`` entirely.
+        # Fall back to the first ``model name`` we can find.
         try:
             with open("/proc/cpuinfo", encoding="utf-8") as fh:
                 for raw in fh:
                     if raw.startswith("model name"):
-                        _, _, value = raw.partition(":")
-                        return value.strip()
+                        value = raw.partition(":")[2].strip()
+                        return [value] if value else None
         except OSError:
-            logger.debug("cannot read /proc/cpuinfo", exc_info=True)
-        return platform.processor() or None
+            pass
+        proc = platform.processor().strip()
+        return [proc] if proc else None
 
-    if system == "Darwin":
-        stdout = _run_text(["sysctl", "-n", "machdep.cpu.brand_string"])
-        if stdout:
-            return stdout.strip() or None
-        return platform.processor() or None
-
-    # Unknown platform: best-effort
-    return platform.processor() or None
+    try:
+        sorted_keys = sorted(models_by_socket.keys(), key=int)
+    except ValueError:
+        sorted_keys = sorted(models_by_socket.keys())
+    return [models_by_socket[pid] for pid in sorted_keys]
 
 
 def _detect_physical_cores() -> int | None:
-    """Return physical (not logical) core count, or None if unknown."""
+    """Return physical (not logical) core count summed across all sockets, or
+    None if unknown (#435 -- Windows now aggregates instead of returning the
+    first socket's count only)."""
     system = platform.system()
     if system == "Windows":
         stdout = _run_text(["wmic", "cpu", "get", "NumberOfCores"])
         if stdout:
+            total = 0
+            found = False
             for line in stdout.splitlines():
                 line = line.strip()
                 if line.isdigit():
-                    return int(line)
+                    total += int(line)
+                    found = True
+            return total if found else None
         return None
     if system == "Linux":
         try:
@@ -144,46 +216,60 @@ def _detect_physical_cores() -> int | None:
 
 
 def get_gpu_info() -> str:
-    """Return GPU model (+ VRAM if known), e.g. ``"NVIDIA RTX 4090 (24GB VRAM)"``.
+    """Return primary GPU model (+ VRAM if known), e.g. ``"NVIDIA RTX 4090 (24GB VRAM)"``.
 
-    Prefers ``nvidia-smi`` for the common case; falls back to ``wmic``
-    (Windows), ``lspci`` (Linux), or ``system_profiler`` (macOS).  Returns
-    ``"(unavailable)"`` when no probe succeeds.
+    Convenience wrapper around :func:`get_gpu_info_lines` that returns the
+    first detected GPU.  For multi-GPU listing (#436) use
+    :func:`get_gpu_info_lines` instead.  Returns ``"(unavailable)"`` when
+    no probe succeeds.
     """
-    nvidia = _detect_gpu_nvidia()
-    if nvidia is not None:
-        return nvidia
-
-    system = platform.system()
-    if system == "Windows":
-        stdout = _run_text(["wmic", "path", "win32_VideoController", "get", "name"])
-        if stdout:
-            lines = [line.strip() for line in stdout.splitlines() if line.strip()]
-            if len(lines) >= 2:
-                # Return the first non-header GPU; multi-GPU is rare on
-                # Windows gaming rigs and the verbose header stays terse.
-                return lines[1]
-    elif system == "Linux":
-        stdout = _run_text(["lspci"])
-        if stdout:
-            for line in stdout.splitlines():
-                lowered = line.lower()
-                if "vga" in lowered or "3d controller" in lowered:
-                    # "01:00.0 VGA compatible controller: NVIDIA ..."
-                    _, _, value = line.partition(":")
-                    _, _, value = value.partition(":")
-                    return value.strip() or line.strip()
-    elif system == "Darwin":
-        stdout = _run_text(["system_profiler", "SPDisplaysDataType"])
-        if stdout:
-            match = re.search(r"Chipset Model:\s*(.+)", stdout)
-            if match:
-                return match.group(1).strip()
-
-    return _UNAVAILABLE
+    lines = get_gpu_info_lines()
+    if not lines:
+        return _UNAVAILABLE
+    return lines[0]
 
 
-def _detect_gpu_nvidia() -> str | None:
+def get_gpu_info_lines() -> list[str]:
+    """Return all GPU model strings detected, one entry per device (#436).
+
+    NVIDIA GPUs include VRAM (e.g. ``"NVIDIA RTX 5090 (32GB VRAM)"``) via
+    ``nvidia-smi``.  Other vendors fall back to platform probes (``wmic`` on
+    Windows, ``lspci`` on Linux, ``system_profiler`` on macOS).  Multi-GPU
+    systems (e.g. iGPU + dGPU, dual NVIDIA) return one entry per device,
+    deduplicated against the NVIDIA list so the same card never appears
+    twice.  Returns ``[]`` when no probe succeeds; callers should display
+    ``"(unavailable)"`` in that case.
+    """
+    nvidia_gpus = _detect_all_gpus_nvidia()
+    platform_gpus = _probe_gpu_names_platform()
+
+    result: list[str] = list(nvidia_gpus)
+    nvidia_signatures = {_gpu_signature(name) for name in nvidia_gpus}
+    for name in platform_gpus:
+        if _gpu_signature(name) not in nvidia_signatures:
+            result.append(name)
+    return result
+
+
+def _gpu_signature(name: str) -> str:
+    """Return a canonical signature for matching duplicate GPU names.
+
+    Strips the ``" (NN GB VRAM)"`` suffix and lowercases so an nvidia-smi
+    entry matches its bare-name twin from ``wmic`` / ``lspci``.
+    """
+    base = name.split(" (")[0].strip()
+    return base.lower()
+
+
+def _detect_all_gpus_nvidia() -> list[str]:
+    """Return all NVIDIA GPUs as ``"<name> (<gb>GB VRAM)"`` strings.
+
+    Strict CSV parser: only entries that match nvidia-smi's
+    ``--format=csv,noheader,nounits`` shape (``name, mib_int``) are
+    returned.  Anything else is dropped so unrelated probe output (e.g.
+    a globally-mocked ``_run_text`` returning ``lspci`` text) cannot
+    pollute the GPU list.
+    """
     stdout = _run_text(
         [
             "nvidia-smi",
@@ -192,16 +278,28 @@ def _detect_gpu_nvidia() -> str | None:
         ]
     )
     if not stdout:
-        return None
-    first = stdout.splitlines()[0].strip()
-    if not first:
-        return None
-    parts = [p.strip() for p in first.split(",")]
-    if len(parts) == 2 and parts[1].isdigit():
-        # Memory is reported in MiB; round to nearest GB for readability.
-        gb = round(int(parts[1]) / 1024)
-        return f"{parts[0]} ({gb}GB VRAM)"
-    return parts[0] or None
+        return []
+    result: list[str] = []
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) == 2 and parts[1].isdigit():
+            # Memory is reported in MiB; round to nearest GB for readability.
+            gb = round(int(parts[1]) / 1024)
+            result.append(f"{parts[0]} ({gb}GB VRAM)")
+    return result
+
+
+def _detect_gpu_nvidia() -> str | None:
+    """Return the first NVIDIA GPU name, or None if nvidia-smi is unavailable.
+
+    Kept for :func:`probe_gpu_vendors` (which only needs a presence check).
+    For full GPU listing use :func:`_detect_all_gpus_nvidia`.
+    """
+    gpus = _detect_all_gpus_nvidia()
+    return gpus[0] if gpus else None
 
 
 def get_memory_info() -> str:
@@ -332,7 +430,14 @@ def probe_gpu_vendors() -> list[str]:
 
 
 def _probe_gpu_names_platform() -> list[str]:
-    """Return raw GPU name strings from platform-specific probes."""
+    """Return GPU name strings from platform-specific probes.
+
+    On Linux the leading ``"BB:DD.F VGA compatible controller: "`` prefix is
+    stripped so the verbose header / multi-GPU listing (#436) shows just the
+    GPU model.  Vendor keyword matching in :func:`probe_gpu_vendors` still
+    works because vendor strings (NVIDIA / Intel / AMD) appear in the
+    suffix.
+    """
     system = platform.system()
     if system == "Windows":
         stdout = _run_text(["wmic", "path", "win32_VideoController", "get", "Name"])
@@ -341,11 +446,18 @@ def _probe_gpu_names_platform() -> list[str]:
     elif system == "Linux":
         stdout = _run_text(["lspci"])
         if stdout:
-            return [
-                line.strip()
-                for line in stdout.splitlines()
-                if "vga" in line.lower() or "3d controller" in line.lower()
-            ]
+            result: list[str] = []
+            for line in stdout.splitlines():
+                if "vga" not in line.lower() and "3d controller" not in line.lower():
+                    continue
+                # "01:00.0 VGA compatible controller: NVIDIA Corporation ..."
+                # Drop the bus address ("01:00.0") and category ("VGA ... :")
+                _, _, after_bus = line.partition(":")
+                _, _, after_category = after_bus.partition(":")
+                cleaned = (after_category or line).strip()
+                if cleaned:
+                    result.append(cleaned)
+            return result
     elif system == "Darwin":
         stdout = _run_text(["system_profiler", "SPDisplaysDataType"])
         if stdout:

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -102,7 +102,7 @@ allaganeye 0.2.x (ffmpeg 8.1, Python 3.12.10, Windows 11)
 
 - `CPU:` 同モデル N ソケット時: `AMD EPYC 7763 64-Core Processor x2 (128C/256T)` (`xN` 表記、コア数は全 CPU 合計)
 - `CPU:` 異モデル混在時: `Intel Xeon Gold 6154 + AMD EPYC 7763 (92C/128T)` (` + ` 連結)
-- `GPU:` 2 つ以上検出時: `GPU:` ヘッダ行 + `    - <name>` の bullet 列挙 (multi-line block)。NVIDIA は `(NGB VRAM)` が付与され、iGPU と dGPU が NVIDIA 名 ベースで重複排除される
+- `GPU:` 2 つ以上検出時: `GPU:` ヘッダ行 + `- <name>` の bullet 列挙 (4 スペース インデント、上の出力例参照)。NVIDIA は `(NGB VRAM)` が付与され、iGPU と dGPU が NVIDIA 名 ベースで重複排除される
 
 ヘッダ各行の意味:
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -86,13 +86,31 @@ Splitting  #################################### 100% 0:00:05
 ...
 ```
 
+#### マルチ CPU / マルチ GPU 環境の出力例 (#435 / #436)
+
+複数 CPU ソケットや iGPU + dGPU 構成の場合、`CPU:` / `GPU:` 行が以下の形式に切り替わる。シングル CPU + シングル GPU では上の単行表示が維持される。
+
+```text
+allaganeye 0.2.x (ffmpeg 8.1, Python 3.12.10, Windows 11)
+  CPU: AMD Ryzen 9 9950X3D 16-Core Processor (16C/32T)
+  GPU:
+    - NVIDIA GeForce RTX 5090 (32GB VRAM)
+    - AMD Radeon(TM) Graphics
+  Memory: 61.6 GB
+  Disk: 1359.5 / 3726.0 GB free on E:
+```
+
+- `CPU:` 同モデル N ソケット時: `AMD EPYC 7763 64-Core Processor x2 (128C/256T)` (`xN` 表記、コア数は全 CPU 合計)
+- `CPU:` 異モデル混在時: `Intel Xeon Gold 6154 + AMD EPYC 7763 (92C/128T)` (` + ` 連結)
+- `GPU:` 2 つ以上検出時: `GPU:` ヘッダ行 + `    - <name>` の bullet 列挙 (multi-line block)。NVIDIA は `(NGB VRAM)` が付与され、iGPU と dGPU が NVIDIA 名 ベースで重複排除される
+
 ヘッダ各行の意味:
 
 | 行 | 意味 | 取得失敗時 |
 |---|---|---|
 | 1 行目 | allaganeye / ffmpeg / Python / OS のバージョン | ffmpeg は `(unknown)` にフォールバック |
-| `CPU:` | CPU モデル + `(物理Core/論理Thread)` (#377) | `(unavailable)` / `(unknown CPU) (NT)` 等 |
-| `GPU:` | GPU モデル (+ NVIDIA のみ VRAM) (#377) | `(unavailable)` |
+| `CPU:` | CPU モデル + `(物理Core/論理Thread)` (#377)。マルチソケットは同モデル `xN` / 異モデル ` + ` 連結、コア数は全 CPU 合計 (#435) | `(unavailable)` / `(unknown CPU) (NT)` 等 |
+| `GPU:` | GPU モデル (+ NVIDIA のみ VRAM) (#377)。2 つ以上検出時は `GPU:` ヘッダ + bullet 列挙の multi-line block (#436) | `(unavailable)` |
 | `Memory:` | 物理メモリ総量 (#377) | `(unavailable)` |
 | `Disk:` | 出力先ディスクの空き / 総量 (#377) | `(unavailable)` |
 

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -33,38 +33,159 @@ def test_get_cpu_info_returns_non_empty_string():
     assert result != ""
 
 
-@patch("allaganeye.system_info._detect_cpu_model", return_value="AMD Ryzen 9 9950X3D")
+@patch(
+    "allaganeye.system_info._detect_cpu_models",
+    return_value=["AMD Ryzen 9 9950X3D"],
+)
 @patch("allaganeye.system_info._detect_physical_cores", return_value=16)
 @patch("allaganeye.system_info.os.cpu_count", return_value=32)
-def test_get_cpu_info_includes_physical_and_logical_counts(_logical, _physical, _model):
+def test_get_cpu_info_includes_physical_and_logical_counts(
+    _logical, _physical, _models
+):
     result = get_cpu_info()
     assert result == "AMD Ryzen 9 9950X3D (16C/32T)"
 
 
-@patch("allaganeye.system_info._detect_cpu_model", return_value="Apple M1")
+@patch("allaganeye.system_info._detect_cpu_models", return_value=["Apple M1"])
 @patch("allaganeye.system_info._detect_physical_cores", return_value=8)
 @patch("allaganeye.system_info.os.cpu_count", return_value=8)
 def test_get_cpu_info_collapses_when_physical_equals_logical(
-    _logical, _physical, _model
+    _logical, _physical, _models
 ):
     """When physical == logical, show only one count (``8T``) to reduce noise."""
     result = get_cpu_info()
     assert result == "Apple M1 (8T)"
 
 
-@patch("allaganeye.system_info._detect_cpu_model", return_value=None)
+@patch("allaganeye.system_info._detect_cpu_models", return_value=None)
 @patch("allaganeye.system_info.os.cpu_count", return_value=None)
-def test_get_cpu_info_unavailable_when_nothing_works(_model, _cores):
+def test_get_cpu_info_unavailable_when_nothing_works(_models, _cores):
     assert get_cpu_info() == _UNAVAILABLE
 
 
-@patch("allaganeye.system_info._detect_cpu_model", return_value=None)
+@patch("allaganeye.system_info._detect_cpu_models", return_value=None)
 @patch("allaganeye.system_info._detect_physical_cores", return_value=None)
 @patch("allaganeye.system_info.os.cpu_count", return_value=8)
-def test_get_cpu_info_uses_fallback_model_when_unknown(_logical, _physical, _model):
+def test_get_cpu_info_uses_fallback_model_when_unknown(_logical, _physical, _models):
     result = get_cpu_info()
     assert "(unknown CPU)" in result
     assert "(8T)" in result
+
+
+# --- #435: multi-CPU aggregation ---
+
+
+@patch(
+    "allaganeye.system_info._detect_cpu_models",
+    return_value=["AMD EPYC 7763 64-Core Processor", "AMD EPYC 7763 64-Core Processor"],
+)
+@patch("allaganeye.system_info._detect_physical_cores", return_value=128)
+@patch("allaganeye.system_info.os.cpu_count", return_value=256)
+def test_get_cpu_info_dual_socket_same_model(_logical, _physical, _models):
+    """Dual-socket same model uses xN notation (#435)."""
+    result = get_cpu_info()
+    assert result == "AMD EPYC 7763 64-Core Processor x2 (128C/256T)"
+
+
+@patch(
+    "allaganeye.system_info._detect_cpu_models",
+    return_value=["Intel Xeon Gold 6154", "AMD EPYC 7763"],
+)
+@patch("allaganeye.system_info._detect_physical_cores", return_value=92)
+@patch("allaganeye.system_info.os.cpu_count", return_value=128)
+def test_get_cpu_info_mixed_models_uses_plus_join(_logical, _physical, _models):
+    """Mixed-model multi-CPU joins with ' + ' (#435)."""
+    result = get_cpu_info()
+    assert result == "Intel Xeon Gold 6154 + AMD EPYC 7763 (92C/128T)"
+
+
+@patch("allaganeye.system_info._detect_cpu_models", return_value=["AMD EPYC 7763"])
+@patch("allaganeye.system_info._detect_physical_cores", return_value=64)
+@patch("allaganeye.system_info.os.cpu_count", return_value=128)
+def test_get_cpu_info_single_socket_uses_bare_name(_logical, _physical, _models):
+    """Single-socket retains the bare model + (CC/TT) format (#435 regression guard)."""
+    result = get_cpu_info()
+    assert result == "AMD EPYC 7763 (64C/128T)"
+
+
+@patch("allaganeye.system_info.platform.system", return_value="Windows")
+def test_detect_cpu_models_windows_returns_all_sockets(_system):
+    """Windows wmic returns every CPU package, not just the first (#435)."""
+    from allaganeye.system_info import _detect_cpu_models
+
+    wmic_output = (
+        "Name\nAMD EPYC 7763 64-Core Processor\nAMD EPYC 7763 64-Core Processor\n"
+    )
+    with patch("allaganeye.system_info._run_text", return_value=wmic_output):
+        result = _detect_cpu_models()
+    assert result == [
+        "AMD EPYC 7763 64-Core Processor",
+        "AMD EPYC 7763 64-Core Processor",
+    ]
+
+
+@patch("allaganeye.system_info.platform.system", return_value="Windows")
+def test_detect_physical_cores_windows_sums_all_sockets(_system):
+    """Windows wmic NumberOfCores is summed across packages (#435)."""
+    from allaganeye.system_info import _detect_physical_cores
+
+    wmic_output = "NumberOfCores\n64\n64\n"
+    with patch("allaganeye.system_info._run_text", return_value=wmic_output):
+        result = _detect_physical_cores()
+    assert result == 128
+
+
+@patch("allaganeye.system_info.platform.system", return_value="Linux")
+def test_detect_cpu_models_linux_dedups_per_socket(_system):
+    """Linux /proc/cpuinfo with two physical IDs returns both socket models (#435)."""
+    from allaganeye.system_info import _detect_cpu_models
+
+    cpuinfo = (
+        "processor\t: 0\n"
+        "physical id\t: 0\n"
+        "model name\t: AMD EPYC 7763 64-Core Processor\n"
+        "\n"
+        "processor\t: 1\n"
+        "physical id\t: 0\n"
+        "model name\t: AMD EPYC 7763 64-Core Processor\n"
+        "\n"
+        "processor\t: 64\n"
+        "physical id\t: 1\n"
+        "model name\t: AMD EPYC 7763 64-Core Processor\n"
+        "\n"
+        "processor\t: 65\n"
+        "physical id\t: 1\n"
+        "model name\t: AMD EPYC 7763 64-Core Processor\n"
+        "\n"
+    )
+    with patch("builtins.open", mock_open(read_data=cpuinfo)):
+        result = _detect_cpu_models()
+    # One entry per physical socket, both identical -> caller renders x2.
+    assert result == [
+        "AMD EPYC 7763 64-Core Processor",
+        "AMD EPYC 7763 64-Core Processor",
+    ]
+
+
+@patch("allaganeye.system_info.platform.system", return_value="Linux")
+def test_detect_cpu_models_linux_mixed_sockets(_system):
+    """Linux /proc/cpuinfo with mixed-model sockets is supported (#435)."""
+    from allaganeye.system_info import _detect_cpu_models
+
+    cpuinfo = (
+        "processor\t: 0\n"
+        "physical id\t: 0\n"
+        "model name\t: Intel Xeon Gold 6154\n"
+        "\n"
+        "processor\t: 18\n"
+        "physical id\t: 1\n"
+        "model name\t: AMD EPYC 7763\n"
+        "\n"
+    )
+    with patch("builtins.open", mock_open(read_data=cpuinfo)):
+        result = _detect_cpu_models()
+    # Order is by physical_id ascending so the display is deterministic.
+    assert result == ["Intel Xeon Gold 6154", "AMD EPYC 7763"]
 
 
 # --- get_gpu_info ---
@@ -190,24 +311,27 @@ def test_run_text_returns_stdout_on_success():
 
 
 @pytest.mark.parametrize(
-    ("cpu", "gpu", "mem", "disk"),
+    ("cpu", "gpus", "mem", "disk", "expected_gpu_line"),
     [
         (
             "AMD Ryzen 9 (16C/32T)",
-            "NVIDIA RTX 5090 (32GB VRAM)",
+            ["NVIDIA RTX 5090 (32GB VRAM)"],
             "64.0 GB",
             "142.5 / 931.5 GB free on E:",
+            "GPU: NVIDIA RTX 5090 (32GB VRAM)",
         ),
-        (_UNAVAILABLE, _UNAVAILABLE, _UNAVAILABLE, _UNAVAILABLE),
+        (_UNAVAILABLE, [], _UNAVAILABLE, _UNAVAILABLE, "GPU: (unavailable)"),
     ],
 )
-def test_print_environment_header_emits_hw_lines(cpu, gpu, mem, disk, tmp_path, capsys):
-    """_print_environment_header emits 4 HW lines including on fallback (#377)."""
+def test_print_environment_header_emits_hw_lines(
+    cpu, gpus, mem, disk, expected_gpu_line, tmp_path, capsys
+):
+    """_print_environment_header emits 4 HW lines including on fallback (#377, #436)."""
     from allaganeye.commands.split_matches import _print_environment_header
 
     with (
         patch("allaganeye.system_info.get_cpu_info", return_value=cpu),
-        patch("allaganeye.system_info.get_gpu_info", return_value=gpu),
+        patch("allaganeye.system_info.get_gpu_info_lines", return_value=gpus),
         patch("allaganeye.system_info.get_memory_info", return_value=mem),
         patch("allaganeye.system_info.get_disk_info", return_value=disk),
     ):
@@ -215,9 +339,121 @@ def test_print_environment_header_emits_hw_lines(cpu, gpu, mem, disk, tmp_path, 
 
     out = capsys.readouterr().out
     assert f"CPU: {cpu}" in out
-    assert f"GPU: {gpu}" in out
+    assert expected_gpu_line in out
     assert f"Memory: {mem}" in out
     assert f"Disk: {disk}" in out
+
+
+# --- #436: multi-GPU listing ---
+
+
+@patch("allaganeye.system_info._run_text")
+def test_get_gpu_info_lines_multiple_nvidia(mock_run):
+    """nvidia-smi multi-line CSV is parsed into multiple GPU entries (#436)."""
+    from allaganeye.system_info import get_gpu_info_lines
+
+    def side_effect(cmd, **_kwargs):
+        if cmd[:1] == ["nvidia-smi"]:
+            return "NVIDIA GeForce RTX 5090, 32768\nNVIDIA GeForce RTX 4090, 24576\n"
+        return None
+
+    mock_run.side_effect = side_effect
+    result = get_gpu_info_lines()
+    assert result == [
+        "NVIDIA GeForce RTX 5090 (32GB VRAM)",
+        "NVIDIA GeForce RTX 4090 (24GB VRAM)",
+    ]
+
+
+@patch("allaganeye.system_info.platform.system", return_value="Windows")
+@patch("allaganeye.system_info._run_text")
+def test_get_gpu_info_lines_dgpu_plus_igpu_windows(mock_run, _system):
+    """dGPU (NVIDIA) + iGPU (Intel) returns both with NVIDIA showing VRAM (#436).
+
+    The platform-probe duplicate of the NVIDIA card is deduped via
+    :func:`_gpu_signature` so the list never shows the same card twice.
+    """
+    from allaganeye.system_info import get_gpu_info_lines
+
+    def side_effect(cmd, **_kwargs):
+        if cmd[:1] == ["nvidia-smi"]:
+            return "NVIDIA GeForce RTX 5090, 32768\n"
+        if cmd[:1] == ["wmic"]:
+            return "Name\nNVIDIA GeForce RTX 5090\nIntel UHD Graphics 770\n"
+        return None
+
+    mock_run.side_effect = side_effect
+    result = get_gpu_info_lines()
+    assert result == [
+        "NVIDIA GeForce RTX 5090 (32GB VRAM)",
+        "Intel UHD Graphics 770",
+    ]
+
+
+@patch("allaganeye.system_info.platform.system", return_value="Windows")
+@patch("allaganeye.system_info._run_text")
+def test_get_gpu_info_lines_no_nvidia_windows(mock_run, _system):
+    """When nvidia-smi is unavailable, wmic provides every GPU (#436)."""
+    from allaganeye.system_info import get_gpu_info_lines
+
+    def side_effect(cmd, **_kwargs):
+        if cmd[:1] == ["nvidia-smi"]:
+            return None
+        if cmd[:1] == ["wmic"]:
+            return "Name\nAMD Radeon RX 7900 XTX\nIntel UHD Graphics\n"
+        return None
+
+    mock_run.side_effect = side_effect
+    result = get_gpu_info_lines()
+    assert result == ["AMD Radeon RX 7900 XTX", "Intel UHD Graphics"]
+
+
+@patch("allaganeye.system_info._run_text", return_value=None)
+def test_get_gpu_info_lines_returns_empty_when_no_probe_succeeds(_run):
+    """No probe success -> empty list (caller should display unavailable)."""
+    from allaganeye.system_info import get_gpu_info_lines
+
+    assert get_gpu_info_lines() == []
+
+
+@patch("allaganeye.system_info.platform.system", return_value="Linux")
+@patch("allaganeye.system_info._run_text")
+def test_probe_gpu_names_platform_strips_lspci_bus_prefix(mock_run, _system):
+    """Linux lspci output strips bus address + category prefix (#436)."""
+    from allaganeye.system_info import _probe_gpu_names_platform
+
+    mock_run.return_value = (
+        "00:02.0 VGA compatible controller: Intel Corporation UHD Graphics\n"
+        "01:00.0 3D controller: NVIDIA Corporation GA107M [GeForce RTX 3050]\n"
+    )
+    result = _probe_gpu_names_platform()
+    assert result == [
+        "Intel Corporation UHD Graphics",
+        "NVIDIA Corporation GA107M [GeForce RTX 3050]",
+    ]
+
+
+def test_print_environment_header_renders_multi_gpu_as_multi_line(tmp_path, capsys):
+    """Multi-GPU systems emit a multi-line ``GPU:`` block with bullet entries (#436)."""
+    from allaganeye.commands.split_matches import _print_environment_header
+
+    with (
+        patch("allaganeye.system_info.get_cpu_info", return_value="X"),
+        patch(
+            "allaganeye.system_info.get_gpu_info_lines",
+            return_value=["NVIDIA RTX 5090 (32GB VRAM)", "Intel UHD Graphics"],
+        ),
+        patch("allaganeye.system_info.get_memory_info", return_value="64.0 GB"),
+        patch("allaganeye.system_info.get_disk_info", return_value="1 GB"),
+    ):
+        _print_environment_header(tmp_path)
+
+    out = capsys.readouterr().out
+    assert "  GPU:\n" in out
+    assert "    - NVIDIA RTX 5090 (32GB VRAM)" in out
+    assert "    - Intel UHD Graphics" in out
+    # Single-line "GPU: NVIDIA ..." must NOT appear when multi-GPU rendering kicks in.
+    assert "  GPU: NVIDIA" not in out
 
 
 # --- Non-Windows parser coverage (#377 follow-up) ---
@@ -229,13 +465,13 @@ def test_print_environment_header_emits_hw_lines(cpu, gpu, mem, disk, tmp_path, 
 # Linux/macOS user's verbose header to ``(unavailable)``.
 
 
-# --- G1: _detect_cpu_model Linux /proc/cpuinfo ---
+# --- G1: _detect_cpu_models Linux /proc/cpuinfo (single-socket fallback) ---
 
 
 @patch("allaganeye.system_info.platform.system", return_value="Linux")
-def test_detect_cpu_model_linux_parses_proc_cpuinfo(_system):
-    """Linux branch extracts 'model name' value from /proc/cpuinfo."""
-    from allaganeye.system_info import _detect_cpu_model
+def test_detect_cpu_models_linux_parses_proc_cpuinfo_without_physical_id(_system):
+    """Containers / qemu often omit 'physical id'; we still extract the model."""
+    from allaganeye.system_info import _detect_cpu_models
 
     cpuinfo = (
         "processor\t: 0\n"
@@ -247,19 +483,19 @@ def test_detect_cpu_model_linux_parses_proc_cpuinfo(_system):
         "model name\t: AMD Ryzen 9 9950X3D 16-Core Processor\n"
     )
     with patch("builtins.open", mock_open(read_data=cpuinfo)):
-        result = _detect_cpu_model()
-    assert result == "AMD Ryzen 9 9950X3D 16-Core Processor"
+        result = _detect_cpu_models()
+    assert result == ["AMD Ryzen 9 9950X3D 16-Core Processor"]
 
 
 @patch("allaganeye.system_info.platform.system", return_value="Linux")
 @patch("allaganeye.system_info.platform.processor", return_value="")
-def test_detect_cpu_model_linux_falls_back_when_no_model_name(_proc, _system):
+def test_detect_cpu_models_linux_falls_back_when_no_model_name(_proc, _system):
     """Linux branch returns None when /proc/cpuinfo lacks 'model name'."""
-    from allaganeye.system_info import _detect_cpu_model
+    from allaganeye.system_info import _detect_cpu_models
 
     cpuinfo = "processor\t: 0\nvendor_id\t: AuthenticAMD\n"
     with patch("builtins.open", mock_open(read_data=cpuinfo)):
-        result = _detect_cpu_model()
+        result = _detect_cpu_models()
     # With no model line AND platform.processor() returning empty, we
     # must surface None so the caller can mark CPU as unknown.
     assert result is None

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -546,10 +546,14 @@ def test_detect_physical_cores_linux_returns_none_on_empty_file(_system):
 
 
 @patch("allaganeye.system_info.platform.system", return_value="Linux")
-@patch("allaganeye.system_info._detect_gpu_nvidia", return_value=None)
 @patch("allaganeye.system_info._run_text")
-def test_get_gpu_info_linux_parses_lspci_vga_line(mock_run, _nvidia, _system):
-    """Linux branch extracts the GPU name from a 'VGA compatible controller' line."""
+def test_get_gpu_info_linux_parses_lspci_vga_line(mock_run, _system):
+    """Linux branch extracts the GPU name from a 'VGA compatible controller' line.
+
+    `_detect_all_gpus_nvidia`'s strict CSV parser rejects the lspci-shaped
+    mock output (no comma + digit), so no separate ``_detect_gpu_nvidia``
+    patch is needed (#436 review).
+    """
     mock_run.return_value = (
         "00:00.0 Host bridge: Intel Corporation 12th Gen Core Host Bridge\n"
         "01:00.0 VGA compatible controller: "
@@ -561,9 +565,8 @@ def test_get_gpu_info_linux_parses_lspci_vga_line(mock_run, _nvidia, _system):
 
 
 @patch("allaganeye.system_info.platform.system", return_value="Linux")
-@patch("allaganeye.system_info._detect_gpu_nvidia", return_value=None)
 @patch("allaganeye.system_info._run_text")
-def test_get_gpu_info_linux_parses_lspci_3d_controller_line(mock_run, _nvidia, _system):
+def test_get_gpu_info_linux_parses_lspci_3d_controller_line(mock_run, _system):
     """Linux branch also matches '3D controller' lines (common on laptops)."""
     mock_run.return_value = (
         "00:02.0 VGA compatible controller: Intel Corporation UHD Graphics\n"
@@ -579,9 +582,8 @@ def test_get_gpu_info_linux_parses_lspci_3d_controller_line(mock_run, _nvidia, _
 
 
 @patch("allaganeye.system_info.platform.system", return_value="Darwin")
-@patch("allaganeye.system_info._detect_gpu_nvidia", return_value=None)
 @patch("allaganeye.system_info._run_text")
-def test_get_gpu_info_darwin_parses_chipset_model(mock_run, _nvidia, _system):
+def test_get_gpu_info_darwin_parses_chipset_model(mock_run, _system):
     """Darwin branch extracts 'Chipset Model: X' via regex."""
     mock_run.return_value = (
         "Graphics/Displays:\n\n"
@@ -594,11 +596,8 @@ def test_get_gpu_info_darwin_parses_chipset_model(mock_run, _nvidia, _system):
 
 
 @patch("allaganeye.system_info.platform.system", return_value="Darwin")
-@patch("allaganeye.system_info._detect_gpu_nvidia", return_value=None)
 @patch("allaganeye.system_info._run_text")
-def test_get_gpu_info_darwin_unavailable_when_no_chipset_line(
-    mock_run, _nvidia, _system
-):
+def test_get_gpu_info_darwin_unavailable_when_no_chipset_line(mock_run, _system):
     """Darwin branch falls back when system_profiler output lacks Chipset Model."""
     mock_run.return_value = "Graphics/Displays:\n\n    (info missing)\n"
     assert get_gpu_info() == _UNAVAILABLE


### PR DESCRIPTION
## 概要

`-v` (verbose) ヘッダの CPU / GPU 表示を multi-socket / multi-GPU 環境で正しく動作するよう刷新 (l1-residual Phase C)。シングル CPU / シングル GPU の表示は現状維持。#435 + #436 を `system_info.py` で同時に修正、受け入れ条件は issue ごと独立検証 (Iron Law 1)。

## 受け入れ条件

### #435 (マルチ CPU 環境でコア数表記が論理矛盾)

- [x] マルチ CPU 環境で物理コア数が全 CPU 合計で表示される -- Windows `wmic cpu get NumberOfCores` を sum 集計、Linux `/proc/cpuinfo` の `(physical_id, core_id)` ペア dedup は元から正しい (実装は `allaganeye/system_info.py:181-201` + 単体テスト `test_detect_physical_cores_windows_sums_all_sockets`)
- [x] 論理コア数 (`os.cpu_count()`) との整合 -- 物理 (sum) と論理 (`os.cpu_count`) を共に全 CPU 合計値にしたので不整合解消 (`get_cpu_info` の `(NC/NT)` 出力ロジック、`test_get_cpu_info_dual_socket_same_model` 等で確認)
- [x] CPU 名が単一モデル前提でない表示形式 -- `_detect_cpu_models()` が socket 単位 list を返し、`get_cpu_info` で 同モデル `xN` / 異モデル ` + ` 連結に切替 (`test_get_cpu_info_dual_socket_same_model` / `test_get_cpu_info_mixed_models_uses_plus_join`)
- [x] シングル CPU 環境で表示が破壊されない -- list が 1 要素なら従来の `<model> (CC/TT)` をそのまま emit (`test_get_cpu_info_single_socket_uses_bare_name` + 既存 `test_get_cpu_info_includes_physical_and_logical_counts` を `_detect_cpu_models` mock に書き換え後 pass)

### #436 (マルチ GPU / iGPU + dGPU を verbose で全表示)

- [x] マルチ GPU / iGPU 環境で構成が把握可能になる -- `get_gpu_info_lines()` が NVIDIA (nvidia-smi 全行) + 他 vendor (wmic / lspci / system_profiler) を統合し、verbose ヘッダは複数 GPU 時に multi-line 列挙 (`test_get_gpu_info_lines_dgpu_plus_igpu_windows` + `test_print_environment_header_renders_multi_gpu_as_multi_line`)
- [x] `--gpu` 使用時にどの GPU が使われたか追跡可能 -- metadata.json `system_info.gpu_vendor_used` で記録済み (issue #591 / 実装 PR #596、本 PR ではスコープ外として既存実装に依拠)
- [x] シングル GPU 環境で表示が冗長にならない -- `len(gpus) == 1` なら従来の `GPU: <name>` を emit (`test_print_environment_header_emits_hw_lines` parametrize 1 件目で確認)

## 変更内容

### `allaganeye/system_info.py`

- `_detect_cpu_model()` (singular) -> `_detect_cpu_models()` (list[str]) に置き換え。Windows wmic 全行 / Linux `/proc/cpuinfo` `physical_id` 単位 dedup / Darwin sysctl は単一要素
- `_detect_physical_cores()` Windows ブランチで全 CPU の `NumberOfCores` を sum 集計
- `get_cpu_info()` を 3-way フォーマッタに刷新: 1 socket / 同モデル `xN` / 異モデル ` + ` 連結
- `_detect_all_gpus_nvidia()` 新規追加: nvidia-smi `--format=csv` の strict CSV 全行を `<name> (NGB VRAM)` 形式で list 化
- `get_gpu_info_lines()` 新規追加: NVIDIA + platform probe を `_gpu_signature` ベースで重複排除して統合
- `_detect_gpu_nvidia()` を `_detect_all_gpus_nvidia()[0]` の thin wrapper に変更 (`probe_gpu_vendors` の挙動は変えない)
- `_probe_gpu_names_platform()` Linux ブランチで `"BB:DD.F VGA compatible controller: "` prefix を除去 (clean GPU name)。vendor keyword 検出は suffix に依存するので `probe_gpu_vendors` への影響なし
- `get_gpu_info()` は `get_gpu_info_lines()[0] if lines else _UNAVAILABLE` の wrapper 化

### `allaganeye/commands/split_matches.py`

- `_print_environment_header` を `get_gpu_info_lines()` ベースに変更。空 -> `GPU: (unavailable)` / 1 要素 -> 従来の単行 / 2 要素以上 -> `GPU:` ヘッダ + `    - <name>` bullet 列挙

### `tests/test_system_info.py`

- 既存 `_detect_cpu_model` mock を `_detect_cpu_models` (list 返却) に置換 (5 件)
- multi-CPU 単体テスト 7 件追加 (Windows wmic / Linux `/proc/cpuinfo` per-socket dedup / 同モデル xN / 異モデル + 連結 / single-socket 後方互換)
- multi-GPU 単体テスト 4 件追加 (NVIDIA 複数枚 / iGPU+dGPU / NVIDIA なし wmic / 全 probe 失敗)
- `_probe_gpu_names_platform` Linux 前置除去テスト 1 件追加
- `_print_environment_header` multi-GPU 出力検証テスト 1 件追加 + 既存 parametrize を `get_gpu_info_lines` mock に書き換え

## 検証

### 自動チェック (本 PR 提出前に実行済み)

- [x] `python -m ruff check .` -- All checks passed
- [x] `python -m ruff format --check .` -- 76 files already formatted
- [x] `python -m pyright` -- 0 errors, 0 warnings, 0 informations
- [x] `python -m pytest` -- 882 passed, 1 skipped, 37 deselected (slow)
- [x] `tests/test_ascii_guard.py` -- 4 passed (`x` ASCII / `--` em dash 置換確認済み)

### 実機検証 (Idios 確認お願い)

本変更はマルチ CPU / マルチ GPU 構成での動作確認が本質的に必要だが、Idios 環境はシングル CPU + RTX 5090 + AMD iGPU の構成。以下 2 ステップで確認お願い:

- 現環境 (RTX 5090 + AMD Radeon iGPU + Ryzen 9 9950X3D 1 ソケット) で `allaganeye split <video> -v` を実行し、 verbose header の `CPU:` 行が従来通り `AMD Ryzen 9 9950X3D (16C/32T)` 形式、`GPU:` 行が NVIDIA + AMD iGPU の **2 行 multi-line 表示** になることを目視確認
- マルチ CPU / 純粋 multi-NVIDIA 環境は Idios 手元になく実機確認不能。mock + 単体テストで論理担保 (上記受け入れ条件 [x] 参照)、本 PR では mock-only 検証として運用

#### 確認用コマンド (Idios 環境)

```bash
allaganeye split <短い動画> -v --no-audio | head -20
```

期待される verbose 出力 (RTX 5090 + AMD iGPU):

```
allaganeye 0.2.x (ffmpeg ..., Python ..., Windows ...)
  CPU: AMD Ryzen 9 9950X3D 16-Core Processor (16C/32T)
  GPU:
    - NVIDIA GeForce RTX 5090 (32GB VRAM)
    - AMD Radeon(TM) Graphics
  Memory: ...
  Disk: ...
```

(GPU 名が iGPU と dGPU の両方 multi-line で出ること、NVIDIA に `(32GB VRAM)` が付いてること、bus address や `VGA compatible controller:` 等の prefix が付いてないことが confirm point)

## 関連

- 元 issue: #435 / #436
- 先行 issue / PR (本 PR で `system_info.gpu_vendor_used` に依拠): issue #591 (実装 PR #596)
- l1-residual Phase C (roadmap: `C:\Users\idios\.claude\plans\l1-residual-10-wise-quokka.md`)

## Note

- `Closes` キーワード未使用 (Iron Law 4)。マージ後は `/close-issue 435` / `/close-issue 436` でそれぞれ実測再検証して手動 close
- `×` (U+00D7) / `—` (U+2014) は ASCII guard 違反のため `x` / `--` に統一済み

