### PR TITLE
fix(installer): get-pip.py SHA256 pin を PyPA 最新版に更新 (Refs #649)

### DIFF
--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -411,3 +411,16 @@ CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージ�
 | `.github/workflows/release.yml` (`Cache FFmpeg archive` ステップ) | cache `key` 内 SHA256 (win64-lgpl-shared 版、build-portable-zip.ps1 の SHA256 と同じ値) |
 | `docs/developer-setup.md` §1 | 「ffmpeg / ffprobe 8.1 LGPLv3 推奨」「推奨: ffmpeg 8.1 LGPLv3」の major version 記述 (系列変更時のみ) |
 | `docs/quickstart.md` §10 | 対応 FFmpeg コミット (例: `7f5c90f77e`) の記述 (upstream commit 変更時) |
+
+### get-pip.py の hash drift 対応 (#649)
+
+`$GetPipSha256` ([scripts/build-portable-zip.ps1](../scripts/build-portable-zip.ps1)) は非バージョン管理 URL `https://bootstrap.pypa.io/get-pip.py` を参照しているため、PyPA が pip をリリースするたびに hash が drift し `build-windows` が `SHA256 mismatch` で fail する。FFmpeg / Python embed は versioned URL でピン留めしているのでこの drift は発生しない (get-pip.py 固有の問題)。drift 検知時は以下で更新:
+
+```powershell
+Invoke-WebRequest https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
+Get-FileHash get-pip.py -Algorithm SHA256
+```
+
+得られた SHA256 で `scripts/build-portable-zip.ps1` の `$GetPipSha256` を書き換え → develop-0.2.0 ベースで hotfix PR を先行マージ → 既存 PR を rebase で `build-windows` 復旧、という流れ ([#651](https://github.com/Idios/kobutachan-allaganeye/pull/651) が先例)。
+
+長期対応 (versioned URL `https://bootstrap.pypa.io/pip/24.0/get-pip.py` または `.sha256` sidecar の動的検証) は [#649](https://github.com/Idios/kobutachan-allaganeye/issues/649) §長期対応で検討中。

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -71,6 +71,7 @@ claude/<scope>-* → 実機検証 → PR → /review-pr (受け入れ条件チ�
 - `git push origin v0.x.0` すると [`.github/workflows/release.yml`](../.github/workflows/release.yml) が発火し、Windows Portable ZIP (`allaganeye-v<version>-windows.zip`) のビルドと GitHub Release への成果物自動添付を実行する (#461)
   - ビルドは [`scripts/build-portable-zip.ps1`](../scripts/build-portable-zip.ps1) で Python 3.11 embeddable + FFmpeg LGPLv3 shared (BtbN FFmpeg-Builds win64-lgpl-shared、libdav1d 入り) を同梱する
     - ダウンロードする外部バイナリ (Python embed / get-pip.py / FFmpeg) はスクリプト内に **SHA256 ダイジェストをハードコードして検証** する。ダイジェスト不一致時はビルドを fail。FFmpeg は BtbN の `autobuild-YYYY-MM-DD-HH-MM` タグと特定アセット名を URL にピン留めして再現性を確保する (`latest` タグは日次更新の可動ポインタなので不可)
+      - **`get-pip.py` のみ非バージョン管理 URL (`https://bootstrap.pypa.io/get-pip.py`) のため、PyPA の更新により hash drift が発生する** ([#649](https://github.com/Idios/kobutachan-allaganeye/issues/649))。drift 検知時の更新手順は [`docs/developer-setup.md` §「get-pip.py の hash drift 対応」](developer-setup.md) と [`scripts/build-portable-zip.ps1`](../scripts/build-portable-zip.ps1) の `$GetPipSha256` 周辺コメントを参照。長期対応 (versioned URL or `.sha256` sidecar) は [#649](https://github.com/Idios/kobutachan-allaganeye/issues/649) §長期対応で別途検討
     - 外部バイナリを更新する場合はスクリプト先頭の `$FFmpegBuildTag` / `$FFmpegAssetName` / `$*Sha256` 定数を更新する
   - Release 本文は [`scripts/extract_release_notes.py`](../scripts/extract_release_notes.py) が CHANGELOG.md から該当バージョンのセクションを抽出する
   - タグ名と `pyproject.toml` の `version` が一致しない場合、workflow は fail する

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -51,7 +51,15 @@ $PythonEmbedUrl = "https://www.python.org/ftp/python/$PythonVersion/python-$Pyth
 $PythonEmbedSha256 = '009D6BF7E3B2DDCA3D784FA09F90FE54336D5B60F0E0F305C37F400BF83CFD3B'
 
 $GetPipUrl = 'https://bootstrap.pypa.io/get-pip.py'
-$GetPipSha256 = 'FEBA1C697DF45BE1B539B40D93C102C9EE9DDE1D966303323B830B06F3FBCA3C'
+# #649 -- PyPA refreshes get-pip.py without versioning the URL, so the
+# pinned hash drifts whenever pip releases. When build-windows fails with
+# "SHA256 mismatch for https://bootstrap.pypa.io/get-pip.py", refresh the
+# pin via:
+#   Invoke-WebRequest https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
+#   Get-FileHash get-pip.py -Algorithm SHA256
+# Long-term we should switch to a versioned URL (e.g. .../pip/24.0/get-pip.py)
+# or the bootstrap-served `.sha256` sidecar -- tracked in #649.
+$GetPipSha256 = '106AE019E371C7D8CB3699C75607A9B7A4D31E2B95C575362C8BCFE3D41353FD'
 
 # FFmpeg is pinned to a specific BtbN autobuild so the same allaganeye tag ships
 # the same binary and the LGPLv3 license applies uniformly across CI and Portable ZIP.


### PR DESCRIPTION
## Summary

[#649](https://github.com/Idios/kobutachan-allaganeye/issues/649) (PR #641 Round 3 で発覚): `https://bootstrap.pypa.io/get-pip.py` の hash が PyPA 側更新で drift し、`build-windows` job が `SHA256 mismatch` で fail。本 PR は hotfix として hash を最新値に更新するだけの最小差分。

## 受け入れ条件チェック ([#649](https://github.com/Idios/kobutachan-allaganeye/issues/649))

| # | 受け入れ条件 | 対応 |
|---|---|---|
| 1 | `scripts/build-portable-zip.ps1` の SHA256 hard-code を現在値に更新 | `$GetPipSha256` を `FEBA1...` → `106AE019E371C7D8CB3699C75607A9B7A4D31E2B95C575362C8BCFE3D41353FD` (CI 失敗ログ [job 73377445553](https://github.com/Idios/kobutachan-allaganeye/actions/runs/25050696767/job/73377445553) の actual hash を採用) |
| 2 | PR #641 を含む既存 PR の `build-windows` job が pass する | 本 PR マージ後、各 open PR を rebase で build-windows 再実行 → pass する見込み |
| 3 | 修正 PR を別途作成 → develop-0.2.0 に先行マージ → 既存 PR を rebase で CI 再実行 | 本 PR がそれ |

## 補足

- 将来同種の drift 発生時の **更新手順をコメントで併記** (`Invoke-WebRequest` + `Get-FileHash` の 2 行)
- 長期対応 (versioned URL / `.sha256` sidecar) は [#649](https://github.com/Idios/kobutachan-allaganeye/issues/649) §長期対応で別途検討。本 PR は短時間で CI 復旧することを優先

## Test plan

- [x] CI で `build-windows` の SHA256 verify が pass することを確認 (本 PR push で実機検証)
- 手動で hash 計算してコメント記載の手順が動くことの確認は #649 §長期対応で

🤖 Generated with [Claude Code](https://claude.com/claude-code)
