### PR TITLE
fix: 日本語 path で subprocess cp932 失敗 (Refs #656)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -1399,6 +1399,8 @@ def _probe_ffmpeg_version() -> str:
             [find_ffmpeg(), "-version"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=True,
             timeout=5,
         )

--- a/allaganeye/system_info.py
+++ b/allaganeye/system_info.py
@@ -39,6 +39,8 @@ def _run_text(cmd: list[str], *, timeout: float = _SUBPROCESS_TIMEOUT_S) -> str 
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=True,
             timeout=timeout,
         )

--- a/allaganeye/video/probe.py
+++ b/allaganeye/video/probe.py
@@ -53,6 +53,8 @@ def probe_video(video_path: Path) -> ProbeResult:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=True,
             timeout=30,
         )

--- a/allaganeye/video/splitter.py
+++ b/allaganeye/video/splitter.py
@@ -82,6 +82,8 @@ def _ffmpeg_split(
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
     except FileNotFoundError as e:

--- a/docs/coding-conventions.md
+++ b/docs/coding-conventions.md
@@ -58,6 +58,13 @@ Conventional Commits 形式:
 - docstring・コメント内も同様に ASCII を推奨（pytest -v 等で出力される可能性があるため）
 - 日本語テキストは引き続き OK（コメント・docstring 内）
 
+### subprocess.run の text=True と encoding (#656)
+
+- `subprocess.run(text=True, ...)` を使う場合、**必ず** `encoding="utf-8", errors="replace"` を明示する
+- 省略すると Python は `locale.getpreferredencoding(False)` (Windows = cp932) を使い、ffmpeg/ffprobe の UTF-8 stderr に日本語含む path が含まれると `UnicodeDecodeError` で `_readerthread` (subprocess.py) が死に process が exit 1 で終了する (#656)
+- `errors="replace"` で異常 byte を U+FFFD で置換し reader thread の防御線とする
+- `text=False` (binary mode) の場合は decode が走らないため対象外 (例: `audio/extract.py` / `video/detector.py` / `video/gpu_detector.py`)
+
 ## エラーハンドリング
 
 - `allaganeye/exceptions.py` にエラークラスを定義

--- a/tests/test_subprocess_encoding.py
+++ b/tests/test_subprocess_encoding.py
@@ -1,0 +1,106 @@
+"""#656 -- subprocess.run(text=True) is encoding='utf-8', errors='replace' を明示する.
+
+Windows OS default encoding (cp932) は ffmpeg/ffprobe の UTF-8 stderr を decode できず、
+日本語含む path で UnicodeDecodeError を起こす。本 test は全 ``subprocess.run(text=True, ...)``
+呼び出しで ``encoding='utf-8'`` + ``errors='replace'`` が指定されていることを mock で pin する。
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from allaganeye.commands.split_matches import _probe_ffmpeg_version
+from allaganeye.system_info import _run_text
+from allaganeye.video.probe import probe_video
+from allaganeye.video.splitter import _ffmpeg_split
+
+
+def _make_run_capture(
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> tuple[Any, dict[str, Any]]:
+    """Return a fake ``subprocess.run`` + dict to capture kwargs."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **kwargs: Any) -> MagicMock:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        result = MagicMock()
+        result.stdout = stdout
+        result.stderr = stderr
+        result.returncode = returncode
+        return result
+
+    return fake_run, captured
+
+
+def _assert_utf8_encoding(captured: dict[str, Any], where: str) -> None:
+    kwargs = captured.get("kwargs", {})
+    assert kwargs.get("encoding") == "utf-8", f"{where}: encoding='utf-8' 必須 (#656)"
+    assert kwargs.get("errors") == "replace", f"{where}: errors='replace' 必須 (#656)"
+    assert kwargs.get("text") is True, f"{where}: text=True 維持"
+
+
+def test_probe_video_uses_utf8_encoding(tmp_path: Path) -> None:
+    """probe_video の subprocess.run は encoding='utf-8', errors='replace' を渡す (#656)."""
+    video = tmp_path / "テスト.mp4"
+    video.write_bytes(b"")
+    fake_run, captured = _make_run_capture(
+        stdout='{"format": {"duration": "10.0"}, "streams": []}'
+    )
+    # Probe の戻り値組み立てが内部で stream/format を要求しても、
+    # subprocess.run の kwargs は captured 済み (mock 直後に書き込まれる) なので
+    # 後段の例外は suppress する。
+    with (
+        patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe"),
+        patch("allaganeye.video.probe.subprocess.run", side_effect=fake_run),
+        contextlib.suppress(Exception),
+    ):
+        probe_video(video)
+    _assert_utf8_encoding(captured, "probe.py")
+
+
+def test_ffmpeg_split_uses_utf8_encoding(tmp_path: Path) -> None:
+    """splitter._ffmpeg_split の subprocess.run は encoding='utf-8' を渡す (#656)."""
+    input_path = tmp_path / "テスト.mp4"
+    input_path.write_bytes(b"")
+    output = tmp_path / "out.mp4"
+    fake_run, captured = _make_run_capture(returncode=0)
+    with (
+        patch("allaganeye.video.splitter.find_ffmpeg", return_value="ffmpeg"),
+        patch("allaganeye.video.splitter.subprocess.run", side_effect=fake_run),
+        contextlib.suppress(Exception),
+    ):
+        _ffmpeg_split(input_path, start=0.0, end=1.0, output=output)
+    _assert_utf8_encoding(captured, "splitter.py")
+
+
+def test_run_text_uses_utf8_encoding() -> None:
+    """system_info._run_text の subprocess.run は encoding='utf-8' を渡す (#656)."""
+    fake_run, captured = _make_run_capture(stdout="ok")
+    with patch("allaganeye.system_info.subprocess.run", side_effect=fake_run):
+        _run_text(["dummy"])
+    _assert_utf8_encoding(captured, "system_info.py")
+
+
+def test_probe_ffmpeg_version_uses_utf8_encoding() -> None:
+    """split_matches._probe_ffmpeg_version の subprocess.run は encoding='utf-8' を渡す (#656).
+
+    関数内で ``import subprocess`` しているが、Python の import cache によって
+    global ``subprocess`` module を共有する。``find_ffmpeg`` を mock し、
+    ``subprocess.run`` を patch することで kwargs を捕捉する。
+    """
+    fake_run, captured = _make_run_capture(stdout="ffmpeg version 8.1\n")
+    # split_matches.py:_probe_ffmpeg_version は関数 local で
+    # ``from allaganeye.ffmpeg_path import find_ffmpeg`` / ``import subprocess`` するため、
+    # 元の module の symbol を patch する (関数呼出ごとに re-resolve される)。
+    with (
+        patch("allaganeye.ffmpeg_path.find_ffmpeg", return_value="ffmpeg"),
+        patch("subprocess.run", side_effect=fake_run),
+    ):
+        _probe_ffmpeg_version()
+    _assert_utf8_encoding(captured, "split_matches.py")


### PR DESCRIPTION
## Summary

[#656](https://github.com/Idios/kobutachan-allaganeye/issues/656) の対応。Windows OS default encoding (cp932) で ffmpeg/ffprobe の UTF-8 stderr を decode できず、日本語含む path で UnicodeDecodeError を起こしていた問題を修正。

PR [#647](https://github.com/Idios/kobutachan-allaganeye/pull/647) ([#646](https://github.com/Idios/kobutachan-allaganeye/issues/646)) の B1 受け入れ条件実機検証中、本 worktree `busy-banzai-b6ab2b` のレビューセッションで Idios が日本語含むファイル名 (`コピー.mkv`) を drop して再現発見。

## 受け入れ条件チェック ([#656](https://github.com/Idios/kobutachan-allaganeye/issues/656))

| # | 受け入れ条件 | 対応 |
|---|---|---|
| 1 | 4 箇所の `subprocess.run(text=True, ...)` に `encoding="utf-8", errors="replace"` 追加 | [allaganeye/video/probe.py](allaganeye/video/probe.py#L55) / [allaganeye/video/splitter.py](allaganeye/video/splitter.py#L84) / [allaganeye/system_info.py](allaganeye/system_info.py#L41) / [allaganeye/commands/split_matches.py](allaganeye/commands/split_matches.py#L1402) |
| 2 | 日本語含む path で `python -m allaganeye detect "<日本語パス>"` 成功 (UnicodeDecodeError 出ない) | machine-unverifiable: マージ後 / 別 session で Idios 手動検証 (`feedback_user_realmachine_test_request.md` 規約準拠) |
| 3 | GUI Tauri で日本語含む動画 drop → detect 成功 → CompleteScreen 遷移 | 同上 |
| 4 | pytest で cp932 decode 失敗パターンの test 追加 | [tests/test_subprocess_encoding.py](tests/test_subprocess_encoding.py) (4 ケース、すべて pass) |
| 5 | ruff check / ruff format / pyright / pytest 全通過 | 全 OK (Test plan 参照) |

## 設計改修

`subprocess.run(text=True, ...)` で `encoding` 引数を省略すると Python は `locale.getpreferredencoding(False)` (Windows = cp932 / Shift-JIS) を使う。一方 ffmpeg / ffprobe は UTF-8 で stderr を出力するため、日本語含む path で `UnicodeDecodeError: 'cp932' codec can't decode byte 0x83 in position 3584: illegal multibyte sequence` が `_readerthread` (subprocess.py:1599) で発生し process が exit 1 で終了。CLI 出力が JSON-line stream の途中で壊れて GUI Tauri command が parse できない (PR #647 で実装した error UI に「検知に失敗しました」が出る経路だが root cause は subprocess encoding)。

修正: 該当 4 箇所の `subprocess.run(text=True, ...)` に `encoding="utf-8", errors="replace"` を追加。`errors="replace"` で異常 byte は U+FFFD で置換し reader thread が死なないように防御。

- `allaganeye/video/probe.py` `probe_video()` ffprobe 呼び出し
- `allaganeye/video/splitter.py` `_ffmpeg_split()` ffmpeg 呼び出し
- `allaganeye/system_info.py` `_run_text()` 汎用 subprocess helper
- `allaganeye/commands/split_matches.py` `_probe_ffmpeg_version()` ffmpeg version 取得

binary mode (`text=False`) の他箇所 (`audio/extract.py` / `video/detector.py` / `video/gpu_detector.py`) は decode 経路が走らないため影響なし、修正対象外。

## test 追加

[tests/test_subprocess_encoding.py](tests/test_subprocess_encoding.py) を新設、4 関数の `subprocess.run` kwargs を mock で pin (`encoding` / `errors` / `text` の 3 引数を逐条 assert):

- `test_probe_video_uses_utf8_encoding`
- `test_ffmpeg_split_uses_utf8_encoding`
- `test_run_text_uses_utf8_encoding`
- `test_probe_ffmpeg_version_uses_utf8_encoding`

`split_matches._probe_ffmpeg_version` は関数 local で `import subprocess` / `from allaganeye.ffmpeg_path import find_ffmpeg` するため、global `subprocess.run` と `allaganeye.ffmpeg_path.find_ffmpeg` を patch する形で kwargs を捕捉。

## Test plan

- [x] `python -m ruff check allaganeye/video/probe.py allaganeye/video/splitter.py allaganeye/system_info.py allaganeye/commands/split_matches.py tests/test_subprocess_encoding.py` — All checks passed
- [x] `python -m ruff format --check ...` — 5 files already formatted
- [x] `python -m pyright allaganeye/video/probe.py allaganeye/video/splitter.py allaganeye/system_info.py allaganeye/commands/split_matches.py tests/test_subprocess_encoding.py` — 0 errors, 0 warnings, 0 informations
- [x] `python -m pytest tests/test_probe.py tests/test_splitter.py tests/test_system_info.py tests/test_split_matches.py tests/test_subprocess_encoding.py` — 264 passed in 24.70s (本 PR で +4 ケース、回帰なし)

machine-unverifiable (Idios 手動、別 session で実機検証):

- 日本語含む path で `python -m allaganeye detect "E:\royalstraightflesh\videos\20260116\2026-01-17 00-43-10 - コピー.mkv" --progress-format json` が UnicodeDecodeError なく成功
- GUI Tauri (`npm run tauri dev`) で日本語含む動画 drop → start_detect 成功 → CompleteScreen 遷移

## 関連

- 派生元: [#647](https://github.com/Idios/kobutachan-allaganeye/pull/647) Round 3 実機検証 ([#646](https://github.com/Idios/kobutachan-allaganeye/issues/646))
- 影響範囲: L1 detect / split / probe / system_info の `text=True` 4 箇所、Windows 環境のみ (Linux/macOS は OS default 通常 UTF-8)
- 類似: #292 (closed) `[bug] conftest.py の em dash により Windows cp932 で pytest が INTERNALERROR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
