### PR TITLE
docs: PR 作成・レビュー時の base 同期 + 並行 PR + 摘出処置運用化 (Refs #659)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -33,6 +33,7 @@ cat <<'EOF'
 6. **NO PR CREATION WITHOUT VERIFIED CHECKS**
    - PR 作成前に変更ファイル path に応じた自動チェック (Python: `ruff check .` / `ruff format --check .` / `pyright` / `pytest`、GUI: `npm run lint` / `typecheck` / `test` / `build` / `cargo check`) を全 pass させる。「軽微だから skip」「Python のみだから GUI 側不要」は Red Flag (失敗パターン A 再発)
    - ロジック変更 (`gpu_detector.py` / `audio/*.py` / `video/detector.py` / `gui/src-tauri/**` 等) を含む場合は、ユーザー (Idios) に実機検証 (GPU / audio / 長時間動画 / GUI Tauri 起動) を `AskUserQuestion` で依頼する。「mock テスト pass = 実機検証不要」は Red Flag (失敗パターン B 再発)
+   - **PR 作成 Pre-flight (#659 で運用化)**: `git fetch origin <base>` → `git log HEAD..origin/<base>` で取り込み未済 commit を確認 → 当 PR の touched files と交差するなら `git merge origin/<base>` で取り込み + 自動チェック再実行 → `gh pr list --search "<元issue#>" --state all` で並行 worktree PR 重複確認。「コンフリクト出ないから OK」「最近 fetch したから OK」は Red Flag (失敗パターン C 再発、`feedback_pr_review_base_merge_regression.md` / `feedback_concurrent_worktree_pr_check.md` 参照)
    - PR 本文には machine-verified を `[x]` で、machine-unverifiable を plain bullet `-` で書き分ける (`feedback_pr_validate_checklist.md` 規約)。詳細手順は `feedback_pr_pre_creation_checks.md` / `feedback_user_realmachine_test_request.md` 参照
 
 ## Red Flags (この思考が浮かんだら STOP)
@@ -47,6 +48,9 @@ cat <<'EOF'
 | 「観察 (修正不要) とコメントしておこう」 | #399 B 違反。別 issue 起票 or escalate |
 | 「ローカル lint 通ったから PR 出して大丈夫」 | Iron Law 6 違反。変更 path から必要 job を判定 (Python / GUI / installer / docs)。GUI 変更を含むなら `npm run lint` / `typecheck` / `test` / `build` / `cargo check` も実行 |
 | 「mock テスト pass = 実機検証不要」 | Iron Law 6 違反。GPU / audio / 長時間動画 / GUI Tauri は mock 不可。該当 path 変更時は `AskUserQuestion` で依頼 |
+| 「コンフリクト出ないから base 取り込み確認は不要」 | Iron Law 6 Pre-flight 違反。merge 可否と機能 regression は別軸。PR #627 Round 4 の失敗パターン C 再発 |
+| 「並行 worktree PR は計画段階で確認したから PR 作成時は skip」 | Iron Law 6 Pre-flight 違反。計画後に別 worktree が PR 提出するケースあり (#646 / #647)。PR 作成時にも実施 |
+| 「(A) PR 内修正は PR が大きくなるから別 issue にしよう」 | レビュー摘出問題は原則 (A) PR 内追加修正 (`feedback_pr_internal_fix_policy.md` 昇格)。サイズだけで (B) を選ばない |
 
 詳細は `docs/l2-workflow.md` を参照。Iron Law が不明確な場合は先に l2-workflow.md を読むこと。
 </EXTREMELY_IMPORTANT>

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: PR をレビュー（base ブランチ確認・受け入れ条件ゲート・CI・ロジック/ドキュメント整合性・ギャップ分析・摘出課題トリアージ）し、摘出した全課題を PR コメント / 新規 issue / 既存 issue 追記 のいずれかに必ず振り分ける (握り潰し禁止)。受け入れ条件全満たし + 摘出課題 (A) ゼロ で LGTM 候補、そうでなければ修正依頼または派生 issue 起票。マージ後は紐づく issue クローズを `/close-issue` skill (または手動クローズ) にハンドオフする (本 skill 内では `gh issue close` を実行しない)。レビュー専用セッションのため PR ブランチへの編集・commit・push は行わない
+description: PR をレビュー（base ブランチ同期確認 = 最新化 + 直近マージ PR 影響 + 並行 worktree PR 重複、受け入れ条件ゲート、CI、ロジック/ドキュメント整合性、ギャップ分析、摘出課題トリアージ）し、摘出した全課題を (A) PR 内追加修正 (Recommended、デフォルト) / (B) 新規 issue 起票 (限定例外) / (C) 既存 issue 追記 (限定例外) のいずれかに必ず振り分ける (握り潰し禁止)。受け入れ条件全満たし + 摘出課題ゼロ で LGTM 候補、そうでなければ原則 (A) PR 内追加修正で完結する。マージ後は紐づく issue クローズを `/close-issue` skill (または手動クローズ) にハンドオフする (本 skill 内では `gh issue close` を実行しない)。レビュー専用セッションのため PR ブランチへの編集・commit・push は行わない
 user-invocable: true
 argument-hint: <PR番号>
 ---
@@ -22,10 +22,69 @@ gh pr view $ARGUMENTS --json title,body,headRefName,baseRefName,files,commits,la
 gh pr diff $ARGUMENTS
 ```
 
-### 2. ベースブランチ確認
+### 2. ベースブランチ同期確認
+
+CI green は **内部整合性のみ** を保証し、base 取り込み時の機能 regression や並行 worktree PR 重複は検出できない。Step 3 (受け入れ条件) に入る前に、base 最新化 + 直近マージ PR 影響 + 並行 PR 重複を必ず確認する。
+
+> read-only 操作のみで完結するため、本 SKILL 冒頭「重要」節 (PR ブランチ編集禁止) と整合する。`git checkout` / `git merge` / `git rebase` / `git push` は本 step でも一切実行しない。
+
+#### 2.1 ベースブランチ形式確認
 
 - `baseRefName` が `develop-x.x.x` 形式であることを確認 (`main` 直接は通常禁止)
 - 例外はホットフィックス PR のみ
+
+#### 2.2 base 最新化と直近マージ PR 列挙 (`feedback_pr_review_base_merge_regression.md` 昇格)
+
+```bash
+# base を最新化 (read-only 操作)
+git fetch origin <baseRefName>
+
+# PR メタを取得 (作成日時、base/head SHA、touched files、mergeStateStatus)
+gh pr view "$ARGUMENTS" --json createdAt,baseRefOid,headRefOid,changedFiles,files,mergeStateStatus
+
+# PR 作成日以降に同 base へマージされた他 PR を列挙
+gh pr list --base <baseRefName> --state merged \
+  --search "merged:>=<PR.createdAt>" \
+  --json number,title,mergedAt,files --limit 30
+```
+
+各列挙 PR の `files[].path` と当該 PR の `files[].path` を **交差判定** し、交差ありの PR を「影響候補」としてリスト化する。交差ゼロなら本 step は「影響候補なし」で 2.3 を skip 可。
+
+#### 2.3 base 同期判定と進め方確認 (影響候補がある場合のみ)
+
+- `mergeStateStatus` が `BEHIND` の場合、PR head は base 最新を取り込んでいない
+- 影響候補 PR がある + `BEHIND` の組合せでは、base / head の同ファイル grep 対比で develop 側追加機能 (新フィールド・関数引数・schema 変更・新規エクスポート等) の保持を逐条確認する。`gh api "repos/<owner>/<repo>/contents/<path>?ref=<ref>"` で base / PR head 双方を取得して `diff` で比較する手順は `feedback_pr_review_base_merge_regression.md` の §How to apply を参照
+- 結果を AskUserQuestion で 3 択提示する:
+  - **(A) PR 作成者に rebase / merge 取り込み + 再検証を依頼するコメントを投稿** (Recommended) — 機能 regression リスクあり時の既定
+  - **(B) 影響候補は確認済み・regression なしと判定し Step 3 へ進む** — base / head grep 対比で develop 側追加が PR head に保持されていることを実証できた場合
+  - **(C) 詳細調査を続ける** — 判定保留
+
+#### 2.4 並行 worktree 同 issue PR 重複確認 (`feedback_concurrent_worktree_pr_check.md` 昇格)
+
+```bash
+# PR が参照する元 issue 番号を抽出 (closingIssuesReferences + 本文 Refs #N)
+gh pr view "$ARGUMENTS" --json closingIssuesReferences,body
+
+# 各 issue について同 issue を参照する PR を全件検索 (open / merged / closed 含む)
+gh pr list --search "<元issue#>" --state all \
+  --json number,headRefName,state,createdAt,mergedAt --limit 20
+```
+
+当該 PR 以外に open or merged の PR が検出されたら AskUserQuestion で 3 択提示する:
+
+- **(A) 重複扱いで close 提案** (Recommended、明らかな機能重複時) — PR 作成者に方針相談コメントを投稿
+- **(B) スコープ分担で並走** — 各 PR がカバーする範囲を本 PR レビュー報告に明記
+- **(C) 既マージ済みで対象外** — 別 PR が既にマージ済みで本 PR が不要なら close 提案
+
+並行 PR 検出ゼロなら Step 6 レポート末尾に「並行 PR 確認: 検出ゼロ」と 1 行記録する。
+
+##### Red Flags
+
+| 浮かんだ思考 | 実態 |
+|---|---|
+| 「最近 fetch したから OK」 | 数分でも別 PR がマージされうる。Step 2.2 は毎レビュー実施 |
+| 「mergeStateStatus が CLEAN だから影響候補も問題なし」 | CLEAN は merge 可否のみで機能 regression は判定しない |
+| 「並行 PR は計画段階で確認済みのはずだから skip」 | 計画後に別 worktree が PR を提出するケースあり (#646 / PR #647)。Step 2.4 はレビュー時にも実施 |
 
 ### 3. 受け入れ条件チェックリスト (#367 対策)
 
@@ -105,15 +164,39 @@ Step 3 (受け入れ条件) / Step 5 (ロジック・ドキュメント) が拾�
 
 ここで列挙した観点は Step 5b トリアージ表で必ず処置分類を付ける。観察コメントのみで終える (= 握り潰す) のは禁止。
 
-### 5b. 摘出課題のトリアージ (二択強制、握り潰し禁止)
+### 5b. 摘出課題のトリアージ (握り潰し禁止、原則 (A) で完結)
 
 Step 3 (受け入れ条件未達) / Step 4 (CI 失敗) / Step 5 (ロジック・ドキュメント不整合) / Step 5a (ギャップ分析) で洗い出した**すべての摘出課題**を下記トリアージ表に記載する。各行は必ず処置分類 (A / B / C) のいずれかに割り当てる。**未分類 (観察のみ / 握り潰し / スコープ対象外と自己判断して無視) は禁止**。
 
-**処置分類 (3 択)**
+> **方針: 摘出問題は原則 (A) PR 内追加修正で PR を完結させる** (`feedback_pr_internal_fix_policy.md` 2026-04-27 PR #615 確定方針の skill 昇格)。**理由: レビュー摘出のたびに別 issue を起票すると issue が減らないどころか増え、運用が破綻する。本 PR 内で完結できる修正は本 PR で行う方が追跡コストが低い。** 別 issue 起票は後述の限定例外 trigger に該当する場合のみ。
 
-- **(A) PR コメント**: 本 PR のスコープ内で修正依頼する (Step 7 「修正依頼コメント投稿」で PR 作成セッションに依頼)
-- **(B) 新規 issue 起票**: 本 PR のスコープ外だが追跡必要な課題 (Step 7 完了後または Step 8 マージ後に `/create-task` で起票)
-- **(C) 既存 issue 追記**: 既存 issue の受け入れ条件・残タスクに該当するため、当該 issue にコメントで方針記録を追記
+**処置分類 (3 択、(A) Recommended)**
+
+- **(A) PR コメントで本 PR 内修正依頼 (Recommended、デフォルト)**: 本 PR 内で追加修正してマージまで進める。Step 7「修正依頼コメント投稿」で PR 作成セッションに依頼。**摘出課題はまずこの選択肢を検討する**
+- **(B) 新規 issue 起票 (限定例外)**: 以下の trigger のいずれかに該当する課題のみ。Step 7 完了後または Step 8 マージ後に `/create-task` で起票:
+  - **別領域・別機能** (例: 別ファイル群のセキュリティ問題、別レイヤー実装、別担当領域) で着手 issue スコープ外
+  - **大規模リファクタ** (独立設計が必要、工数 1 セッション超、本 PR に同梱すると diff が肥大化して受け入れ条件検証が破綻する)
+  - **外部依存・側チケット調整が必要** (上流ライブラリ変更、別リポ修正待ち等)
+- **(C) 既存 issue 追記 (限定例外)**: 既存 issue の受け入れ条件・残タスクに該当するため、当該 issue にコメントで方針記録を追記。同 issue の重複起票を避けるとき
+
+**AskUserQuestion で処置選択肢を提示する場合**: (A) を必ず最初の選択肢として `(Recommended)` ラベル付きで表示する。**`(Recommended)` ラベルは表示順規約であって最終選択結果を強制するものではない**。(B) / (C) は限定例外 trigger を `description` フィールドに明記する。**(B) trigger 強該当時は description で具体的に該当根拠を説明** する (例: 「audio module は本 PR スコープ外 = 別レイヤー、独立 security 修正 → (B) 該当」)。例:
+
+```
+options: [
+  { label: "(A) 本 PR 内で追加修正 (Recommended)", description: "本 PR の品質を底上げする修正は (A) で同梱が原則 (`feedback_pr_internal_fix_policy.md`)" },
+  { label: "(B) 別 issue 起票 (別領域 / 大規模 / 外部依存のみ)", description: "本件は audio module で本 PR スコープ外 (detector/format) → 別領域 trigger 強該当、独立した security 修正" },
+  { label: "(C) 既存 issue 追記", description: "既存 issue #N が同テーマで未クローズ → 重複起票回避" }
+]
+```
+
+**(A) を選ばない理由として NG な合理化** (これらが浮かんだら STOP):
+
+| 浮かんだ思考 | 実態 |
+|---|---|
+| 「PR が大きくなるから別 issue にしよう」 | (A) が原則。サイズだけを理由に (B) を選ばない。本当に diff が肥大化するなら「大規模リファクタ」trigger を満たすか先に判定 |
+| 「本 PR の受け入れ条件と直結しないから別 issue」 | (A) が原則。本 PR の品質を底上げする修正は (A) で同梱する。直結性ではなく「別領域・別機能」trigger を満たすかで判定 |
+| 「軽微だから別 issue で後でまとめて」 | (A) が原則。軽微なら本 PR 内で即時修正の方が安い。後回しにすると忘れる |
+| 「摘出課題が多いから一部は別 issue で分離」 | 件数では分離しない。各課題ごとに (A) / (B) trigger を独立判定する |
 
 **判定基準**
 
@@ -159,6 +242,13 @@ Step 5b のトリアージ表を前提に `AskUserQuestion` で以下を提示�
 - **前回差分**: <Round 2 以降のみ: 前 Round で指摘した課題のうち解消したもの / 未解消のもの>
 - **本 Round 新出**: <Round 2 以降のみ: 本 Round で新規に発見した課題>
 - (Round 1 では上記 2 行を省略可)
+
+## ベース同期確認 (Step 2)
+
+- **形式 (2.1)**: `baseRefName` = <name> (`develop-x.x.x` 形式の確認結果)
+- **base 最新化と直近マージ PR (2.2)**: `mergeStateStatus` = <CLEAN / BEHIND>、影響候補 PR = <なし / [#N (touched: `<path>`)]>
+- **同期判定 (2.3)**: skip (影響候補なし) / 確認済み・regression なし / 取り込み依頼コメント投稿 / 詳細調査
+- **並行 worktree PR (2.4)**: 検出ゼロ / [#M (理由: 重複 / 並走 / 既マージ)] (束ね PR の場合は `- #500: <結果>` `- #501: <結果>` のように issue ごとに bullet で列記)
 
 ## 受け入れ条件チェック (逐条)
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -181,7 +181,7 @@ Step 3 (受け入れ条件未達) / Step 4 (CI 失敗) / Step 5 (ロジック・
 
 **AskUserQuestion で処置選択肢を提示する場合**: (A) を必ず最初の選択肢として `(Recommended)` ラベル付きで表示する。**`(Recommended)` ラベルは表示順規約であって最終選択結果を強制するものではない**。(B) / (C) は限定例外 trigger を `description` フィールドに明記する。**(B) trigger 強該当時は description で具体的に該当根拠を説明** する (例: 「audio module は本 PR スコープ外 = 別レイヤー、独立 security 修正 → (B) 該当」)。例:
 
-```
+```js
 options: [
   { label: "(A) 本 PR 内で追加修正 (Recommended)", description: "本 PR の品質を底上げする修正は (A) で同梱が原則 (`feedback_pr_internal_fix_policy.md`)" },
   { label: "(B) 別 issue 起票 (別領域 / 大規模 / 外部依存のみ)", description: "本件は audio module で本 PR スコープ外 (detector/format) → 別領域 trigger 強該当、独立した security 修正" },

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,22 @@
 
 ### Iron Law 6: PR 作成前検証
 
+#### ベース同期確認 (Pre-flight、`feedback_pr_review_base_merge_regression.md` / `feedback_concurrent_worktree_pr_check.md` 昇格)
+
+<!--
+plain bullet `-` で記述する (validate-checklist は `[x]` 化を要求しない、CI ゲート増設なし)。
+PR 作成前 Pre-flight 4 ステップ (`docs/l2-workflow.md` §「PR 作成前 Pre-flight」参照):
+1. `git fetch origin <base>` で base 最新化
+2. `git log HEAD..origin/<base> --oneline` で取り込み未済 commit 列挙
+3. 取り込み未済 commit が当 PR の `git diff --name-only origin/<base>` と path 交差するなら取り込み + 検証再実行
+4. `gh pr list --search "<元issue#>" --state all` で並行 PR の有無確認
+-->
+
+- PR 作成時の base HEAD: `<sha>` (`git rev-parse origin/<base>` 出力)
+- PR head の base 取り込み: 取り込み不要 (base 進行なし) / merge 済み (commit `<sha>`) / rebase 済み
+- 直近マージ PR の影響: なし / [#N] (touched files 交差: `<path>` → 確認済み)
+- 並行 PR 確認 (`gh pr list --search "<元issue#>" --state all`): なし / [#N] (理由: 別スコープ並走 / 重複なし)
+
 #### Self-Test Report (machine-verified — 全件 `[x]` で validate-checklist 通過)
 
 <!--

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,8 +251,9 @@ L2 からは**単一ワークツリー + skill ベースディスパッチ**を�
 
 ## PR 作成ルール
 
-詳細は `docs/l2-workflow.md` を参照。Iron Law 6 (`.claude/hooks/session-start.sh`) と `feedback_pr_pre_creation_checks.md` / `feedback_user_realmachine_test_request.md` も参照。要約:
+詳細は `docs/l2-workflow.md` を参照。Iron Law 6 (`.claude/hooks/session-start.sh`) と `feedback_pr_pre_creation_checks.md` / `feedback_user_realmachine_test_request.md` / `feedback_pr_review_base_merge_regression.md` / `feedback_concurrent_worktree_pr_check.md` も参照。要約:
 
+- **PR 作成 Pre-flight (Iron Law 6 サブ条、#659)**: `git fetch origin <base>` → `git log HEAD..origin/<base> --oneline` で取り込み未済 commit 列挙 → `git diff --name-only` で当 PR と取り込み未済 commit の touched files 交差判定 (交差ありなら `git merge origin/<base>` で取り込み + 自動チェック再実行) → `gh pr list --search "<元issue#>" --state all` で並行 worktree PR 重複確認。結果は PR テンプレ §「ベース同期確認」 に plain bullet で記録。詳細は [docs/l2-workflow.md](docs/l2-workflow.md) §「PR 作成 Pre-flight」
 - **PR 作成前 (Iron Law 6)**: 変更ファイル path から必要な自動チェックを判定して全 pass させる:
   - **python-core** (`allaganeye/**/*.py`, `tests/**/*.py`, `pyproject.toml`): `ruff check .` / `ruff format --check .` / `pyright` / `pytest`
   - **gui-frontend** (`gui/src/**`, `gui/package.json`, `gui/tsconfig.json` 等): `cd gui && npm run lint` / `npm run typecheck` / `npm test` / `npm run build`

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -69,6 +69,49 @@ main (リリースタグのみ)
 
 反復利用される手順があれば、実運用でパターンが固まった時点で新規 skill を追加する (事前に空の skill は作らない)。
 
+## PR 作成 Pre-flight (Iron Law 6 サブ条)
+
+PR 作成前に base 最新化と並行 worktree PR 重複を必ず確認する。`feedback_pr_review_base_merge_regression.md` (PR #627 Round 4 で発覚した base 取り込み機能 regression) と `feedback_concurrent_worktree_pr_check.md` (#646 / PR #647 並行作業重複) の skill / 規約昇格として運用化 (2026-04-29 #659)。
+
+### 4 ステップ手順
+
+```bash
+# 1. base 最新化 (read-only fetch)
+git fetch origin <base>            # <base> = develop-0.2.0 等
+
+# 2. 取り込み未済 commit 列挙
+git log HEAD..origin/<base> --oneline
+
+# 3. touched files 交差判定 (取り込み未済 commit が当 PR と同 path を触っていないか)
+#    - 当 PR の touched files
+git diff --name-only origin/<base>
+#    - 取り込み未済 commit の touched files
+git diff --name-only HEAD origin/<base>
+#    両者の交差ありなら、base 取り込み (merge or rebase) + 検証再実行が必要
+
+# 4. 並行 worktree 同 issue PR 重複確認
+gh pr list --search "<元issue#>" --state all \
+  --json number,headRefName,state,createdAt
+```
+
+### 判定
+
+- **取り込み未済 commit ゼロ**: そのまま PR 作成
+- **取り込み未済 commit あり、touched files 交差なし**: 取り込み不要、PR 作成 (base HEAD は Pre-flight 実施時点を記録)
+- **取り込み未済 commit あり、touched files 交差あり**: `git merge origin/<base>` (または rebase) で取り込み → Iron Law 6 自動チェック (`ruff` / `pyright` / `pytest` / `npm run lint`/`typecheck`/`test`/`build` / `cargo check` 等、変更 path に応じて) を再実行 → PR 作成
+- **並行 PR 検出**: 各 PR の状態 (open / merged) を確認。重複なら計画見直し or `AskUserQuestion` でユーザー判断
+
+確認結果は **PR テンプレート §「ベース同期確認」** (4 項目を plain bullet で) に記録する。validate-checklist は plain bullet を無視するため CI ゲートは増設しないが、レビュー時に `/review-pr` Step 2 が `gh pr view` 経由で機械的に再確認するため、握り潰しは禁止。
+
+### Red Flags
+
+| 浮かんだ思考 | 実態 |
+|---|---|
+| 「コンフリクト出ないから OK」 | merge 可否 (CONFLICT 不在) と機能 regression は別軸。base / head の同ファイル grep 対比が必要 |
+| 「最近 fetch したから OK」 | 数分でも別 PR がマージされうる。PR 作成直前に再 fetch する |
+| 「並行 PR は計画段階で確認したから skip」 | 計画後に別 worktree が PR を提出するケースあり (#646 / PR #647)。PR 作成時にも実施 |
+| 「Pre-flight で path 交差なしと判定したから自動チェック skip」 | path 交差判定と Iron Law 6 自動チェックは独立軸。Iron Law 6 は変更 path 別に毎 PR 作成時に実施 |
+
 ## レビュー受け入れ基準 (#367 対策)
 
 PR #343 のような「複数 Issue が不完全修正のままクローズされる」事故を防ぐため、`/review-pr` skill は以下を自動検証する:


### PR DESCRIPTION
## 概要

PR 作成・レビュー時に base 最新化 + 直近マージ PR 影響 + 並行 worktree PR 重複を強制確認する運用ゲートを `/review-pr` skill / PR テンプレ / `docs/l2-workflow.md` / `CLAUDE.md` / Iron Law 6 サブ条として昇格。あわせてレビュー摘出問題は原則「PR 内追加修正で完結」方針 (`feedback_pr_internal_fix_policy.md`, 2026-04-27 PR #615 確定) を `/review-pr` Step 5b に Recommended ラベル必須として昇格。 Refs #659

## 変更点

- `/review-pr` SKILL.md: Step 2 を 4 サブステップ化 (2.1 形式 / 2.2 base 最新化 + 直近マージ PR 列挙 / 2.3 同期判定 + AskUserQuestion / 2.4 並行 worktree PR 重複確認)
- `/review-pr` SKILL.md: Step 5b 冒頭に「原則 (A) PR 内追加修正で完結」太字方針 + (A) Recommended ラベル必須 + (B) 限定例外 trigger (別領域 / 大規模 / 外部依存) + Red Flag テーブル
- `/review-pr` SKILL.md: Step 6 レビュー報告テンプレに「ベース同期確認 (Step 2)」専用セクションを追加 (2.1〜2.4 構造化 bullet、束ね PR の N issue 個別記録例も明示)
- `.github/pull_request_template.md`: 「ベース同期確認 (Pre-flight)」節を Self-Test Report の前に新設 (4 plain bullet)
- `docs/l2-workflow.md`: 「PR 作成 Pre-flight (Iron Law 6 サブ条)」 section 新設 (4 ステップ手順 + 判定 + Red Flags)
- `CLAUDE.md`: PR 作成ルールに Pre-flight bullet + 関連 feedback_*.md 参照追記
- `.claude/hooks/session-start.sh`: Iron Law 6 に Pre-flight サブ条 + Red Flags 表に 3 行追加
- memory 3 ファイル末尾に「2026-04-29 から skill / template / Iron Law に昇格」追記

## 受け入れ基準 / 確認項目 (Iron Law 1: 逐条検証)

- [x] 1. `/review-pr` skill Step 2 が 4 サブステップ (2.1〜2.4) に拡張、`gh pr list --base ... --search "merged:>=..."` および同 issue 並行 PR 検索が逐条記載 — 対応 diff: `.claude/skills/review-pr/SKILL.md` Step 2 全体
- [x] 2. `.github/pull_request_template.md` に「ベース同期確認」節追加、4 項目すべて plain bullet `-` (validate-checklist 規約整合) — 対応 diff: `.github/pull_request_template.md` 「ベース同期確認 (Pre-flight)」節
- [x] 3. `docs/l2-workflow.md` の PR 作成節に Pre-flight 4 ステップ追加 — 対応 diff: `docs/l2-workflow.md` 「PR 作成 Pre-flight (Iron Law 6 サブ条)」section
- [x] 4. `CLAUDE.md` PR 作成ルールに 1 行追加 — 対応 diff: `CLAUDE.md` PR 作成ルール先頭 bullet
- [x] 5. `.claude/hooks/session-start.sh` Iron Law 6 サブ条追記 — 対応 diff: Iron Law 6 末尾 + Red Flags 表 3 行追加
- [x] 6. `/review-pr` Step 5b 冒頭に「摘出問題は原則 (A) PR 内追加修正で完結」太字明示 + AskUserQuestion で `(A) ... (Recommended)` ラベル必須 + 例外条件 + Red Flag — 対応 diff: `.claude/skills/review-pr/SKILL.md` Step 5b 冒頭〜
- [x] 7. memory 3 ファイル末尾に「2026-04-29 から ... に昇格」追記 — 対応 diff: 各 memory ファイル末尾
- [x] 8. empirical-prompt-tuning による検証で連続 2 iter 収束達成 — 対応 log: plan ファイル §「Iteration log」、Iter 3 (シナリオ A 再 = 不明瞭点 0) + Iter 4 (シナリオ D 再 = 不明瞭点 0) で連続 2 iter 新規不明瞭点ゼロ達成

## PR チェックリスト (Iron Law 遵守確認)

### Iron Law 1: 受け入れ条件検証

- [x] 元 issue #659 の `## 受け入れ条件` を上記で逐条検証
- [x] UI/出力変更なし (docs / skills / hook のみ、CLI / GUI 出力変更なし) のためサンプル添付不要

### Iron Law 3: スコープ遵守 (scope-guard)

- [x] 変更ファイルがすべて元 issue #659 のスコープ内 (`git diff --stat`: 5 ファイル、すべて受け入れ条件 1〜7 に対応)
- [x] スコープ外変更なし

### Iron Law 4: クローズキーワード禁止

- [x] 本文・コミットメッセージに `Closes` / `Fixes` / `Resolves` キーワードが含まれていない (`Refs #659` のみ使用)

### Iron Law 6: PR 作成前検証

#### ベース同期確認 (Pre-flight、`feedback_pr_review_base_merge_regression.md` / `feedback_concurrent_worktree_pr_check.md` 昇格)

- PR 作成時の base HEAD: `13363ed20170f2c073476cf797b80377984f2079` (`git rev-parse origin/develop-0.2.0` 出力)
- PR head の base 取り込み: 取り込み不要 (base 進行あり = PR #647 / PR #657 各 1 件マージ済みだが、touched files 交差なし)
- 直近マージ PR の影響: なし (PR #647 = `gui/*` のみ / PR #657 = `allaganeye/*` + `docs/coding-conventions.md` + `tests/test_subprocess_encoding.py` で、本 PR の `.claude/skills/` + `.github/` + `docs/l2-workflow.md` + `CLAUDE.md` + `hooks/session-start.sh` と完全分離)
- 並行 PR 確認 (`gh pr list --search "659" --state all`): 検出ゼロ

#### Self-Test Report (machine-verified — 全件 `[x]` で validate-checklist 通過)

- [x] `ruff check .` — N/A: python-core 変更なし (.claude/hooks の sh + docs / md のみ)
- [x] `ruff format --check .` — N/A: python-core 変更なし
- [x] `pyright` — N/A: python-core 変更なし
- [x] `pytest` — N/A: python-core 変更なし
- [x] `cd gui && npm run lint` — N/A: gui-frontend 変更なし
- [x] `cd gui && npm run typecheck` — N/A: gui-frontend 変更なし
- [x] `cd gui && npm test` — N/A: gui-frontend 変更なし
- [x] `cd gui && npm run build` — N/A: gui-frontend 変更なし
- [x] `cargo check --manifest-path gui/src-tauri/Cargo.toml` — N/A: gui-rust 変更なし
- [x] `Invoke-Pester -Path scripts/tests/` — N/A: installer-pester 変更なし

#### 関連ドキュメント / マトリクス更新

- [x] 関連ドキュメント更新 — 本 PR 自体が `docs/l2-workflow.md` / `CLAUDE.md` / PR テンプレ / Iron Law を更新
- [x] **新規 CLI オプション追加時**: マトリクス更新 — N/A: CLI オプション追加なし
- [x] CLAUDE.md / `docs/l2-workflow.md` の更新要否確認 — 本 PR で更新済み
- [x] 出力書式変更時の `docs/cli-spec.md` 更新 — N/A: 出力書式変更なし
- [x] docs / 識別子のリネーム時 §「<旧名>」grep — 旧 §「ベースブランチ確認」/§「(二択強制」 grep で残骸ゼロ確認済み (`feedback_doc_section_ref_check.md` 規約)

#### 実機検証 (machine-unverifiable — plain bullet で書く)

- 該当なし (`gpu_detector.py` / `audio/` / `video/detector.py` / `gui/` 変更なし、docs / skills / hook only path 改修)
- empirical-prompt-tuning による subagent dispatch 評価を 4 シナリオ × 4 iter 実施 (シナリオ A 中央値 / B no-op edge / C 並行 PR + 別領域 / D 束ね PR + CI fail + 別領域 hold-out)、連続 2 iter (Iter 3 + Iter 4) で新規不明瞭点ゼロ達成 → 詳細は `C:/Users/idios/.claude/plans/pr-pr-pr-review-pr-pr-agile-dragonfly.md` §「Iteration log」

## 関連

- Refs #659
- Base branch: `develop-0.2.0`
- Session: peaceful-agnesi-4d38ed
- 関連 memory: `feedback_pr_review_base_merge_regression.md` / `feedback_concurrent_worktree_pr_check.md` / `feedback_pr_internal_fix_policy.md` / `feedback_skill_revision_empirical.md`
- 関連 PR: PR #627 (base 取り込み機能 regression が発覚した契機) / PR #647 (#646 並行 worktree 重複の事例) / PR #615 (`feedback_pr_internal_fix_policy.md` 方針確定)

## 備考

- CI 自動化 (PR head が origin/base から up-to-date でない場合に fail させる GitHub Actions) は別 issue 化で扱う (今回スコープ外、ユーザー判断で確定)
- empirical-prompt-tuning による subagent 評価を実施したのは「skill / 規約改修は書き手には欠陥が見えない」原則 (`feedback_skill_revision_empirical.md`)。Iter 2 で Step 6 テンプレの暗黙性、Iter 3 で束ね PR テンプレ例示不足 + (B) trigger description placeholder の 2 件を検出し補強適用、Iter 4 で反映確認 (新規不明瞭点ゼロ)
