### PR TITLE
fix(gui): detect 子プロセスの UTF-8 stdout 強制 + lossy decode (Refs #656)

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2249,7 +2249,7 @@ async fn start_detect(
     // would kill the reader with `InvalidData`. We read raw bytes per
     // newline and apply `String::from_utf8_lossy` so any stray non-UTF-8
     // byte becomes U+FFFD instead of aborting the stream. `PYTHONIOENCODING
-    // = utf-8` set above is the primary fix; this is the defensive layer.
+    // = utf-8:replace` set above is the primary fix; this is the defensive layer.
     let mut reader = BufReader::new(stdout);
     let mut line_buf: Vec<u8> = Vec::with_capacity(1024);
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2176,6 +2176,11 @@ async fn start_detect(
     if let Some(cwd) = &cmd_spec.cwd {
         cmd.current_dir(cwd);
     }
+    // #656 -- Windows の Python は default で `sys.stdout.encoding=cp932`
+    // になるため、日本語含む path を JSON-line stream に乗せて出力すると
+    // Rust 側 (UTF-8 前提の reader) で decode 失敗する。`PYTHONIOENCODING`
+    // を utf-8 に固定して CLI 側 stdout/stderr を UTF-8 強制する。
+    cmd.env("PYTHONIOENCODING", "utf-8");
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -2204,16 +2209,27 @@ async fn start_detect(
 
     // Stderr drains in parallel into a bounded tail buffer so the OS
     // pipe doesn't fill up if the CLI is chatty under -v / verbose.
+    // #656 -- avoid `lines()` for the same UTF-8 強制 reason as stdout
+    // above. The tail is exposed only when the child exits non-zero, so
+    // line semantics are not load-bearing -- we just need the trailing
+    // bytes intact for the GUI error display.
     let stderr_handle = tokio::spawn(async move {
         let max_tail = 2048usize;
         let mut tail: Vec<u8> = Vec::with_capacity(4096);
-        let mut reader = BufReader::new(stderr).lines();
-        while let Ok(Some(line)) = reader.next_line().await {
-            tail.extend_from_slice(line.as_bytes());
-            tail.push(b'\n');
-            if tail.len() > max_tail * 2 {
-                let drop = tail.len() - max_tail;
-                tail.drain(0..drop);
+        let mut reader = BufReader::new(stderr);
+        let mut buf: Vec<u8> = Vec::with_capacity(1024);
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf).await {
+                Ok(0) => break,
+                Ok(_) => {
+                    tail.extend_from_slice(&buf);
+                    if tail.len() > max_tail * 2 {
+                        let drop = tail.len() - max_tail;
+                        tail.drain(0..drop);
+                    }
+                }
+                Err(_) => break,
             }
         }
         tail
@@ -2221,11 +2237,26 @@ async fn start_detect(
 
     let mut metadata_path: Option<String> = None;
     let mut total_matches: u64 = 0;
-    let mut reader = BufReader::new(stdout).lines();
+    // #656 -- `AsyncBufReadExt::lines()` returns `String` and therefore
+    // imposes strict UTF-8 decoding on the Python child's stdout. On
+    // Windows the child's `sys.stdout.encoding` defaults to cp932 (or any
+    // ANSI code page), so a JSON-line stream containing 日本語 path bytes
+    // would kill the reader with `InvalidData`. We read raw bytes per
+    // newline and apply `String::from_utf8_lossy` so any stray non-UTF-8
+    // byte becomes U+FFFD instead of aborting the stream. `PYTHONIOENCODING
+    // = utf-8` set above is the primary fix; this is the defensive layer.
+    let mut reader = BufReader::new(stdout);
+    let mut line_buf: Vec<u8> = Vec::with_capacity(1024);
 
     loop {
-        match reader.next_line().await {
-            Ok(Some(line)) => {
+        line_buf.clear();
+        match reader.read_until(b'\n', &mut line_buf).await {
+            Ok(0) => break,
+            Ok(_) => {
+                while matches!(line_buf.last(), Some(b'\n') | Some(b'\r')) {
+                    line_buf.pop();
+                }
+                let line = String::from_utf8_lossy(&line_buf);
                 if let Some(progress) = parse_detect_progress_line(&line) {
                     if progress.phase == "done" {
                         if let Some(ref p) = progress.metadata_path {
@@ -2238,7 +2269,6 @@ async fn start_detect(
                     let _ = app.emit("detect-progress", progress);
                 }
             }
-            Ok(None) => break,
             Err(e) => {
                 // stdout pipe hiccup -- still try to wait the child so
                 // we don't leak a zombie.  The error path below sets the

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2182,8 +2182,10 @@ async fn start_detect(
     // #656 -- Windows の Python は default で `sys.stdout.encoding=cp932`
     // になるため、日本語含む path を JSON-line stream に乗せて出力すると
     // Rust 側 (UTF-8 前提の reader) で decode 失敗する。`PYTHONIOENCODING`
-    // を utf-8 に固定して CLI 側 stdout/stderr を UTF-8 強制する。
-    cmd.env("PYTHONIOENCODING", "utf-8");
+    // を `utf-8:replace` に固定して CLI 側 stdout/stderr を UTF-8 強制し、
+    // encode 不能 byte は U+FFFD で置換する (PR #657 Python 側
+    // `errors="replace"` と対称)。
+    cmd.env("PYTHONIOENCODING", "utf-8:replace");
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -4458,5 +4460,45 @@ mod tests {
         assert!(!serialized.contains("metadata_path"));
         assert!(!serialized.contains("\"matches\""));
         assert!(!serialized.contains("\"message\""));
+    }
+
+    /// #656 review Round 1 摘出 #3 -- detect 経路 stdout reader
+    /// (`start_detect` 内 `read_until` + 改行 trim + `from_utf8_lossy`)
+    /// の core logic を bytes 入力で再現し、invalid UTF-8 byte は U+FFFD
+    /// に置換され、CRLF は両方 trim されることを確認する。production
+    /// code は inline (関数抽出未) のため同型ロジックを test 内で再構築。
+    #[tokio::test]
+    async fn stdout_decode_replaces_invalid_utf8_and_trims_crlf() {
+        // 0x83, 0x84 は単独で UTF-8 invalid (continuation byte 領域)。
+        // cp932 では multi-byte の前半 byte で日本語 path に頻出する。
+        let raw: &[u8] = &[
+            b'h', b'i', 0x83, 0x84, b'\n', b'b', b'y', b'e', b'\r', b'\n',
+        ];
+        let mut reader = BufReader::new(raw);
+        let mut buf: Vec<u8> = Vec::new();
+
+        // line 1: invalid byte は from_utf8_lossy で U+FFFD に置換
+        let n = reader.read_until(b'\n', &mut buf).await.unwrap();
+        assert!(n > 0);
+        while matches!(buf.last(), Some(b'\n') | Some(b'\r')) {
+            buf.pop();
+        }
+        let line = String::from_utf8_lossy(&buf);
+        assert_eq!(line, "hi\u{FFFD}\u{FFFD}");
+
+        // line 2: CRLF (\r\n) は while ループで両方 pop
+        buf.clear();
+        let n = reader.read_until(b'\n', &mut buf).await.unwrap();
+        assert!(n > 0);
+        while matches!(buf.last(), Some(b'\n') | Some(b'\r')) {
+            buf.pop();
+        }
+        let line = String::from_utf8_lossy(&buf);
+        assert_eq!(line, "bye");
+
+        // EOF: read_until returns Ok(0)
+        buf.clear();
+        let n = reader.read_until(b'\n', &mut buf).await.unwrap();
+        assert_eq!(n, 0);
     }
 }


### PR DESCRIPTION
## Summary

[#656](https://github.com/Idios/kobutachan-allaganeye/issues/656) の継続対応。PR [#657](https://github.com/Idios/kobutachan-allaganeye/pull/657) マージ後の post-merge 実機検証 (`/close-issue 656`) で**受け入れ条件 #3 (GUI Tauri 日本語 path drop) が fail**。「stdout read error: stream did not contain valid UTF-8」が発生し「検知に失敗しました」UI に至る。Idios 判断で issue #656 をスコープ拡大して継続 open し、Rust 側を二段防御で修正する。

## 受け入れ条件チェック ([#656](https://github.com/Idios/kobutachan-allaganeye/issues/656))

| # | 受け入れ条件 | 対応 |
|---|---|---|
| 1 | 4 箇所の `subprocess.run(text=True, ...)` に `encoding="utf-8", errors="replace"` 追加 | PR [#657](https://github.com/Idios/kobutachan-allaganeye/pull/657) でマージ済 |
| 2 | 日本語含む path で `python -m allaganeye detect "<日本語パス>"` 成功 (UnicodeDecodeError 出ない) | machine-unverifiable: マージ後 / 別 session で Idios 手動検証 (`feedback_user_realmachine_test_request.md` 規約準拠) |
| 3 | GUI Tauri で日本語含む動画 drop → detect 成功 → CompleteScreen 遷移 | 同上 (本 PR の主検証対象) |
| 4 | pytest で cp932 decode 失敗パターンの test 追加 | PR [#657](https://github.com/Idios/kobutachan-allaganeye/pull/657) でマージ済 (`tests/test_subprocess_encoding.py`) |
| 5 | ruff check / ruff format / pyright / pytest 全通過 | PR [#657](https://github.com/Idios/kobutachan-allaganeye/pull/657) でマージ済 |
| 追加 (本 PR) | Rust (Tauri) 側で Python 子プロセスの stdout/stderr UTF-8 decode 失敗を防ぐ | [gui/src-tauri/src/lib.rs](gui/src-tauri/src/lib.rs) detect 経路 3 箇所修正 |

## 設計改修

### 案 A (主因 fix): `PYTHONIOENCODING=utf-8:replace`

[gui/src-tauri/src/lib.rs](gui/src-tauri/src/lib.rs) の `start_detect` (`Command::new(&cmd_spec.program)`) に `cmd.env("PYTHONIOENCODING", "utf-8:replace")` を追加。Windows での Python は default で `sys.stdout.encoding=cp932` (or ANSI code page) になるため、CLI 側で日本語含む path を JSON-line stream に乗せて出力すると Rust 側 (UTF-8 前提の reader) で decode 失敗する。本環境変数で CLI 側 stdout/stderr を UTF-8 に固定し、encode 不能 byte は U+FFFD で置換する (PR #657 Python 側 `errors="replace"` と対称、Round 1 摘出 #4 対応)。

### 案 B (defensive layer): `read_until` + `String::from_utf8_lossy`

`tokio::io::AsyncBufReadExt::lines()` は内部で `String` を返すため UTF-8 decode 必須。これを `read_until(b'\n')` + `String::from_utf8_lossy` に置き換え、UTF-8 として decode できない byte が残っても U+FFFD で置換して reader が死なないようにする。stderr drain 側も同じ理由で `lines()` 経路を排除 (tail buffer 用途で line semantics は load-bearing でないため bytes-based 化が clean)。

## 修正対象

[gui/src-tauri/src/lib.rs](gui/src-tauri/src/lib.rs) `start_detect` の 3 箇所:

- spawn 直前 (`cmd.stdin/stdout/stderr` 設定の前): `cmd.env("PYTHONIOENCODING", "utf-8:replace")` 追加 (案 A)
- stderr drain (旧 `BufReader::new(stderr).lines()`): `read_until` ベース bytes 蓄積に変更 (案 B)
- stdout reader (旧 `BufReader::new(stdout).lines()`): `read_until` + `from_utf8_lossy` で defensive decode (案 B)

合計修正: production code 3 箇所 + 単体テスト 1 件追加 (`stdout_decode_replaces_invalid_utf8_and_trims_crlf`、Round 1 摘出 #3 対応)。

## 修正対象外 (scope creep 回避)

ffmpeg / ffprobe 直接呼び出し経路 ([gui/src-tauri/src/lib.rs:283](gui/src-tauri/src/lib.rs#L283) / [721](gui/src-tauri/src/lib.rs#L721) / [1298](gui/src-tauri/src/lib.rs#L1298) / [1574](gui/src-tauri/src/lib.rs#L1574)) は本 PR scope 外。issue #656 のスコープは Python subprocess の cp932 失敗。ffmpeg 経路の同種問題があるかは別 issue で扱う (Iron Law 3)。

## Test plan

- [x] `cargo check --manifest-path gui/src-tauri/Cargo.toml` — pass
- [x] `cargo clippy --manifest-path gui/src-tauri/Cargo.toml -- -D warnings` — pass (warnings as errors)
- [x] `cargo test --manifest-path gui/src-tauri/Cargo.toml --lib` — 150 passed, 0 failed (Round 1 摘出 #1 base merge `origin/develop-0.2.0` 取り込み合成 build + Round 1 摘出 #3 で追加した `stdout_decode_replaces_invalid_utf8_and_trims_crlf` 1 件含む)

machine-unverifiable (Idios 手動、別 session で実機検証):

- 受け入れ条件 #2: 日本語含む path で `python -m allaganeye detect "E:\royalstraightflesh\videos\20260116\2026-01-17 00-43-10 - コピー.mkv" --progress-format json` が UnicodeDecodeError なく成功
- 受け入れ条件 #3 (本 PR 主検証): GUI Tauri (`cd gui && npm run tauri dev`) で日本語含む動画 drop → start_detect 成功 → CompleteScreen 遷移、`stdout read error: stream did not contain valid UTF-8` が出ないこと

## 関連

- 派生元: PR [#657](https://github.com/Idios/kobutachan-allaganeye/pull/657) マージ後の post-merge 実機検証 (`/close-issue 656`)
- 元 issue: [#656](https://github.com/Idios/kobutachan-allaganeye/issues/656) (スコープ拡大して継続 open、本 PR マージ + 実機検証 OK 確認後にクローズ予定)
- 派生 issue: [#658](https://github.com/Idios/kobutachan-allaganeye/issues/658) (AST regression test、独立進行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

