### PR TITLE
docs: 全 Tauri command の master 一覧 doc を新設 (Refs #619)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,23 @@ jobs:
       - name: Cargo test (lib)
         run: cargo test --lib --manifest-path gui/src-tauri/Cargo.toml
 
+  doc-tauri-commands-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check tauri-commands.md drift vs lib.rs
+        shell: bash
+        run: |
+          set -euo pipefail
+          LIB_COUNT=$(grep -c "^#\[tauri::command\]" gui/src-tauri/src/lib.rs)
+          DOC_COUNT=$(grep -cE "^\| [0-9]+ \|" docs/tauri-commands.md)
+          if [ "$LIB_COUNT" -ne "$DOC_COUNT" ]; then
+            echo "::error::docs/tauri-commands.md drift: lib.rs has $LIB_COUNT #[tauri::command], doc table has $DOC_COUNT rows. Update docs/tauri-commands.md to match (issue #619)."
+            exit 1
+          fi
+          echo "OK: $LIB_COUNT tauri commands documented"
+
   installer-pester:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,17 +154,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check tauri-commands.md drift vs lib.rs
+      - name: Check tauri-commands.md drift vs lib.rs (name-level set-diff)
         shell: bash
         run: |
           set -euo pipefail
-          LIB_COUNT=$(grep -c "^#\[tauri::command\]" gui/src-tauri/src/lib.rs)
-          DOC_COUNT=$(grep -cE "^\| [0-9]+ \|" docs/tauri-commands.md)
-          if [ "$LIB_COUNT" -ne "$DOC_COUNT" ]; then
-            echo "::error::docs/tauri-commands.md drift: lib.rs has $LIB_COUNT #[tauri::command], doc table has $DOC_COUNT rows. Update docs/tauri-commands.md to match (issue #619)."
+          # 1. lib.rs から #[tauri::command] 直後の関数名を抽出 (sync/async 両対応、awk で grep -P 不要)
+          awk '/^#\[tauri::command\]/{getline; sub(/^.*fn[[:space:]]+/, ""); sub(/[(].*$/, ""); print}' \
+            gui/src-tauri/src/lib.rs | sort -u > /tmp/lib_commands.txt
+          # 2. doc table 1 列目の command 名を抽出 (`backtick` 囲み)
+          grep -E "^\| [0-9]+ \|" docs/tauri-commands.md \
+            | awk -F'|' '{print $3}' | tr -d '` ' | sort -u > /tmp/doc_commands.txt
+          # 3. set 比較 — rename / 誤コピー / 行数だけ合致するケースも検出
+          if ! diff -u /tmp/lib_commands.txt /tmp/doc_commands.txt; then
+            echo "::error::docs/tauri-commands.md drift: command name mismatch. Update docs/tauri-commands.md to match gui/src-tauri/src/lib.rs (issue #619)."
             exit 1
           fi
-          echo "OK: $LIB_COUNT tauri commands documented"
+          LIB_COUNT=$(wc -l < /tmp/lib_commands.txt)
+          echo "OK: $LIB_COUNT tauri commands documented (name-level match)"
 
   installer-pester:
     runs-on: windows-latest

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -4,6 +4,7 @@
 
 - [CLI コマンド仕様](cli-spec.md) — `allaganeye` のサブコマンド / オプション
 - [GUI UI Architecture](ui-architecture.md) — L2a Tauri GUI の screen / phase state machine (Phase 2 基盤、Phase 3/4 で拡張)
+- [Tauri Commands リファレンス](tauri-commands.md) — `gui/src-tauri/src/lib.rs` 内の全 `#[tauri::command]` 一覧 (signature + 想定エラー + AppError code 推奨)
 - [metadata.json 仕様](metadata-spec.md) — CLI ↔ GUI の唯一の契約
 - [リリース戦略](release-strategy.md) — develop-x.x.x / main のブランチ運用
 
@@ -74,7 +75,7 @@ spawn された CLI プロセスは `ProcessMap` (Rust side、#523) に登録さ
 
 preview 画面での `<video>` 再生には axum ベースの局所 HTTP サーバ (#465) が使われる。これは **subprocess ではなく Rust プロセス内の async task** で、token ベースの path allowlisting で 127.0.0.1 にのみ bind する。ffmpeg は呼ばず (ブラウザの native decode)、Range リクエストに対応する。
 
-詳細: [ui-architecture.md §video playback](ui-architecture.md) / `gui/src-tauri/src/lib.rs` の `register_video` / `serve_video`。
+詳細: [ui-architecture.md §video playback](ui-architecture.md) / `gui/src-tauri/src/lib.rs` の `register_video` / `serve_video` ([tauri-commands.md](tauri-commands.md) #12 の signature と想定エラー参照)。
 
 ## 3. データフロー
 
@@ -142,4 +143,5 @@ sequenceDiagram
 - [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) ffmpeg 実行中の安全な中断 (ProcessMap)
 - [#466](https://github.com/Idios/kobutachan-allaganeye/issues/466) Phase 4 export 本物化 (subprocess 経路の本格利用)
 - [#451](https://github.com/Idios/kobutachan-allaganeye/issues/451) / [#452](https://github.com/Idios/kobutachan-allaganeye/issues/452) L2b installer (bundle 形態 / 配布)
-- [cli-spec.md](cli-spec.md) / [ui-architecture.md](ui-architecture.md) / [metadata-spec.md](metadata-spec.md) / [release-strategy.md](release-strategy.md)
+- [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) Tauri Commands リファレンス新設 ([tauri-commands.md](tauri-commands.md))
+- [cli-spec.md](cli-spec.md) / [ui-architecture.md](ui-architecture.md) / [tauri-commands.md](tauri-commands.md) / [metadata-spec.md](metadata-spec.md) / [release-strategy.md](release-strategy.md)

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -53,20 +53,24 @@
 
 - すべての command は async / sync 問わず Tauri runtime で execute される
 - **frontend (TypeScript) 側の error narrowing**: `gui/src/lib/appError.ts` の `appErrorMessage(e)` / `appErrorCodeIs(e, code)` / `isAppError(e)` ヘルパーを使う。Tauri が `AppError` を JSON object として serialize するため、invoke 失敗時の Promise.reject 値は `{ code, message, hint?, stacktrace? }` の object になる
-  ```ts
-  import { appErrorCodeIs, appErrorMessage } from '../lib/appError';
-  try {
-    await invoke('apply_changes', { path, metadata, expectedMtimeMs });
-  } catch (e) {
-    if (appErrorCodeIs(e, 'state.mtime_conflict')) {
-      // 競合専用の UI 分岐
-    } else {
-      showError(appErrorMessage(e));
-    }
-  }
-  ```
 - **`AppError` 構造**: `code: String` (domain-specific identifier) / `message: String` / `hint: Option<String>` / `stacktrace: Option<String>`。enum ではなく struct で、code 値は domain.error_kind 形式の自由文字列 (例: `io.file_not_found`、`parse.json_invalid`、`state.mtime_conflict`)
 - **`?` 演算子の自動変換**: Rust 側 `error.rs` に `From<std::io::Error>` / `From<serde_json::Error>` / `From<String>` / `From<&str>` impl があり、各 helper の error を `?` で AppError に variant-aware に自動変換できる。例: `std::io::Error::NotFound` → `AppError { code: "io.file_not_found" }`
+
+frontend narrowing の使用例:
+
+```ts
+import { appErrorCodeIs, appErrorMessage } from '../lib/appError';
+
+try {
+  await invoke('apply_changes', { path, metadata, expectedMtimeMs });
+} catch (e) {
+  if (appErrorCodeIs(e, 'state.mtime_conflict')) {
+    // 競合専用の UI 分岐
+  } else {
+    showError(appErrorMessage(e));
+  }
+}
+```
 
 ## CI による doc 整合性検査
 

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -2,11 +2,13 @@
 
 `gui/src-tauri/src/lib.rs` 内の全 `#[tauri::command]` の master 一覧。frontend (TypeScript) と backend (Rust) の error contract と invoke 経路を確定する doc。
 
-## エラー型の現状と migration 計画
+## エラー型 (migration 完了)
 
-- 戻り値型: 現状の全 23 command が `Result<T, String>` (legacy raw String) または `bool` 直接 を返す
-- `AppError` 構造体 (`gui/src-tauri/src/error.rs`、PR [#661](https://github.com/Idios/kobutachan-allaganeye/pull/661) Refs [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) で導入済) は新規・改修対象 command 用 builder として予約。**legacy 23 command の `Result<T, String> → Result<T, AppError>` migration は別途派生 issue で実施予定** (PR #661 §scope 外参照)
-- 本 doc の「想定エラーケース / AppError code 推奨」列は migration 時に採用すべき domain-specific code (例: `io.file_not_found`、`parse.json_invalid`) の指針。frontend 側は当面 `try { JSON.parse(errString) } catch` で structured / legacy 判別可能な実装を維持する
+- 戻り値型: **全 23 command が `Result<T, AppError>` または `bool` 直接 (`is_process_running`) を返す** (PR [#665](https://github.com/Idios/kobutachan-allaganeye/pull/665) で legacy `Result<T, String>` から完全 migration 済)
+- `AppError` 構造体 (`gui/src-tauri/src/error.rs`、PR [#661](https://github.com/Idios/kobutachan-allaganeye/pull/661) Refs [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) で導入) のフィールド: `code: String` (domain-specific identifier、例 `io.file_not_found`) / `message: String` / `hint: Option<String>` / `stacktrace: Option<String>`
+- `From<std::io::Error>` / `From<serde_json::Error>` / `From<String>` / `From<&str>` impl があり、`?` 演算子で自動変換される (PR #665 で追加)。`std::io::Error` は `ErrorKind` から domain code を派生 (例 `NotFound` → `io.file_not_found`)
+- frontend 側 narrowing: `gui/src/lib/appError.ts` の `appErrorMessage(e)` / `appErrorCodeIs(e, code)` / `isAppError(e)` ヘルパーを使う。Tauri は `AppError` を JSON object として frontend に渡し、invoke 失敗時 Promise.reject 値が AppError instance になる
+- 本 doc の「想定エラーケース / AppError code」列は実装と整合する domain.error_kind 命名 (例: `io.file_not_found`、`parse.json_invalid`、`state.mtime_conflict`)
 
 ## 分類タグ
 
@@ -21,37 +23,50 @@
 
 ## 全 command 一覧
 
-| # | command | params | Result type | 分類 | 想定エラーケース | AppError code 推奨 (migration 時) |
+| # | command | params | Result type | 分類 | 想定エラーケース | AppError code |
 |---|---|---|---|---|---|---|
-| 1 | `load_metadata` | `path: String` | `Result<Value, String>` | I/O | (a) ファイル不在、(b) JSON parse 失敗、(c) 読み取り権限なし、(d) JSON root が object でない | (a) `io.file_not_found`、(b) `parse.json_invalid`、(c) `io.permission_denied`、(d) `parse.schema_invalid` |
-| 2 | `get_metadata_mtime` | `path: String` | `Result<Option<u64>, String>` | I/O | (a) ファイル不在 (= None で返却)、(b) 読み取り権限なし | (b) `io.permission_denied` |
-| 3 | `apply_changes` | `path: String, metadata: Value, expected_mtime_ms: Option<u64>` | `Result<u64, String>` | I/O + state-mutating | (a) mtime conflict (外部書き換え検出)、(b) backup 作成失敗、(c) atomic write 失敗、(d) JSON serialize 失敗 | (a) `state.mtime_conflict`、(b) `io.backup_failed`、(c) `io.write_failed`、(d) `parse.json_serialize_failed` |
-| 4 | `save_draft` | `path: String, draft: Value` | `Result<(), String>` | I/O + state-mutating | (a) sibling `.draft.json` への書き込み失敗 | (a) `io.write_failed` |
-| 5 | `load_draft` | `path: String` | `Result<Option<Value>, String>` | I/O | (a) draft ファイル不在 (= None で返却)、(b) JSON parse 失敗 | (b) `parse.json_invalid` |
-| 6 | `clear_draft` | `path: String` | `Result<(), String>` | I/O + state-mutating | (a) draft 削除失敗 (権限等) | (a) `io.delete_failed` |
-| 7 | `restore_from_original` | `path: String` | `Result<(), String>` | I/O + state-mutating | (a) backup 不在、(b) backup → original copy 失敗 | (a) `io.file_not_found`、(b) `io.copy_failed` |
-| 8 | `check_backup_exists` | `path: String` | `Result<bool, String>` | I/O | (常に bool で返却、エラーケースほぼなし) | - |
-| 9 | `read_recent` | (なし) | `Result<Vec<RecentEntry>, String>` | I/O | (a) `recent.json` parse 失敗、(b) 読み取り失敗 | (a) `parse.json_invalid`、(b) `io.read_failed` |
-| 10 | `add_recent` | `path: String` | `Result<Vec<RecentEntry>, String>` | I/O + state-mutating | (a) `recent.json` 書き込み失敗、(b) パス validate 失敗 | (a) `io.write_failed`、(b) `validation.path_invalid` |
-| 11 | `clear_recent` | (なし) | `Result<(), String>` | I/O + state-mutating | (a) `recent.json` 書き込み失敗 | (a) `io.write_failed` |
-| 12 | `register_video` | `path: String` | `Result<RegisteredVideo, String>` | state-mutating | (a) 動画ファイル不在、(b) directory pass、(c) 読み取り権限なし | (a) `io.file_not_found`、(b) `validation.not_a_file`、(c) `io.permission_denied` |
-| 13 | `probe_video` | `path: String` | `Result<VideoProbeInfo, String>` | subprocess | (a) ffprobe 不在、(b) ffprobe 起動失敗、(c) ffprobe 出力 parse 失敗 | (a) `ffmpeg.not_found`、(b) `subprocess.spawn_failed`、(c) `parse.ffprobe_output_invalid` |
-| 14 | `generate_match_thumbnails` | `video_path: String, match_index: u32, boundary_t_seconds: f64, window_seconds: f64, count: u32` | `Result<Vec<ThumbnailEntry>, String>` | subprocess + I/O | (a) ffmpeg 不在、(b) seek 範囲外、(c) thumbnail 書き込み失敗 | (a) `ffmpeg.not_found`、(b) `validation.range_invalid`、(c) `io.write_failed` |
+| 1 | `load_metadata` | `path: String` | `Result<Value, AppError>` | I/O | (a) ファイル不在、(b) JSON parse 失敗、(c) 読み取り権限なし、(d) JSON root が object でない | (a) `io.file_not_found`、(b) `parse.json_invalid`、(c) `io.permission_denied`、(d) `parse.schema_invalid` |
+| 2 | `get_metadata_mtime` | `path: String` | `Result<Option<u64>, AppError>` | I/O | (a) ファイル不在 (= None で返却)、(b) 読み取り権限なし | (b) `io.permission_denied` |
+| 3 | `apply_changes` | `path: String, metadata: Value, expected_mtime_ms: Option<u64>` | `Result<u64, AppError>` | I/O + state-mutating | (a) mtime conflict (外部書き換え検出)、(b) backup 作成失敗、(c) atomic write 失敗、(d) JSON serialize 失敗 | (a) `state.mtime_conflict`、(b) `io.backup_failed`、(c) `io.write_failed`、(d) `parse.json_serialize_failed` |
+| 4 | `save_draft` | `path: String, draft: Value` | `Result<(), AppError>` | I/O + state-mutating | (a) sibling `.draft.json` への書き込み失敗 | (a) `io.write_failed` |
+| 5 | `load_draft` | `path: String` | `Result<Option<Value>, AppError>` | I/O | (a) draft ファイル不在 (= None で返却)、(b) JSON parse 失敗 | (b) `parse.json_invalid` |
+| 6 | `clear_draft` | `path: String` | `Result<(), AppError>` | I/O + state-mutating | (a) draft 削除失敗 (権限等) | (a) `io.delete_failed` |
+| 7 | `restore_from_original` | `path: String` | `Result<(), AppError>` | I/O + state-mutating | (a) backup 不在、(b) backup → original copy 失敗 | (a) `io.file_not_found`、(b) `io.copy_failed` |
+| 8 | `check_backup_exists` | `path: String` | `Result<bool, AppError>` | I/O | (常に bool で返却、エラーケースほぼなし) | - |
+| 9 | `read_recent` | (なし) | `Result<Vec<RecentEntry>, AppError>` | I/O | (a) `recent.json` parse 失敗、(b) 読み取り失敗 | (a) `parse.json_invalid`、(b) `io.read_failed` |
+| 10 | `add_recent` | `path: String` | `Result<Vec<RecentEntry>, AppError>` | I/O + state-mutating | (a) `recent.json` 書き込み失敗、(b) パス validate 失敗 | (a) `io.write_failed`、(b) `validation.path_invalid` |
+| 11 | `clear_recent` | (なし) | `Result<(), AppError>` | I/O + state-mutating | (a) `recent.json` 書き込み失敗 | (a) `io.write_failed` |
+| 12 | `register_video` | `path: String` | `Result<RegisteredVideo, AppError>` | state-mutating | (a) 動画ファイル不在、(b) directory pass、(c) 読み取り権限なし | (a) `io.file_not_found`、(b) `validation.not_a_file`、(c) `io.permission_denied` |
+| 13 | `probe_video` | `path: String` | `Result<VideoProbeInfo, AppError>` | subprocess | (a) ffprobe 不在、(b) ffprobe 起動失敗、(c) ffprobe 出力 parse 失敗 | (a) `ffmpeg.not_found`、(b) `subprocess.spawn_failed`、(c) `parse.ffprobe_output_invalid` |
+| 14 | `generate_match_thumbnails` | `video_path: String, match_index: u32, boundary_t_seconds: f64, window_seconds: f64, count: u32` | `Result<Vec<ThumbnailEntry>, AppError>` | subprocess + I/O | (a) ffmpeg 不在、(b) seek 範囲外、(c) thumbnail 書き込み失敗 | (a) `ffmpeg.not_found`、(b) `validation.range_invalid`、(c) `io.write_failed` |
 | 15 | `is_process_running` | (なし) | `bool` | pure | (返り値は bool 直接、エラーなし) | - |
-| 16 | `kill_tracked_processes` | (なし) | `Result<u32, String>` | subprocess + state-mutating | (a) kill コマンド失敗 | (a) `process.kill_failed` |
+| 16 | `kill_tracked_processes` | (なし) | `Result<u32, AppError>` | subprocess + state-mutating | (a) kill コマンド失敗 | (a) `process.kill_failed` |
 | 17 | `force_exit_app` | `app: tauri::AppHandle` | (返り値なし) | state-mutating | (即時 app exit、エラーケースなし) | - |
-| 18 | `open_folder_in_explorer` | `path: String` | `Result<(), String>` | subprocess | (a) フォルダ不在、(b) explorer 起動失敗 | (a) `io.file_not_found`、(b) `subprocess.spawn_failed` |
-| 19 | `export_match` | `app: AppHandle, video_path: String, start_seconds: f64, end_seconds: f64, output_path: String, codec: ExportCodec, h264_encoder: Option<H264Encoder>, match_index: u32` | `Result<ExportResult, String>` | subprocess + I/O | (a) ffmpeg 不在、(b) GPU encoder 初期化失敗 (NVENC/QSV/AMF, libx264 fallback で recover)、(c) input video 不在、(d) output 書き込み失敗 | (a) `ffmpeg.not_found`、(b) `ffmpeg.encoder_init_failed`、(c) `io.file_not_found`、(d) `io.write_failed` |
+| 18 | `open_folder_in_explorer` | `path: String` | `Result<(), AppError>` | subprocess | (a) フォルダ不在、(b) explorer 起動失敗 | (a) `io.file_not_found`、(b) `subprocess.spawn_failed` |
+| 19 | `export_match` | `app: AppHandle, video_path: String, start_seconds: f64, end_seconds: f64, output_path: String, codec: ExportCodec, h264_encoder: Option<H264Encoder>, match_index: u32` | `Result<ExportResult, AppError>` | subprocess + I/O | (a) ffmpeg 不在、(b) GPU encoder 初期化失敗 (NVENC/QSV/AMF, libx264 fallback で recover)、(c) input video 不在、(d) output 書き込み失敗 | (a) `ffmpeg.not_found`、(b) `ffmpeg.encoder_init_failed`、(c) `io.file_not_found`、(d) `io.write_failed` |
 | 20 | `select_h264_encoder_for_export` | `vendors: Vec<String>, preference: Vec<String>` | `EncoderInfo` | pure | (純粋関数、エラーなし) | - |
-| 21 | `start_detect` | `app: AppHandle, video_path: String, output_dir: String, params: DetectParams` | `Result<DetectResult, String>` | subprocess | (a) python CLI 不在、(b) python -m fallback 失敗、(c) detect 実行中エラー | (a) `python.not_found`、(b) `subprocess.spawn_failed`、(c) `subprocess.exit_failed` |
-| 22 | `get_log_dir` | (なし) | `Result<String, String>` | pure | (a) install_dir 取得失敗 (極端ケース) | (a) `path.install_dir_unresolved` |
-| 23 | `dev_force_panic` | (なし) | `Result<(), String>` | state-mutating | **意図的 panic** (`#[cfg(debug_assertions)]` 限定、PR #661 E2E 検証用) | - (panic で異常終了が期待動作) |
+| 21 | `start_detect` | `app: AppHandle, video_path: String, output_dir: String, params: DetectParams` | `Result<DetectResult, AppError>` | subprocess | (a) python CLI 不在、(b) python -m fallback 失敗、(c) detect 実行中エラー | (a) `python.not_found`、(b) `subprocess.spawn_failed`、(c) `subprocess.exit_failed` |
+| 22 | `get_log_dir` | (なし) | `Result<String, AppError>` | pure | (a) install_dir 取得失敗 (極端ケース) | (a) `path.install_dir_unresolved` |
+| 23 | `dev_force_panic` | (なし) | `Result<(), AppError>` | state-mutating | **意図的 panic** (`#[cfg(debug_assertions)]` 限定、PR #661 E2E 検証用) | - (panic で異常終了が期待動作) |
 
 ## 補足
 
 - すべての command は async / sync 問わず Tauri runtime で execute される
-- **frontend (TypeScript) 側の error narrowing**: `try { JSON.parse(errString) } catch` で structured `AppError` (= 派生 issue 後の対応 command) と legacy raw String を判別可能。現在は全 23 command が legacy raw String を返すため `JSON.parse` は通常 throw する
-- **`AppError` 構造**: `code: String` (domain-specific identifier) / `message: String` / `hint: Option<String>` / `stacktrace: Option<String>`。enum ではなく struct で、code 値は domain.error_kind 形式の自由文字列 (本 doc では `io.file_not_found` 等の命名規約を推奨)
+- **frontend (TypeScript) 側の error narrowing**: `gui/src/lib/appError.ts` の `appErrorMessage(e)` / `appErrorCodeIs(e, code)` / `isAppError(e)` ヘルパーを使う。Tauri が `AppError` を JSON object として serialize するため、invoke 失敗時の Promise.reject 値は `{ code, message, hint?, stacktrace? }` の object になる
+  ```ts
+  import { appErrorCodeIs, appErrorMessage } from '../lib/appError';
+  try {
+    await invoke('apply_changes', { path, metadata, expectedMtimeMs });
+  } catch (e) {
+    if (appErrorCodeIs(e, 'state.mtime_conflict')) {
+      // 競合専用の UI 分岐
+    } else {
+      showError(appErrorMessage(e));
+    }
+  }
+  ```
+- **`AppError` 構造**: `code: String` (domain-specific identifier) / `message: String` / `hint: Option<String>` / `stacktrace: Option<String>`。enum ではなく struct で、code 値は domain.error_kind 形式の自由文字列 (例: `io.file_not_found`、`parse.json_invalid`、`state.mtime_conflict`)
+- **`?` 演算子の自動変換**: Rust 側 `error.rs` に `From<std::io::Error>` / `From<serde_json::Error>` / `From<String>` / `From<&str>` impl があり、各 helper の error を `?` で AppError に variant-aware に自動変換できる。例: `std::io::Error::NotFound` → `AppError { code: "io.file_not_found" }`
 
 ## CI による doc 整合性検査
 
@@ -59,8 +74,8 @@
 
 ## 関連
 
-- 派生元: [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) 本 doc 新設
+- 派生元: [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) 本 doc 新設 + 全 23 command の AppError migration (PR #665)
 - AppError 型定義: `gui/src-tauri/src/error.rs` (PR [#661](https://github.com/Idios/kobutachan-allaganeye/pull/661), Refs [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614))
-- legacy migration 派生 issue: [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) §scope 外参照 (`AppError migration for legacy 23 commands`)
-- frontend invoke の主な利用箇所: `gui/src/state/*.ts`, `gui/src/lib/tauri.ts`
+- frontend narrowing helper: `gui/src/lib/appError.ts` (PR #665 で新設)
+- frontend invoke の主な利用箇所: `gui/src/state/metadataStore.ts` / `gui/src/state/recentStore.ts` / `gui/src/lib/globalErrorListener.ts`
 - 関連実装 PR: [#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) (`register_video` / `probe_video` / `generate_match_thumbnails`) / [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) (`kill_tracked_processes`) / [#591](https://github.com/Idios/kobutachan-allaganeye/issues/591) (`select_h264_encoder_for_export`) / [#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) (`start_detect`) / [#571](https://github.com/Idios/kobutachan-allaganeye/issues/571) (`read_recent` / `add_recent` / `clear_recent`)

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -27,7 +27,7 @@
 |---|---|---|---|---|---|---|
 | 1 | `load_metadata` | `path: String` | `Result<Value, AppError>` | I/O | (a) ファイル不在、(b) JSON parse 失敗、(c) 読み取り権限なし、(d) JSON root が object でない | (a) `io.file_not_found`、(b) `parse.json_invalid`、(c) `io.permission_denied`、(d) `parse.schema_invalid` |
 | 2 | `get_metadata_mtime` | `path: String` | `Result<Option<u64>, AppError>` | I/O | (a) ファイル不在 (= None で返却)、(b) 読み取り権限なし | (b) `io.permission_denied` |
-| 3 | `apply_changes` | `path: String, metadata: Value, expected_mtime_ms: Option<u64>` | `Result<u64, AppError>` | I/O + state-mutating | (a) mtime conflict (外部書き換え検出)、(b) backup 作成失敗、(c) atomic write 失敗、(d) JSON serialize 失敗 | (a) `state.mtime_conflict`、(b) `io.backup_failed`、(c) `io.write_failed`、(d) `parse.json_serialize_failed` |
+| 3 | `apply_changes` | `path: String, metadata: Value, expected_mtime_ms: Option<u64>` | `Result<u64, AppError>` | I/O + state-mutating | (a) mtime conflict (外部書き換え検出)、(b) backup 作成失敗、(c) atomic write 失敗、(d) JSON serialize 失敗、(e) post-apply mtime 取得失敗 (extreme case、書き込み直後にファイルが消失/権限変更等) | (a) `state.mtime_conflict`、(b) `io.backup_failed`、(c) `io.write_failed`、(d) `parse.json_serialize_failed`、(e) `io.read_failed` |
 | 4 | `save_draft` | `path: String, draft: Value` | `Result<(), AppError>` | I/O + state-mutating | (a) sibling `.draft.json` への書き込み失敗 | (a) `io.write_failed` |
 | 5 | `load_draft` | `path: String` | `Result<Option<Value>, AppError>` | I/O | (a) draft ファイル不在 (= None で返却)、(b) JSON parse 失敗 | (b) `parse.json_invalid` |
 | 6 | `clear_draft` | `path: String` | `Result<(), AppError>` | I/O + state-mutating | (a) draft 削除失敗 (権限等) | (a) `io.delete_failed` |

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -1,0 +1,66 @@
+# Tauri Commands リファレンス
+
+`gui/src-tauri/src/lib.rs` 内の全 `#[tauri::command]` の master 一覧。frontend (TypeScript) と backend (Rust) の error contract と invoke 経路を確定する doc。
+
+## エラー型の現状と migration 計画
+
+- 戻り値型: 現状の全 23 command が `Result<T, String>` (legacy raw String) または `bool` 直接 を返す
+- `AppError` 構造体 (`gui/src-tauri/src/error.rs`、PR [#661](https://github.com/Idios/kobutachan-allaganeye/pull/661) Refs [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) で導入済) は新規・改修対象 command 用 builder として予約。**legacy 23 command の `Result<T, String> → Result<T, AppError>` migration は別途派生 issue で実施予定** (PR #661 §scope 外参照)
+- 本 doc の「想定エラーケース / AppError code 推奨」列は migration 時に採用すべき domain-specific code (例: `io.file_not_found`、`parse.json_invalid`) の指針。frontend 側は当面 `try { JSON.parse(errString) } catch` で structured / legacy 判別可能な実装を維持する
+
+## 分類タグ
+
+| タグ | 説明 |
+|---|---|
+| `pure` | 入力から決定的に出力を計算、副作用なし |
+| `I/O` | ファイル読み書き / metadata 取得 |
+| `subprocess` | ffmpeg / ffprobe / python CLI / explorer 等の外部プロセス起動 |
+| `state-mutating` | in-memory registry 更新 / app exit / panic 誘発 等の副作用 |
+
+複数該当する場合は `+` で結合 (例: `subprocess + state-mutating`)。
+
+## 全 command 一覧
+
+| # | command | params | Result type | 分類 | 想定エラーケース | AppError code 推奨 (migration 時) |
+|---|---|---|---|---|---|---|
+| 1 | `load_metadata` | `path: String` | `Result<Value, String>` | I/O | (a) ファイル不在、(b) JSON parse 失敗、(c) 読み取り権限なし、(d) JSON root が object でない | (a) `io.file_not_found`、(b) `parse.json_invalid`、(c) `io.permission_denied`、(d) `parse.schema_invalid` |
+| 2 | `get_metadata_mtime` | `path: String` | `Result<Option<u64>, String>` | I/O | (a) ファイル不在 (= None で返却)、(b) 読み取り権限なし | (b) `io.permission_denied` |
+| 3 | `apply_changes` | `path: String, metadata: Value, expected_mtime_ms: Option<u64>` | `Result<u64, String>` | I/O + state-mutating | (a) mtime conflict (外部書き換え検出)、(b) backup 作成失敗、(c) atomic write 失敗、(d) JSON serialize 失敗 | (a) `state.mtime_conflict`、(b) `io.backup_failed`、(c) `io.write_failed`、(d) `parse.json_serialize_failed` |
+| 4 | `save_draft` | `path: String, draft: Value` | `Result<(), String>` | I/O + state-mutating | (a) sibling `.draft.json` への書き込み失敗 | (a) `io.write_failed` |
+| 5 | `load_draft` | `path: String` | `Result<Option<Value>, String>` | I/O | (a) draft ファイル不在 (= None で返却)、(b) JSON parse 失敗 | (b) `parse.json_invalid` |
+| 6 | `clear_draft` | `path: String` | `Result<(), String>` | I/O + state-mutating | (a) draft 削除失敗 (権限等) | (a) `io.delete_failed` |
+| 7 | `restore_from_original` | `path: String` | `Result<(), String>` | I/O + state-mutating | (a) backup 不在、(b) backup → original copy 失敗 | (a) `io.file_not_found`、(b) `io.copy_failed` |
+| 8 | `check_backup_exists` | `path: String` | `Result<bool, String>` | I/O | (常に bool で返却、エラーケースほぼなし) | - |
+| 9 | `read_recent` | (なし) | `Result<Vec<RecentEntry>, String>` | I/O | (a) `recent.json` parse 失敗、(b) 読み取り失敗 | (a) `parse.json_invalid`、(b) `io.read_failed` |
+| 10 | `add_recent` | `path: String` | `Result<Vec<RecentEntry>, String>` | I/O + state-mutating | (a) `recent.json` 書き込み失敗、(b) パス validate 失敗 | (a) `io.write_failed`、(b) `validation.path_invalid` |
+| 11 | `clear_recent` | (なし) | `Result<(), String>` | I/O + state-mutating | (a) `recent.json` 書き込み失敗 | (a) `io.write_failed` |
+| 12 | `register_video` | `path: String` | `Result<RegisteredVideo, String>` | state-mutating | (a) 動画ファイル不在、(b) directory pass、(c) 読み取り権限なし | (a) `io.file_not_found`、(b) `validation.not_a_file`、(c) `io.permission_denied` |
+| 13 | `probe_video` | `path: String` | `Result<VideoProbeInfo, String>` | subprocess | (a) ffprobe 不在、(b) ffprobe 起動失敗、(c) ffprobe 出力 parse 失敗 | (a) `ffmpeg.not_found`、(b) `subprocess.spawn_failed`、(c) `parse.ffprobe_output_invalid` |
+| 14 | `generate_match_thumbnails` | `video_path: String, match_index: u32, boundary_t_seconds: f64, window_seconds: f64, count: u32` | `Result<Vec<ThumbnailEntry>, String>` | subprocess + I/O | (a) ffmpeg 不在、(b) seek 範囲外、(c) thumbnail 書き込み失敗 | (a) `ffmpeg.not_found`、(b) `validation.range_invalid`、(c) `io.write_failed` |
+| 15 | `is_process_running` | (なし) | `bool` | pure | (返り値は bool 直接、エラーなし) | - |
+| 16 | `kill_tracked_processes` | (なし) | `Result<u32, String>` | subprocess + state-mutating | (a) kill コマンド失敗 | (a) `process.kill_failed` |
+| 17 | `force_exit_app` | `app: tauri::AppHandle` | (返り値なし) | state-mutating | (即時 app exit、エラーケースなし) | - |
+| 18 | `open_folder_in_explorer` | `path: String` | `Result<(), String>` | subprocess | (a) フォルダ不在、(b) explorer 起動失敗 | (a) `io.file_not_found`、(b) `subprocess.spawn_failed` |
+| 19 | `export_match` | `app: AppHandle, video_path: String, start_seconds: f64, end_seconds: f64, output_path: String, codec: ExportCodec, h264_encoder: Option<H264Encoder>, match_index: u32` | `Result<ExportResult, String>` | subprocess + I/O | (a) ffmpeg 不在、(b) GPU encoder 初期化失敗 (NVENC/QSV/AMF, libx264 fallback で recover)、(c) input video 不在、(d) output 書き込み失敗 | (a) `ffmpeg.not_found`、(b) `ffmpeg.encoder_init_failed`、(c) `io.file_not_found`、(d) `io.write_failed` |
+| 20 | `select_h264_encoder_for_export` | `vendors: Vec<String>, preference: Vec<String>` | `EncoderInfo` | pure | (純粋関数、エラーなし) | - |
+| 21 | `start_detect` | `app: AppHandle, video_path: String, output_dir: String, params: DetectParams` | `Result<DetectResult, String>` | subprocess | (a) python CLI 不在、(b) python -m fallback 失敗、(c) detect 実行中エラー | (a) `python.not_found`、(b) `subprocess.spawn_failed`、(c) `subprocess.exit_failed` |
+| 22 | `get_log_dir` | (なし) | `Result<String, String>` | pure | (a) install_dir 取得失敗 (極端ケース) | (a) `path.install_dir_unresolved` |
+| 23 | `dev_force_panic` | (なし) | `Result<(), String>` | state-mutating | **意図的 panic** (`#[cfg(debug_assertions)]` 限定、PR #661 E2E 検証用) | - (panic で異常終了が期待動作) |
+
+## 補足
+
+- すべての command は async / sync 問わず Tauri runtime で execute される
+- **frontend (TypeScript) 側の error narrowing**: `try { JSON.parse(errString) } catch` で structured `AppError` (= 派生 issue 後の対応 command) と legacy raw String を判別可能。現在は全 23 command が legacy raw String を返すため `JSON.parse` は通常 throw する
+- **`AppError` 構造**: `code: String` (domain-specific identifier) / `message: String` / `hint: Option<String>` / `stacktrace: Option<String>`。enum ではなく struct で、code 値は domain.error_kind 形式の自由文字列 (本 doc では `io.file_not_found` 等の命名規約を推奨)
+
+## CI による doc 整合性検査
+
+`.github/workflows/ci.yml` の `doc-tauri-commands-drift` job が `gui/src-tauri/src/lib.rs` 内の `#[tauri::command]` 数と本 doc の table 行数を比較し、不一致時に CI を fail させる (本 doc 漏れ防止、issue [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) 受け入れ条件 2)。command を追加・削除した場合は本 doc の table 行も同時に更新すること。
+
+## 関連
+
+- 派生元: [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) 本 doc 新設
+- AppError 型定義: `gui/src-tauri/src/error.rs` (PR [#661](https://github.com/Idios/kobutachan-allaganeye/pull/661), Refs [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614))
+- legacy migration 派生 issue: [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) §scope 外参照 (`AppError migration for legacy 23 commands`)
+- frontend invoke の主な利用箇所: `gui/src/state/*.ts`, `gui/src/lib/tauri.ts`
+- 関連実装 PR: [#465](https://github.com/Idios/kobutachan-allaganeye/issues/465) (`register_video` / `probe_video` / `generate_match_thumbnails`) / [#523](https://github.com/Idios/kobutachan-allaganeye/issues/523) (`kill_tracked_processes`) / [#591](https://github.com/Idios/kobutachan-allaganeye/issues/591) (`select_h264_encoder_for_export`) / [#569](https://github.com/Idios/kobutachan-allaganeye/issues/569) (`start_detect`) / [#571](https://github.com/Idios/kobutachan-allaganeye/issues/571) (`read_recent` / `add_recent` / `clear_recent`)

--- a/gui/src-tauri/src/error.rs
+++ b/gui/src-tauri/src/error.rs
@@ -25,6 +25,14 @@ impl AppError {
         }
     }
 
+    /// `hint` フィールドを設定する builder。
+    ///
+    /// 将来用 — 現状 production code では未使用 (test のみ参照、PR #665 Round 2
+    /// 課題 5 (c) で保留決定)。lib.rs 側 AppError::new(...) の主要箇所に hint
+    /// を後付けで配るための小規模拡張で活用予定 (例: `state.mtime_conflict`
+    /// で「他プロセスでの書き換えを確認してください」等)。frontend 側 helper は
+    /// `gui/src/lib/appError.ts::appErrorHint` で同じく保留中。
+    #[allow(dead_code)]
     pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
         self.hint = Some(hint.into());
         self
@@ -36,14 +44,6 @@ impl AppError {
         self
     }
 
-    /// Serialize to a JSON string. Used when interfacing with `Result<T, String>`
-    /// signature-bound APIs (legacy-shaped Err values). For Tauri commands that
-    /// declare `Result<T, AppError>` directly, Tauri's auto-serialize via the
-    /// `Serialize` derive is preferred — `to_wire_string` is unnecessary there.
-    #[allow(dead_code)]
-    pub fn to_wire_string(&self) -> String {
-        serde_json::to_string(self).unwrap_or_else(|_| self.message.clone())
-    }
 }
 
 impl fmt::Display for AppError {
@@ -54,10 +54,12 @@ impl fmt::Display for AppError {
 
 impl std::error::Error for AppError {}
 
-/// `?` 演算子で `std::io::Error` を AppError に自動変換する。code は default
-/// `io.error`、message は `e.to_string()`。call site で context-specific code
-/// に上書きしたい場合は `.map_err(|e| AppError::new("io.specific", e.to_string()))`
-/// を使う。
+/// `?` 演算子で `std::io::Error` を AppError に自動変換する。code は
+/// `ErrorKind` から派生 (`NotFound` → `io.file_not_found`、`PermissionDenied`
+/// → `io.permission_denied` 等)、message は `e.to_string()`。
+/// call site で context-specific code に上書きしたい場合は
+/// `.map_err(|e| AppError::new("io.<specific_kind>", e.to_string()))`
+/// (例: `io.read_failed`、`io.write_failed` 等の domain.error_kind 形式) を使う。
 impl From<std::io::Error> for AppError {
     fn from(e: std::io::Error) -> Self {
         let code = match e.kind() {
@@ -80,20 +82,14 @@ impl From<serde_json::Error> for AppError {
     }
 }
 
-/// 既存 `Err("...".to_string())` / `format!(...)` ベースの呼び出し箇所での後方互換 +
-/// `?` 演算子で String error を AppError として propagate するための From impl。
-/// code は `internal.error` 固定。call site が message に code を組み込むケース
-/// (例 `format!("io.read_failed: {}", e)`) は使わず、`AppError::new("io.read_failed", ...)`
-/// で構造化することを推奨。
+/// `?` 演算子で `String` error を AppError として propagate するための impl。
+/// 主に `Result<_, String>` を返す内部 helper (例 `run_ffmpeg_export_attempt`)
+/// を `Result<_, AppError>` を返す Tauri command 内で `?` 経由で呼び出すケース
+/// で使われる。code は `internal.error` 固定。新規コードでは call site で
+/// `AppError::new("domain.error_kind", message)` を構築するのが望ましい。
 impl From<String> for AppError {
     fn from(message: String) -> Self {
         AppError::new("internal.error", message)
-    }
-}
-
-impl From<&str> for AppError {
-    fn from(message: &str) -> Self {
-        AppError::new("internal.error", message.to_string())
     }
 }
 
@@ -175,10 +171,11 @@ mod tests {
 
     #[test]
     fn serialize_app_error_roundtrips() {
+        // Tauri が AppError を frontend に渡す時と同じ serde Serialize 経路を
+        // 直接 test する (旧 to_wire_string は production 未使用で削除済)。
         let e = AppError::new("io.read_failed", "could not read file")
             .with_hint("check file permissions");
-        let s = e.to_wire_string();
-        let parsed: serde_json::Value = serde_json::from_str(&s).expect("valid json");
+        let parsed = serde_json::to_value(&e).expect("valid json");
         assert_eq!(parsed["code"], "io.read_failed");
         assert_eq!(parsed["message"], "could not read file");
         assert_eq!(parsed["hint"], "check file permissions");

--- a/gui/src-tauri/src/error.rs
+++ b/gui/src-tauri/src/error.rs
@@ -16,11 +16,6 @@ pub struct AppError {
 }
 
 impl AppError {
-    /// Builder used by `#[allow(dead_code)]`-tagged constructors below — kept
-    /// for the upcoming AppError migration of legacy commands (派生 issue).
-    /// Until that migration lands, all accessors are unused in production
-    /// (only the test module references them), hence the allowance.
-    #[allow(dead_code)]
     pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code: code.into(),
@@ -30,7 +25,6 @@ impl AppError {
         }
     }
 
-    #[allow(dead_code)]
     pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
         self.hint = Some(hint.into());
         self
@@ -42,8 +36,10 @@ impl AppError {
         self
     }
 
-    /// Serialize to a JSON string suitable for Tauri command `Result<T, String>` Err values.
-    /// Frontend should `try { JSON.parse(msg) } catch` to detect structured vs legacy raw strings.
+    /// Serialize to a JSON string. Used when interfacing with `Result<T, String>`
+    /// signature-bound APIs (legacy-shaped Err values). For Tauri commands that
+    /// declare `Result<T, AppError>` directly, Tauri's auto-serialize via the
+    /// `Serialize` derive is preferred — `to_wire_string` is unnecessary there.
     #[allow(dead_code)]
     pub fn to_wire_string(&self) -> String {
         serde_json::to_string(self).unwrap_or_else(|_| self.message.clone())
@@ -53,6 +49,51 @@ impl AppError {
 impl fmt::Display for AppError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}] {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for AppError {}
+
+/// `?` 演算子で `std::io::Error` を AppError に自動変換する。code は default
+/// `io.error`、message は `e.to_string()`。call site で context-specific code
+/// に上書きしたい場合は `.map_err(|e| AppError::new("io.specific", e.to_string()))`
+/// を使う。
+impl From<std::io::Error> for AppError {
+    fn from(e: std::io::Error) -> Self {
+        let code = match e.kind() {
+            std::io::ErrorKind::NotFound => "io.file_not_found",
+            std::io::ErrorKind::PermissionDenied => "io.permission_denied",
+            std::io::ErrorKind::AlreadyExists => "io.already_exists",
+            std::io::ErrorKind::WouldBlock => "io.would_block",
+            std::io::ErrorKind::TimedOut => "io.timed_out",
+            _ => "io.error",
+        };
+        AppError::new(code, e.to_string())
+    }
+}
+
+/// `?` 演算子で `serde_json::Error` を AppError に自動変換する。code は
+/// `parse.json_invalid` 固定。message は `e.to_string()` で line/column 情報を含む。
+impl From<serde_json::Error> for AppError {
+    fn from(e: serde_json::Error) -> Self {
+        AppError::new("parse.json_invalid", e.to_string())
+    }
+}
+
+/// 既存 `Err("...".to_string())` / `format!(...)` ベースの呼び出し箇所での後方互換 +
+/// `?` 演算子で String error を AppError として propagate するための From impl。
+/// code は `internal.error` 固定。call site が message に code を組み込むケース
+/// (例 `format!("io.read_failed: {}", e)`) は使わず、`AppError::new("io.read_failed", ...)`
+/// で構造化することを推奨。
+impl From<String> for AppError {
+    fn from(message: String) -> Self {
+        AppError::new("internal.error", message)
+    }
+}
+
+impl From<&str> for AppError {
+    fn from(message: &str) -> Self {
+        AppError::new("internal.error", message.to_string())
     }
 }
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -25,6 +25,8 @@ use uuid::Uuid;
 mod error;
 mod logging;
 
+use error::AppError;
+
 /// #465 -- per-token mapping from opaque UUID to absolute video file path.
 ///
 /// Shared between the axum server's handler state and the Tauri commands so
@@ -68,22 +70,36 @@ pub struct RegisteredVideo {
 }
 
 #[tauri::command]
-async fn load_metadata(path: String) -> Result<Value, String> {
+async fn load_metadata(path: String) -> Result<Value, AppError> {
     load_metadata_sync(&PathBuf::from(&path))
 }
 
-fn load_metadata_sync(meta_path: &Path) -> Result<Value, String> {
+fn load_metadata_sync(meta_path: &Path) -> Result<Value, AppError> {
     if !meta_path.exists() {
-        return Err(format!("metadata file not found: {}", meta_path.display()));
+        return Err(AppError::new(
+            "io.file_not_found",
+            format!("metadata file not found: {}", meta_path.display()),
+        ));
     }
-    let content = fs::read_to_string(meta_path)
-        .map_err(|e| format!("read failed ({}): {}", meta_path.display(), e))?;
-    let value: Value = serde_json::from_str(&content)
-        .map_err(|e| format!("invalid JSON in {}: {}", meta_path.display(), e))?;
+    let content = fs::read_to_string(meta_path).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("read failed ({}): {}", meta_path.display(), e),
+        )
+    })?;
+    let value: Value = serde_json::from_str(&content).map_err(|e| {
+        AppError::new(
+            "parse.json_invalid",
+            format!("invalid JSON in {}: {}", meta_path.display(), e),
+        )
+    })?;
     if !value.is_object() {
-        return Err(format!(
-            "metadata file {} root must be a JSON object",
-            meta_path.display()
+        return Err(AppError::new(
+            "parse.schema_invalid",
+            format!(
+                "metadata file {} root must be a JSON object",
+                meta_path.display()
+            ),
         ));
     }
     Ok(value)
@@ -93,7 +109,7 @@ fn load_metadata_sync(meta_path: &Path) -> Result<Value, String> {
 /// or `None` when the file is missing. Used by the GUI to detect external
 /// modifications between load and apply.
 #[tauri::command]
-async fn get_metadata_mtime(path: String) -> Result<Option<u64>, String> {
+async fn get_metadata_mtime(path: String) -> Result<Option<u64>, AppError> {
     Ok(file_mtime_ms(&PathBuf::from(&path)))
 }
 
@@ -110,13 +126,16 @@ async fn apply_changes(
     path: String,
     metadata: Value,
     expected_mtime_ms: Option<u64>,
-) -> Result<u64, String> {
+) -> Result<u64, AppError> {
     let meta_path = PathBuf::from(&path);
     apply_changes_sync(&meta_path, &metadata, expected_mtime_ms)?;
     file_mtime_ms(&meta_path).ok_or_else(|| {
-        format!(
-            "apply succeeded but could not read post-write mtime: {}",
-            meta_path.display()
+        AppError::new(
+            "io.read_failed",
+            format!(
+                "apply succeeded but could not read post-write mtime: {}",
+                meta_path.display()
+            ),
         )
     })
 }
@@ -124,49 +143,60 @@ async fn apply_changes(
 /// #517 — persist the in-memory edit buffer as `metadata.draft.json` next to
 /// the live `metadata.json`. Survives WebView reloads and app crashes.
 #[tauri::command]
-async fn save_draft(path: String, draft: Value) -> Result<(), String> {
+async fn save_draft(path: String, draft: Value) -> Result<(), AppError> {
     save_draft_sync(&PathBuf::from(&path), &draft)
 }
 
 /// #517 — reload the draft buffer if one exists. Returns `None` when no
 /// draft is on disk (fresh session or post-apply state).
 #[tauri::command]
-async fn load_draft(path: String) -> Result<Option<Value>, String> {
+async fn load_draft(path: String) -> Result<Option<Value>, AppError> {
     load_draft_sync(&PathBuf::from(&path))
 }
 
 /// #517 — delete the draft file. Called after a successful `apply` so a
 /// restart doesn't re-prompt about stale edits.
 #[tauri::command]
-async fn clear_draft(path: String) -> Result<(), String> {
+async fn clear_draft(path: String) -> Result<(), AppError> {
     clear_draft_sync(&PathBuf::from(&path))
 }
 
-fn draft_path_for(meta_path: &Path) -> Result<PathBuf, String> {
-    let parent = meta_path
-        .parent()
-        .ok_or_else(|| format!("metadata path has no parent: {}", meta_path.display()))?;
+fn draft_path_for(meta_path: &Path) -> Result<PathBuf, AppError> {
+    let parent = meta_path.parent().ok_or_else(|| {
+        AppError::new(
+            "validation.path_invalid",
+            format!("metadata path has no parent: {}", meta_path.display()),
+        )
+    })?;
     Ok(parent.join("metadata.draft.json"))
 }
 
-fn save_draft_sync(meta_path: &Path, draft: &Value) -> Result<(), String> {
+fn save_draft_sync(meta_path: &Path, draft: &Value) -> Result<(), AppError> {
     let draft_path = draft_path_for(meta_path)?;
     write_metadata_atomic(&draft_path, draft)
 }
 
-fn load_draft_sync(meta_path: &Path) -> Result<Option<Value>, String> {
+fn load_draft_sync(meta_path: &Path) -> Result<Option<Value>, AppError> {
     let draft_path = draft_path_for(meta_path)?;
     if !draft_path.exists() {
         return Ok(None);
     }
-    let content = fs::read_to_string(&draft_path)
-        .map_err(|e| format!("read draft failed ({}): {}", draft_path.display(), e))?;
-    let value: Value = serde_json::from_str(&content)
-        .map_err(|e| format!("invalid JSON in draft {}: {}", draft_path.display(), e))?;
+    let content = fs::read_to_string(&draft_path).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("read draft failed ({}): {}", draft_path.display(), e),
+        )
+    })?;
+    let value: Value = serde_json::from_str(&content).map_err(|e| {
+        AppError::new(
+            "parse.json_invalid",
+            format!("invalid JSON in draft {}: {}", draft_path.display(), e),
+        )
+    })?;
     Ok(Some(value))
 }
 
-fn clear_draft_sync(meta_path: &Path) -> Result<(), String> {
+fn clear_draft_sync(meta_path: &Path) -> Result<(), AppError> {
     let draft_path = draft_path_for(meta_path)?;
     if !draft_path.exists() {
         // Nothing to clear — treat as success so callers don't have to
@@ -174,34 +204,43 @@ fn clear_draft_sync(meta_path: &Path) -> Result<(), String> {
         return Ok(());
     }
     fs::remove_file(&draft_path).map_err(|e| {
-        format!("remove draft failed ({}): {}", draft_path.display(), e)
+        AppError::new(
+            "io.delete_failed",
+            format!("remove draft failed ({}): {}", draft_path.display(), e),
+        )
     })
 }
 
 /// #516 — atomically restore metadata.json from the first-Apply backup.
 #[tauri::command]
-async fn restore_from_original(path: String) -> Result<(), String> {
+async fn restore_from_original(path: String) -> Result<(), AppError> {
     restore_from_original_sync(&PathBuf::from(&path))
 }
 
-fn restore_from_original_sync(meta_path: &Path) -> Result<(), String> {
-    let parent = meta_path
-        .parent()
-        .ok_or_else(|| format!("metadata path has no parent: {}", meta_path.display()))?;
+fn restore_from_original_sync(meta_path: &Path) -> Result<(), AppError> {
+    let parent = meta_path.parent().ok_or_else(|| {
+        AppError::new(
+            "validation.path_invalid",
+            format!("metadata path has no parent: {}", meta_path.display()),
+        )
+    })?;
     let original_path = parent.join("metadata.original.json");
     if !original_path.exists() {
-        return Err(format!(
-            "no backup to restore: {}",
-            original_path.display()
+        return Err(AppError::new(
+            "io.file_not_found",
+            format!("no backup to restore: {}", original_path.display()),
         ));
     }
-    let content = fs::read_to_string(&original_path)
-        .map_err(|e| format!("read backup failed ({}): {}", original_path.display(), e))?;
+    let content = fs::read_to_string(&original_path).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("read backup failed ({}): {}", original_path.display(), e),
+        )
+    })?;
     let value: Value = serde_json::from_str(&content).map_err(|e| {
-        format!(
-            "parse backup failed ({}): {}",
-            original_path.display(),
-            e
+        AppError::new(
+            "parse.json_invalid",
+            format!("parse backup failed ({}): {}", original_path.display(), e),
         )
     })?;
     write_metadata_atomic(meta_path, &value)
@@ -210,11 +249,14 @@ fn restore_from_original_sync(meta_path: &Path) -> Result<(), String> {
 /// #516 — report whether a metadata.original.json exists next to the active
 /// metadata.json. Used by the GUI to enable/disable the [元に戻す] button.
 #[tauri::command]
-async fn check_backup_exists(path: String) -> Result<bool, String> {
+async fn check_backup_exists(path: String) -> Result<bool, AppError> {
     let meta_path = PathBuf::from(&path);
-    let parent = meta_path
-        .parent()
-        .ok_or_else(|| format!("metadata path has no parent: {}", meta_path.display()))?;
+    let parent = meta_path.parent().ok_or_else(|| {
+        AppError::new(
+            "validation.path_invalid",
+            format!("metadata path has no parent: {}", meta_path.display()),
+        )
+    })?;
     Ok(parent.join("metadata.original.json").exists())
 }
 
@@ -271,12 +313,19 @@ fn strip_extended_path_prefix(p: &str) -> String {
 /// `target/debug/recent.json` (gitignored). The same review also moved the
 /// thumbnail cache (`thumb_cache_dir`, #465) to `<install dir>/cache/`
 /// for the same philosophy.
-fn recent_path() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe()
-        .map_err(|e| format!("failed to resolve current_exe: {}", e))?;
-    let dir = exe
-        .parent()
-        .ok_or_else(|| format!("current_exe has no parent: {}", exe.display()))?;
+fn recent_path() -> Result<PathBuf, AppError> {
+    let exe = std::env::current_exe().map_err(|e| {
+        AppError::new(
+            "path.install_dir_unresolved",
+            format!("failed to resolve current_exe: {}", e),
+        )
+    })?;
+    let dir = exe.parent().ok_or_else(|| {
+        AppError::new(
+            "path.install_dir_unresolved",
+            format!("current_exe has no parent: {}", exe.display()),
+        )
+    })?;
     Ok(dir.join("recent.json"))
 }
 
@@ -315,7 +364,7 @@ fn normalize_path_key(p: &str) -> String {
 /// #571 — push `entry` to the front of the history, dedup by `path`, and
 /// truncate to `RECENT_LIMIT`. Returns the post-write list so the caller
 /// (Zustand store) can mirror it without an extra `read_recent` round trip.
-fn add_recent_sync(path: &Path, entry: RecentEntry) -> Result<Vec<RecentEntry>, String> {
+fn add_recent_sync(path: &Path, entry: RecentEntry) -> Result<Vec<RecentEntry>, AppError> {
     let mut list = read_recent_sync(path);
     // Dedup via `normalize_path_key` (case-insensitive + separator-insensitive).
     // The drop happens before we push so the new entry's mtime / addedAt
@@ -332,39 +381,66 @@ fn add_recent_sync(path: &Path, entry: RecentEntry) -> Result<Vec<RecentEntry>, 
 /// #571 — wipe the history (used by the GUI's "履歴をクリア" affordance and
 /// by tests). Treats "file already absent" as success so callers don't have
 /// to special-case the fresh-install state.
-fn clear_recent_sync(path: &Path) -> Result<(), String> {
+fn clear_recent_sync(path: &Path) -> Result<(), AppError> {
     if !path.exists() {
         return Ok(());
     }
-    fs::remove_file(path)
-        .map_err(|e| format!("remove recent.json failed ({}): {}", path.display(), e))
+    fs::remove_file(path).map_err(|e| {
+        AppError::new(
+            "io.delete_failed",
+            format!("remove recent.json failed ({}): {}", path.display(), e),
+        )
+    })
 }
 
-fn write_recent_atomic(path: &Path, list: &[RecentEntry]) -> Result<(), String> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| format!("recent path has no parent: {}", path.display()))?;
+fn write_recent_atomic(path: &Path, list: &[RecentEntry]) -> Result<(), AppError> {
+    let parent = path.parent().ok_or_else(|| {
+        AppError::new(
+            "validation.path_invalid",
+            format!("recent path has no parent: {}", path.display()),
+        )
+    })?;
     if !parent.exists() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("create dir {} failed: {}", parent.display(), e))?;
+        fs::create_dir_all(parent).map_err(|e| {
+            AppError::new(
+                "io.write_failed",
+                format!("create dir {} failed: {}", parent.display(), e),
+            )
+        })?;
     }
     let mut tmp_path = path.to_path_buf();
     let tmp_name = match path.file_name() {
         Some(n) => format!("{}.tmp", n.to_string_lossy()),
-        None => return Err(format!("recent path has no file name: {}", path.display())),
+        None => {
+            return Err(AppError::new(
+                "validation.path_invalid",
+                format!("recent path has no file name: {}", path.display()),
+            ))
+        }
     };
     tmp_path.set_file_name(tmp_name);
-    let serialized = serde_json::to_string_pretty(list)
-        .map_err(|e| format!("serialize recent failed: {}", e))?;
-    fs::write(&tmp_path, serialized)
-        .map_err(|e| format!("write tmp {} failed: {}", tmp_path.display(), e))?;
+    let serialized = serde_json::to_string_pretty(list).map_err(|e| {
+        AppError::new(
+            "parse.json_serialize_failed",
+            format!("serialize recent failed: {}", e),
+        )
+    })?;
+    fs::write(&tmp_path, serialized).map_err(|e| {
+        AppError::new(
+            "io.write_failed",
+            format!("write tmp {} failed: {}", tmp_path.display(), e),
+        )
+    })?;
     if let Err(e) = fs::rename(&tmp_path, path) {
         let _ = fs::remove_file(&tmp_path);
-        return Err(format!(
-            "rename {} -> {} failed: {}",
-            tmp_path.display(),
-            path.display(),
-            e
+        return Err(AppError::new(
+            "io.write_failed",
+            format!(
+                "rename {} -> {} failed: {}",
+                tmp_path.display(),
+                path.display(),
+                e
+            ),
         ));
     }
     Ok(())
@@ -385,7 +461,7 @@ fn prune_missing(entries: Vec<RecentEntry>) -> Vec<RecentEntry> {
 }
 
 #[tauri::command]
-async fn read_recent() -> Result<Vec<RecentEntry>, String> {
+async fn read_recent() -> Result<Vec<RecentEntry>, AppError> {
     let path = recent_path()?;
     let raw = read_recent_sync(&path);
     let original_len = raw.len();
@@ -400,13 +476,20 @@ async fn read_recent() -> Result<Vec<RecentEntry>, String> {
 }
 
 #[tauri::command]
-async fn add_recent(path: String) -> Result<Vec<RecentEntry>, String> {
+async fn add_recent(path: String) -> Result<Vec<RecentEntry>, AppError> {
     let video_path = PathBuf::from(&path);
     if !video_path.exists() {
-        return Err(format!("file not found: {}", video_path.display()));
+        return Err(AppError::new(
+            "io.file_not_found",
+            format!("file not found: {}", video_path.display()),
+        ));
     }
-    let meta = fs::metadata(&video_path)
-        .map_err(|e| format!("stat failed ({}): {}", video_path.display(), e))?;
+    let meta = fs::metadata(&video_path).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("stat failed ({}): {}", video_path.display(), e),
+        )
+    })?;
     let size_bytes = meta.len();
     let mtime_ms = meta
         .modified()
@@ -453,7 +536,7 @@ async fn add_recent(path: String) -> Result<Vec<RecentEntry>, String> {
 fn add_recent_with_prune(
     path: &Path,
     entry: RecentEntry,
-) -> Result<Vec<RecentEntry>, String> {
+) -> Result<Vec<RecentEntry>, AppError> {
     let inserted = add_recent_sync(path, entry)?;
     let initial_len = inserted.len();
     let pruned = prune_missing(inserted);
@@ -464,7 +547,7 @@ fn add_recent_with_prune(
 }
 
 #[tauri::command]
-async fn clear_recent() -> Result<(), String> {
+async fn clear_recent() -> Result<(), AppError> {
     clear_recent_sync(&recent_path()?)
 }
 
@@ -476,7 +559,7 @@ async fn clear_recent() -> Result<(), String> {
 /// `http://127.0.0.1:{port}/video/{token}` and is only reachable from the
 /// same machine; the server binds exclusively to 127.0.0.1.
 #[tauri::command]
-async fn register_video(path: String) -> Result<RegisteredVideo, String> {
+async fn register_video(path: String) -> Result<RegisteredVideo, AppError> {
     let file_path = PathBuf::from(&path);
     let canonical = validate_video_path(&file_path)?;
 
@@ -517,7 +600,7 @@ struct VideoProbeInfo {
 }
 
 #[tauri::command]
-async fn probe_video(path: String) -> Result<VideoProbeInfo, String> {
+async fn probe_video(path: String) -> Result<VideoProbeInfo, AppError> {
     let file_path = PathBuf::from(&path);
     let canonical = validate_video_path(&file_path)?;
     probe_video_with(&canonical, "ffprobe").await
@@ -528,9 +611,14 @@ async fn probe_video(path: String) -> Result<VideoProbeInfo, String> {
 async fn probe_video_with(
     path: &Path,
     ffprobe: &str,
-) -> Result<VideoProbeInfo, String> {
+) -> Result<VideoProbeInfo, AppError> {
     let size_bytes = fs::metadata(path)
-        .map_err(|e| format!("stat failed ({}): {}", path.display(), e))?
+        .map_err(|e| {
+            AppError::new(
+                "io.read_failed",
+                format!("stat failed ({}): {}", path.display(), e),
+            )
+        })?
         .len();
 
     let output = tokio::process::Command::new(ffprobe)
@@ -543,37 +631,69 @@ async fn probe_video_with(
         .arg(path)
         .output()
         .await
-        .map_err(|e| format!("ffprobe spawn failed: {e}"))?;
+        .map_err(|e| {
+            AppError::new(
+                "subprocess.spawn_failed",
+                format!("ffprobe spawn failed: {e}"),
+            )
+        })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!(
-            "ffprobe failed (exit {:?}): {}",
-            output.status.code(),
-            stderr.trim()
+        return Err(AppError::new(
+            "subprocess.exit_failed",
+            format!(
+                "ffprobe failed (exit {:?}): {}",
+                output.status.code(),
+                stderr.trim()
+            ),
         ));
     }
 
-    let json: Value = serde_json::from_slice(&output.stdout)
-        .map_err(|e| format!("ffprobe json parse failed: {e}"))?;
+    let json: Value = serde_json::from_slice(&output.stdout).map_err(|e| {
+        AppError::new(
+            "parse.ffprobe_output_invalid",
+            format!("ffprobe json parse failed: {e}"),
+        )
+    })?;
 
     let streams = json
         .get("streams")
         .and_then(|s| s.as_array())
-        .ok_or_else(|| "ffprobe output missing 'streams' array".to_string())?;
+        .ok_or_else(|| {
+            AppError::new(
+                "parse.ffprobe_output_invalid",
+                "ffprobe output missing 'streams' array",
+            )
+        })?;
     let video_stream = streams
         .iter()
         .find(|s| s.get("codec_type").and_then(|v| v.as_str()) == Some("video"))
-        .ok_or_else(|| "no video stream in ffprobe output".to_string())?;
+        .ok_or_else(|| {
+            AppError::new(
+                "parse.ffprobe_output_invalid",
+                "no video stream in ffprobe output",
+            )
+        })?;
 
     let width = video_stream
         .get("width")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| "video stream missing width".to_string())? as u32;
+        .ok_or_else(|| {
+            AppError::new(
+                "parse.ffprobe_output_invalid",
+                "video stream missing width",
+            )
+        })? as u32;
     let height = video_stream
         .get("height")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| "video stream missing height".to_string())? as u32;
+        .ok_or_else(|| {
+            AppError::new(
+                "parse.ffprobe_output_invalid",
+                "video stream missing height",
+            )
+        })? as u32;
     let codec = video_stream
         .get("codec_name")
         .and_then(|v| v.as_str())
@@ -590,16 +710,29 @@ async fn probe_video_with(
             video_stream.get("avg_frame_rate").and_then(|v| v.as_str()),
         )
     })
-    .ok_or_else(|| "cannot determine frame rate".to_string())?;
+    .ok_or_else(|| {
+        AppError::new(
+            "parse.ffprobe_output_invalid",
+            "cannot determine frame rate",
+        )
+    })?;
 
     let duration_seconds = json
         .get("format")
         .and_then(|f| f.get("duration"))
         .and_then(|v| v.as_str())
         .and_then(|s| s.parse::<f64>().ok())
-        .ok_or_else(|| "format.duration missing or unparseable".to_string())?;
+        .ok_or_else(|| {
+            AppError::new(
+                "parse.ffprobe_output_invalid",
+                "format.duration missing or unparseable",
+            )
+        })?;
     if duration_seconds <= 0.0 {
-        return Err("duration is non-positive".to_string());
+        return Err(AppError::new(
+            "validation.range_invalid",
+            "duration is non-positive",
+        ));
     }
 
     let file_name = path
@@ -639,20 +772,31 @@ fn parse_frame_rate_str(s: Option<&str>) -> Option<f64> {
 
 /// Validate that `path` points to an existing regular file and return the
 /// canonicalized absolute path on success.
-fn validate_video_path(path: &Path) -> Result<PathBuf, String> {
+fn validate_video_path(path: &Path) -> Result<PathBuf, AppError> {
     if !path.exists() {
-        return Err(format!("video file not found: {}", path.display()));
-    }
-    let meta = fs::metadata(path)
-        .map_err(|e| format!("stat failed ({}): {}", path.display(), e))?;
-    if !meta.is_file() {
-        return Err(format!(
-            "video path is not a regular file: {}",
-            path.display()
+        return Err(AppError::new(
+            "io.file_not_found",
+            format!("video file not found: {}", path.display()),
         ));
     }
-    fs::canonicalize(path)
-        .map_err(|e| format!("canonicalize failed ({}): {}", path.display(), e))
+    let meta = fs::metadata(path).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("stat failed ({}): {}", path.display(), e),
+        )
+    })?;
+    if !meta.is_file() {
+        return Err(AppError::new(
+            "validation.not_a_file",
+            format!("video path is not a regular file: {}", path.display()),
+        ));
+    }
+    fs::canonicalize(path).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("canonicalize failed ({}): {}", path.display(), e),
+        )
+    })
 }
 
 /// Pure helper: mint a new UUID, insert `(token, path)` into the token map,
@@ -667,15 +811,18 @@ fn register_video_sync(path: &Path, tokens: &mut HashMap<Uuid, PathBuf>) -> Uuid
 /// Ensure the local video server is listening on 127.0.0.1 and return the
 /// bound port. Idempotent: re-uses the existing port on every call after the
 /// first.
-async fn ensure_server_started() -> Result<u16, String> {
+async fn ensure_server_started() -> Result<u16, AppError> {
     let mut guard = video_server().lock().await;
     if let Some(port) = guard.port {
         return Ok(port);
     }
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .map_err(|e| format!("bind 127.0.0.1:0 failed: {}", e))?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.map_err(|e| {
+        AppError::new(
+            "subprocess.spawn_failed",
+            format!("bind 127.0.0.1:0 failed: {}", e),
+        )
+    })?;
     let addr = listener
         .local_addr()
         .map_err(|e| format!("local_addr failed: {}", e))?;
@@ -735,39 +882,51 @@ fn apply_changes_sync(
     meta_path: &Path,
     payload: &Value,
     expected_mtime_ms: Option<u64>,
-) -> Result<(), String> {
+) -> Result<(), AppError> {
     // #514 — refuse to overwrite a file that has been modified externally
     // since the caller last loaded it. Target not existing is not a conflict
     // (treat as a fresh write).
     if let Some(expected) = expected_mtime_ms {
         if meta_path.exists() {
             let actual = file_mtime_ms(meta_path).ok_or_else(|| {
-                format!("cannot read mtime of {}", meta_path.display())
+                AppError::new(
+                    "io.read_failed",
+                    format!("cannot read mtime of {}", meta_path.display()),
+                )
             })?;
             if actual != expected {
-                return Err(format!(
-                    "conflict: external modification detected ({} expected mtime {}, got {})",
-                    meta_path.display(),
-                    expected,
-                    actual
+                return Err(AppError::new(
+                    "state.mtime_conflict",
+                    format!(
+                        "conflict: external modification detected ({} expected mtime {}, got {})",
+                        meta_path.display(),
+                        expected,
+                        actual
+                    ),
                 ));
             }
         }
     }
 
 
-    let parent = meta_path
-        .parent()
-        .ok_or_else(|| format!("metadata path has no parent: {}", meta_path.display()))?;
+    let parent = meta_path.parent().ok_or_else(|| {
+        AppError::new(
+            "validation.path_invalid",
+            format!("metadata path has no parent: {}", meta_path.display()),
+        )
+    })?;
     let original_path = parent.join("metadata.original.json");
 
     if meta_path.exists() && !original_path.exists() {
         fs::copy(meta_path, &original_path).map_err(|e| {
-            format!(
-                "failed to back up {} to {}: {}",
-                meta_path.display(),
-                original_path.display(),
-                e
+            AppError::new(
+                "io.backup_failed",
+                format!(
+                    "failed to back up {} to {}: {}",
+                    meta_path.display(),
+                    original_path.display(),
+                    e
+                ),
             )
         })?;
     }
@@ -775,32 +934,55 @@ fn apply_changes_sync(
     write_metadata_atomic(meta_path, payload)
 }
 
-fn write_metadata_atomic(path: &Path, payload: &Value) -> Result<(), String> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| format!("metadata path has no parent: {}", path.display()))?;
+fn write_metadata_atomic(path: &Path, payload: &Value) -> Result<(), AppError> {
+    let parent = path.parent().ok_or_else(|| {
+        AppError::new(
+            "validation.path_invalid",
+            format!("metadata path has no parent: {}", path.display()),
+        )
+    })?;
     if !parent.exists() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("create dir {} failed: {}", parent.display(), e))?;
+        fs::create_dir_all(parent).map_err(|e| {
+            AppError::new(
+                "io.write_failed",
+                format!("create dir {} failed: {}", parent.display(), e),
+            )
+        })?;
     }
     let mut tmp_path = path.to_path_buf();
     let tmp_name = match path.file_name() {
         Some(n) => format!("{}.tmp", n.to_string_lossy()),
-        None => return Err(format!("metadata path has no file name: {}", path.display())),
+        None => {
+            return Err(AppError::new(
+                "validation.path_invalid",
+                format!("metadata path has no file name: {}", path.display()),
+            ))
+        }
     };
     tmp_path.set_file_name(tmp_name);
 
-    let serialized = serde_json::to_string_pretty(payload)
-        .map_err(|e| format!("serialize failed: {}", e))?;
-    fs::write(&tmp_path, serialized)
-        .map_err(|e| format!("write tmp {} failed: {}", tmp_path.display(), e))?;
+    let serialized = serde_json::to_string_pretty(payload).map_err(|e| {
+        AppError::new(
+            "parse.json_serialize_failed",
+            format!("serialize failed: {}", e),
+        )
+    })?;
+    fs::write(&tmp_path, serialized).map_err(|e| {
+        AppError::new(
+            "io.write_failed",
+            format!("write tmp {} failed: {}", tmp_path.display(), e),
+        )
+    })?;
     if let Err(e) = fs::rename(&tmp_path, path) {
         let _ = fs::remove_file(&tmp_path);
-        return Err(format!(
-            "rename {} -> {} failed: {}",
-            tmp_path.display(),
-            path.display(),
-            e
+        return Err(AppError::new(
+            "io.write_failed",
+            format!(
+                "rename {} -> {} failed: {}",
+                tmp_path.display(),
+                path.display(),
+                e
+            ),
         ));
     }
     Ok(())
@@ -844,16 +1026,20 @@ fn compute_video_cache_hash(video_path: &Path, mtime_ms: u64) -> String {
 /// `recent.json` (#571). Tool deletion = folder deletion = no leftover
 /// state in the user profile. Production = `<bundle install dir>/cache/...`,
 /// dev = `target/debug/cache/...` (gitignored).
-fn thumb_cache_dir(video_hash: &str) -> Result<PathBuf, String> {
-    let exe = std::env::current_exe()
-        .map_err(|e| format!("failed to resolve current_exe: {}", e))?;
-    let dir = exe
-        .parent()
-        .ok_or_else(|| format!("current_exe has no parent: {}", exe.display()))?;
-    Ok(dir
-        .join("cache")
-        .join(video_hash)
-        .join("thumbs"))
+fn thumb_cache_dir(video_hash: &str) -> Result<PathBuf, AppError> {
+    let exe = std::env::current_exe().map_err(|e| {
+        AppError::new(
+            "path.install_dir_unresolved",
+            format!("failed to resolve current_exe: {}", e),
+        )
+    })?;
+    let dir = exe.parent().ok_or_else(|| {
+        AppError::new(
+            "path.install_dir_unresolved",
+            format!("current_exe has no parent: {}", exe.display()),
+        )
+    })?;
+    Ok(dir.join("cache").join(video_hash).join("thumbs"))
 }
 
 /// #465 -- compute the evenly-spaced timestamps for a given boundary window.
@@ -905,26 +1091,51 @@ async fn generate_match_thumbnails(
     boundary_t_seconds: f64,
     window_seconds: f64,
     count: u32,
-) -> Result<Vec<ThumbnailEntry>, String> {
+) -> Result<Vec<ThumbnailEntry>, AppError> {
     let video = PathBuf::from(&video_path);
     if !video.exists() {
-        return Err(format!("video file not found: {}", video.display()));
+        return Err(AppError::new(
+            "io.file_not_found",
+            format!("video file not found: {}", video.display()),
+        ));
     }
-    let meta = fs::metadata(&video)
-        .map_err(|e| format!("stat failed ({}): {}", video.display(), e))?;
+    let meta = fs::metadata(&video).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("stat failed ({}): {}", video.display(), e),
+        )
+    })?;
     let mtime_ms = meta
         .modified()
-        .map_err(|e| format!("mtime failed ({}): {}", video.display(), e))?
+        .map_err(|e| {
+            AppError::new(
+                "io.read_failed",
+                format!("mtime failed ({}): {}", video.display(), e),
+            )
+        })?
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
-        .map_err(|e| format!("mtime before epoch ({}): {}", video.display(), e))?;
-    let canonical = fs::canonicalize(&video)
-        .map_err(|e| format!("canonicalize failed ({}): {}", video.display(), e))?;
+        .map_err(|e| {
+            AppError::new(
+                "io.read_failed",
+                format!("mtime before epoch ({}): {}", video.display(), e),
+            )
+        })?;
+    let canonical = fs::canonicalize(&video).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("canonicalize failed ({}): {}", video.display(), e),
+        )
+    })?;
 
     let video_hash = compute_video_cache_hash(&canonical, mtime_ms);
     let cache_dir = thumb_cache_dir(&video_hash)?;
-    fs::create_dir_all(&cache_dir)
-        .map_err(|e| format!("create cache dir {} failed: {}", cache_dir.display(), e))?;
+    fs::create_dir_all(&cache_dir).map_err(|e| {
+        AppError::new(
+            "io.write_failed",
+            format!("create cache dir {} failed: {}", cache_dir.display(), e),
+        )
+    })?;
 
     let timestamps = compute_candidate_timestamps(boundary_t_seconds, window_seconds, count);
     let semaphore = Arc::new(Semaphore::new(4));
@@ -936,12 +1147,14 @@ async fn generate_match_thumbnails(
         let video_for_task = canonical.clone();
         let sem = Arc::clone(&semaphore);
         tasks.push(async move {
-            let _permit = sem
-                .acquire_owned()
-                .await
-                .map_err(|e| format!("semaphore closed: {}", e))?;
+            let _permit = sem.acquire_owned().await.map_err(|e| {
+                AppError::new(
+                    "internal.error",
+                    format!("semaphore closed: {}", e),
+                )
+            })?;
             ensure_thumbnail_exists(&video_for_task, t, &out_path).await?;
-            Ok::<ThumbnailEntry, String>(ThumbnailEntry {
+            Ok::<ThumbnailEntry, AppError>(ThumbnailEntry {
                 t_seconds: t,
                 file_path: out_path.to_string_lossy().to_string(),
             })
@@ -963,7 +1176,7 @@ async fn ensure_thumbnail_exists(
     video_path: &Path,
     t_seconds: f64,
     out_path: &Path,
-) -> Result<(), String> {
+) -> Result<(), AppError> {
     if let Ok(meta) = fs::metadata(out_path) {
         if meta.is_file() && meta.len() > 0 {
             return Ok(());
@@ -972,7 +1185,10 @@ async fn ensure_thumbnail_exists(
     if let Some(parent) = out_path.parent() {
         if !parent.exists() {
             fs::create_dir_all(parent).map_err(|e| {
-                format!("create dir {} failed: {}", parent.display(), e)
+                AppError::new(
+                    "io.write_failed",
+                    format!("create dir {} failed: {}", parent.display(), e),
+                )
             })?;
         }
     }
@@ -997,15 +1213,23 @@ async fn ensure_thumbnail_exists(
         .arg(out_path)
         .output()
         .await
-        .map_err(|e| format!("spawn ffmpeg failed at t={}: {}", t_arg, e))?;
+        .map_err(|e| {
+            AppError::new(
+                "subprocess.spawn_failed",
+                format!("spawn ffmpeg failed at t={}: {}", t_arg, e),
+            )
+        })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!(
-            "ffmpeg failed at t={} (exit={:?}): {}",
-            t_arg,
-            output.status.code(),
-            stderr.trim()
+        return Err(AppError::new(
+            "subprocess.exit_failed",
+            format!(
+                "ffmpeg failed at t={} (exit={:?}): {}",
+                t_arg,
+                output.status.code(),
+                stderr.trim()
+            ),
         ));
     }
     Ok(())
@@ -1038,7 +1262,7 @@ async fn is_process_running() -> bool {
 /// were alive at kill time. Best-effort -- already-dead children are silently
 /// skipped so partial kills don't block the exit flow.
 #[tauri::command]
-async fn kill_tracked_processes() -> Result<u32, String> {
+async fn kill_tracked_processes() -> Result<u32, AppError> {
     let tracker = process_tracker();
     let mut guard = tracker.lock().await;
     let count = guard.len() as u32;
@@ -1307,31 +1531,38 @@ fn validate_export_request(
     video_path: &Path,
     start_seconds: f64,
     end_seconds: f64,
-) -> Result<(), String> {
+) -> Result<(), AppError> {
     if !video_path.exists() {
-        return Err(format!(
-            "video file not found: {}",
-            video_path.display()
+        return Err(AppError::new(
+            "io.file_not_found",
+            format!("video file not found: {}", video_path.display()),
         ));
     }
-    let meta = fs::metadata(video_path)
-        .map_err(|e| format!("stat failed ({}): {}", video_path.display(), e))?;
+    let meta = fs::metadata(video_path).map_err(|e| {
+        AppError::new(
+            "io.read_failed",
+            format!("stat failed ({}): {}", video_path.display(), e),
+        )
+    })?;
     if !meta.is_file() {
-        return Err(format!(
-            "video path is not a regular file: {}",
-            video_path.display()
+        return Err(AppError::new(
+            "validation.not_a_file",
+            format!("video path is not a regular file: {}", video_path.display()),
         ));
     }
     if !start_seconds.is_finite() || start_seconds < 0.0 {
-        return Err(format!(
-            "start_seconds must be >= 0 (got {})",
-            start_seconds
+        return Err(AppError::new(
+            "validation.range_invalid",
+            format!("start_seconds must be >= 0 (got {})", start_seconds),
         ));
     }
     if !end_seconds.is_finite() || end_seconds <= start_seconds {
-        return Err(format!(
-            "end_seconds must be > start_seconds (got start={}, end={})",
-            start_seconds, end_seconds
+        return Err(AppError::new(
+            "validation.range_invalid",
+            format!(
+                "end_seconds must be > start_seconds (got start={}, end={})",
+                start_seconds, end_seconds
+            ),
         ));
     }
     Ok(())
@@ -1353,12 +1584,12 @@ fn validate_export_request(
 ///
 /// `output_path` がルート / 親なし (file_name only など) の場合は no-op で
 /// Ok を返す (現在のディレクトリを意味すると解釈)。
-fn validate_output_parent_exists(output_path: &Path) -> Result<(), String> {
+fn validate_output_parent_exists(output_path: &Path) -> Result<(), AppError> {
     if let Some(parent) = output_path.parent() {
         if !parent.as_os_str().is_empty() && !parent.exists() {
-            return Err(format!(
-                "output directory does not exist: {}",
-                parent.display()
+            return Err(AppError::new(
+                "io.file_not_found",
+                format!("output directory does not exist: {}", parent.display()),
             ));
         }
     }
@@ -1371,15 +1602,19 @@ fn validate_output_parent_exists(output_path: &Path) -> Result<(), String> {
 /// - 存在しない path は明示エラー
 /// - 非 Windows 環境では unsupported エラー
 /// - 上記をパスしたら Ok (caller は spawn を試みる)
-fn validate_open_folder_request(path: &str) -> Result<(), String> {
+fn validate_open_folder_request(path: &str) -> Result<(), AppError> {
     if !Path::new(path).exists() {
-        return Err(format!("path does not exist: {}", path));
+        return Err(AppError::new(
+            "io.file_not_found",
+            format!("path does not exist: {}", path),
+        ));
     }
     #[cfg(not(target_os = "windows"))]
     {
-        return Err(
-            "open_folder_in_explorer is only supported on Windows".to_string(),
-        );
+        return Err(AppError::new(
+            "platform.unsupported",
+            "open_folder_in_explorer is only supported on Windows",
+        ));
     }
     #[cfg(target_os = "windows")]
     {
@@ -1400,7 +1635,7 @@ fn validate_open_folder_request(path: &str) -> Result<(), String> {
 /// Windows のみ対応 (CLAUDE.md に「対応プラットフォーム: Windows のみ」と
 /// 明記)。将来 Linux / macOS 対応する際は `xdg-open` / `open` で分岐する。
 #[tauri::command]
-fn open_folder_in_explorer(path: String) -> Result<(), String> {
+fn open_folder_in_explorer(path: String) -> Result<(), AppError> {
     validate_open_folder_request(&path)?;
 
     #[cfg(target_os = "windows")]
@@ -1409,7 +1644,12 @@ fn open_folder_in_explorer(path: String) -> Result<(), String> {
         Command::new("explorer.exe")
             .arg(&path)
             .spawn()
-            .map_err(|e| format!("failed to launch explorer: {}", e))?;
+            .map_err(|e| {
+                AppError::new(
+                    "subprocess.spawn_failed",
+                    format!("failed to launch explorer: {}", e),
+                )
+            })?;
     }
 
     Ok(())
@@ -1667,7 +1907,7 @@ async fn export_match(
     codec: ExportCodec,
     h264_encoder: Option<H264Encoder>,
     match_index: u32,
-) -> Result<ExportResult, String> {
+) -> Result<ExportResult, AppError> {
     let video = PathBuf::from(&video_path);
     validate_export_request(&video, start_seconds, end_seconds)?;
 
@@ -1818,7 +2058,7 @@ async fn export_match(
                 fallback_from: None,
             },
         );
-        return Err(msg);
+        return Err(AppError::new("subprocess.exit_failed", msg));
     }
 
     // No retry -- surface the primary failure.
@@ -1838,7 +2078,7 @@ async fn export_match(
             fallback_from: None,
         },
     );
-    Err(msg)
+    Err(AppError::new("subprocess.exit_failed", msg))
 }
 
 fn build_export_result(output: &Path, match_index: u32, started: Instant) -> ExportResult {
@@ -2143,17 +2383,23 @@ async fn start_detect(
     video_path: String,
     output_dir: String,
     params: DetectParams,
-) -> Result<DetectResult, String> {
+) -> Result<DetectResult, AppError> {
     let video = PathBuf::from(&video_path);
     if !video.exists() {
-        return Err(format!("video file not found: {}", video.display()));
+        return Err(AppError::new(
+            "io.file_not_found",
+            format!("video file not found: {}", video.display()),
+        ));
     }
     let output_buf = PathBuf::from(&output_dir);
     if let Err(e) = fs::create_dir_all(&output_buf) {
-        return Err(format!(
-            "create output dir failed ({}): {}",
-            output_buf.display(),
-            e
+        return Err(AppError::new(
+            "io.write_failed",
+            format!(
+                "create output dir failed ({}): {}",
+                output_buf.display(),
+                e
+            ),
         ));
     }
 
@@ -2271,7 +2517,7 @@ async fn start_detect(
                     ..Default::default()
                 },
             );
-            return Err("detect cancelled".to_string());
+            return Err(AppError::new("subprocess.cancelled", "detect cancelled"));
         }
     };
 
@@ -2300,11 +2546,14 @@ async fn start_detect(
                 ..Default::default()
             },
         );
-        return Err(msg);
+        return Err(AppError::new("subprocess.exit_failed", msg));
     }
 
     let metadata_path = metadata_path.ok_or_else(|| {
-        "detect completed but no metadata_path was emitted".to_string()
+        AppError::new(
+            "internal.error",
+            "detect completed but no metadata_path was emitted",
+        )
     })?;
 
     Ok(DetectResult {
@@ -2316,10 +2565,15 @@ async fn start_detect(
 /// #614 -- Returns the install-directory log path (`<install_dir>/logs`) so the
 /// frontend ErrorModal can show the user where crash logs are written.
 #[tauri::command]
-fn get_log_dir() -> Result<String, String> {
+fn get_log_dir() -> Result<String, AppError> {
     logging::log_dir()
         .map(|p| p.to_string_lossy().to_string())
-        .map_err(|e| format!("could not resolve log dir: {}", e))
+        .map_err(|e| {
+            AppError::new(
+                "path.install_dir_unresolved",
+                format!("could not resolve log dir: {}", e),
+            )
+        })
 }
 
 /// #614 -- Dev-only command that triggers a panic. Used by the frontend smoke
@@ -2335,7 +2589,7 @@ fn get_log_dir() -> Result<String, String> {
 /// boundary, letting the WebView keep running.
 #[cfg(debug_assertions)]
 #[tauri::command]
-async fn dev_force_panic() -> Result<(), String> {
+async fn dev_force_panic() -> Result<(), AppError> {
     panic!("dev_force_panic invoked from frontend");
 }
 
@@ -2553,7 +2807,7 @@ mod tests {
         fs::write(&meta, r#"{"ok":true}"#).unwrap();
 
         let err = restore_from_original_sync(&meta).unwrap_err();
-        assert!(err.contains("no backup to restore"));
+        assert!(err.message.contains("no backup to restore"));
     }
 
     #[test]
@@ -2920,7 +3174,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let meta = tmp.path().join("metadata.json");
         let err = load_metadata_sync(&meta).unwrap_err();
-        assert!(err.contains("metadata file not found"));
+        assert!(err.message.contains("metadata file not found"));
     }
 
     #[test]
@@ -2929,7 +3183,7 @@ mod tests {
         let meta = tmp.path().join("metadata.json");
         fs::write(&meta, r#"{"source": "a.mkv", invalid"#).unwrap();
         let err = load_metadata_sync(&meta).unwrap_err();
-        assert!(err.contains("invalid JSON"));
+        assert!(err.message.contains("invalid JSON"));
     }
 
     #[test]
@@ -2949,7 +3203,7 @@ mod tests {
         // Valid JSON but root is an array — Python side's read_metadata also rejects this.
         fs::write(&meta, r#"["not", "an", "object"]"#).unwrap();
         let err = load_metadata_sync(&meta).unwrap_err();
-        assert!(err.contains("must be a JSON object"));
+        assert!(err.message.contains("must be a JSON object"));
     }
 
     // #514 — mtime-based exclusive control for apply_changes.
@@ -2978,7 +3232,7 @@ mod tests {
         let stale: u64 = 1;
 
         let err = apply_changes_sync(&meta, &json!({"v": 2}), Some(stale)).unwrap_err();
-        assert!(err.starts_with("conflict:"), "unexpected error: {err}");
+        assert!(err.message.starts_with("conflict:"), "unexpected error: {err}");
 
         // Conflict must not overwrite the file.
         let current: Value =
@@ -3053,7 +3307,7 @@ mod tests {
         // apply_changes_sync with the stale initial mtime must refuse the write.
         let err = apply_changes_sync(&meta, &json!({"v": 2}), Some(initial_mtime))
             .unwrap_err();
-        assert!(err.starts_with("conflict:"), "unexpected error: {err}");
+        assert!(err.message.starts_with("conflict:"), "unexpected error: {err}");
 
         // File still reflects the external write (not overwritten).
         let current: Value =
@@ -3089,7 +3343,7 @@ mod tests {
         // The original m1 is now stale — attempting to apply with it must fail
         // (regression guard: prevents accepting pre-first-apply handles).
         let err = apply_changes_sync(&meta, &json!({"v": 4}), Some(m1)).unwrap_err();
-        assert!(err.starts_with("conflict:"), "unexpected error: {err}");
+        assert!(err.message.starts_with("conflict:"), "unexpected error: {err}");
     }
 
     // #517 — draft auto-save tests.
@@ -3152,7 +3406,7 @@ mod tests {
         fs::write(&draft_file, r#"{"broken": invalid"#).unwrap();
 
         let err = load_draft_sync(&meta).unwrap_err();
-        assert!(err.contains("invalid JSON in draft"));
+        assert!(err.message.contains("invalid JSON in draft"));
     }
 
     #[test]
@@ -3233,7 +3487,7 @@ mod tests {
         let missing = tmp.path().join("does_not_exist.mp4");
         let err = validate_video_path(&missing).unwrap_err();
         assert!(
-            err.contains("not found"),
+            err.message.contains("not found"),
             "expected 'not found' in error, got: {}",
             err
         );
@@ -3247,7 +3501,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let err = validate_video_path(tmp.path()).unwrap_err();
         assert!(
-            err.contains("not a regular file"),
+            err.message.contains("not a regular file"),
             "expected 'not a regular file' in error, got: {}",
             err
         );
@@ -3452,7 +3706,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            err.contains("ffprobe spawn failed") || err.contains("ffprobe failed"),
+            err.message.contains("ffprobe spawn failed") || err.message.contains("ffprobe failed"),
             "unexpected error: {}",
             err
         );
@@ -3885,7 +4139,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let missing = tmp.path().join("nope.mp4");
         let err = validate_export_request(&missing, 0.0, 10.0).unwrap_err();
-        assert!(err.contains("not found"), "got: {}", err);
+        assert!(err.message.contains("not found"), "got: {}", err);
     }
 
     /// #466 -- `end <= start` must fail immediately (otherwise ffmpeg's
@@ -3897,9 +4151,9 @@ mod tests {
         let video = tmp.path().join("clip.mp4");
         fs::write(&video, b"fake mp4").unwrap();
         let err_equal = validate_export_request(&video, 10.0, 10.0).unwrap_err();
-        assert!(err_equal.contains("end_seconds"), "got: {}", err_equal);
+        assert!(err_equal.message.contains("end_seconds"), "got: {}", err_equal);
         let err_lt = validate_export_request(&video, 20.0, 10.0).unwrap_err();
-        assert!(err_lt.contains("end_seconds"), "got: {}", err_lt);
+        assert!(err_lt.message.contains("end_seconds"), "got: {}", err_lt);
     }
 
     /// #466 -- negative start times are rejected. ffmpeg treats `-ss <0`
@@ -3910,7 +4164,7 @@ mod tests {
         let video = tmp.path().join("clip.mp4");
         fs::write(&video, b"fake mp4").unwrap();
         let err = validate_export_request(&video, -1.0, 10.0).unwrap_err();
-        assert!(err.contains("start_seconds"), "got: {}", err);
+        assert!(err.message.contains("start_seconds"), "got: {}", err);
     }
 
     /// #466 -- NaN / non-finite values are rejected (they would otherwise
@@ -3921,9 +4175,9 @@ mod tests {
         let video = tmp.path().join("clip.mp4");
         fs::write(&video, b"fake mp4").unwrap();
         let err_nan_start = validate_export_request(&video, f64::NAN, 10.0).unwrap_err();
-        assert!(err_nan_start.contains("start_seconds"), "got: {}", err_nan_start);
+        assert!(err_nan_start.message.contains("start_seconds"), "got: {}", err_nan_start);
         let err_inf_end = validate_export_request(&video, 0.0, f64::INFINITY).unwrap_err();
-        assert!(err_inf_end.contains("end_seconds"), "got: {}", err_inf_end);
+        assert!(err_inf_end.message.contains("end_seconds"), "got: {}", err_inf_end);
     }
 
     /// #466 review #4: 出力先親ディレクトリが存在しなければエラー。
@@ -3934,7 +4188,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let nested = tmp.path().join("nope").join("clip.mp4");
         let err = validate_output_parent_exists(&nested).unwrap_err();
-        assert!(err.contains("does not exist"), "got: {}", err);
+        assert!(err.message.contains("does not exist"), "got: {}", err);
     }
 
     /// #466 review #4: 親ディレクトリが存在すれば Ok。
@@ -3958,7 +4212,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let bogus = tmp.path().join("does-not-exist");
         let err = validate_open_folder_request(&bogus.to_string_lossy()).unwrap_err();
-        assert!(err.contains("does not exist"), "got: {}", err);
+        assert!(err.message.contains("does not exist"), "got: {}", err);
     }
 
     /// #545 review #6: 存在するディレクトリは accept (Windows のみ Ok、
@@ -3978,7 +4232,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let err =
             validate_open_folder_request(&tmp.path().to_string_lossy()).unwrap_err();
-        assert!(err.contains("Windows"), "got: {}", err);
+        assert!(err.message.contains("Windows"), "got: {}", err);
     }
 
     /// #545 mystifying-ptolemy-d112b5 review (2026-04-25): track_child →

--- a/gui/src/lib/appError.test.ts
+++ b/gui/src/lib/appError.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appErrorCodeIs,
+  appErrorHint,
+  appErrorMessage,
+  isAppError,
+} from './appError';
+
+describe('isAppError', () => {
+  it('returns true for object with code and message', () => {
+    expect(
+      isAppError({ code: 'io.file_not_found', message: 'not found' }),
+    ).toBe(true);
+  });
+
+  it('returns true for object with optional hint and stacktrace fields', () => {
+    expect(
+      isAppError({
+        code: 'state.mtime_conflict',
+        message: 'conflict',
+        hint: 'reload',
+        stacktrace: 'at line 1',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for raw string (legacy fallback)', () => {
+    expect(isAppError('legacy raw error')).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isAppError(null)).toBe(false);
+    expect(isAppError(undefined)).toBe(false);
+  });
+
+  it('returns false when code is missing', () => {
+    expect(isAppError({ message: 'incomplete' })).toBe(false);
+  });
+
+  it('returns false when message is missing', () => {
+    expect(isAppError({ code: 'io.read_failed' })).toBe(false);
+  });
+
+  it('returns false when code is non-string', () => {
+    expect(isAppError({ code: 42, message: 'x' })).toBe(false);
+  });
+
+  it('returns false for Error instance (no code field)', () => {
+    expect(isAppError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('appErrorMessage', () => {
+  it('extracts message from AppError', () => {
+    expect(
+      appErrorMessage({ code: 'io.read_failed', message: 'read fail' }),
+    ).toBe('read fail');
+  });
+
+  it('falls back to Error.message', () => {
+    expect(appErrorMessage(new Error('oops'))).toBe('oops');
+  });
+
+  it('coerces raw string to string (legacy fallback)', () => {
+    expect(appErrorMessage('legacy raw')).toBe('legacy raw');
+  });
+
+  it('coerces null/undefined to their string representation', () => {
+    expect(appErrorMessage(null)).toBe('null');
+    expect(appErrorMessage(undefined)).toBe('undefined');
+  });
+});
+
+describe('appErrorCodeIs', () => {
+  it('matches expected code', () => {
+    expect(
+      appErrorCodeIs(
+        { code: 'state.mtime_conflict', message: '' },
+        'state.mtime_conflict',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects mismatched code', () => {
+    expect(
+      appErrorCodeIs(
+        { code: 'io.read_failed', message: '' },
+        'state.mtime_conflict',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects non-AppError safely (false rather than throw)', () => {
+    expect(appErrorCodeIs('legacy raw', 'state.mtime_conflict')).toBe(false);
+    expect(appErrorCodeIs(null, 'state.mtime_conflict')).toBe(false);
+    expect(appErrorCodeIs(new Error('boom'), 'state.mtime_conflict')).toBe(
+      false,
+    );
+  });
+});
+
+describe('appErrorHint', () => {
+  it('returns hint when present', () => {
+    expect(
+      appErrorHint({
+        code: 'io.read_failed',
+        message: '',
+        hint: 'check perms',
+      }),
+    ).toBe('check perms');
+  });
+
+  it('returns null when hint missing', () => {
+    expect(appErrorHint({ code: 'io.read_failed', message: '' })).toBeNull();
+  });
+
+  it('returns null for non-AppError', () => {
+    expect(appErrorHint('legacy raw')).toBeNull();
+    expect(appErrorHint(null)).toBeNull();
+    expect(appErrorHint(new Error('boom'))).toBeNull();
+  });
+
+  it('returns null when hint is non-string', () => {
+    expect(
+      appErrorHint({
+        code: 'io.read_failed',
+        message: '',
+        hint: 42 as unknown as string,
+      }),
+    ).toBeNull();
+  });
+});

--- a/gui/src/lib/appError.ts
+++ b/gui/src/lib/appError.ts
@@ -1,0 +1,60 @@
+/**
+ * #619 / #614 — Tauri command の `Result<T, AppError>` で frontend 側に届く
+ * structured error の narrowing helper。
+ *
+ * Tauri は Rust 側の `error::AppError` (`gui/src-tauri/src/error.rs`) を
+ * `serde::Serialize` 経由で JSON object として frontend に渡す。invoke 失敗時
+ * の Promise reject value はその object そのもの:
+ *
+ *   { code: "io.file_not_found", message: "...", hint?: "...", stacktrace?: "..." }
+ *
+ * 旧実装は `Err("...".to_string())` で raw String を返していたため、catch ブロッ
+ * クは `e instanceof Error ? e.message : String(e)` で文字列化していた。本
+ * ヘルパーは structured AppError (PR #665 で全 23 commands を migration) と
+ * legacy raw String の両方に対応する。
+ *
+ * 詳細フォーマットは `docs/tauri-commands.md` 参照。
+ */
+
+export interface AppError {
+  code: string;
+  message: string;
+  hint?: string;
+  stacktrace?: string;
+}
+
+/** invoke の reject value が AppError object かを判定する type guard。 */
+export function isAppError(e: unknown): e is AppError {
+  if (typeof e !== 'object' || e === null) return false;
+  const obj = e as Record<string, unknown>;
+  return typeof obj.code === 'string' && typeof obj.message === 'string';
+}
+
+/**
+ * invoke の reject value から user-facing message を取り出す。
+ * - AppError → `e.message`
+ * - Error instance → `e.message`
+ * - その他 (legacy raw String 等) → `String(e)`
+ */
+export function appErrorMessage(e: unknown): string {
+  if (isAppError(e)) return e.message;
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+/**
+ * AppError の `code` が `expected` と一致するかを判定。
+ * legacy raw String や非 AppError では false (= 「該当 code ではない」) を返すので
+ * 安全に分岐に使える。
+ */
+export function appErrorCodeIs(e: unknown, expected: string): boolean {
+  return isAppError(e) && e.code === expected;
+}
+
+/**
+ * AppError の hint があれば返す。なければ null。UI で「対処ヒント」を出す
+ * ときに使う想定。
+ */
+export function appErrorHint(e: unknown): string | null {
+  return isAppError(e) && typeof e.hint === 'string' ? e.hint : null;
+}

--- a/gui/src/lib/appError.ts
+++ b/gui/src/lib/appError.ts
@@ -52,8 +52,13 @@ export function appErrorCodeIs(e: unknown, expected: string): boolean {
 }
 
 /**
- * AppError の hint があれば返す。なければ null。UI で「対処ヒント」を出す
- * ときに使う想定。
+ * AppError の hint があれば返す。なければ null。UI で「対処ヒント」を出すための helper。
+ *
+ * **将来用** — 現状 production の Rust 側 AppError コンストラクタは hint を
+ * 設定しない (PR #665 Round 2 課題 5 (c) で保留決定)。lib.rs 側の主要
+ * AppError::new(...) 箇所に `with_hint(...)` を後付けで配る小規模拡張で活用
+ * 予定 (例: `state.mtime_conflict` で「他プロセスでの書き換えを確認して
+ * ください」、`io.permission_denied` で「ファイルの権限を確認してください」等)。
  */
 export function appErrorHint(e: unknown): string | null {
   return isAppError(e) && typeof e.hint === 'string' ? e.hint : null;

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { create } from 'zustand';
 
+import { appErrorCodeIs, appErrorMessage } from '../lib/appError';
 import { sampleMetadata } from '../data/sampleMetadata';
 import type { Match, Metadata, TypeOverride } from '../types/metadata';
 import { MetadataSchema } from '../types/metadata.schema';
@@ -201,8 +202,11 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       cancelDraftSave();
       await get().clearDraft();
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      if (msg.startsWith('conflict:')) {
+      const msg = appErrorMessage(e);
+      // #619: structured AppError 化以後は code-based 判定を優先。legacy raw
+      // String fallback として `msg.startsWith('conflict:')` も残す
+      // (古い command が migration 漏れしていても conflict UI を出せるよう)。
+      if (appErrorCodeIs(e, 'state.mtime_conflict') || msg.startsWith('conflict:')) {
         set({ applying: false, conflictError: msg });
       } else {
         set({ applying: false, applyError: msg });
@@ -260,7 +264,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         metadata: null,
         filePath: null,
         dirty: false,
-        loadError: e instanceof Error ? e.message : String(e),
+        loadError: appErrorMessage(e),
         hasBackup: false,
         loadedMtimeMs: null,
         conflictError: null,
@@ -331,7 +335,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
     } catch (e) {
       set({
         restoring: false,
-        restoreError: e instanceof Error ? e.message : String(e),
+        restoreError: appErrorMessage(e),
       });
     }
   },
@@ -380,7 +384,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
     } catch (e) {
       // Surface the failure via state — scheduleDraftSave's fire-and-forget
       // call would otherwise swallow the rejection silently (see F1 review).
-      set({ draftSaveError: e instanceof Error ? e.message : String(e) });
+      set({ draftSaveError: appErrorMessage(e) });
     } finally {
       set({ draftSaving: false });
     }
@@ -412,7 +416,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
     } catch (e) {
       set({
         pendingDraft: null,
-        draftLoadError: e instanceof Error ? e.message : String(e),
+        draftLoadError: appErrorMessage(e),
       });
     }
   },

--- a/gui/src/state/recentStore.ts
+++ b/gui/src/state/recentStore.ts
@@ -1,6 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
 import { create } from 'zustand';
 
+import { appErrorMessage } from '../lib/appError';
+
 /**
  * #571 — single entry in the persisted recent-videos history. Mirrors the
  * Rust `RecentEntry` struct (lib.rs).
@@ -56,7 +58,7 @@ export const useRecentStore = create<RecentState>((set) => ({
       set({ entries, loaded: true, loadError: null });
     } catch (e) {
       set({
-        loadError: e instanceof Error ? e.message : String(e),
+        loadError: appErrorMessage(e),
         loaded: true,
       });
     }
@@ -70,7 +72,7 @@ export const useRecentStore = create<RecentState>((set) => ({
         : [];
       set({ entries, addError: null });
     } catch (e) {
-      set({ addError: e instanceof Error ? e.message : String(e) });
+      set({ addError: appErrorMessage(e) });
     }
   },
 


### PR DESCRIPTION
## Summary

- `docs/tauri-commands.md` を新設。`gui/src-tauri/src/lib.rs` 内の全 **23 件** の `#[tauri::command]` を 1 つの table に集約 (command 名 / params / Result type / 分類タグ / 想定エラー / AppError code)
- **legacy 23 command を全て `Result<T, String>` → `Result<T, AppError>` に migrate** (Round 1 Review 課題 2 対応)。Rust 側 80+ Err 構築箇所、frontend 側 catch narrowing helper、test 16 件を含む
- `docs/system-architecture.md` に 3 箇所 link 追加 (冒頭横断 list / §2.4 video 配信 / §6 関連 doc)
- `.github/workflows/ci.yml` に `doc-tauri-commands-drift` job 追加 (lib.rs の `#[tauri::command]` 直後の関数名と doc table 1 列目を sort -u + diff で照合し drift で CI fail)

## エラー型 migration の実装内容

### Rust 側 (`gui/src-tauri/src/error.rs` + `lib.rs`)
- `error.rs` に `From<std::io::Error>` / `From<serde_json::Error>` / `From<String>` / `From<&str>` impl を追加。`?` 演算子で各種 error → AppError を自動変換可能。`std::io::Error` は `ErrorKind` から domain code を派生 (`NotFound` → `io.file_not_found`、`PermissionDenied` → `io.permission_denied`、etc.)
- `lib.rs` の全 23 command + 関連 helper の戻り値型を `Result<T, AppError>` に変更。各 Err 構築箇所に doc table 「AppError code」列の domain.error_kind 命名を適用 (`io.file_not_found` / `parse.json_invalid` / `state.mtime_conflict` / `ffmpeg.encoder_init_failed` / `subprocess.exit_failed` 等)
- 既存 unit test 16 サイトを `err.contains(...)` → `err.message.contains(...)` に更新 (3 箇所は `err.starts_with` → `err.message.starts_with`)

### Frontend 側 (`gui/src/lib/appError.ts` 新設 + `state/*.ts`)
- `gui/src/lib/appError.ts` 新設: `AppError` 型 + `isAppError(e)` type guard + `appErrorMessage(e)` / `appErrorCodeIs(e, code)` / `appErrorHint(e)` helper
- `metadataStore.ts`: 7 catch サイトで `appErrorMessage(e)` を使用。apply の conflict 判定を code-based (`state.mtime_conflict`) に変更 (legacy raw String fallback 用に `msg.startsWith('conflict:')` も併存)
- `recentStore.ts`: 2 catch サイトで `appErrorMessage(e)` 採用

### Doc
- `docs/tauri-commands.md` §エラー型 を「migration 完了」状態に更新。Result type 列を `Result<T, AppError>` に置換。frontend narrowing 使用例 (`appErrorCodeIs`) と `?` 演算子自動変換の説明を追加

## 受け入れ条件 (issue #619)

- [x] `docs/tauri-commands.md` を新設し、すべての `#[command]` を以下フォーマットで一覧化:
  - command 名 / params / Result type → table 列 1-4
  - 想定エラーケース (file not found / permission / json parse fail / ffmpeg fail 等) → table 列 6
  - 対応する AppError code (#614 で定義される struct と整合) → table 列 7。**実装と整合する domain.error_kind 形式**で記載。AppError は struct + 自由 string code 形式 (enum ではない、PR #661 確定)
  - 「pure / I/O / subprocess / state-mutating」分類タグ → table 列 5
- [x] `gui/src-tauri/src/lib.rs` と doc の差分を CI で簡易 grep 検査 (command 名漏れ防止) → `.github/workflows/ci.yml` の `doc-tauri-commands-drift` job、Round 1 Review 課題 1 で行数比較 → command 名 set-diff にリッチ化済 (commit 26e6e7b)
- [x] `docs/system-architecture.md` から本 doc への参照リンク追加 → 冒頭横断 list / §2.4 / §6 の 3 箇所
- [x] 本 doc が plan: ethereal-skipping-goose の W1-9 (W1-6 完了後) で実施される → commit message に明記、W1-6 = #614 は 2026-04-30 に PR #661 でクローズ済

## ローカル検証

```bash
# Rust
cd gui/src-tauri && cargo check    # pass
cd gui/src-tauri && cargo test --lib    # 149 passed; 0 failed

# Frontend
cd gui && npm run typecheck    # pass
cd gui && npm test -- --run    # 566 passed

# CI drift check (ローカル dry-run)
LIB=23 DOC=23 (name-level diff exit=0)
```

## Test plan (レビュアー検証項目)

> `pr-checklist` workflow 衝突回避のため bullet 記法 (詳細は #624)。

- CI 全 job (gui-rust / gui-frontend / doc-tauri-commands-drift / markdownlint / installer-pester / python / validate-checklist) が緑
- レビュー観点:
  - (a) 各 command の Err call site で AppError code 命名が doc table と整合しているか
  - (b) frontend narrowing helper (`appErrorMessage` / `appErrorCodeIs`) の使用パターンが妥当か
  - (c) 旧 `msg.startsWith('conflict:')` が削除ではなく code-based 判定との fallback として併存している点 (途中 migration 状態でも UI が壊れないため)
- `docs/system-architecture.md` の 3 箇所 link が rendered で機能することを確認

## Round 1 Review 対応 ([upbeat-agnesi-df6bf8])

- 課題 1 (CI drift check robustness): commit `26e6e7b` で行数比較 → command 名 set-diff に強化済 (awk + sort -u + diff -u、Windows + Linux 両環境 portable)
- 課題 2 (legacy 23 command の AppError migration): commit `ea9bca9` で全 commands + frontend narrowing + doc 更新まで完遂

## 関連

- Refs #619
- 依存先 (完了済): #614 (PR #661, 2026-04-30 クローズ済) — AppError struct の定義元
- plan: ethereal-skipping-goose Wave 1 W1-9
- pr-checklist workflow 矛盾は #624 で別途追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)
