### PR TITLE
fix(gui): scorebar 分類進捗を Refining bar に統合 (Refs #664)

### DIFF
--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -663,6 +663,87 @@ describe('DetectingScreen', () => {
     ).toContain('No match boundaries detected.');
   });
 
+  // #664 -- Refining bar に scorebar 分類進捗を統合する。refine 完了
+  // (progress=88) では bar 100% に達せず ~67% で止まり、scorebar が
+  // 完了 (progress=97) して初めて bar 100% になる。pct1/pct2 の終端は
+  // PHASE_WINDOWS から導出する形に変更したため、PHASE_WINDOWS の重みを
+  // 後で再調整しても bar の式は追従する。
+  it('Refining bar reaches ~67% at refine completion (#664)', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+    act(() => {
+      // refine 完了 = progress 88 (PHASE_WINDOWS.refine[1])。
+      // pct2 = (88 - 70) / (97 - 70) * 100 ≈ 66.67% → round = 67%
+      emitDetectProgress({ phase: 'refine', completed: 4, total: 4 });
+    });
+    const refiningRow = screen.getByTestId('phase-row-refining');
+    expect(refiningRow.textContent).toContain('67%');
+    expect(refiningRow.textContent).not.toContain('100%');
+  });
+
+  it('Refining bar reaches 100% at scorebar completion (#664)', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+    act(() => {
+      // scorebar 完了 = progress 97 (PHASE_WINDOWS.scorebar[1])。
+      // pct2 = (97 - 70) / (97 - 70) * 100 = 100%
+      emitDetectProgress({ phase: 'scorebar', completed: 35, total: 35 });
+    });
+    const refiningRow = screen.getByTestId('phase-row-refining');
+    expect(refiningRow.textContent).toContain('100%');
+  });
+
+  it('Refining sub label switches refine -> 分類 across phases (#664)', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(listenMock).toHaveBeenCalled();
+    });
+
+    // refine phase 中: sub = "refine"
+    act(() => {
+      emitDetectProgress({ phase: 'refine', completed: 1, total: 4 });
+    });
+    let refiningRow = screen.getByTestId('phase-row-refining');
+    expect(refiningRow.textContent).toContain('refine');
+    expect(refiningRow.textContent).not.toContain('分類');
+
+    // scorebar phase に遷移すると sub が "分類" に切替
+    act(() => {
+      emitDetectProgress({ phase: 'scorebar', completed: 1, total: 35 });
+    });
+    refiningRow = screen.getByTestId('phase-row-refining');
+    expect(refiningRow.textContent).toContain('分類');
+    expect(refiningRow.textContent).not.toContain('refine');
+  });
+
   it('falls back to loadSample when no video is selected (StateSwitcher dev mode)', async () => {
     // Reset to a clean state without selectedVideoPath -- mimics the
     // StateSwitcher hopping straight into "detecting" without going

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -527,8 +527,20 @@ function DetectingRunningView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const pct1 = Math.min(100, progress * (100 / 70)); // scan finishes at 70%
-  const pct2 = Math.max(0, Math.min(100, ((progress - 70) * 100) / 18)); // refine fills 70-88
+  // #664 -- Refining bar は refine + scorebar を統合表示する。pct2 100%
+  // = refine + scorebar 両方完了。refine 完了 (progress=88) で bar ~67%
+  // 程度に達し、scorebar 進行で bar 67→100% に進む。PHASE_WINDOWS の
+  // 重み (refine 18 : scorebar 9 ≒ 67:33) は維持し全体 %/ETA に regression
+  // なし。定数二重管理を避けるため両 bar の終端を PHASE_WINDOWS から導出。
+  const scanEnd = PHASE_WINDOWS.scan[1];
+  const refineStart = PHASE_WINDOWS.refine[0];
+  const refiningEnd = PHASE_WINDOWS.scorebar[1];
+  const pct1 = Math.min(100, (progress * 100) / scanEnd);
+  const pct2 = Math.max(
+    0,
+    Math.min(100, ((progress - refineStart) * 100) / (refiningEnd - refineStart)),
+  );
+  const refiningSub = phaseLabel === 'scorebar' ? '分類' : 'refine';
 
   const displayFile = selectedVideoPath?.split(/[/\\]/).pop() ?? '(video)';
   const eta = computeEta(progress, elapsed);
@@ -561,7 +573,7 @@ function DetectingRunningView({
 
       <div className={styles.phases}>
         <PhaseRow name="Detecting" jp="粗スキャン" pct={pct1} sub="scan" />
-        <PhaseRow name="Refining" jp="精密計測" pct={pct2} sub="refine" />
+        <PhaseRow name="Refining" jp="精密計測" pct={pct2} sub={refiningSub} />
       </div>
 
       <div className={styles.divider} />
@@ -653,7 +665,10 @@ function PhaseRow({ name, jp, pct, sub }: PhaseRowProps) {
   const fillClass =
     pct >= 100 ? `${styles.barFill} ${styles.barFillDone}` : styles.barFill;
   return (
-    <div className={styles.phaseRow}>
+    <div
+      className={styles.phaseRow}
+      data-testid={`phase-row-${name.toLowerCase()}`}
+    >
       <div className={styles.phaseLabel}>
         <span className={`${styles.phaseName} ${className}`}>{name}</span>
         <span className={styles.phaseJp}>{jp}</span>


### PR DESCRIPTION
## Summary

DetectingScreen の Refining (精密計測) bar が Pass 2 refine 完了で 100% に達した後、scorebar 分類処理 (~90-120 秒) が bar に反映されず「両方 100% なのに作業が続いている」体感問題があった。Refining bar の終端を scorebar 完了まで延長し、bar 100% = 精密計測 + 分類両方完了 にする。

## 関連 issue

Refs #664 (本 PR で受け入れ条件全項目を満たす想定。`Closes` キーワードは付けず手動クローズ)

## 変更点

- `gui/src/screens/DetectingScreen.tsx`
  - `pct2` 計算式を refine [70-88] から refine + scorebar [70-97] に拡張
  - `pct1` / `pct2` の終端を `PHASE_WINDOWS` から導出 (定数二重管理防止)
  - `PhaseRow` の `sub` を `phase=scorebar` のとき `分類` に動的切替
  - `PhaseRow` に `data-testid` を追加 (テストから行を取得可能に)
- `gui/src/screens/DetectingScreen.test.tsx`
  - `pct2` 境界値テスト 2 件追加 (refine 完了 67% / scorebar 完了 100%)
  - sub ラベル切替テスト 1 件追加 (refine→分類)

## 影響範囲 / regression

- `PHASE_WINDOWS` の値は不変。`computeOverallPercent` / `computeEta` のロジックも不変 (全体 % / ETA に regression なし)
- CLI / Tauri Rust 側への変更なし
- 既存 537 件のテストは全 pass を確認

## ベース同期確認 (Iron Law 6 サブ条 #659)

- `git fetch origin develop-0.2.0` 実施
- 取り込み未済 commit: `9f504af feat(gui): GUI クラッシュ・エラー伝搬ハンドリング (Refs #614) (#661)`
- 当 PR の touched files (`gui/src/screens/DetectingScreen.tsx`, `gui/src/screens/DetectingScreen.test.tsx`) と #661 の touched files (ErrorBoundary / ErrorModal / globalErrorListener / errorStore / main.tsx / src-tauri/* / docs/* / .github/*) は**交差なし**
- → `git merge origin/develop-0.2.0` skip (規約: 交差なしの場合 skip 可)
- 並行 worktree PR 検索 (`gh pr list --search "664 in:title,body"`): 該当なし

## Self-Test Report

machine-verified (PR 提出前に実行 pass を確認):

- [x] `npm run lint` (eslint .)
- [x] `npm run typecheck` (tsc --noEmit)
- [x] `npm test` (vitest run, 537 tests / 39 files passed; 新規 3 テストも全 pass)
- [x] `npm run build` (vite build, dist 生成 OK)

machine-unverifiable (Idios 実機検証):

- 実機 Tauri 起動 (`npm run tauri dev`) で長時間動画 (1:25:22 / 1080p / 60fps) を detect:
  - Refining bar が refine 中 0→~67%、scorebar 中 ~67→100% に推移するのを目視確認 → OK
  - sub ラベルが refine → 分類 に切り替わるのを目視確認 → OK
  - 全体 %, ETA に regression なしを目視確認 → OK

## Test plan

- [x] vitest 自動テスト全 pass
- [x] 実機 Tauri 起動で Refining bar 推移 (refine→scorebar 統合) 確認
- [x] 実機 Tauri 起動で sub ラベル切替 (refine→分類) 確認
- [x] 全体 % / ETA に regression なしを確認

## スコープ外 (#664 で別 issue 起票なしで保留)

- `PHASE_WINDOWS` の重み再調整 (refine/scorebar 比を実機データに厳密一致)
- audio phase ([3, 60]) の Refining bar 統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)
