### PR TITLE
refactor(skill): /review-pr の checkout 禁止を read 目的に緩和 (Refs #673)

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -28,7 +28,7 @@ gh pr diff $ARGUMENTS
 
 CI green は **内部整合性のみ** を保証し、base 取り込み時の機能 regression や並行 worktree PR 重複は検出できない。Step 3 (受け入れ条件) に入る前に、base 最新化 + 直近マージ PR 影響 + 並行 PR 重複を必ず確認する。
 
-> read-only 操作のみで完結するため、本 SKILL 冒頭「重要」節 (PR ブランチ編集禁止) と整合する。`git checkout` / `git merge` / `git rebase` / `git push` は本 step でも一切実行しない。
+> read-only 操作のみで完結するため、本 SKILL 冒頭「重要」節 (PR ブランチ書き込み禁止) と整合する。`git merge` / `git rebase` / `git push` は本 step でも一切実行しない。`git checkout` は冒頭の方針に従い read 目的でのみ許可だが、Step 2 (base 同期確認) は `gh` / `git fetch` / `git log` で完結するため checkout する必要はない。
 
 #### 2.1 ベースブランチ形式確認
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -9,9 +9,11 @@ argument-hint: <PR番号>
 
 ## 重要: このスキルは「レビュー専用セッション」として動作する
 
-`/review-pr` で起動されたセッションは PR ブランチへの `git checkout` / `Edit` / `Write` / `git commit` / `git push` を一切行わない。指摘事項は PR コメントで PR 作成セッションに依頼する (セッション間の責務分離を維持する)。
+`/review-pr` で起動されたセッションは PR ブランチへの **書き込み系操作 (`Edit` / `Write` / `git commit` / `git push`) を一切行わない**。指摘事項は PR コメントで PR 作成セッションに依頼する (セッション間の責務分離を維持する)。
 
-背景: 2026-04-22 PR #490 / #495 レビュー時、レビューセッションが合意なく修正 commit & push を実施したため明示的な訂正を受けた。PR ブランチ・PR 本文は PR 作成セッションの作業領域で、レビューセッションは観察・指摘・依頼に徹する。
+`git checkout` 自体は read 系操作のため、**ソースを読む目的でのみ許可する** (例: `gh pr diff` だけでは追えない複数ファイル横断の相互参照を IDE で開いて読みたい場合)。ただし checkout 後も `Edit` / `Write` / `git commit` / `git push` は依然禁止。現 worktree のブランチを切り替えたくない場合は `git worktree add ../<name> <PR-branch>` で別 worktree を立てて読む方法も取れる。
+
+背景: 2026-04-22 PR #490 / #495 レビュー時、レビューセッションが合意なく修正 commit & push を実施したため明示的な訂正を受けた (#505)。PR ブランチ・PR 本文は PR 作成セッションの作業領域で、レビューセッションは観察・指摘・依頼に徹する。本質は「書き込みによる責務分離破り」を防ぐことで、checkout 単体は責務分離を破らないため #673 で read 目的に限り許可へ緩和した。
 
 ## 手順
 
@@ -307,7 +309,7 @@ Step 5b のトリアージ表を前提に `AskUserQuestion` で以下を提示�
 
 ### 修正依頼コメント投稿 (修正依頼時)
 
-レビュー専用セッションは PR ブランチを編集せず、PR コメントで PR 作成セッションに修正を依頼する。**`git checkout <PR-branch>` / `Edit` / `Write` / `git commit` / `git push` は行わない**。
+レビュー専用セッションは PR ブランチを編集せず、PR コメントで PR 作成セッションに修正を依頼する。**`Edit` / `Write` / `git commit` / `git push` は行わない** (書き込み系の禁止)。`git checkout <PR-branch>` 自体は read 目的なら可だが、checkout 後も `Edit` / `Write` / `git commit` / `git push` に滑らないこと (詳細は本ファイル冒頭「重要」節参照)。
 
 1. PR コメントで具体的な修正指示を記録する。コメント本文には次の要素を含める:
 

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -547,7 +547,7 @@ Plan モードで計画合意 → 実装 (TodoWrite で進捗管理) → PR 作�
 修正が必要な場合の扱いは起動コンテキストで分ける:
 
 - **PR 作成と同一セッションで `/review-pr` を呼んだ場合**: 同セッション内で PR ブランチに追加コミットを積み、再度 `/review-pr` を呼び出す。
-- **レビュー専用セッション (セッション先頭で `/review-pr` のみ実行) の場合**: PR ブランチへの `git checkout` / `Edit` / `commit` / `push` は一切行わず、PR コメントで PR 作成セッションに具体的な修正指示を依頼する。PR 作成セッションが修正 commit & push した後、別セッション or 同レビューセッションで `/review-pr` を再実行して受け入れ条件を再確認する。詳細は `.claude/skills/review-pr/SKILL.md` §「修正依頼コメント投稿」を参照。
+- **レビュー専用セッション (セッション先頭で `/review-pr` のみ実行) の場合**: PR ブランチへの **書き込み系操作 (`Edit` / `commit` / `push`) は一切行わず**、PR コメントで PR 作成セッションに具体的な修正指示を依頼する (`git checkout` 自体は read 目的なら可。詳細は `.claude/skills/review-pr/SKILL.md` 冒頭「重要」節参照)。PR 作成セッションが修正 commit & push した後、別セッション or 同レビューセッションで `/review-pr` を再実行して受け入れ条件を再確認する。詳細は `.claude/skills/review-pr/SKILL.md` §「修正依頼コメント投稿」を参照。
 
 ## worktree メンテナンス (#477)
 


### PR DESCRIPTION
Refs #673 / 部分上書き #505

## 概要

`/review-pr` skill の「レビュー専用セッション」制約で `git checkout` が `Edit` / `Write` / `git commit` / `git push` と一括で「一切行わない」とされていたが、checkout 自体は read 系操作で責務分離を破らない。書き込み系 (`Edit` / `Write` / `git commit` / `git push`) のみを明示禁止し、`git checkout` は read 目的なら許可するよう記述を緩和した。

## 変更内容

`.claude/skills/review-pr/SKILL.md` 内の 2 箇所を緩和、Red flags 表の該当行は文言維持:

| # | 箇所 | 変更内容 |
|---|---|---|
| 1 | 冒頭「重要: このスキルは『レビュー専用セッション』として動作する」節 | 禁止リストから `git checkout` を除外 + read 目的限定で許可する旨と推奨パターン (`git worktree add` での別 worktree 立ち上げ) を追記 |
| 2 | Step 7「修正依頼コメント投稿」節 | 禁止リストから `git checkout <PR-branch>` を除外 + read 目的なら可、ただし checkout 後も Edit/Write/commit/push に滑らないことを明記 |
| 3 | Red flags 表「PR ブランチを checkout して自分で修正した方が速い」行 | **文言維持** (緩和は read までで、「checkout → 自分で修正」思考は依然 NG) |

## 背景

#505 で PR #490/#495 のインシデント (レビューセッションが合意なく修正 commit & push した) を受けて「レビュー専用セッション前提」を一本化した際、禁止リストに `git checkout` も含めた。本質的に防ぎたいのは「書き込みによる責務分離破り」で、`git checkout` 単体は責務分離を破らない。ノート PC + Windows セッションで `gh pr diff` だけでは追えないケースもあり、checkout して IDE で読む選択肢を残したい。ユーザー (Idios) と確認の上で緩和合意。

## 受け入れ条件と Self-Test Report

#673 受け入れ条件 6 項目に対し、自動検証可能な項目は `[x]` (machine-verified)、人間レビュー対象は plain bullet で記載 (l2-workflow §「Self-Test Report 規約」):

- [x] markdownlint pass (`bash scripts/check-markdownlint.sh` で 65 ファイル 0 errors)
- 冒頭「重要」節の禁止リストから `git checkout` を除外し、「read 目的なら可」を明示 → SKILL.md L11-L15 で確認可
- Step 7 の禁止リストから `git checkout <PR-branch>` を除外し、read 目的なら可と明示 → SKILL.md L312 で確認可
- Red flags 表の該当行は文言維持 → SKILL.md L520 で確認可
- 推奨パターンを補足 (別 worktree 展開 / checkout 後も Edit/Write 禁止再確認) → SKILL.md L13, L312 で確認可
- PR 本文で #505 を Refs し「逆方向の部分上書き」を明記 → 本 PR 冒頭 + 「背景」節で記載

## 実機検証 trigger

該当なし (ロジック変更を含まない skill ドキュメント編集のみ)。

## Pre-flight チェック

- `git fetch origin develop-0.2.0` 実行: base 取り込み未済 commit ゼロ (HEAD は develop-0.2.0 と up-to-date)
- `gh pr list --search "673"`: 並行 PR 検出ゼロ
- 変更 path: `.claude/skills/review-pr/SKILL.md` のみ → Python / GUI / installer 自動チェックは対象外

[vigilant-williamson-cb2809]
