### PR TITLE
docs: L2 (v0.2.0) 残作業 roadmap (8 brainstorming groups)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,23 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/ffmpeg.tar.xz
-          key: btbn-ffmpeg-linux64-lgpl-shared-8.1-d3b400378b8180fcc59249331ce03c75520404d9e62f950e4eb827f810cc7c53
+          key: btbn-ffmpeg-linux64-lgpl-shared-8.1-ec7546052026c12079e5bc4c69ff811c40f5b44610d8854cca17dda8e192529f
 
       - name: Download FFmpeg archive (cache miss)
         if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL -o /tmp/ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-22-13-15/ffmpeg-n8.1-10-g7f5c90f77e-linux64-lgpl-shared-8.1.tar.xz"
+          # BtbN は nightly autobuild を一定期間で削除するため URL pin が陳腐化する。
+          # 上流が `n8.1.1` (FFmpeg patch release) に切り替わった (2026-05-06 build)。
+          # 長期対応は #681 (versioned URL or .sha256 動的検証) で追跡。短期 fix のみ本 PR で実施。
+          curl -fsSL -o /tmp/ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-05-06-13-32/ffmpeg-n8.1.1-linux64-lgpl-shared-8.1.tar.xz"
 
       - name: Install ffmpeg (BtbN LGPLv3 n8.1 shared, pinned)
         shell: bash
         run: |
           set -euo pipefail
-          FFMPEG_SHA256="d3b400378b8180fcc59249331ce03c75520404d9e62f950e4eb827f810cc7c53"
+          FFMPEG_SHA256="ec7546052026c12079e5bc4c69ff811c40f5b44610d8854cca17dda8e192529f"
           echo "$FFMPEG_SHA256  /tmp/ffmpeg.tar.xz" | sha256sum -c -
           mkdir -p /tmp/ffmpeg
           tar -xJf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg --strip-components=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/build-cache
-          key: btbn-ffmpeg-win64-lgpl-shared-8.1-fef865cab8a097f07f1dcba66d73be94742b79d952cf6fd8643bd42c18995034
+          key: btbn-ffmpeg-win64-lgpl-shared-8.1-16f409ab737538778f9cd4bfc69953e2e1dc2558f6dc5ca17cc72083d60dc735
 
       - name: Install GUI dependencies (#570)
         shell: pwsh

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -389,7 +389,7 @@ CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージ�
 | `scripts/build-portable-zip.ps1` | `$PythonVersion = '3.11.9'` + `$PythonEmbedSha256` |
 | `docs/developer-setup.md` §1 | 「Python 3.11 (3.11.9 推奨)」の記載 |
 
-### FFmpeg (現在 BtbN LGPLv3 n8.1 shared / `autobuild-2026-04-22-13-15` に固定)
+### FFmpeg (現在 BtbN LGPLv3 n8.1 shared / `autobuild-2026-05-06-13-32` に固定)
 
 更新手順:
 
@@ -410,7 +410,7 @@ CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージ�
 | `.github/workflows/ci.yml` (`Cache FFmpeg archive` / `Download FFmpeg archive (cache miss)` / `Install ffmpeg` の 3 ステップ) | cache `key` 内 SHA256 + DL step の URL + install step の `FFMPEG_SHA256` (linux64-lgpl-shared 版) |
 | `.github/workflows/release.yml` (`Cache FFmpeg archive` ステップ) | cache `key` 内 SHA256 (win64-lgpl-shared 版、build-portable-zip.ps1 の SHA256 と同じ値) |
 | `docs/developer-setup.md` §1 | 「ffmpeg / ffprobe 8.1 LGPLv3 推奨」「推奨: ffmpeg 8.1 LGPLv3」の major version 記述 (系列変更時のみ) |
-| `docs/quickstart.md` §10 | 対応 FFmpeg コミット (例: `7f5c90f77e`) の記述 (upstream commit 変更時) |
+| `docs/quickstart.md` §10 | 対応 FFmpeg ソース ref (例: `n8.1.1` release tag、または旧 format での commit hash `7f5c90f77e`) の記述 (upstream ref 変更時) |
 
 ### get-pip.py の hash drift 対応 (#649)
 

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -406,7 +406,7 @@ CI / Portable ZIP / 開発環境の 3 環境で Python と FFmpeg のバージ�
 
 | 場所 | キー |
 | --- | --- |
-| `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` (`$FFmpegSourceCommit` は asset 名から自動抽出) |
+| `scripts/build-portable-zip.ps1` | `$FFmpegBuildTag` / `$FFmpegAsset` / `$FFmpegSha256` (`$FFmpegSourceRef` は asset 名から自動抽出) |
 | `.github/workflows/ci.yml` (`Cache FFmpeg archive` / `Download FFmpeg archive (cache miss)` / `Install ffmpeg` の 3 ステップ) | cache `key` 内 SHA256 + DL step の URL + install step の `FFMPEG_SHA256` (linux64-lgpl-shared 版) |
 | `.github/workflows/release.yml` (`Cache FFmpeg archive` ステップ) | cache `key` 内 SHA256 (win64-lgpl-shared 版、build-portable-zip.ps1 の SHA256 と同じ値) |
 | `docs/developer-setup.md` §1 | 「ffmpeg / ffprobe 8.1 LGPLv3 推奨」「推奨: ffmpeg 8.1 LGPLv3」の major version 記述 (系列変更時のみ) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -148,6 +148,6 @@ Portable ZIP には以下のソフトウェアが同梱されています。詳�
 - **Python**: PSF License (`python\LICENSE.txt`)
 - **FFmpeg**: LGPLv3 (`ffmpeg\LICENSE.txt` に全文)
   - ビルド: [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) の win64-lgpl-shared build
-  - 対応 FFmpeg コミット: [git.ffmpeg.org](https://git.ffmpeg.org/ffmpeg.git) の commit `7f5c90f77e` (v8.1 系列)
+  - 対応 FFmpeg ソース ref: [git.ffmpeg.org](https://git.ffmpeg.org/ffmpeg.git) の release tag `n8.1.1` (v8.1 系列)
 
 allaganeye 本体 (MIT) は FFmpeg バイナリをサブプロセスとしてのみ呼び出しているため、LGPLv3 の linking 制約は allaganeye 本体には及びません。同梱している shared-build DLL は FFmpeg 実行ファイルが動的にロードし、LGPLv3 の配布条件は同梱ライセンステキストで充足しています。

--- a/docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md
+++ b/docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md
@@ -127,6 +127,115 @@ wave 3 (release gate):
 /superpowers:brainstorming Group H の問題を解決したい (#643 #365 lint + CLI)
 ```
 
+## 3-bis. Lane 構造 (複数セッション並行運用)
+
+複数の Claude Code session を立ち上げて並行作業する場合の lane 設計。各 lane は独立した worktree (`.claude/worktrees/<auto-name>/`) で動かし、ファイル衝突を回避できる単位を `Lane I-A` / `Lane IV-a` 等の lane id で区別する。
+
+### file 共有 matrix (衝突回避の根拠)
+
+| group | `lib.rs` | `PreviewScreen` | `ExportScreen` | `ErrorModal` | 横断 (全画面) | `build-portable-zip.ps1` | `.eslintrc` | workflow yml | Python CLI |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| A (#663) | 全 17 command | | | | | | | | |
+| B (#679 #648 #644) | 3 command | | | | | | | | |
+| C (#633 #645 #677) | | ✓ | (#633) | | | | | | |
+| D (#678 #669) | | | ✓ (#678) | ✓ | | | | | |
+| E #680 | | | ✓ | | | | | | |
+| E #676 | | path | path | | 全画面 path | | | | |
+| F (#617 #616 #668 #681) | | | | | | ✓ | | ✓ #616 | |
+| G (#624 #458 #682) | | | | | | | | ✓ #624 | |
+| H #643 | | | | | (lint で全 TS 影響) | | ✓ | | |
+| H #365 | | | | | | | | | ✓ |
+
+### Lane 配置 (4 wave 設計)
+
+```text
+═══════════════════════════════════════════════════════════════════════════
+wave 0  (4 並行 lane、起点 + 独立 polish)
+═══════════════════════════════════════════════════════════════════════════
+  Lane I-A   [Rust backend 起点]   Group A (#663)
+             1 spec / 1 章、wave 1 Lane I-B の前提
+             PR #661 で確立した template に倣う
+
+  Lane IV-a  [配布 / installer]    Group F (#617 #616 #668 #681)
+             1 spec / 4 章 (or 4 PR 並行)
+             #681 (BtbN URL / get-pip.py 長期対応) に PR #683 短期 fix を吸収
+
+  Lane IV-b  [workflow / CI / docs] Group G (#624 #458 #682)
+             1 spec / 3 章 (or 3 PR 並行)
+
+  Lane IV-c  [lint / CLI polish]   Group H (#643 #365)
+             1 spec / 2 章
+             ESLint config + 違反箇所 / allaganeye CLI progress bar
+
+═══════════════════════════════════════════════════════════════════════════
+wave 1  (Lane I-A merge 後、3 並行 lane、メイン実装層)
+═══════════════════════════════════════════════════════════════════════════
+  Lane I-B   [Rust backend 直列]   Group B (#679 → #648 → #644)
+             1 spec / 3 章、Group A AppError 経路に乗る
+
+  Lane II-a  [TS / PreviewScreen]  Group C (#633 → #645 → #677)
+             1 spec / 3 章、PreviewScreen 共有で直列必須
+
+  Lane II-b  [TS / ExportScreen]   Group D + E#680 統合 (#678 → #669 → #680)
+             1 spec / 3 章、ExportScreen 共有で直列、ErrorModal は局所だが
+             error mapping → テンプレ埋込の自然な流れ
+
+═══════════════════════════════════════════════════════════════════════════
+wave 2  (Lane II マージ後、1 lane、横断 cleanup)
+═══════════════════════════════════════════════════════════════════════════
+  Lane III   [横断 UI cleanup]     Group E #676 (file path 全画面横断)
+             1 spec / 1 章、wave 1 の TS lane 完走後
+
+═══════════════════════════════════════════════════════════════════════════
+wave 3  (release gate)
+═══════════════════════════════════════════════════════════════════════════
+  - docs/l2-e2e-checklist.md 全項目 PASS (Idios 実機検証)
+  - 全 PR マージ確認
+  - /release skill で v0.2.0 タグ + GitHub Release
+═══════════════════════════════════════════════════════════════════════════
+```
+
+### 各 wave の同時並行 worktree 数
+
+| wave | 並行 worktree 数 | 主目的 |
+| --- | --- | --- |
+| wave 0 | **4** | A 起点 + F / G / H 独立 polish |
+| wave 1 | **3** | B (lib.rs) / C (Preview) / D+E#680 (Export) |
+| wave 2 | **1** | 横断 UI cleanup |
+| wave 3 | — | release gate (Idios 実機 + /release) |
+
+最大並行度 = 4 (wave 0)。
+
+### 各 Lane の brainstorming 入り口
+
+新しい Claude Code session を立ち上げて、各 lane の入り口で `superpowers:brainstorming` を起動する:
+
+```text
+# wave 0 (4 並行 OK)
+/superpowers:brainstorming Lane I-A: Group A の問題を解決したい (#663 AppError migration、PR #661 template に倣う)
+/superpowers:brainstorming Lane IV-a: Group F の問題を解決したい (#617 #616 #668 #681 配布まわり)
+/superpowers:brainstorming Lane IV-b: Group G の問題を解決したい (#624 #458 #682 workflow / CI / docs)
+/superpowers:brainstorming Lane IV-c: Group H の問題を解決したい (#643 ESLint + #365 CLI progress bar)
+
+# wave 1 (Lane I-A merged 後、3 並行 OK)
+/superpowers:brainstorming Lane I-B: Group B の問題を解決したい (#679 → #648 → #644 lib.rs 直列、Group A AppError 経路に乗る)
+/superpowers:brainstorming Lane II-a: Group C の問題を解決したい (#633 → #645 → #677 PreviewScreen UX)
+/superpowers:brainstorming Lane II-b: Group D + E#680 統合 (#678 → #669 → #680 ExportScreen + ErrorModal)
+
+# wave 2 (Lane II 完走後)
+/superpowers:brainstorming Lane III: Group E #676 (横断 file path 表示)
+```
+
+### 並行運用の実務ガイド (各セッションで)
+
+1. **Iron Law 6 PR Pre-flight** を毎回実施
+   - `git fetch origin develop-0.2.0` + 取り込み未済 commit 確認
+   - `gh pr list --state open --search "claude/"` で他 lane の進捗確認 (並行 4 worktree のため特に重要)
+2. **base 同期**: 他 lane が先に merge された場合、`git merge origin/develop-0.2.0` で取り込み後 CI 再実行 (`docs/l2-workflow.md` §PR 作成 Pre-flight 適用)
+3. **session-id**: 各 worktree path の最終ディレクトリ名を session-id として PR 本文に記載
+4. **bulk 操作禁止**: lane を跨いだ一括 close / 一括 label 付与は AskUserQuestion 必須 (Iron Law 2)
+5. **依存関係**: Lane I-A (Group A AppError) merge を待たずに Lane I-B (Group B) を開始するのは禁止 (lib.rs 衝突)
+
 ## 4. deferred / v0.2.0 対象外
 
 ### v0.2.0 外確定 (deferred ラベル維持、6 件)

--- a/docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md
+++ b/docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md
@@ -1,0 +1,184 @@
+# L2 (v0.2.0) 残作業 roadmap — 8 brainstorming groups
+
+> **Status**: v0.2.0 release ゲート向け、open issue 棚卸しと再編成
+> **作成**: 2026-05-07 / session `dazzling-mestorf-10914f`
+> **Scope**: L2 (v0.2.0) 残 open issue (本日まで Tier 0 #618 #484 / Tier 1 #653 / 親 #105 / graceful kill #523 完了)
+
+## 1. 完了済 (本日まで、本 plan の対象外)
+
+| # | スコープ | 状態 | 備考 |
+| --- | --- | --- | --- |
+| #618 | Tier 0 axum spec doc | CLOSED | PR #672 (2026-05-07) |
+| #484 | Tier 0 E2E checklist doc | CLOSED | PR #672 |
+| #653 | Tier 1 StateSwitcher dev only | CLOSED | PR #675 (2026-05-07) |
+| #523 | graceful kill | CLOSED | PR #540 + #545 (Phase 分割、ケース C)、本セッションで /close-issue |
+| #105 | GUI サポート (L2a 親 issue) | CLOSED | L2a sub-issue 14 件全 CLOSED + production build 確認、本セッションで /close-issue |
+
+## 2. v0.2.0 残作業 — 8 brainstorming groups
+
+合計 **20 issue / 8 groups**。各 group は 1 spec / 1-3 章で扱える独立 scope。
+
+### Group A: AppError migration 先行 (1 件、wave 1 起点)
+
+| # | priority | 概要 |
+| --- | --- | --- |
+| #663 | P3 (refactor) | legacy 17 Tauri command の AppError migration (PR #661 で確立した template に従う) |
+
+**並行安全度**: high (独立) / **brainstorming 単位**: 1 spec / 1 章
+**理由**: `gui/src-tauri/src/lib.rs` 17 command を AppError 移行する #663 を先行させると、Group B の Rust 修正が AppError 経路に乗る
+
+### Group B: lib.rs 系 backend bugs (3 件、Group A 後に直列)
+
+| # | priority | 概要 |
+| --- | --- | --- |
+| #679 | P2 (bug) | production build の detect で CMD 窓表示 — `Command::creation_flags(CREATE_NO_WINDOW)` |
+| #648 | P3 (bug) | `parse_detect_progress_line` の silent skip — `log::warn` + 既知 prefix doc 化 |
+| #644 | P3 (bug) | `run_split` で brightness_samples が metadata.json に書かれない — 出力 + docs 整合 |
+
+**並行安全度**: low (lib.rs 共有 → 直列) / **brainstorming 単位**: 1 spec / 3 章
+
+### Group C: PreviewScreen / sample mode UX (3 件、直列推奨)
+
+| # | priority | 概要 |
+| --- | --- | --- |
+| #633 | P2 | sample mode 全画面 read-only 化 (#589 派生) |
+| #645 | P3 | preview 微細タイムライン (±5s 輝度波形) — #465 派生 |
+| #677 | P3 (bug) | SideRail のアイコンが選択 UI に見えるが機能なし |
+
+**並行安全度**: mid (PreviewScreen 共有) / **brainstorming 単位**: 1 spec / 3 章
+**直列順**: #633 (排他ガード先行) → #645 (編集 UX 拡張後続) / #677 (独立だが画面 UI 系で同 PR 化可)
+
+### Group D: ErrorModal / Export エラー UX (2 件、PR #661 継続)
+
+| # | priority | 概要 |
+| --- | --- | --- |
+| #678 | P2 (bug) | Export 失敗時 [object Object] 表示 — error mapping 整理 |
+| #669 | P3 | ErrorModal の bug_report テンプレ自動埋込 (#458 連動) |
+
+**並行安全度**: high (ErrorModal 局所) / **brainstorming 単位**: 1 spec / 2 章
+**直列順**: #678 (error mapping を整える) → #669 (テンプレ埋込で再利用)
+
+### Group E: 横断 UI bugs (2 件、独立)
+
+| # | priority | 概要 |
+| --- | --- | --- |
+| #676 | P3 (bug) | GUI 全画面で file path 表示が不揃い — CSS / token 統一 |
+| #680 | P3 (bug) | Export 出力先 default が存在しないフォルダ — ExportScreen 局所 |
+
+**並行安全度**: high (独立 UI bug) / **brainstorming 単位**: 1 spec / 2 章
+
+### Group F: l2b 配布まわり (4 件、PR 並行可)
+
+| # | priority | 概要 |
+| --- | --- | --- |
+| #617 | P2 | `allaganeye.bat` ダブルクリックで GUI (`allaganeye-gui.exe`) 起動 |
+| #616 | P3 | CI artifact zip 名にバージョン番号付与 (`allaganeye-portable-windows-vX.Y.Z`) |
+| #668 | P2 | Portable ZIP 同梱物の起動時健全性チェック |
+| #681 | P2 | `get-pip.py` SHA pin → versioned URL / .sha256 動的検証 (PR #675 follow-up) |
+
+**並行安全度**: high (全 file 独立) / **brainstorming 単位**: 1 spec / 4 章 (or 4 PR 並行)
+
+### Group G: l2-workflow / CI / docs (3 件)
+
+| # | priority | 概要 |
+| --- | --- | --- |
+| #624 | P2 (bug) | pr-checklist が CLAUDE.md PR template の Test plan を誤検出 → CI bug |
+| #458 | P2 | bug_report.yml (同意チェック付き) 新設 — 外部ユーザー受け入れ準備 |
+| #682 | P3 | /review-pr skill: 同種パターン全件 grep + 修正の必須化 (PR #675 follow-up) |
+
+**並行安全度**: high (CI yml + skill md + issue template、独立) / **brainstorming 単位**: 1 spec / 3 章
+
+### Group H: lint / CLI 系 polish (2 件)
+
+| # | priority | 概要 |
+| --- | --- | --- |
+| #643 | P3 | ESLint `no-restricted-globals` で `window.confirm` / `alert` / `prompt` を禁止 (Tauri 2 silent loss 再発防止) |
+| #365 | bug (P3 相当、tier label 付与は本 plan で `l1-residual` → `task` に migration) | 進捗バーの ETA 表示にラベル不在 (#329 不完全修正の再対応) |
+
+**並行安全度**: high (lint config + CLI 進捗バー、独立) / **brainstorming 単位**: 1 spec / 2 章
+**注**: #365 は L1 CLI 由来 bug だが、Idios 判断で v0.2.0 内に取り込む (本セッション 2026-05-07 disposition)
+
+## 3. 推奨着手順 (依存最小、並行最大)
+
+```text
+wave 0 (即時並行可): Group F (4 件) + Group G (3 件) + Group H (2 件)
+                     = 9 issue, 3 brainstorming spec を並行
+wave 1: Group A (#663 AppError migration) 単独 → merge (Group B の前提)
+wave 2: Group B (#679 → #648 → #644 直列、lib.rs 共有)
+        並行 Group C (#633 → #645 / #677、PreviewScreen 共有)
+        並行 Group D (#678 → #669、ErrorModal 連続)
+        並行 Group E (#676 / #680、独立)
+wave 3 (release gate):
+  - docs/l2-e2e-checklist.md 全項目 PASS (Idios 実機検証)
+  - Tier 2-3 全 PR マージ確認
+  - /release skill で v0.2.0 タグ + GitHub Release
+```
+
+### 各 group の brainstorming 入り口
+
+```text
+/superpowers:brainstorming Group A の問題を解決したい (#663 AppError migration)
+/superpowers:brainstorming Group B の問題を解決したい (#679 #648 #644 lib.rs 直列)
+/superpowers:brainstorming Group C の問題を解決したい (#633 #645 #677 PreviewScreen)
+/superpowers:brainstorming Group D の問題を解決したい (#678 #669 ErrorModal)
+/superpowers:brainstorming Group E の問題を解決したい (#676 #680 横断 UI bugs)
+/superpowers:brainstorming Group F の問題を解決したい (#617 #616 #668 #681 配布)
+/superpowers:brainstorming Group G の問題を解決したい (#624 #458 #682 workflow)
+/superpowers:brainstorming Group H の問題を解決したい (#643 #365 lint + CLI)
+```
+
+## 4. deferred / v0.2.0 対象外
+
+### v0.2.0 外確定 (deferred ラベル維持、6 件)
+
+| # | 概要 |
+| --- | --- |
+| #518 | note → warnings: Warning[] 構造化 (将来検討) |
+| #635 | PR Test plan checkbox convention 明文化 |
+| #670 | 動画 HTTP server 改善 (#618 派生) |
+| #671 | E2E test 自動化 feasibility (#484 派生) |
+| #432 | Permission denied 全体見直し |
+| #374 | metadata.json note AV1 codec 不正確 |
+
+### L1 residual (v0.2.0 外、L1 メンテ pool、5 件)
+
+issue: #412 / #576 / #634 / #652 / #654 / #658 — `l1-residual` ラベル付与済 (#365 は本 plan で v0.2.0 取り込みに migration)
+
+### L3+ 将来 layer (多数)
+
+issue: #28 / #32 / #63 / #125-#137 / #139-#152 / #326 / #372-#373 / #376 / #479-#481 — L3 OCR / L4 ML / L5 自動編集 / 拡張 layer (#106 は本セッションで CLOSED)
+
+## 5. 関連 doc / Iron Law 整合
+
+### 関連 doc
+
+- `docs/l2-workflow.md` — PR Pre-flight / Self-Test Report / (A) PR 内修正優先 / 実機検証 trigger
+- `docs/system-architecture.md` — #527 別 exe 方式 / dispatch 表 / Tauri bundle 方針
+- `docs/ui-architecture.md` — 画面 5 + phase SM / 排他管理 / エラーハンドリング §4
+- `docs/release-process.md` §v0.2.0 固有項目 — release 判定基準
+- `docs/axum-video-server.md` (#618 / PR #672) — Tier 0 spec
+- `docs/l2-e2e-checklist.md` (#484 / PR #672) — release gate
+
+### Iron Law 整合 (`.claude/hooks/session-start.sh`)
+
+- **Iron Law 1**: 各 issue の受け入れ条件全項目を逐条検証 — group 内の各章で担保
+- **Iron Law 2**: 3 件以上の bulk 操作 (label 変更 / 一括 close / 一括 close 候補追加) は AskUserQuestion 必須
+- **Iron Law 3**: scope creep 禁止 — group 内でも 1 PR = 1 章 (= 1 issue) を原則
+- **Iron Law 4**: PR / commit に Closes / Fixes / Resolves 禁止、`Refs #N` のみ。マージ後 `/close-issue` で実測再検証
+- **Iron Law 6**: PR 作成 Pre-flight (`git fetch origin develop-0.2.0` + 取り込み未済 commit 確認 + 並行 worktree PR 重複確認) 必須
+
+### Memory feedback
+
+- `feedback_gh_command_ja_heredoc.md` — gh CLI 日本語本文は `printf | --body-file -` または HEREDOC
+- `feedback_skill_revision_empirical.md` — skill 大幅改訂時は empirical-prompt-tuning 推奨
+- `feedback_taskstop_child_process_leak.md` — `run_in_background` + TaskStop の子プロセス残留に注意
+
+## 6. 着手前 Pre-flight チェックリスト
+
+各 group 着手時に再確認:
+
+- [ ] `gh issue view <num>` で受け入れ条件をフルコピー (Iron Law 1)
+- [ ] `git fetch origin develop-0.2.0 && git log HEAD..origin/develop-0.2.0 --oneline` で取り込み未済 commit 確認 (Iron Law 6)
+- [ ] `gh pr list --search "<元 issue#>" --state all` で並行 worktree PR 重複確認 (Iron Law 6)
+- [ ] 着手 group 内に `gui/src-tauri/src/lib.rs` 共有 issue があれば直列順を確認 (Group A → B)
+- [ ] 着手 group 内に `gui/src/screens/PreviewScreen.tsx` 共有 issue があれば直列順を確認 (Group C)

--- a/docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md
+++ b/docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md
@@ -93,7 +93,7 @@
 | # | priority | 概要 |
 | --- | --- | --- |
 | #643 | P3 | ESLint `no-restricted-globals` で `window.confirm` / `alert` / `prompt` を禁止 (Tauri 2 silent loss 再発防止) |
-| #365 | bug (P3 相当、tier label 付与は本 plan で `l1-residual` → `task` に migration) | 進捗バーの ETA 表示にラベル不在 (#329 不完全修正の再対応) |
+| #365 | bug (P3 相当、Idios 判断で v0.2.0 内取り込み disposition、ラベル付替は別途実施) | 進捗バーの ETA 表示にラベル不在 (#329 不完全修正の再対応) |
 
 **並行安全度**: high (lint config + CLI 進捗バー、独立) / **brainstorming 単位**: 1 spec / 2 章
 **注**: #365 は L1 CLI 由来 bug だが、Idios 判断で v0.2.0 内に取り込む (本セッション 2026-05-07 disposition)
@@ -101,13 +101,12 @@
 ## 3. 推奨着手順 (依存最小、並行最大)
 
 ```text
-wave 0 (即時並行可): Group F (4 件) + Group G (3 件) + Group H (2 件)
-                     = 9 issue, 3 brainstorming spec を並行
-wave 1: Group A (#663 AppError migration) 単独 → merge (Group B の前提)
-wave 2: Group B (#679 → #648 → #644 直列、lib.rs 共有)
-        並行 Group C (#633 → #645 / #677、PreviewScreen 共有)
-        並行 Group D (#678 → #669、ErrorModal 連続)
-        並行 Group E (#676 / #680、独立)
+wave 0 (即時並行可): Group A (#663 AppError migration、wave 1 起点) + Group F (4 件) + Group G (3 件) + Group H (2 件)
+                     = 10 issue, 4 brainstorming spec を並行
+wave 1 (Lane I-A merge 後): Group B (#679 → #648 → #644 直列、lib.rs 共有)
+        並行 Group C (#633 → #645 → #677、PreviewScreen 共有)
+        並行 Group D + E#680 (#678 → #669 → #680、ExportScreen + ErrorModal 連続)
+wave 2 (Lane II マージ後): Group E #676 (横断 file path)
 wave 3 (release gate):
   - docs/l2-e2e-checklist.md 全項目 PASS (Idios 実機検証)
   - Tier 2-3 全 PR マージ確認
@@ -158,7 +157,9 @@ wave 0  (4 並行 lane、起点 + 独立 polish)
 
   Lane IV-a  [配布 / installer]    Group F (#617 #616 #668 #681)
              1 spec / 4 章 (or 4 PR 並行)
-             #681 (BtbN URL / get-pip.py 長期対応) に PR #683 短期 fix を吸収
+             #681 (`get-pip.py` SHA pin 長期対応) のスコープに BtbN URL 陳腐化問題も
+             同根の versioned URL / .sha256 動的検証として包含する方針 (PR #683 で
+             短期 fix 後、Lane IV-a 着手時に #681 の受け入れ条件に追記して扱う)
 
   Lane IV-b  [workflow / CI / docs] Group G (#624 #458 #682)
              1 spec / 3 章 (or 3 PR 並行)
@@ -249,9 +250,9 @@ wave 3  (release gate)
 | #432 | Permission denied 全体見直し |
 | #374 | metadata.json note AV1 codec 不正確 |
 
-### L1 residual (v0.2.0 外、L1 メンテ pool、5 件)
+### L1 residual (v0.2.0 外、L1 メンテ pool、6 件)
 
-issue: #412 / #576 / #634 / #652 / #654 / #658 — `l1-residual` ラベル付与済 (#365 は本 plan で v0.2.0 取り込みに migration)
+issue: #412 / #576 / #634 / #652 / #654 / #658 — `l1-residual` ラベル付与済 (#365 は本 plan で v0.2.0 取り込み disposition、ラベル変更は別途 Idios 操作)
 
 ### L3+ 将来 layer (多数)
 

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -119,7 +119,7 @@ function Assert-FFmpegLayout {
   }
 }
 
-function Get-FFmpegSourceCommit {
+function Get-FFmpegSourceRef {
   <#
   Extract the upstream FFmpeg source ref (commit hash or release tag) from a
   BtbN asset name. Both refs let users fetch the exact source under LGPLv3
@@ -136,9 +136,9 @@ function Get-FFmpegSourceCommit {
       (e.g. ffmpeg-n8.1.1-win64-lgpl-shared-8.1)
       -> returns release tag "n8.1.1"
 
-  Function name kept as `Get-FFmpegSourceCommit` for back-compat with the
-  Format-ReadmeContent caller; semantics generalised to "source ref" so the
-  README LGPLv3 attribution stays correct under both naming formats.
+  Renamed from `Get-FFmpegSourceCommit` (PR #683 review #9) so the function
+  name reflects the post-rename semantics ("source ref" covers both commit
+  hash and release tag, consistent with BtbN's two naming formats).
   #>
   param(
     [Parameter(Mandatory = $true)][string]$AssetName
@@ -166,7 +166,7 @@ function Format-ReadmeContent {
     [Parameter(Mandatory = $true)][string]$Version,
     [Parameter(Mandatory = $true)][string]$FFmpegVersion,
     [Parameter(Mandatory = $true)][string]$FFmpegBuildTag,
-    [Parameter(Mandatory = $true)][string]$FFmpegSourceCommit,
+    [Parameter(Mandatory = $true)][string]$FFmpegSourceRef,
     [switch]$IncludeGui
   )
   $guiSection = if ($IncludeGui) {
@@ -233,7 +233,7 @@ $guiLicenseLine- Python: PSF License (python\LICENSE.txt)
 - FFmpeg: LGPLv3 (full text in ffmpeg\LICENSE.txt)
     Build:         ffmpeg n$FFmpegVersion win64-lgpl-shared build (BtbN/FFmpeg-Builds)
     Build tag:     $FFmpegBuildTag
-    Source:        https://git.ffmpeg.org/ffmpeg.git (ref $FFmpegSourceCommit)
+    Source:        https://git.ffmpeg.org/ffmpeg.git (ref $FFmpegSourceRef)
     Build scripts: https://github.com/BtbN/FFmpeg-Builds
 
 allaganeye (MIT) invokes the FFmpeg binary as a separate subprocess only.
@@ -378,7 +378,7 @@ if (-not (Test-Path $FFmpegZip)) {
 $FFmpegExtract = Join-Path $BuildDir 'ffmpeg-extracted'
 Expand-Archive -Path $FFmpegZip -DestinationPath $FFmpegExtract -Force
 $FFmpegLayout = Assert-FFmpegLayout -ExtractDir $FFmpegExtract
-$FFmpegSourceCommit = Get-FFmpegSourceCommit -AssetName $FFmpegAsset
+$FFmpegSourceRef = Get-FFmpegSourceRef -AssetName $FFmpegAsset
 $FFmpegDest = Join-Path $PayloadDir 'ffmpeg'
 New-Item -ItemType Directory -Force -Path $FFmpegDest | Out-Null
 # Shared build: copy ffmpeg.exe, ffprobe.exe, and all DLLs. ffplay.exe is excluded
@@ -422,7 +422,7 @@ $Readme = Format-ReadmeContent `
   -Version $Version `
   -FFmpegVersion $FFmpegVersion `
   -FFmpegBuildTag $FFmpegBuildTag `
-  -FFmpegSourceCommit $FFmpegSourceCommit `
+  -FFmpegSourceRef $FFmpegSourceRef `
   -IncludeGui:$TauriIncluded
 Set-Content -Path (Join-Path $PayloadDir 'README.txt') -Value $Readme -Encoding UTF8
 

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -69,10 +69,10 @@ $GetPipSha256 = '66904BCCB878E363DB6236EA900E6935E507DCB887E9F178F6212EDFE7F46A7
 # CI workflows (`.github/workflows/ci.yml`) must be updated with the matching
 # linux64-lgpl-shared asset at the same build tag; see docs/developer-setup.md § 9.
 $FFmpegVersion = '8.1'
-$FFmpegBuildTag = 'autobuild-2026-04-22-13-15'
-$FFmpegAsset = 'ffmpeg-n8.1-10-g7f5c90f77e-win64-lgpl-shared-8.1'
+$FFmpegBuildTag = 'autobuild-2026-05-06-13-32'
+$FFmpegAsset = 'ffmpeg-n8.1.1-win64-lgpl-shared-8.1'
 $FFmpegUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$FFmpegBuildTag/$FFmpegAsset.zip"
-$FFmpegSha256 = 'FEF865CAB8A097F07F1DCBA66D73BE94742B79D952CF6FD8643BD42C18995034'
+$FFmpegSha256 = '16F409AB737538778F9CD4BFC69953E2E1DC2558F6DC5CA17CC72083D60DC735'
 
 function Invoke-Download {
   param(
@@ -121,17 +121,38 @@ function Assert-FFmpegLayout {
 
 function Get-FFmpegSourceCommit {
   <#
-  Extract the upstream FFmpeg git commit hash from a BtbN asset name.
-  BtbN assets embed it as: ffmpeg-n<version>-<count>-g<commit>-<target>-<variant>
-  So users can fetch the exact source under LGPLv3 obligations.
+  Extract the upstream FFmpeg source ref (commit hash or release tag) from a
+  BtbN asset name. Both refs let users fetch the exact source under LGPLv3
+  obligations (commit hash via `git checkout <hash>`, release tag via
+  `git checkout n8.1.1` from the FFmpeg upstream repo).
+
+  BtbN embeds it as one of two formats:
+    - Old (autobuild-YYYY-MM-DD prior to BtbN's patch-release naming switch
+      ca. 2026-05-06): ffmpeg-n<version>-<count>-g<commit>-<target>-<variant>
+      (e.g. ffmpeg-n8.1-10-g7f5c90f77e-win64-lgpl-shared-8.1)
+      -> returns commit hash "7f5c90f77e"
+    - New (BtbN switched to bare patch-release tags, no count + commit hash
+      in the name): ffmpeg-n<version>-<target>-<variant>
+      (e.g. ffmpeg-n8.1.1-win64-lgpl-shared-8.1)
+      -> returns release tag "n8.1.1"
+
+  Function name kept as `Get-FFmpegSourceCommit` for back-compat with the
+  Format-ReadmeContent caller; semantics generalised to "source ref" so the
+  README LGPLv3 attribution stays correct under both naming formats.
   #>
   param(
     [Parameter(Mandatory = $true)][string]$AssetName
   )
-  if ($AssetName -match '^ffmpeg-n[^-]+-[^-]+-g([0-9a-f]+)-') {
+  # Old format first: extract commit hash from the trailing -g<hex>- segment.
+  if ($AssetName -match '^ffmpeg-n[^-]+-[0-9]+-g([0-9a-f]+)-') {
     return $matches[1]
   }
-  throw "Cannot extract upstream source commit from asset name: $AssetName"
+  # New format: bare release tag (n<version>) immediately followed by the
+  # target/variant segment (alphabetic prefix like "win64", "linux64").
+  if ($AssetName -match '^ffmpeg-(n\d+(?:\.\d+)+)-[A-Za-z]') {
+    return $matches[1]
+  }
+  throw "Cannot extract upstream source ref (commit hash or release tag) from asset name: $AssetName"
 }
 
 function Format-ReadmeContent {
@@ -212,7 +233,7 @@ $guiLicenseLine- Python: PSF License (python\LICENSE.txt)
 - FFmpeg: LGPLv3 (full text in ffmpeg\LICENSE.txt)
     Build:         ffmpeg n$FFmpegVersion win64-lgpl-shared build (BtbN/FFmpeg-Builds)
     Build tag:     $FFmpegBuildTag
-    Source:        https://git.ffmpeg.org/ffmpeg.git (commit $FFmpegSourceCommit)
+    Source:        https://git.ffmpeg.org/ffmpeg.git (ref $FFmpegSourceCommit)
     Build scripts: https://github.com/BtbN/FFmpeg-Builds
 
 allaganeye (MIT) invokes the FFmpeg binary as a separate subprocess only.

--- a/scripts/tests/build-portable-zip.Tests.ps1
+++ b/scripts/tests/build-portable-zip.Tests.ps1
@@ -106,14 +106,26 @@ Describe 'Assert-FFmpegLayout' {
 }
 
 Describe 'Get-FFmpegSourceCommit' {
-  It 'extracts the upstream commit from a valid BtbN asset name' {
-    $commit = Get-FFmpegSourceCommit -AssetName 'ffmpeg-n8.1-123-g7f5c90f77e-win64-lgpl-shared.zip'
-    $commit | Should -Be '7f5c90f77e'
+  It 'extracts the upstream commit from a valid BtbN asset name (old format: count + commit hash)' {
+    # Old BtbN naming: ffmpeg-n<version>-<count>-g<commit>-<target>-<variant>.
+    # Function returns the commit hash so README.txt can point users at the
+    # exact source under LGPLv3 obligations.
+    $ref = Get-FFmpegSourceCommit -AssetName 'ffmpeg-n8.1-123-g7f5c90f77e-win64-lgpl-shared.zip'
+    $ref | Should -Be '7f5c90f77e'
+  }
+
+  It 'extracts the release tag from a valid BtbN asset name (new format: bare patch release)' {
+    # New BtbN naming (since ca. 2026-05-06): ffmpeg-n<version>-<target>-<variant>.
+    # Function returns the release tag (n<version>) since the commit hash is
+    # no longer embedded in the asset name. Both refs let users fetch the
+    # exact source under LGPLv3 obligations.
+    $ref = Get-FFmpegSourceCommit -AssetName 'ffmpeg-n8.1.1-win64-lgpl-shared-8.1.zip'
+    $ref | Should -Be 'n8.1.1'
   }
 
   It 'throws when the asset name does not match the BtbN pattern' {
     { Get-FFmpegSourceCommit -AssetName 'unexpected-name.zip' } |
-      Should -Throw -ExpectedMessage '*Cannot extract upstream source commit*'
+      Should -Throw -ExpectedMessage '*Cannot extract upstream source ref*'
   }
 }
 

--- a/scripts/tests/build-portable-zip.Tests.ps1
+++ b/scripts/tests/build-portable-zip.Tests.ps1
@@ -10,8 +10,9 @@ Scope (#528 / #551 / #583):
   1. Invoke-Download verifies matching SHA256 / throws on mismatch.
   2. Assert-FFmpegLayout throws when the extracted archive has no `bin/`,
      returns Root/Bin/License paths when valid.
-  3. Get-FFmpegSourceCommit extracts the upstream commit from valid BtbN
-     asset names / throws on unexpected names.
+  3. Get-FFmpegSourceRef extracts the upstream commit (old BtbN naming) or
+     release tag (new BtbN naming) from valid BtbN asset names / throws on
+     unexpected names.
   4. Format-ReadmeContent includes the LGPLv3 attribution + BtbN /
      win64-lgpl-shared pointers required by Portable ZIP license compliance.
   5. Get-LauncherTemplate preserves the python exit code propagation idiom
@@ -105,12 +106,12 @@ Describe 'Assert-FFmpegLayout' {
   }
 }
 
-Describe 'Get-FFmpegSourceCommit' {
+Describe 'Get-FFmpegSourceRef' {
   It 'extracts the upstream commit from a valid BtbN asset name (old format: count + commit hash)' {
     # Old BtbN naming: ffmpeg-n<version>-<count>-g<commit>-<target>-<variant>.
     # Function returns the commit hash so README.txt can point users at the
     # exact source under LGPLv3 obligations.
-    $ref = Get-FFmpegSourceCommit -AssetName 'ffmpeg-n8.1-123-g7f5c90f77e-win64-lgpl-shared.zip'
+    $ref = Get-FFmpegSourceRef -AssetName 'ffmpeg-n8.1-123-g7f5c90f77e-win64-lgpl-shared.zip'
     $ref | Should -Be '7f5c90f77e'
   }
 
@@ -119,12 +120,12 @@ Describe 'Get-FFmpegSourceCommit' {
     # Function returns the release tag (n<version>) since the commit hash is
     # no longer embedded in the asset name. Both refs let users fetch the
     # exact source under LGPLv3 obligations.
-    $ref = Get-FFmpegSourceCommit -AssetName 'ffmpeg-n8.1.1-win64-lgpl-shared-8.1.zip'
+    $ref = Get-FFmpegSourceRef -AssetName 'ffmpeg-n8.1.1-win64-lgpl-shared-8.1.zip'
     $ref | Should -Be 'n8.1.1'
   }
 
   It 'throws when the asset name does not match the BtbN pattern' {
-    { Get-FFmpegSourceCommit -AssetName 'unexpected-name.zip' } |
+    { Get-FFmpegSourceRef -AssetName 'unexpected-name.zip' } |
       Should -Throw -ExpectedMessage '*Cannot extract upstream source ref*'
   }
 }
@@ -135,7 +136,7 @@ Describe 'Format-ReadmeContent' {
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
       -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
-      -FFmpegSourceCommit '7f5c90f77e'
+      -FFmpegSourceRef '7f5c90f77e'
 
     $readme | Should -Match 'LGPLv3'
     $readme | Should -Match 'BtbN/FFmpeg-Builds'
@@ -157,7 +158,7 @@ Describe 'Format-ReadmeContent' {
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
       -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
-      -FFmpegSourceCommit '7f5c90f77e' `
+      -FFmpegSourceRef '7f5c90f77e' `
       -IncludeGui:$true
     $readme | Should -Match 'double-click'
     $readme | Should -Match 'WebView2 Runtime'
@@ -172,7 +173,7 @@ Describe 'Format-ReadmeContent' {
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
       -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
-      -FFmpegSourceCommit '7f5c90f77e' `
+      -FFmpegSourceRef '7f5c90f77e' `
       -IncludeGui:$true
     $readme | Should -Match 'Allagan Eye GUI'
     $readme | Should -Match 'Tauri 2'
@@ -186,10 +187,23 @@ Describe 'Format-ReadmeContent' {
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
       -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
-      -FFmpegSourceCommit '7f5c90f77e'
+      -FFmpegSourceRef '7f5c90f77e'
     $readme | Should -Not -Match 'WebView2 Runtime'
     $readme | Should -Not -Match 'Allagan Eye GUI'
     $readme | Should -Not -Match 'allaganeye-gui\.exe'
+  }
+
+  It 'embeds release tag as source ref for new BtbN naming format (#683)' {
+    # 新 BtbN naming (n8.1.1) では Get-FFmpegSourceRef が release tag を返し、
+    # README には (ref n8.1.1) で記述される。`(commit ...)` の旧文言が残らない
+    # ことも併せて verify (PR #683 review #10)。
+    $readme = Format-ReadmeContent `
+      -Version '0.2.0' `
+      -FFmpegVersion '8.1' `
+      -FFmpegBuildTag 'autobuild-2026-05-06-13-32' `
+      -FFmpegSourceRef 'n8.1.1'
+    $readme | Should -Match '\(ref n8\.1\.1\)'
+    $readme | Should -Not -Match '\(commit n8\.1\.1\)'
   }
 }
 


### PR DESCRIPTION
## 概要

PR #672 (Tier 0 docs) / PR #675 (Tier 1 #653) のマージ完了 + 本セッションでの `/close-issue 105` `/close-issue 523` 実施を踏まえ、L2 (v0.2.0) 残 open issue を全洗いし、`brainstorming` skill で扱いやすい単位 8 group に再編成した plan doc を新設。

各 group は 1 spec / 1-3 章で扱える独立 scope。並行作業の依存関係 (lib.rs 共有 / PreviewScreen 共有 / ErrorModal 連続) を明示。Idios 判断 (2026-05-07) で Lane 構造 (4 wave / 最大並行 4 worktree) も §3-bis として追記済。

加えて、本 PR push 時に発覚した CI infrastructure bug (BtbN ffmpeg URL 陳腐化、404) と、関連する build-portable-zip.ps1 の新 BtbN naming 不対応問題を Iron Law 6 (CI green) 担保のため同 PR 内で短期 fix として合併修正 (Idios 判断、2026-05-07)。

Round 1 review 10 件 (commit `6e27ccc`) + Round 2 review 1 件 (commit `57511b9`、R2-1 doc rename 同期) を全件対応済。

## 変更内容

### 主目的: doc 新設 + Lane 構造追記

- 新設: `docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md`
  - §1-§2: 完了済 + 8 brainstorming groups
  - §3 推奨着手順 + §3-bis Lane 構造 (複数セッション並行運用、最大並行 4 worktree)
  - §4-§6: deferred / 関連 doc / Pre-flight チェックリスト

### Iron Law 6 担保: CI / installer 短期 fix (合併、2 commit)

- commit `aa1b666` — `.github/workflows/ci.yml` の linux64 BtbN URL 更新 (新 SHA `ec75...`)
- commit `110478f` — `scripts/build-portable-zip.ps1` の win64 BtbN naming 対応 (新 SHA `16F4...`、Get-FFmpegSourceRef 両 format 対応)

### Round 1 review 対応 (commit `6e27ccc`、10 件全件 (A) PR 内)

#### ブロッカー 4 件 (P1)

- **#1**: `release.yml:99` cache key を新 win64 SHA に同期
- **#2**: `docs/developer-setup.md:392` autobuild URL `2026-04-22-13-15` → `2026-05-06-13-32`
- **#3**: `docs/quickstart.md:151` 「commit `7f5c90f77e`」→「release tag `n8.1.1`」+ ref 表記
- **#4**: `docs/developer-setup.md:413` 表例文言を ref 文言に整合

#### 軽微 6 件 (P3)

- **#5**: roadmap §4 L1 residual 「5 件」→「6 件」
- **#6**: roadmap §3 を §3-bis Lane 構造の wave 番号と統一
- **#7**: roadmap §2/§4 #365 ラベル記述を現実状態 (`bug` のみ) に整合
- **#8**: roadmap §3-bis Lane IV-a #681 「吸収」→「Lane 着手時に受け入れ条件追記」
- **#9**: `Get-FFmpegSourceCommit` → `Get-FFmpegSourceRef` rename (build-portable-zip.ps1 5箇所 + Pester 8箇所)
- **#10**: Pester に新 format e2e (`(ref n8.1.1)` 出力検証) 追加

### Round 2 review 対応 (commit `57511b9`、1 件 (A) PR 内)

- **R2-1**: `docs/developer-setup.md:409` 表内の `$FFmpegSourceCommit` → `$FFmpegSourceRef` rename 同期 (Round 1 #9 cross-reference 漏れ)

## 8 brainstorming groups

| group | scope | 件数 | 並行安全度 |
| --- | --- | --- | --- |
| A | AppError migration 先行 (#663) | 1 | high (wave 1 起点) |
| B | lib.rs 系 backend bugs (#679 / #648 / #644) | 3 | low (lib.rs 共有 → 直列) |
| C | PreviewScreen / sample mode UX (#633 / #645 / #677) | 3 | mid (PreviewScreen 共有) |
| D | ErrorModal / Export エラー UX (#678 / #669) | 2 | high (ErrorModal 局所) |
| E | 横断 UI bugs (#676 / #680) | 2 | mid (#676 横断、#680 局所) |
| F | l2b 配布 (#617 / #616 / #668 / #681) | 4 | high (file 独立) |
| G | l2-workflow / CI / docs (#624 / #458 / #682) | 3 | high (独立) |
| H | lint / CLI 系 polish (#643 / #365) | 2 | high (独立) |
| **合計** | — | **20** | — |

## 完了済 (本 doc 対象外)

- Tier 0: #618 / #484 — PR #672 で CLOSED
- Tier 1: #653 — PR #675 で CLOSED
- 親 issue: #105 (L2a sub-issue 14 件全 CLOSED で本セッション `/close-issue`) / #523 (PR #540 + #545 Phase 分割で本セッション `/close-issue`)

## 長期対応 (deferred)

BtbN URL 陳腐化問題は #681 (`get-pip.py` SHA pin と同根) のスコープに追加して扱う方針 (Lane IV-a 着手時に #681 受け入れ条件に追記)。

## Self-Test Report

### machine-verifiable

- [x] markdownlint pass (本 PR で touch した 3 doc 全て)
- [x] CI fix の SHA256 ローカル検証:
  - linux64: `ec7546052026c12079e5bc4c69ff811c40f5b44610d8854cca17dda8e192529f` ✓
  - win64: `16F409AB737538778F9CD4BFC69953E2E1DC2558F6DC5CA17CC72083D60DC735` ✓
- [x] Pester ローカル全 15 tests PASS (`Invoke-Pester scripts/tests/build-portable-zip.Tests.ps1`)
- [x] CI 全 9 job pass + release skip (commit `6e27ccc` 時点で全 green、commit `57511b9` で再 run 中)
- [x] Iron Law 6 PR Pre-flight 完了
- [x] Round 1 review 10 件全件 (A) PR 内対応済 (commit `6e27ccc`)
- [x] Round 2 review R2-1 (developer-setup.md:409 `$FFmpegSourceCommit` → `$FFmpegSourceRef` rename 同期、commit `57511b9`)
- [x] cross-reference 確認: `grep -E "FFmpegSourceCommit"` で残る参照は build-portable-zip.ps1:139 の rename 経緯 doc コメントのみ (意図的残置)

### machine-unverifiable

- 本 doc は plan / 棚卸しなので実機検証なし
- 各 group 着手時に当該 group の brainstorming spec 段階で実機検証 trigger を確認 (`docs/l2-workflow.md` §実機検証 trigger 表 に従う)
- release.yml は tag push 時のみ起動するため CI で test されない。Idios の手動検証 (`pwsh ./scripts/build-portable-zip.ps1 -Version 0.2.0-test` で cache miss 経路の SHA256 verify が PASS することを確認) を release v0.2.0 タグ前に推奨

## Iron Law 整合

- Iron Law 1: Round 1/2 review 全件を逐条検証して全件対応
- Iron Law 2: bulk 操作なし
- Iron Law 3: 本 doc は scope 整理のみ。CI / installer fix + Round 1 #9 rename + R2-1 doc 同期は Iron Law 6 担保のための合併修正で Idios 判断 (2026-05-07) で同 PR に含めた scope 例外
- Iron Law 4: 本 PR / commit 本文に `Closes` / `Fixes` / `Resolves` キーワードなし
- Iron Law 6: PR Pre-flight 完了

session-id: dazzling-mestorf-10914f

🤖 Generated with [Claude Code](https://claude.com/claude-code)
