### PR TITLE
feat(gui): ESLint で window.confirm/alert/prompt を block (Refs #643)

### DIFF
--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -63,6 +63,8 @@
 
 **アンチパターン**: dirty=true なのに confirm せず遷移する設計 (#589 修正前の `PreviewScreen` の handleBack / handleExport が該当、現在は §2.4.1 / §2.4.14 経由で §1.3 準拠 + canonical 文言統一済)。
 
+**lint 強制 ([#643](https://github.com/Idios/kobutachan-allaganeye/issues/643))**: 上記 canonical 違反 (`window.confirm` / `window.alert` / `window.prompt` の bare 呼び出しおよび `window.X` 経由 member access) は `gui/eslint.config.js` の `no-restricted-globals` + `no-restricted-properties` で **error として block** する。`npm run lint` / CI gui-frontend job が fail し、IDE 上でも即時警告される。エラーメッセージに plugin-dialog 代替 API へのリンクを含める。
+
 ### 1.4 sample mode (filePath==null) の read-only 明示
 
 **原則**: `metadataStore.loadSample()` で読み込まれた sample metadata (`metadataStore.filePath === null`) は **編集不可 (read-only)** として扱い、編集系 UI 部品はすべて grayed out + 上部に常時 hint を表示する。

--- a/gui/eslint.config.js
+++ b/gui/eslint.config.js
@@ -3,6 +3,20 @@ import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 
+// #643: Tauri 2 WebView2 disables window.confirm/alert/prompt as no-op.
+// Generate identical messages for `no-restricted-globals` (bare global)
+// and `no-restricted-properties` (`window.X` member access) from a single
+// source so future updates to plugin-dialog suggestions or §1.3 reference
+// don't drift across the 6 entries (3 globals × 2 rules).
+const TAURI_DIALOG_RESTRICTIONS = [
+  { name: 'confirm', suggestion: '`import { ask } from "@tauri-apps/plugin-dialog"`' },
+  { name: 'alert', suggestion: '`import { message } from "@tauri-apps/plugin-dialog"`' },
+  { name: 'prompt', suggestion: 'plugin-dialog equivalents' },
+];
+
+const tauriDialogMessage = ({ name, suggestion }) =>
+  `Tauri 2 WebView2 disables window.${name}. Use ${suggestion} instead. See docs/ui-interaction-spec.md §1.3.`;
+
 export default [
   {
     ignores: [
@@ -28,47 +42,22 @@ export default [
     rules: {
       ...reactHooks.configs.recommended.rules,
 
-      // #643: Tauri 2 WebView2 disables window.confirm/alert/prompt as no-op.
-      // Catch both bare global calls and `window.X` member access.
+      // #643: Catch both bare global calls and `window.X` member access.
       // See docs/ui-interaction-spec.md §1.3.
       'no-restricted-globals': [
         'error',
-        {
-          name: 'confirm',
-          message:
-            'Tauri 2 WebView2 disables window.confirm. Use `import { ask } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
-        },
-        {
-          name: 'alert',
-          message:
-            'Tauri 2 WebView2 disables window.alert. Use `import { message } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
-        },
-        {
-          name: 'prompt',
-          message:
-            'Tauri 2 WebView2 disables window.prompt. Use plugin-dialog equivalents instead. See docs/ui-interaction-spec.md §1.3.',
-        },
+        ...TAURI_DIALOG_RESTRICTIONS.map((r) => ({
+          name: r.name,
+          message: tauriDialogMessage(r),
+        })),
       ],
       'no-restricted-properties': [
         'error',
-        {
+        ...TAURI_DIALOG_RESTRICTIONS.map((r) => ({
           object: 'window',
-          property: 'confirm',
-          message:
-            'Tauri 2 WebView2 disables window.confirm. Use `import { ask } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
-        },
-        {
-          object: 'window',
-          property: 'alert',
-          message:
-            'Tauri 2 WebView2 disables window.alert. Use `import { message } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
-        },
-        {
-          object: 'window',
-          property: 'prompt',
-          message:
-            'Tauri 2 WebView2 disables window.prompt. Use plugin-dialog equivalents instead. See docs/ui-interaction-spec.md §1.3.',
-        },
+          property: r.name,
+          message: tauriDialogMessage(r),
+        })),
       ],
     },
   },

--- a/gui/eslint.config.js
+++ b/gui/eslint.config.js
@@ -27,6 +27,49 @@ export default [
     plugins: { 'react-hooks': reactHooks },
     rules: {
       ...reactHooks.configs.recommended.rules,
+
+      // #643: Tauri 2 WebView2 disables window.confirm/alert/prompt as no-op.
+      // Catch both bare global calls and `window.X` member access.
+      // See docs/ui-interaction-spec.md §1.3.
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'confirm',
+          message:
+            'Tauri 2 WebView2 disables window.confirm. Use `import { ask } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+        {
+          name: 'alert',
+          message:
+            'Tauri 2 WebView2 disables window.alert. Use `import { message } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+        {
+          name: 'prompt',
+          message:
+            'Tauri 2 WebView2 disables window.prompt. Use plugin-dialog equivalents instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+      ],
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'window',
+          property: 'confirm',
+          message:
+            'Tauri 2 WebView2 disables window.confirm. Use `import { ask } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+        {
+          object: 'window',
+          property: 'alert',
+          message:
+            'Tauri 2 WebView2 disables window.alert. Use `import { message } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+        {
+          object: 'window',
+          property: 'prompt',
+          message:
+            'Tauri 2 WebView2 disables window.prompt. Use plugin-dialog equivalents instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
## 概要

Tauri 2 WebView2 の security 制約により `window.confirm/alert/prompt` が no-op になる silent loss 問題 (PR #628 で実体修正済) を、lint レベルで予防する rule を追加する。bare global と `window.X` member access の両経路を block する。

## 変更ファイル

- `gui/eslint.config.js`: `no-restricted-globals` + `no-restricted-properties` を `src/**/*.{ts,tsx}` block に追加
- `docs/ui-interaction-spec.md`: §1.3 末尾に「lint 強制 (#643)」段落追加

## 受け入れ条件マッピング (Iron Law 1)

issue [#643](https://github.com/Idios/kobutachan-allaganeye/issues/643) の受け入れ条件 5 項目を逐条検証:

- [x] `gui/eslint.config.js` に `no-restricted-globals` 相当の rule 追加
  → `gui/eslint.config.js` の `src/**/*.{ts,tsx}` block の `rules` 内、`no-restricted-globals` (3 globals) + `no-restricted-properties` (3 globals × `object: 'window'`) として追加
- [x] エラーメッセージに plugin-dialog 代替 API + `docs/ui-interaction-spec.md` §1.3 リンクを含める
  → 各 rule の `message` field に「Use `import { ... } from "@tauri-apps/plugin-dialog"`」+ 「See docs/ui-interaction-spec.md §1.3」を含む
- [x] 故意に `window.confirm` を含むコードを書いた branch で CI lint が fail することを確認 (検証 PR #685 CLOSED + CI run https://github.com/Idios/kobutachan-allaganeye/actions/runs/25529744519)
  → 別途検証 PR を立てて CI run URL evidence を本 PR Self-Test Report 末尾に追記する (Step 5)
- [x] CI grep check を併設するか判断 → **不要**判断
  → 理由: ESLint で IDE 警告 + CI fail を兼ね、grep はコメント / docstring 内の言及まで誤検出する (現状 `gui/src/screens/PreviewScreen.tsx:445` と `gui/src/components/RestoreButton.tsx:9` の説明コメント内 `window.confirm` がそれにあたる)
- [x] `docs/ui-interaction-spec.md` §1.3 末尾に「lint で強制」記述を追加
  → 「**lint 強制 (#643)**」段落を §1.3 末尾に追加

## Self-Test Report

### machine-verified

- [x] `cd gui && npm run lint` (新 rule で `gui/src/` 全 PASS)
- [x] `cd gui && npm run typecheck`
- [x] `cd gui && npm test`
- [x] `cd gui && npm run build`
- [x] `cd gui/src-tauri && cargo check`
- [x] 違反コード検証 PR #685 (CLOSED, not MERGED): CI run https://github.com/Idios/kobutachan-allaganeye/actions/runs/25529744519 で no-restricted-globals 3 件 + no-restricted-properties 3 件 = 計 6 violation を block することを確認

### machine-unverifiable

(なし、Idios 実機検証不要)

## 関連

- 派生元 PR: [#628](https://github.com/Idios/kobutachan-allaganeye/pull/628) (#589 修正、commit `cc94f1f` で `window.confirm` → plugin-dialog ask 一括 migrate)
- 親 issue: [#589](https://github.com/Idios/kobutachan-allaganeye/issues/589) (PreviewScreen state mutation flow + dirty consume confirm)
- 関連 doc: `docs/ui-interaction-spec.md` §1.3 (silent loss 防止: dirty consume 側で confirm)
- spec: `docs/superpowers/specs/2026-05-08-l2-lane-ivc-group-h-design.md` §4

session-id: musing-davinci-38136f

🤖 Generated with [Claude Code](https://claude.com/claude-code)
