### PR TITLE
test: verify ESLint blocks Tauri 2 silent loss patterns (Refs #643, expected to fail CI)

### DIFF
--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -63,6 +63,8 @@
 
 **アンチパターン**: dirty=true なのに confirm せず遷移する設計 (#589 修正前の `PreviewScreen` の handleBack / handleExport が該当、現在は §2.4.1 / §2.4.14 経由で §1.3 準拠 + canonical 文言統一済)。
 
+**lint 強制 ([#643](https://github.com/Idios/kobutachan-allaganeye/issues/643))**: 上記 canonical 違反 (`window.confirm` / `window.alert` / `window.prompt` の bare 呼び出しおよび `window.X` 経由 member access) は `gui/eslint.config.js` の `no-restricted-globals` + `no-restricted-properties` で **error として block** する。`npm run lint` / CI gui-frontend job が fail し、IDE 上でも即時警告される。エラーメッセージに plugin-dialog 代替 API へのリンクを含める。
+
 ### 1.4 sample mode (filePath==null) の read-only 明示
 
 **原則**: `metadataStore.loadSample()` で読み込まれた sample metadata (`metadataStore.filePath === null`) は **編集不可 (read-only)** として扱い、編集系 UI 部品はすべて grayed out + 上部に常時 hint を表示する。

--- a/gui/eslint.config.js
+++ b/gui/eslint.config.js
@@ -27,6 +27,49 @@ export default [
     plugins: { 'react-hooks': reactHooks },
     rules: {
       ...reactHooks.configs.recommended.rules,
+
+      // #643: Tauri 2 WebView2 disables window.confirm/alert/prompt as no-op.
+      // Catch both bare global calls and `window.X` member access.
+      // See docs/ui-interaction-spec.md §1.3.
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'confirm',
+          message:
+            'Tauri 2 WebView2 disables window.confirm. Use `import { ask } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+        {
+          name: 'alert',
+          message:
+            'Tauri 2 WebView2 disables window.alert. Use `import { message } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+        {
+          name: 'prompt',
+          message:
+            'Tauri 2 WebView2 disables window.prompt. Use plugin-dialog equivalents instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+      ],
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'window',
+          property: 'confirm',
+          message:
+            'Tauri 2 WebView2 disables window.confirm. Use `import { ask } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+        {
+          object: 'window',
+          property: 'alert',
+          message:
+            'Tauri 2 WebView2 disables window.alert. Use `import { message } from "@tauri-apps/plugin-dialog"` instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+        {
+          object: 'window',
+          property: 'prompt',
+          message:
+            'Tauri 2 WebView2 disables window.prompt. Use plugin-dialog equivalents instead. See docs/ui-interaction-spec.md §1.3.',
+        },
+      ],
     },
   },
   {

--- a/gui/src/__verify_eslint_643__.tsx
+++ b/gui/src/__verify_eslint_643__.tsx
@@ -1,0 +1,18 @@
+// gui/src/__verify_eslint_643__.tsx
+//
+// This file is intentionally invalid for ESLint verification of #643.
+// It MUST be deleted (along with the verification PR being closed without
+// merge) once CI fail evidence is captured. Do not merge this file into
+// any long-lived branch.
+
+export function _verify643(): void {
+  // Bare global calls (no-restricted-globals)
+  confirm('bare global confirm');
+  alert('bare global alert');
+  prompt('bare global prompt');
+
+  // window.X member access (no-restricted-properties)
+  window.confirm('member access confirm');
+  window.alert('member access alert');
+  window.prompt('member access prompt');
+}


### PR DESCRIPTION
## 目的

PR #684 (Refs #643) で追加した `no-restricted-globals` + `no-restricted-properties` rule が、`window.confirm/alert/prompt` の bare global / member access 両経路を CI で block することを **CI fail evidence** として記録する検証 PR。

## ⚠️ この PR は merge しない

`gui/src/__verify_eslint_643__.tsx` に 6 件の違反コードを意図的に追加してある。CI gui-frontend lint job が exit 1 + 6 errors を報告することを確認したら、本 PR は **close without merge** する (実装は本流 PR #684 で merge)。

## 期待する CI 挙動

- `gui-frontend` job の `npm run lint` step が exit 1
- 6 violations 報告:
  - `no-restricted-globals`: `confirm` / `alert` / `prompt` 各 1 件 (合計 3)
  - `no-restricted-properties`: `window.confirm` / `window.alert` / `window.prompt` 各 1 件 (合計 3)
- 各 message に `@tauri-apps/plugin-dialog` 代替 API と `docs/ui-interaction-spec.md` §1.3 リンクが含まれる

## 関連

- 本流 PR: #684
- spec: `docs/superpowers/specs/2026-05-08-l2-lane-ivc-group-h-design.md` §6.2

session-id: musing-davinci-38136f-eslint-verify
