### PR TITLE
fix(cli): 進捗バー ETA 表示の改善 (label / placeholder / visual baseline 維持) (Refs #365)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TypedDict
 
+from click._termui_impl import ProgressBar as _ClickProgressBar  # subclass 用 (#365)
 import typer
 
 from allaganeye.audio.matcher import BgmHit
@@ -1067,23 +1068,58 @@ def _stdout_supports_eager_phases() -> bool:
     return sys.stdout.isatty()
 
 
-def _eta_progressbar(length: int, label: str, *, suppress_click_eta: bool = False):  # type: ignore[no-untyped-def]
-    """Create a progress bar with explicit ETA label (#329).
+class _ETAProgressBar(_ClickProgressBar):
+    """Progress bar with explicit 'ETA: H:MM:SS' label (#365).
+
+    click のデフォルト ``%(info)s`` placeholder は ``<percent>  <eta>``
+    をラベルなしで展開するだけのため、ユーザーには時刻文字列だけが見え、
+    経過時間/残り時間/動画内位置のどれか判別できない (#329 元 issue,
+    PR #343 不完全修正、#365 で再対応)。
+
+    本 subclass は ``format_progress_line`` を override し以下に統一:
+
+        Detecting  ###################---  93% ETA: 0:00:22
+
+    ``show_eta=False`` (GPU mode #438 の ``suppress_click_eta=True``
+    経路) では ETA セクションを出さず percent のみ表示。caller 側が
+    self-computed ETA を label に組み込む既存挙動と互換。
+
+    依存する click 8.x の public method:
+      - ``format_bar()``    -- bar 文字列
+      - ``format_pct()``    -- "  N%" or "NN%" (左 padding あり)
+      - ``format_eta()``    -- "H:MM:SS" or "" (eta_known=False / show_eta=False のとき空)
+      - ``self.label``      -- ljust 済みラベル
+      - ``self.show_eta``   -- ETA 表示フラグ
+      - ``self.eta_known``  -- ETA 計算可能フラグ (1 update 後に True)
+    """
+
+    def format_progress_line(self) -> str:
+        bar = self.format_bar()
+        pct = self.format_pct()
+        if self.show_eta and self.eta_known:
+            eta = self.format_eta()
+            return f"{self.label}{bar} {pct} ETA: {eta}"
+        return f"{self.label}{bar} {pct}"
+
+
+def _eta_progressbar(
+    length: int, label: str, *, suppress_click_eta: bool = False
+) -> _ETAProgressBar:
+    """Create a progress bar with explicit ETA label (#329 / #365).
 
     Labels are left-justified to ``_PROGRESS_LABEL_WIDTH`` so that
-    Detecting / Refining / Splitting bars align vertically.
+    Detecting / Refining / Scorebar / Splitting bars align vertically.
 
     When ``suppress_click_eta`` is True (GPU mode, #438), click's own
-    ETA is hidden.  GPU chunk completion is non-linear so click's rate
-    estimator produces nonsense (e.g. ``3d 08:08:52``); the caller
-    supplies a self-computed ETA in the label instead.
+    ETA is hidden (``show_eta=False``); caller supplies a self-computed
+    ETA in the label instead. ``_ETAProgressBar.format_progress_line``
+    consumes ``show_eta`` to skip the 'ETA: ' tail in that path.
     """
-    import click
-
-    return click.progressbar(
+    return _ETAProgressBar(
+        iterable=None,
         length=length,
         label=label.ljust(_PROGRESS_LABEL_WIDTH),
-        bar_template="%(label)s%(bar)s %(info)s",
+        bar_template="",  # 未使用 (format_progress_line を override したため)
         show_eta=not suppress_click_eta,
         show_percent=True,
     )

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -11,8 +11,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TypedDict
 
-from click._termui_impl import ProgressBar as _ClickProgressBar  # subclass 用 (#365)
 import typer
+from click._termui_impl import ProgressBar as _ClickProgressBar  # subclass 用 (#365)
 
 from allaganeye.audio.matcher import BgmHit
 from allaganeye.config import SplitConfig
@@ -1096,7 +1096,7 @@ class _ETAProgressBar(_ClickProgressBar):
     def format_progress_line(self) -> str:
         bar = self.format_bar()
         pct = self.format_pct()
-        if self.show_eta and self.eta_known:
+        if self.show_eta and self.eta_known and not self.finished:
             eta = self.format_eta()
             return f"{self.label}{bar} {pct} ETA: {eta}"
         return f"{self.label}{bar} {pct}"

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -1087,9 +1087,9 @@ class _ETAProgressBar(_ClickProgressBar):
 
         Detecting  ###################---  93% ETA: 0:00:22
 
-    ``eta_known=False`` (update 未呼び出し / 1 秒以内) のときも ETA
-    セクションを出し ``ETA: --:--:--`` placeholder を表示する (Idios
-    feedback for #365: pre-update でも ETA を出す改善)。
+    ``eta_known=False`` (update 未呼び出し / make_step の 1 秒 debounce
+    gate 内) のときも ETA セクションを出し ``ETA: --:--:--`` placeholder
+    を表示する (Idios feedback for #365: pre-update でも ETA を出す改善)。
 
     ``show_eta=False`` (GPU mode #438 の ``suppress_click_eta=True``
     経路) では ETA セクションを出さず percent のみ表示。caller 側が
@@ -1137,6 +1137,14 @@ def _eta_progressbar(
         length=length,
         label=label.ljust(_PROGRESS_LABEL_WIDTH),
         bar_template="",  # 未使用 (format_progress_line を override したため)
+        # click.progressbar() factory 経由では empty_char='-' / width=36 が default
+        # だが、ProgressBar.__init__ class 直接インスタンス化では empty_char=' ' /
+        # width=30 と異なる default を持つ。issue #365 期待動作
+        # `Detecting  ####---  93% ETA: 0:00:22` の `####---` (dash empty char +
+        # 36 width) を維持するため明示する (PR #687 review feedback #1+#2 対応)。
+        fill_char="#",
+        empty_char="-",
+        width=36,
         show_eta=not suppress_click_eta,
         show_percent=True,
     )

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -1111,9 +1111,9 @@ class _ETAProgressBar(_ClickProgressBar):
         bar = self.format_bar()
         pct = self.format_pct()
         if self.show_eta and not self.finished:
-            # eta_known=False (update 未呼び出し / 1 秒以内) のとき format_eta()
-            # は空文字列を返すので、'--:--:--' placeholder で常時 ETA を表示する
-            # (Idios feedback: pre-update でも ETA を出す改善、#365)。
+            # eta_known=False (update 未呼び出し / make_step の 1 秒 debounce gate 内)
+            # のとき format_eta() は空文字列を返すので、'--:--:--' placeholder で
+            # 常時 ETA を表示する (Idios feedback: pre-update でも ETA を出す改善、#365)。
             eta = self.format_eta() or "--:--:--"
             return f"{self.label}{bar} {pct} ETA: {eta}"
         return f"{self.label}{bar} {pct}"

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -870,9 +870,16 @@ def _run_detection(
             # Long videos (2h+) used to sit at "Detecting 0%" for 2-3
             # minutes while the first chunk decoded; this shows users
             # the work has started and how many chunks to expect.
+            # Include "ETA: --:--:--" placeholder so users see a consistent
+            # ETA position from dispatch through chunk completion (#365
+            # Idios feedback: pre-update でも ETA を出す改善、CPU mode
+            # の commit 6e48381 と一貫する). Once the first chunk
+            # completes, ``on_chunk`` overwrites this label with the
+            # caller-computed ETA.
             detecting_bar.label = (
-                f"Detecting [dispatching {num_chunks} chunks, "
-                f"first result pending...]".ljust(_PROGRESS_LABEL_WIDTH)
+                f"Detecting [dispatching {num_chunks} chunks, ETA: --:--:--]".ljust(
+                    _PROGRESS_LABEL_WIDTH
+                )
             )
             detecting_bar.render_progress()
 

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -1080,9 +1080,16 @@ class _ETAProgressBar(_ClickProgressBar):
 
         Detecting  ###################---  93% ETA: 0:00:22
 
+    ``eta_known=False`` (update 未呼び出し / 1 秒以内) のときも ETA
+    セクションを出し ``ETA: --:--:--`` placeholder を表示する (Idios
+    feedback for #365: pre-update でも ETA を出す改善)。
+
     ``show_eta=False`` (GPU mode #438 の ``suppress_click_eta=True``
     経路) では ETA セクションを出さず percent のみ表示。caller 側が
     self-computed ETA を label に組み込む既存挙動と互換。
+
+    ``finished=True`` (100% 完了) では ETA: 00:00:00 を出さず percent
+    のみ表示 (click 親 class と整合)。
 
     依存する click 8.x の public method:
       - ``format_bar()``    -- bar 文字列
@@ -1096,8 +1103,11 @@ class _ETAProgressBar(_ClickProgressBar):
     def format_progress_line(self) -> str:
         bar = self.format_bar()
         pct = self.format_pct()
-        if self.show_eta and self.eta_known and not self.finished:
-            eta = self.format_eta()
+        if self.show_eta and not self.finished:
+            # eta_known=False (update 未呼び出し / 1 秒以内) のとき format_eta()
+            # は空文字列を返すので、'--:--:--' placeholder で常時 ETA を表示する
+            # (Idios feedback: pre-update でも ETA を出す改善、#365)。
+            eta = self.format_eta() or "--:--:--"
             return f"{self.label}{bar} {pct} ETA: {eta}"
         return f"{self.label}{bar} {pct}"
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -79,10 +79,10 @@ allaganeye 0.1.1 (ffmpeg 8.1, Python 3.12.10, Windows 11)
 Probing: recording.mkv
   Duration: 10228.7s, Resolution: 1920x1080, FPS: 60.00, Codec: h264
 Detecting match boundaries (interval=3.0s, threshold=15.0, workers=auto, min_match=300.0s, min_blackout=3.0s, audio=frozen)
-Detecting  #################################### 100% 0:00:22
-Refining   #################################### 100% 0:00:15
-Scorebar   #################################### 100% 0:00:08
-Splitting  #################################### 100% 0:00:05
+Detecting  #################################### 100%
+Refining   #################################### 100%
+Scorebar   #################################### 100%
+Splitting  #################################### 100%
 ...
 ```
 
@@ -133,7 +133,7 @@ Cache hit: detection params from .detection_cache.json
 Detected 8 match(es) in recording.mkv (2:50:28) (cached)
   Match 1:   00:00 -   15:17  (15m17s)  [unknown]
   ...
-Splitting  #################################### 100% 0:00:05
+Splitting  #################################### 100%
   Splitting: 8 matches, 0m05s
 Total: 0m07s
 ```

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -4025,3 +4025,27 @@ def test_eta_progressbar_placeholder_eta_before_first_update() -> None:
 
     assert "ETA: --:--:--" in line, f"missing placeholder in: {line!r}"
     assert "0%" in line
+
+
+def test_eta_progressbar_gpu_dispatching_label_with_eta_placeholder() -> None:
+    """GPU mode dispatching 段階の label に 'ETA: --:--:--' を含む format を verify (#365).
+
+    Caller (on_chunk_dispatch) が更新する label の expected string を bar に
+    直接設定し、format_progress_line() 出力に 'ETA: --:--:--' が含まれる
+    + subclass は ETA tail を出さない (show_eta=False) ことを確認する。
+    chunk 1 完了後は on_chunk が label を上書きするため、この ETA は
+    dispatching 段階にのみ表示される。
+    """
+    bar = _eta_progressbar(100, "Detecting", suppress_click_eta=True)
+    # caller (on_chunk_dispatch) が更新する label 文字列の expected
+    bar.label = "Detecting [dispatching 32 chunks, ETA: --:--:--]".ljust(
+        _PROGRESS_LABEL_WIDTH
+    )
+
+    line = bar.format_progress_line()
+
+    # caller label 内の placeholder を確認
+    assert "ETA: --:--:--" in line, f"caller label placeholder missing in: {line!r}"
+    # subclass は show_eta=False で ETA tail を出さない (二重表示防止 #438)
+    # ETA は label 内 1 つのみ
+    assert line.count("ETA:") == 1, f"expected single ETA occurrence in: {line!r}"

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -4069,7 +4069,7 @@ def test_eta_progressbar_bar_visual_uses_dashes_and_36_width() -> None:
 
     # empty char が '-' (issue #365 期待動作 ####--- に整合)
     assert "-" in line, f"expected '-' as empty char in: {line!r}"
-    # width=36 で 50% 進捗 → 18 fill + 18 empty
+    # width=36 で 50% 進捗 -> 18 fill + 18 empty
     assert "#" * 18 in line, f"expected 18 fills (width=36, 50%): {line!r}"
     assert "-" * 18 in line, f"expected 18 dashes (width=36, 50%): {line!r}"
 

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1,13 +1,18 @@
 """Tests for split_matches pipeline orchestration."""
 
 import json
+import re
+import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from allaganeye.commands.split_matches import (
+    _ETAProgressBar,
+    _PROGRESS_LABEL_WIDTH,
     _auto_sample_interval,
+    _eta_progressbar,
     _load_cache,
     _save_cache,
     run_split,
@@ -648,7 +653,7 @@ def test_splitting_bar_shown_in_normal_run(
     mock_split.return_value = _output_files(tmp_path)
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
 
-    with patch("click.progressbar") as mock_bar:
+    with patch(f"{MODULE}._ETAProgressBar") as mock_bar:
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
@@ -679,7 +684,7 @@ def test_progressbar_shows_eta_label(mock_probe, mock_detect, mock_split, tmp_pa
     # (which would suppress click ETA on Detecting per #438).
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, use_gpu=False)
 
-    with patch("click.progressbar") as mock_bar:
+    with patch(f"{MODULE}._ETAProgressBar") as mock_bar:
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
@@ -713,7 +718,7 @@ def test_progressbar_suppresses_click_eta_on_detecting_in_gpu_mode(
     mock_split.return_value = _output_files(tmp_path)
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, use_gpu=True)
 
-    with patch("click.progressbar") as mock_bar:
+    with patch(f"{MODULE}._ETAProgressBar") as mock_bar:
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
@@ -1131,7 +1136,7 @@ def test_progressbar_length(mock_probe, mock_detect, mock_split, tmp_path):
     mock_split.return_value = _output_files(tmp_path)
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
 
-    with patch("click.progressbar") as mock_bar:
+    with patch(f"{MODULE}._ETAProgressBar") as mock_bar:
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
@@ -1154,7 +1159,7 @@ def test_progressbar_tiny_video(mock_probe, mock_detect, mock_split, tmp_path):
     mock_split.return_value = _output_files(tmp_path)
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
 
-    with patch("click.progressbar") as mock_bar:
+    with patch(f"{MODULE}._ETAProgressBar") as mock_bar:
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
@@ -1176,7 +1181,7 @@ def test_progressbar_auto_interval(mock_probe, mock_detect, mock_split, tmp_path
     mock_split.return_value = _output_files(tmp_path)
     config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
 
-    with patch("click.progressbar") as mock_bar:
+    with patch(f"{MODULE}._ETAProgressBar") as mock_bar:
         mock_bar.return_value.__enter__ = lambda s: s
         mock_bar.return_value.__exit__ = lambda s, *a: None
         mock_bar.return_value.update = lambda n: None
@@ -3963,3 +3968,60 @@ def test_quiet_no_cache_only_output_listing(
     assert f"Output: {tmp_path}" in out
     assert "match_001.mp4" in out
     assert "Metadata:" in out
+
+
+# ============================================================
+# #365: progress bar ETA ラベル付与の format 検証
+# ============================================================
+
+_ETA_LINE_PATTERN = re.compile(r"\b\d{1,3}%\s+ETA:\s+\d+:\d{2}:\d{2}\b")
+
+
+def _drive_to_known_eta(bar: _ETAProgressBar, completed: int) -> None:
+    """Force eta_known by simulating elapsed time + progress.
+
+    click ProgressBar は ``start`` / ``last_eta`` が現在時刻で初期化され、
+    ``make_step`` 内の ``time.time() - self.last_eta < 1.0`` 条件が True の
+    間は ``eta_known`` が更新されない。テストでは ``start`` と ``last_eta``
+    を 10 秒前に巻き戻した上で update() し、``make_step`` 内の条件を
+    満たして ``eta_known=True`` にする。
+    """
+    past = time.time() - 10.0  # 10s 前から動いていた体
+    bar.start = past
+    bar.last_eta = past
+    bar.update(completed)
+
+
+@pytest.mark.parametrize("label", ["Detecting", "Refining", "Scorebar", "Splitting"])
+def test_eta_progressbar_label_present_for_all_bars(label: str) -> None:
+    """4 bar 全てで 'ETA: H:MM:SS' label を出すこと (#365)."""
+    bar = _eta_progressbar(100, label)
+    _drive_to_known_eta(bar, 50)
+
+    line = bar.format_progress_line()
+
+    assert line.startswith(label.ljust(_PROGRESS_LABEL_WIDTH))
+    assert "ETA: " in line, f"missing 'ETA: ' label in: {line!r}"
+    assert _ETA_LINE_PATTERN.search(line), f"format mismatch: {line!r}"
+
+
+def test_eta_progressbar_suppresses_eta_in_gpu_mode() -> None:
+    """suppress_click_eta=True (GPU mode #438) では ETA tail を出さず percent のみ."""
+    bar = _eta_progressbar(100, "Detecting", suppress_click_eta=True)
+    _drive_to_known_eta(bar, 50)
+
+    line = bar.format_progress_line()
+
+    assert "ETA: " not in line
+    assert re.search(r"\b\d{1,3}%\s*$", line.rstrip()), line
+
+
+def test_eta_progressbar_no_eta_before_first_update() -> None:
+    """update 前 (eta_known=False) は ETA tail を出さず percent のみ."""
+    bar = _eta_progressbar(100, "Detecting")
+    # _drive_to_known_eta を呼ばない -- start_time=None / eta_known=False のまま
+
+    line = bar.format_progress_line()
+
+    assert "ETA: " not in line
+    assert "0%" in line

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -4016,12 +4016,12 @@ def test_eta_progressbar_suppresses_eta_in_gpu_mode() -> None:
     assert re.search(r"\b\d{1,3}%\s*$", line.rstrip()), line
 
 
-def test_eta_progressbar_no_eta_before_first_update() -> None:
-    """update 前 (eta_known=False) は ETA tail を出さず percent のみ."""
+def test_eta_progressbar_placeholder_eta_before_first_update() -> None:
+    """update 前 (eta_known=False) は 'ETA: --:--:--' placeholder を出す (#365 Idios feedback)."""
     bar = _eta_progressbar(100, "Detecting")
     # _drive_to_known_eta を呼ばない -- eta_known=False のまま (start は初期化済みだが update 未実行で eta_known は False)
 
     line = bar.format_progress_line()
 
-    assert "ETA: " not in line
+    assert "ETA: --:--:--" in line, f"missing placeholder in: {line!r}"
     assert "0%" in line

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -672,7 +672,9 @@ def test_progressbar_shows_eta_label(mock_probe, mock_detect, mock_split, tmp_pa
     """Progress bars enable ETA and percent display in CPU mode (#329).
 
     Guards the contract from issue #329: the user must be able to tell
-    that the time shown is ETA, via ``show_eta=True`` on click.progressbar.
+    that the time shown is ETA, via ``show_eta=True`` on the
+    ``_ETAProgressBar`` subclass (refactored from ``click.progressbar``
+    factory in #365).
     GPU mode deliberately suppresses click's ETA on the Detecting bar
     (#438); that variant is covered by
     :func:`test_progressbar_suppresses_click_eta_on_detecting_in_gpu_mode`.
@@ -4049,3 +4051,35 @@ def test_eta_progressbar_gpu_dispatching_label_with_eta_placeholder() -> None:
     # subclass は show_eta=False で ETA tail を出さない (二重表示防止 #438)
     # ETA は label 内 1 つのみ
     assert line.count("ETA:") == 1, f"expected single ETA occurrence in: {line!r}"
+
+
+def test_eta_progressbar_bar_visual_uses_dashes_and_36_width() -> None:
+    """bar visual (empty_char='-' + width=36) が click.progressbar() factory baseline を維持すること (#365).
+
+    `_eta_progressbar` を `click.progressbar()` factory から `_ETAProgressBar(...)`
+    class 直接インスタンス化に refactor した際、factory と class の defaults 差異
+    (empty_char='-' vs ' '、width=36 vs 30) で silent visual regression が起きうる。
+    issue #365 期待動作 `Detecting  ####---  93% ETA: 0:00:22` の `####---` 部分
+    (dash empty char) を保持するための regression test (PR #687 review feedback #3 対応)。
+    """
+    bar = _eta_progressbar(100, "Detecting")
+    _drive_to_known_eta(bar, 50)
+
+    line = bar.format_progress_line()
+
+    # empty char が '-' (issue #365 期待動作 ####--- に整合)
+    assert "-" in line, f"expected '-' as empty char in: {line!r}"
+    # width=36 で 50% 進捗 → 18 fill + 18 empty
+    assert "#" * 18 in line, f"expected 18 fills (width=36, 50%): {line!r}"
+    assert "-" * 18 in line, f"expected 18 dashes (width=36, 50%): {line!r}"
+
+
+def test_eta_progressbar_finished_no_eta_tail() -> None:
+    """100% 完了時 (finished=True) は 'ETA: ' tail を出さない (commit 9bc3788 仕様、#365、PR #687 review feedback #6 対応)."""
+    bar = _eta_progressbar(100, "Splitting")
+    _drive_to_known_eta(bar, 100)  # 100% で finished=True
+
+    line = bar.format_progress_line()
+
+    assert "ETA:" not in line, f"100% で ETA tail が残存: {line!r}"
+    assert "100%" in line

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -3974,7 +3974,7 @@ def test_quiet_no_cache_only_output_listing(
 # #365: progress bar ETA ラベル付与の format 検証
 # ============================================================
 
-_ETA_LINE_PATTERN = re.compile(r"\b\d{1,3}%\s+ETA:\s+\d+:\d{2}:\d{2}\b")
+_ETA_LINE_PATTERN = re.compile(r"\b\d{1,3}%\s+ETA:\s+(?:\d+d\s+)?\d+:\d{2}:\d{2}\b")
 
 
 def _drive_to_known_eta(bar: _ETAProgressBar, completed: int) -> None:
@@ -4019,7 +4019,7 @@ def test_eta_progressbar_suppresses_eta_in_gpu_mode() -> None:
 def test_eta_progressbar_no_eta_before_first_update() -> None:
     """update 前 (eta_known=False) は ETA tail を出さず percent のみ."""
     bar = _eta_progressbar(100, "Detecting")
-    # _drive_to_known_eta を呼ばない -- start_time=None / eta_known=False のまま
+    # _drive_to_known_eta を呼ばない -- eta_known=False のまま (start は初期化済みだが update 未実行で eta_known は False)
 
     line = bar.format_progress_line()
 


### PR DESCRIPTION
## 概要

PR #343 (#329 修正) で `show_eta=True` を click.progressbar に渡したものの、`bar_template` が `%(info)s` を使っていたため click は `<percent>  <eta>` をラベルなしで展開し、ユーザーには時刻だけが見えて意味が伝わらない不完全修正で merge されていた ([#365](https://github.com/Idios/kobutachan-allaganeye/issues/365))。

`_eta_progressbar` を `_ETAProgressBar(_ClickProgressBar)` subclass + `format_progress_line()` override に refactor し、4 bar (Detecting / Refining / Scorebar / Splitting) で `93% ETA: 0:00:22` 形式に統一する。

## 変更ファイル

- `allaganeye/commands/split_matches.py`: `_ETAProgressBar` 追加、`_eta_progressbar` refactor、`from click._termui_impl import ProgressBar as _ClickProgressBar` を top 追加
- `tests/test_split_matches.py`: `format_progress_line()` の直接 assert test 3 種 (4 bar parametrize + GPU mode + eta_known=False) 追加、既存 6 test の patch 対象を `click.progressbar` から `_ETAProgressBar` に更新

## 受け入れ条件マッピング (Iron Law 1)

issue [#365](https://github.com/Idios/kobutachan-allaganeye/issues/365) には明示的な `## 受け入れ条件` セクションが無いため、「期待動作」と「根本原因分析」を逐条検証:

- [x] **期待動作**: `Detecting ####---  93% ETA: 0:00:22` 形式
  → `_ETAProgressBar.format_progress_line` で `f"{self.label}{bar} {pct} ETA: {eta}"` を生成
- [x] **影響範囲全 4 bar** (`Detecting`, `Refining`, `Scorebar`, `Splitting`)
  → `_eta_progressbar` の戻り型を `_ETAProgressBar` に変えるだけで全 caller (split_matches.py:810/898/922/1130) が新 format を享受
- [x] **直接原因** (`%(info)s` でラベルなし展開) の解消
  → `format_progress_line` override で click の組み込み templating を bypass
- [x] **検出漏れ** (PR #343 のテスト不足) の再発防止
  → `format_progress_line()` の出力に対する parametrize test (4 bar) + regex 一致 + GPU mode 経路 test + eta_known=False test の 3 種を追加

## 実装メモ: click private module の使用

`click.ProgressBar` は public API として export されていない (`click.__init__` に無い)。実クラスは `click._termui_impl.ProgressBar`。subclass のために `from click._termui_impl import ProgressBar as _ClickProgressBar` を使用した。click 8.3.1 (本プロジェクト pin バージョン) で検証済み。

## Self-Test Report

### machine-verified

- [x] `pytest tests/test_split_matches.py` (新 6 assertion 含む全 PASS、180 test)
- [x] `pytest tests/test_regression_330.py tests/test_progress_emitter.py` (regression PASS)
- [x] `pytest -m "not slow and not baseline_regen"` (901 passed, 1 skipped)
- [x] `ruff check .` (exit 0)
- [x] `ruff format --check .` (exit 0)
- [x] `pyright` (0 errors, 0 warnings, 0 informations)

### machine-unverifiable (Idios 実機検証)

- 短い sample 動画で `allaganeye split <video>` 実行 → Detecting / Refining / Scorebar / Splitting 4 bar 全てに `ETA: H:MM:SS` 表示 — **controller format dump で 2026-05-08 verify**: CPU pre-update / mid / 100% + GPU dispatching / mid の 5 scenarios すべて期待通り
- `--gpu` で sample 動画 → ETA 二重表示が起きないこと (GPU mode #438 互換確認) — **controller format dump で 2026-05-08 verify**: caller label `[chunk N/M, ETA ~T]` 経由で ETA 1 つ表示、subclass は `show_eta=False` で ETA tail なし、`line.count("ETA:") == 1` を test で担保
- 既存 metadata.json と diff なし (検知ロジック regression なし) — **本 PR は `_eta_progressbar` の format 変更のみで `video/detector.py` / `video/gpu_detector.py` 等の検知コードは不変**、metadata.json 出力に影響しない

## 関連

- 元 issue: [#329](https://github.com/Idios/kobutachan-allaganeye/issues/329) (CLOSED、不完全修正のため #365 で再対応)
- PR: [#343](https://github.com/Idios/kobutachan-allaganeye/pull/343) (不完全修正)
- GPU mode 経路: PR [#438](https://github.com/Idios/kobutachan-allaganeye/pull/438) (`suppress_click_eta=True`)
- spec: `docs/superpowers/specs/2026-05-08-l2-lane-ivc-group-h-design.md` §5

session-id: musing-davinci-38136f

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 修正履歴 (5 commits cumulative)

| commit | scope | 詳細 |
| --- | --- | --- |
| `0dd5709` | TDD Green 初回実装 | `_ETAProgressBar(_ClickProgressBar)` subclass 導入、`format_progress_line()` override、3 種 test (4 bar parametrize + GPU mode + eta_known=False) |
| `9bc3788` | 1st review fix | import ordering / `not self.finished` guard (100% 完了時 ETA 抑止) / test comment 訂正 / regex `Nd` 対応 |
| `6e48381` | 2nd Idios feedback | CPU mode pre-update に `ETA: --:--:--` placeholder を出すよう条件緩和 (`eta_known` check 撤廃) |
| `10a787b` | 3rd Idios feedback | GPU mode dispatching 段階の caller label に `ETA: --:--:--` 含有 (`on_chunk_dispatch` 修正) + 専用 test |
| `317691a` | 4th `/review-pr` feedback | (#1) `empty_char='-'` (#2) `width=36` 復元 = factory baseline 維持 / (#3) bar visual test / (#4) `cli-spec.md` 100% 出力例追従 / (#5) test docstring 更新 / (#6) finished test / (#7) docstring wording precision |

## 最終的な scope

本 PR (5 commits 累積) の最終 scope:

1. **`_ETAProgressBar` subclass 導入** (元 issue #365 の core fix): `bar_template="%(info)s"` ラベルなし展開を bypass し `Detecting ####---  93% ETA: 0:00:22` 形式に統一
2. **CPU mode pre-update placeholder**: `ETA: --:--:--` を出して経過時間/残り時間の判別可能性を確保
3. **GPU mode dispatching label placeholder**: `Detecting [dispatching N chunks, ETA: --:--:--]` で chunk 開始前も ETA position 一貫表示
4. **100% 完了時の ETA 抑止**: `not self.finished` guard で `ETA: 00:00:00` 誤表示を防止 (click 親 class と整合)
5. **factory baseline 維持** (#1+#2 critical fix): `empty_char='-'` + `width=36` 明示で `####---` visual を class default の `####    ` (空白 + 短 width) regression から防衛
6. **`docs/cli-spec.md` 出力例追従**: 100% 行を新仕様 (ETA 抑止) に整合
