### PR TITLE
refactor(gui): #663 AppError migration 完遂 (legacy fallback 撤去 + per-code default hint 全 80 site 適用) (Lane I-A)

### DIFF
--- a/docs/superpowers/plans/2026-05-08-l2-appError-migration-completion.md
+++ b/docs/superpowers/plans/2026-05-08-l2-appError-migration-completion.md
@@ -1,0 +1,2326 @@
+# AppError migration 完遂 (Lane I-A / #663) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR #665 で完了済の `Result<T, AppError>` migration を踏まえ、#663 の残作業 (legacy fallback 撤去 / per-code default hint 全 80 site 適用 / frontend hint 表示 / docs 整合) を 1 PR で完遂する。
+
+**Architecture:** Rust `error.rs` に per-code default hint helper を導入 → 全 80 site で `.with_default_hint()` chain → frontend store/screens で per-store error+hint pair + inline 2 行目 render → docs / issue body を実態と整合させる。詳細は spec [docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md](../specs/2026-05-08-l2-appError-migration-completion-design.md) (commit `c3a1ddf`) を source of truth とする。
+
+**Tech Stack:** Rust (Tauri 2 backend) / TypeScript + React 19 + Zustand (frontend) / vitest + cargo test / Tauri 2 invoke + serde JSON / markdownlint-cli2 / `gh` CLI for issue body update.
+
+**Iron Law 整合 (本 plan で担保):**
+
+- Iron Law 1 (受け入れ条件): spec § 12 を逐条検証可能な list として保持
+- Iron Law 3 (scope creep): non-goals (spec § 3) を遵守、scope 外検出時は scope-guard skill 起動
+- Iron Law 4 (Closes 禁止): commit / PR 本文に `Refs #663` のみ、issue クローズは別 step (`/close-issue`)
+- Iron Law 5 (曖昧 AskUserQuestion): 5 経路の実機検証は Phase 6 で `AskUserQuestion` で Idios に依頼
+- Iron Law 6 (PR Pre-flight + 実機検証): Phase 6 で完全準拠
+
+---
+
+## File structure (touched files)
+
+```text
+gui/src-tauri/src/
+  error.rs              ← Phase 1 (helper + From impl + 6 new tests)
+  lib.rs                ← Phase 2 (80 sites mechanical)
+
+gui/src/state/
+  metadataStore.ts      ← Phase 3 (5 errorHint state + catch + remove legacy fallback)
+  metadataStore.test.ts ← Phase 3 (8 rewrite + 5 new)
+  recentStore.ts        ← Phase 3 (addErrorHint + loadErrorHint)
+  recentStore.test.ts   ← Phase 3 (2 new)
+
+gui/src/components/
+  ConflictModal.test.tsx ← Phase 3 (test data fix)
+  RestoreButton.tsx      ← Phase 4 (hint 2nd line)
+  RestoreButton.module.css ← Phase 4 (.error → .errorHint pair)
+  RestoreButton.test.tsx ← Phase 4 (2 new tests)
+
+gui/src/screens/
+  DropScreen.tsx + .test.tsx           ← Phase 4 (local errorHint state + render)
+  DetectingScreen.tsx + .test.tsx      ← Phase 4 (local errorHint state + render)
+  PreviewScreen.tsx + .test.tsx        ← Phase 4 (store applyErrorHint render)
+  ExportScreen.tsx + .test.tsx         ← Phase 4 (per-match errorHint reducer)
+
+gui/src/styles/tokens.css
+  + 各 module.css                      ← Phase 4 (.errorHint shared style)
+
+docs/
+  tauri-commands.md      ← Phase 5 (hint mapping table)
+  ui-architecture.md     ← Phase 5 (§ 4.x AppError code 一覧)
+  ui-interaction-spec.md ← Phase 5 (§ 1.5.x error.code 分岐ルール)
+
+(Issue body)
+  #663                   ← Phase 5 (gh issue edit)
+```
+
+**Commit 構成 (Phase = 1 commit):**
+
+1. `feat(gui): AppError::default_hint_for_code helper を追加 (Refs #663)` — Phase 1
+2. `refactor(gui): lib.rs 全 80 site に .with_default_hint() を適用 (Refs #663)` — Phase 2
+3. `feat(gui): metadataStore / recentStore に *ErrorHint state を追加 + legacy fallback 削除 (Refs #663)` — Phase 3
+4. `feat(gui): 各 screen の inline error に hint 2 行目を追加 (Refs #663)` — Phase 4
+5. `docs: AppError default hint mapping を docs に整合させる (Refs #663)` — Phase 5
+
+Phase 6 は PR 提出 step で commit を伴わない (Pre-flight + 実機検証 + PR 作成のみ)。
+
+---
+
+## Task 0: Pre-flight (worktree state verification)
+
+**Files:**
+
+- Read: spec `docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md`
+- Verify: `git status` clean, branch `claude/tender-khayyam-03d618`
+
+- [ ] **Step 1: Confirm working directory and branch**
+
+```bash
+pwd
+# Expected: /e/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/tender-khayyam-03d618
+
+git branch --show-current
+# Expected: claude/tender-khayyam-03d618
+
+git status
+# Expected: nothing to commit, working tree clean (or only spec commit c3a1ddf)
+```
+
+- [ ] **Step 2: Read the spec for full context**
+
+Read `docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md` end-to-end. The spec is the source of truth for all design decisions (22 hint codes, 4-layer architecture, scope boundaries).
+
+- [ ] **Step 3: Verify Iron Law base sync**
+
+```bash
+git fetch origin develop-0.2.0
+git log HEAD..origin/develop-0.2.0 --oneline
+```
+
+Expected: empty (no new commits to pull) OR list of new commits. If non-empty AND any commit touches `gui/src-tauri/src/error.rs|lib.rs|gui/src/state/*|gui/src/components/*|gui/src/screens/*|docs/*`, run `git merge origin/develop-0.2.0` and re-run automated checks. (`docs/l2-workflow.md` § PR 作成 Pre-flight に従う)
+
+- [ ] **Step 4: Verify no parallel worktree PR for #663**
+
+```bash
+gh pr list --search "#663" --state all
+gh pr list --state open --search "claude/"
+```
+
+Expected: no other open PR claiming #663. If a parallel PR exists, halt and ask user via `AskUserQuestion`.
+
+---
+
+## Phase 1: Rust `error.rs` (default hint helper + From impl chains)
+
+### Task 1.1: TDD `default_hint_for_code` helper
+
+**Files:**
+
+- Modify: `gui/src-tauri/src/error.rs`
+
+- [ ] **Step 1: Write the failing test for `default_hint_covers_all_known_codes`**
+
+Add inside the existing `mod tests` in `gui/src-tauri/src/error.rs`:
+
+```rust
+    #[test]
+    fn default_hint_covers_all_known_codes() {
+        let with_hint = [
+            "state.mtime_conflict",
+            "io.file_not_found", "io.read_failed", "io.write_failed",
+            "io.delete_failed", "io.backup_failed",
+            "io.permission_denied", "io.already_exists",
+            "io.would_block", "io.timed_out", "io.error",
+            "parse.json_invalid", "parse.json_serialize_failed",
+            "parse.schema_invalid", "parse.ffprobe_output_invalid",
+            "subprocess.spawn_failed", "subprocess.exit_failed",
+            "validation.path_invalid", "validation.not_a_file", "validation.range_invalid",
+            "path.install_dir_unresolved", "platform.unsupported",
+        ];
+        for code in with_hint {
+            assert!(default_hint_for_code(code).is_some(), "missing hint for code: {}", code);
+        }
+        assert!(default_hint_for_code("subprocess.cancelled").is_none());
+        assert!(default_hint_for_code("internal.error").is_none());
+        assert!(default_hint_for_code("unknown.code").is_none());
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd gui/src-tauri && cargo test --lib --no-fail-fast default_hint_covers_all_known_codes 2>&1 | tail -20
+```
+
+Expected: FAIL with `cannot find function default_hint_for_code in this scope` or similar.
+
+- [ ] **Step 3: Implement `default_hint_for_code` (top-level fn in error.rs, OUTSIDE the `tests` mod)**
+
+Add the following just before the existing `#[derive(Debug, Clone, Serialize)] pub struct PanicPayload` block (i.e. after the `From<String>` impl, before `PanicPayload`):
+
+```rust
+/// AppError code に対する日本語 default hint を返す。未登録 code は None。
+/// 22 entries (現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
+/// validation.* / path.* / platform.* / internal.*)。
+/// 文言は `docs/tauri-commands.md` の AppError default hint mapping table と一致させる
+/// (本 fn が source of truth、docs は mirror)。
+fn default_hint_for_code(code: &str) -> Option<&'static str> {
+    match code {
+        // state
+        "state.mtime_conflict" => Some(
+            "metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください"
+        ),
+        // io (manual call site)
+        "io.file_not_found" => Some(
+            "ファイルが見つかりません。パスを確認するか、allaganeye split を再実行してください"
+        ),
+        "io.read_failed" => Some(
+            "ファイルの読み込みに失敗しました。ディスク状況・ファイルロック状態を確認してください"
+        ),
+        "io.write_failed" => Some(
+            "ファイルの書き込みに失敗しました。空き容量と書き込み権限 (Portable ZIP の install dir が user-writable か) を確認してください"
+        ),
+        "io.delete_failed" => Some(
+            "ファイル / フォルダの削除に失敗しました。他プロセスでロックされていないか確認してください"
+        ),
+        "io.backup_failed" => Some(
+            "バックアップファイルの作成に失敗しました。allaganeye 出力フォルダの空き容量と書き込み権限を確認してください"
+        ),
+        // io (auto from std::io::Error::ErrorKind via From impl)
+        "io.permission_denied" => Some(
+            "ファイルへのアクセス権限がありません。Portable ZIP install dir が user-writable な場所か、ファイル / フォルダが読み取り専用でないか確認してください"
+        ),
+        "io.already_exists" => Some(
+            "ファイルが既に存在します。出力先を変更するか既存ファイルを削除してください"
+        ),
+        "io.would_block" | "io.timed_out" => Some(
+            "I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください"
+        ),
+        "io.error" => Some(
+            "I/O エラーが発生しました。詳細は logs フォルダを確認してください"
+        ),
+        // parse
+        "parse.json_invalid" => Some(
+            "JSON ファイルが破損しています。バックアップ (.bak) からの復元か allaganeye split のやり直しを検討してください"
+        ),
+        "parse.json_serialize_failed" => Some(
+            "JSON 書き出しに失敗しました。同梱 issue テンプレートでバグ報告してください"
+        ),
+        "parse.schema_invalid" => Some(
+            "metadata.json の構造が期待形式と異なります。allaganeye のバージョンと metadata 生成バージョンが一致しているか確認してください"
+        ),
+        "parse.ffprobe_output_invalid" => Some(
+            "ffprobe の出力を解釈できませんでした。ffmpeg / ffprobe を最新の BtbN LGPL ビルドに更新してください"
+        ),
+        // subprocess
+        "subprocess.spawn_failed" => Some(
+            "外部プロセスの起動に失敗しました。ffmpeg / Python / 同梱 runtime が壊れていないか確認してください"
+        ),
+        "subprocess.exit_failed" => Some(
+            "外部プロセスが異常終了しました。logs フォルダの最新ログから詳細を確認してください"
+        ),
+        "subprocess.cancelled" => None, // ユーザー操作によるキャンセルは hint 不要 (UI 側で「キャンセルされました」を表示で十分)
+        // validation
+        "validation.path_invalid" => Some(
+            "入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v)"
+        ),
+        "validation.not_a_file" => Some(
+            "指定されたパスはファイルではありません (フォルダや symlink ではなく動画ファイルを選択してください)"
+        ),
+        "validation.range_invalid" => Some(
+            "入力された数値が許容範囲外です。フォーム下のヒント表示を確認してください"
+        ),
+        // path / platform / internal
+        "path.install_dir_unresolved" => Some(
+            "Portable ZIP の install dir を特定できませんでした。allaganeye-gui.exe を ZIP 展開後の元のフォルダ構成のまま起動してください"
+        ),
+        "platform.unsupported" => Some(
+            "本機能は現在の OS では未対応です。Windows での起動が必要です"
+        ),
+        "internal.error" => None, // 内部エラーで具体的アクションがない (詳細は logs 参照を message 側で示す方針)
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd gui/src-tauri && cargo test --lib --no-fail-fast default_hint_covers_all_known_codes 2>&1 | tail -10
+```
+
+Expected: PASS (`test tests::default_hint_covers_all_known_codes ... ok`).
+
+### Task 1.2: TDD `with_default_hint` method
+
+**Files:**
+
+- Modify: `gui/src-tauri/src/error.rs`
+
+- [ ] **Step 1: Write 3 failing tests**
+
+Add inside `mod tests` (in `gui/src-tauri/src/error.rs`):
+
+```rust
+    #[test]
+    fn with_default_hint_attaches_known_code() {
+        let e = AppError::new("io.read_failed", "could not read").with_default_hint();
+        assert!(e.hint.is_some());
+        assert!(e.hint.unwrap().contains("ディスク状況"));
+    }
+
+    #[test]
+    fn with_default_hint_does_not_overwrite_explicit_hint() {
+        let e = AppError::new("io.read_failed", "msg")
+            .with_hint("custom hint")
+            .with_default_hint();
+        assert_eq!(e.hint.as_deref(), Some("custom hint"));
+    }
+
+    #[test]
+    fn with_default_hint_returns_no_hint_for_unknown_code() {
+        let e = AppError::new("unknown.code", "msg").with_default_hint();
+        assert!(e.hint.is_none());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd gui/src-tauri && cargo test --lib --no-fail-fast with_default_hint 2>&1 | tail -20
+```
+
+Expected: 3 FAIL with `no method named with_default_hint found for struct AppError`.
+
+- [ ] **Step 3: Implement `with_default_hint` method**
+
+Add inside the existing `impl AppError { ... }` block in `gui/src-tauri/src/error.rs` (right after `with_stacktrace`):
+
+```rust
+    /// code に対する default hint を attach する。すでに hint が設定されている場合は
+    /// 上書きせず保持する (call site で `.with_hint("...")` を先に書いた場合の override
+    /// が効く設計、将来 Approach C への hybrid 移行時に必要)。
+    pub fn with_default_hint(mut self) -> Self {
+        if self.hint.is_some() {
+            return self;
+        }
+        self.hint = default_hint_for_code(&self.code).map(String::from);
+        self
+    }
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+cd gui/src-tauri && cargo test --lib --no-fail-fast with_default_hint 2>&1 | tail -10
+```
+
+Expected: 3 PASS.
+
+### Task 1.3: TDD `From<io::Error>` and `From<serde_json::Error>` hint chain
+
+**Files:**
+
+- Modify: `gui/src-tauri/src/error.rs`
+
+- [ ] **Step 1: Write 2 failing tests**
+
+Add inside `mod tests` (in `gui/src-tauri/src/error.rs`):
+
+```rust
+    #[test]
+    fn from_io_error_attaches_default_hint() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "x");
+        let e: AppError = io_err.into();
+        assert_eq!(e.code, "io.file_not_found");
+        assert!(e.hint.is_some());
+    }
+
+    #[test]
+    fn from_serde_json_error_attaches_default_hint() {
+        let json_err = serde_json::from_str::<serde_json::Value>("{ invalid").unwrap_err();
+        let e: AppError = json_err.into();
+        assert_eq!(e.code, "parse.json_invalid");
+        assert!(e.hint.is_some());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd gui/src-tauri && cargo test --lib --no-fail-fast from_io_error from_serde_json_error 2>&1 | tail -20
+```
+
+Expected: 2 FAIL with `assertion 'left == right' failed` (e.hint is None instead of Some(...)).
+
+- [ ] **Step 3: Update From impls to chain `.with_default_hint()`**
+
+In `gui/src-tauri/src/error.rs`, modify the existing `From<std::io::Error>` impl by appending `.with_default_hint()` at the final expression:
+
+```rust
+impl From<std::io::Error> for AppError {
+    fn from(e: std::io::Error) -> Self {
+        let code = match e.kind() {
+            std::io::ErrorKind::NotFound => "io.file_not_found",
+            std::io::ErrorKind::PermissionDenied => "io.permission_denied",
+            std::io::ErrorKind::AlreadyExists => "io.already_exists",
+            std::io::ErrorKind::WouldBlock => "io.would_block",
+            std::io::ErrorKind::TimedOut => "io.timed_out",
+            _ => "io.error",
+        };
+        AppError::new(code, e.to_string()).with_default_hint()
+    }
+}
+```
+
+And the `From<serde_json::Error>` impl:
+
+```rust
+impl From<serde_json::Error> for AppError {
+    fn from(e: serde_json::Error) -> Self {
+        AppError::new("parse.json_invalid", e.to_string()).with_default_hint()
+    }
+}
+```
+
+Leave `From<String>` unchanged — `internal.error` correctly maps to None hint.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+cd gui/src-tauri && cargo test --lib --no-fail-fast from_io_error from_serde_json_error 2>&1 | tail -10
+```
+
+Expected: 2 PASS.
+
+### Task 1.4: Phase 1 full test pass + commit
+
+- [ ] **Step 1: Run full cargo test --lib**
+
+```bash
+cd gui/src-tauri && cargo test --lib 2>&1 | tail -30
+```
+
+Expected: `test result: ok. 155 passed; 0 failed` (149 existing + 6 new).
+
+- [ ] **Step 2: Run cargo check for warnings**
+
+```bash
+cd gui/src-tauri && cargo check 2>&1 | tail -20
+```
+
+Expected: no warnings, especially no `with_hint` dead-code warning (it's used by the existing `serialize_app_error_roundtrips` test and the new `with_default_hint_does_not_overwrite_explicit_hint` test, so `#[allow(dead_code)]` continues to suppress non-test build warnings).
+
+- [ ] **Step 3: Commit Phase 1**
+
+```bash
+cd ../..  # back to worktree root
+git add gui/src-tauri/src/error.rs
+git commit -m "$(cat <<'EOF'
+feat(gui): AppError::default_hint_for_code helper を追加 (Refs #663)
+
+PR #665 で Result<T, AppError> migration が完了済の状態を踏まえ、22 codes
+(state / io.manual / io.auto / parse / subprocess / validation / path /
+platform / internal) に対する日本語 default hint を error.rs の 1 mapping
+table に集約。
+
+主な追加:
+
+- default_hint_for_code(code: &str) -> Option<&'static str> (22 entries)
+- AppError::with_default_hint(self) -> Self (既存 hint があれば上書きしない)
+- From<std::io::Error> / From<serde_json::Error> impl 内で
+  .with_default_hint() を chain (?演算子で自動 hint 付与)
+- 6 件の TDD red→green test (default_hint_covers_all_known_codes /
+  with_default_hint_attaches_known_code /
+  with_default_hint_does_not_overwrite_explicit_hint /
+  with_default_hint_returns_no_hint_for_unknown_code /
+  from_io_error_attaches_default_hint /
+  from_serde_json_error_attaches_default_hint)
+
+Phase 1/5 (spec docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md §5、commit c3a1ddf 参照)。
+
+Refs #663
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit success, 1 file changed.
+
+---
+
+## Phase 2: Rust `lib.rs` mechanical migration
+
+### Task 2.1: Add `.with_default_hint()` chain to all 80 sites
+
+**Files:**
+
+- Modify: `gui/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Verify the current count is 80**
+
+```bash
+grep -c 'AppError::new(' gui/src-tauri/src/lib.rs
+```
+
+Expected: `80`. If this number changed (e.g. after a base merge), pause and reconcile with the spec.
+
+- [ ] **Step 2: Apply mechanical chain to all 80 sites**
+
+For each `AppError::new(code, message_expr)` invocation in `gui/src-tauri/src/lib.rs`, append `.with_default_hint()` at the end of the expression chain (before any `?`, `.into()`, or terminating `;`).
+
+Two patterns occur. **Pattern A** (call as expression terminating an `Err(...)` constructor):
+
+```rust
+// before
+return Err(AppError::new(
+    "state.mtime_conflict",
+    format!("expected mtime {} got {}", expected, actual),
+));
+
+// after
+return Err(AppError::new(
+    "state.mtime_conflict",
+    format!("expected mtime {} got {}", expected, actual),
+).with_default_hint());
+```
+
+**Pattern B** (used in `.map_err(|_| AppError::new(...))` or `.ok_or_else(|| AppError::new(...))`):
+
+```rust
+// before
+.map_err(|e| {
+    AppError::new(
+        "io.read_failed",
+        format!("read recent.json: {}", e),
+    )
+})?;
+
+// after
+.map_err(|e| {
+    AppError::new(
+        "io.read_failed",
+        format!("read recent.json: {}", e),
+    )
+    .with_default_hint()
+})?;
+```
+
+Approach: walk through the file linearly (search-and-edit). After each batch of ~20 edits, run `cargo check` to surface syntax errors early. Useful command to find remaining sites:
+
+```bash
+# Find AppError::new sites that are NOT already followed by .with_default_hint()
+grep -n 'AppError::new(' gui/src-tauri/src/lib.rs | head
+```
+
+After the walk, verify no site was missed:
+
+```bash
+# Count sites that have AppError::new on a line — should be 80
+grep -c 'AppError::new(' gui/src-tauri/src/lib.rs
+# Count sites that already have .with_default_hint() called somewhere within ~10 lines after AppError::new
+# (rough sanity check — every AppError::new should have a corresponding .with_default_hint())
+grep -c 'with_default_hint' gui/src-tauri/src/lib.rs
+```
+
+Expected after migration: both `80`. If `with_default_hint` count is less, find missing sites by searching `AppError::new` and checking each.
+
+- [ ] **Step 3: Run cargo check to verify compile**
+
+```bash
+cd gui/src-tauri && cargo check 2>&1 | tail -30
+```
+
+Expected: `Finished` with no errors. Warnings are acceptable but should be reviewed (no new warnings expected — `with_default_hint` returns `Self` so chain is type-compatible).
+
+- [ ] **Step 4: Run full cargo test --lib**
+
+```bash
+cd gui/src-tauri && cargo test --lib 2>&1 | tail -20
+```
+
+Expected: `test result: ok. 155 passed; 0 failed` (existing 149 + Phase 1 added 6, all still passing — chain is non-breaking since hint is additive).
+
+- [ ] **Step 5: Commit Phase 2**
+
+```bash
+cd ../..
+git add gui/src-tauri/src/lib.rs
+git commit -m "$(cat <<'EOF'
+refactor(gui): lib.rs 全 80 site に .with_default_hint() を適用 (Refs #663)
+
+Phase 1 で追加した default_hint_for_code mapping を実際に通すため、lib.rs
+の全 80 site の AppError::new(code, msg) 呼び出しに .with_default_hint()
+を chain。22 unique codes が production AppError 経由で hint 付き object
+として frontend に届くようになる。
+
+mechanical migration のみ。新規ロジックなし、既存 cargo test --lib 155 件
+すべて pass (regression なし)。From<io::Error> / From<serde_json::Error>
+経路の自動 hint 付与は Phase 1 の impl 改修で完了済。
+
+Phase 2/5 (spec §6 mechanical 章)。
+
+Refs #663
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit success, 1 file changed.
+
+---
+
+## Phase 3: Frontend stores (metadataStore + recentStore) + legacy fallback removal
+
+### Task 3.1: Pre-read frontend store + test files
+
+**Files:**
+
+- Read: `gui/src/state/metadataStore.ts` / `recentStore.ts` / corresponding `.test.ts` files
+
+- [ ] **Step 1: Re-read metadataStore.ts**
+
+Identify the 5 catch blocks that produce error state (current line refs from spec § 7):
+
+- `runApply` catch (line 204-214) — sets `applyError` / `conflictError`
+- `load` catch (line 262-275) — sets `loadError`
+- `restore` catch (line 335-340) — sets `restoreError`
+- `saveDraft` catch (line 384-388) — sets `draftSaveError`
+- `loadDraft` catch (line 416-421) — sets `draftLoadError`
+
+Note: Each catch must set `*ErrorHint: appErrorHint(e)` in addition to `*Error: appErrorMessage(e)`. The `runApply` catch also branches on conflict — `conflictError` does NOT get a hint (scope-out per spec § 3).
+
+- [ ] **Step 2: Re-read recentStore.ts**
+
+Identify the 2 catch blocks:
+
+- `load` catch (line 59-64) — sets `loadError`
+- `add` catch (line 74-76) — sets `addError`
+
+- [ ] **Step 3: Identify the existing 8 conflict test cases in metadataStore.test.ts**
+
+```bash
+grep -n "'conflict:" gui/src/state/metadataStore.test.ts
+```
+
+Expected: 4-8 lines containing legacy raw-string conflict test cases. Each one needs to be rewritten to construct an `AppError`-shaped object instead.
+
+### Task 3.2: TDD metadataStore *ErrorHint state fields
+
+**Files:**
+
+- Modify: `gui/src/state/metadataStore.ts`
+- Modify: `gui/src/state/metadataStore.test.ts`
+
+- [ ] **Step 1: Write 5 failing tests**
+
+Add to `gui/src/state/metadataStore.test.ts` (in a new `describe` block at end of file or grouped with existing apply/load tests):
+
+```typescript
+describe('AppError hint pair (#663)', () => {
+  beforeEach(() => {
+    useMetadataStore.getState().clear();
+  });
+
+  it('apply path: applyErrorHint is set when AppError carries hint', async () => {
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockImplementation(async (cmd) => {
+      if (cmd === 'apply_changes') {
+        // Tauri rejects with the AppError-shaped object directly
+        throw {
+          code: 'io.write_failed',
+          message: 'disk full',
+          hint: 'check free disk space',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+    useMetadataStore.setState({
+      metadata: { source: 'x', matches: [] } as never,
+      filePath: '/tmp/m.json',
+      loadedMtimeMs: 1000,
+    });
+    await useMetadataStore.getState().apply();
+    const s = useMetadataStore.getState();
+    expect(s.applyError).toBe('disk full');
+    expect(s.applyErrorHint).toBe('check free disk space');
+  });
+
+  it('load path: loadErrorHint is set when AppError carries hint', async () => {
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockImplementation(async () => {
+      throw {
+        code: 'io.file_not_found',
+        message: 'no such file',
+        hint: 'check path',
+      };
+    });
+    await useMetadataStore.getState().load('/tmp/missing.json');
+    const s = useMetadataStore.getState();
+    expect(s.loadError).toBe('no such file');
+    expect(s.loadErrorHint).toBe('check path');
+  });
+
+  it('restore path: restoreErrorHint is set', async () => {
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockImplementation(async (cmd) => {
+      if (cmd === 'restore_from_original') {
+        throw { code: 'io.backup_failed', message: 'no backup', hint: 'create backup first' };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+    useMetadataStore.setState({ filePath: '/tmp/m.json' });
+    await useMetadataStore.getState().restore();
+    const s = useMetadataStore.getState();
+    expect(s.restoreError).toBe('no backup');
+    expect(s.restoreErrorHint).toBe('create backup first');
+  });
+
+  it('saveDraft path: draftSaveErrorHint is set', async () => {
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockImplementation(async (cmd) => {
+      if (cmd === 'save_draft') {
+        throw { code: 'io.write_failed', message: 'disk full', hint: 'free space' };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+    useMetadataStore.setState({
+      filePath: '/tmp/m.json',
+      metadata: { source: 'x', matches: [] } as never,
+    });
+    await useMetadataStore.getState().saveDraft();
+    const s = useMetadataStore.getState();
+    expect(s.draftSaveError).toBe('disk full');
+    expect(s.draftSaveErrorHint).toBe('free space');
+  });
+
+  it('loadDraft path: draftLoadErrorHint is set', async () => {
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockImplementation(async (cmd) => {
+      if (cmd === 'load_draft') {
+        throw { code: 'parse.json_invalid', message: 'bad json', hint: 'corrupt draft' };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+    useMetadataStore.setState({
+      filePath: '/tmp/m.json',
+      metadata: { source: 'x', matches: [] } as never,
+    });
+    await useMetadataStore.getState().loadDraft();
+    const s = useMetadataStore.getState();
+    expect(s.draftLoadError).toBe('bad json');
+    expect(s.draftLoadErrorHint).toBe('corrupt draft');
+  });
+
+  it('legacy raw-Error reject keeps hint null', async () => {
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockImplementation(async () => {
+      throw new Error('plain error string');
+    });
+    await useMetadataStore.getState().load('/tmp/x.json');
+    const s = useMetadataStore.getState();
+    expect(s.loadError).toBe('plain error string');
+    expect(s.loadErrorHint).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd gui && npm test -- --run metadataStore.test.ts 2>&1 | tail -40
+```
+
+Expected: 6 FAIL with `Property 'applyErrorHint' does not exist on type 'MetadataState'` (TypeScript) or `expect(undefined).toBe('check free disk space')` (runtime).
+
+- [ ] **Step 3: Add 5 errorHint state fields + import `appErrorHint`**
+
+In `gui/src/state/metadataStore.ts`:
+
+a) Update import on line 4:
+
+```typescript
+import { appErrorCodeIs, appErrorHint, appErrorMessage } from '../lib/appError';
+```
+
+b) Add 5 fields to `MetadataState` interface (next to their corresponding `*Error` fields):
+
+```typescript
+  loadError: string | null;
+  loadErrorHint: string | null;       // ← 新規 (#663)
+
+  applying: boolean;
+  applyError: string | null;
+  applyErrorHint: string | null;       // ← 新規 (#663)
+
+  // ...
+
+  /** #516: last restore error message, if any. */
+  restoreError: string | null;
+  /** #663: hint for restoreError, if AppError carried one. */
+  restoreErrorHint: string | null;     // ← 新規
+
+  // ...
+
+  /** #517: last draft load error (corrupt draft / parse failure). */
+  draftLoadError: string | null;
+  /** #663: hint for draftLoadError. */
+  draftLoadErrorHint: string | null;   // ← 新規
+
+  draftSaving: boolean;
+  // ...
+  draftSaveError: string | null;
+  /** #663: hint for draftSaveError. */
+  draftSaveErrorHint: string | null;   // ← 新規
+```
+
+c) Add 5 fields to default state (the `return { ... }` of `create<>` at lines ~217-235):
+
+```typescript
+  loadError: null,
+  loadErrorHint: null,         // ← 新規
+  applying: false,
+  applyError: null,
+  applyErrorHint: null,        // ← 新規
+
+  hasBackup: false,
+  restoring: false,
+  restoreError: null,
+  restoreErrorHint: null,      // ← 新規
+
+  loadedMtimeMs: null,
+  conflictError: null,
+  pendingDraft: null,
+  draftLoadError: null,
+  draftLoadErrorHint: null,    // ← 新規
+  draftSaving: false,
+  draftSaveError: null,
+  draftSaveErrorHint: null,    // ← 新規
+```
+
+d) Update the `clear()` action (line ~305) to reset all 5 hint fields:
+
+```typescript
+  clear: () => {
+    cancelDraftSave();
+    set({
+      metadata: null,
+      filePath: null,
+      dirty: false,
+      loadError: null,
+      loadErrorHint: null,
+      applying: false,
+      applyError: null,
+      applyErrorHint: null,
+      hasBackup: false,
+      restoring: false,
+      restoreError: null,
+      restoreErrorHint: null,
+      loadedMtimeMs: null,
+      conflictError: null,
+      pendingDraft: null,
+      draftLoadError: null,
+      draftLoadErrorHint: null,
+      draftSaving: false,
+      draftSaveError: null,
+      draftSaveErrorHint: null,
+    });
+  },
+```
+
+e) Update `loadSample()` action (line ~471) similarly:
+
+```typescript
+  loadSample: () => {
+    cancelDraftSave();
+    set({
+      metadata: sampleMetadata,
+      filePath: null,
+      dirty: false,
+      loadError: null,
+      loadErrorHint: null,
+      applying: false,
+      applyError: null,
+      applyErrorHint: null,
+      hasBackup: false,
+      restoring: false,
+      restoreError: null,
+      restoreErrorHint: null,
+      loadedMtimeMs: null,
+      conflictError: null,
+      pendingDraft: null,
+      draftLoadError: null,
+      draftLoadErrorHint: null,
+      draftSaving: false,
+      draftSaveError: null,
+      draftSaveErrorHint: null,
+    });
+  },
+```
+
+- [ ] **Step 4: Update each catch block to set hint**
+
+In `gui/src/state/metadataStore.ts`:
+
+a) `runApply` catch (line ~204-214):
+
+```typescript
+    } catch (e) {
+      const msg = appErrorMessage(e);
+      const hint = appErrorHint(e);
+      // #663: PR #665 で全 23 commands が AppError 化済のため、legacy raw String
+      // fallback (msg.startsWith('conflict:')) は廃止する。code === 'state.mtime_conflict'
+      // のみで分岐する。
+      if (appErrorCodeIs(e, 'state.mtime_conflict')) {
+        set({ applying: false, conflictError: msg });
+      } else {
+        set({ applying: false, applyError: msg, applyErrorHint: hint });
+      }
+    }
+```
+
+b) `load` catch (line ~262-275):
+
+```typescript
+    } catch (e) {
+      set({
+        metadata: null,
+        filePath: null,
+        dirty: false,
+        loadError: appErrorMessage(e),
+        loadErrorHint: appErrorHint(e),
+        hasBackup: false,
+        loadedMtimeMs: null,
+        conflictError: null,
+        pendingDraft: null,
+        draftLoadError: null,
+        draftSaveError: null,
+      });
+    }
+```
+
+c) `restore` catch (line ~335-340):
+
+```typescript
+    } catch (e) {
+      set({
+        restoring: false,
+        restoreError: appErrorMessage(e),
+        restoreErrorHint: appErrorHint(e),
+      });
+    }
+```
+
+d) `saveDraft` catch (line ~384-388):
+
+```typescript
+    } catch (e) {
+      // Surface the failure via state — scheduleDraftSave's fire-and-forget
+      // call would otherwise swallow the rejection silently (see F1 review).
+      set({ draftSaveError: appErrorMessage(e), draftSaveErrorHint: appErrorHint(e) });
+    } finally {
+      set({ draftSaving: false });
+    }
+```
+
+e) `loadDraft` catch (line ~416-421):
+
+```typescript
+    } catch (e) {
+      set({
+        pendingDraft: null,
+        draftLoadError: appErrorMessage(e),
+        draftLoadErrorHint: appErrorHint(e),
+      });
+    }
+```
+
+f) Also clear `*ErrorHint` on success paths where existing code clears `*Error`. Specifically in `load` success (line ~244-256), add hint clears:
+
+```typescript
+      set({
+        metadata: parsed as unknown as Metadata,
+        filePath: path,
+        dirty: false,
+        loadError: null,
+        loadErrorHint: null,         // ← 追加
+        applyError: null,
+        applyErrorHint: null,        // ← 追加
+        restoreError: null,
+        restoreErrorHint: null,      // ← 追加
+        loadedMtimeMs: mtime ?? null,
+        conflictError: null,
+        pendingDraft: null,
+        draftLoadError: null,
+        draftLoadErrorHint: null,    // ← 追加
+        draftSaveError: null,
+        draftSaveErrorHint: null,    // ← 追加
+      });
+```
+
+`runApply` success (line ~191-198): the existing reset clears `applyError: null`, add `applyErrorHint: null`:
+
+```typescript
+      set({
+        metadata: normalized,
+        dirty: false,
+        applying: false,
+        applyError: null,
+        applyErrorHint: null,       // ← 追加
+        loadedMtimeMs: newMtime,
+        conflictError: null,
+      });
+```
+
+`runApply` start (line ~183) `set({ applying: true, applyError: null, conflictError: null })`:
+
+```typescript
+    set({ applying: true, applyError: null, applyErrorHint: null, conflictError: null });
+```
+
+`restore` start (line ~329) `set({ restoring: true, restoreError: null })`:
+
+```typescript
+    set({ restoring: true, restoreError: null, restoreErrorHint: null });
+```
+
+`saveDraft` start (line ~381) `set({ draftSaving: true, draftSaveError: null })`:
+
+```typescript
+    set({ draftSaving: true, draftSaveError: null, draftSaveErrorHint: null });
+```
+
+`loadDraft` early returns on null/stale draft (line ~399, ~412): add `draftLoadErrorHint: null` alongside `draftLoadError: null`:
+
+```typescript
+        set({ pendingDraft: null, draftLoadError: null, draftLoadErrorHint: null });
+```
+
+(both occurrences in loadDraft).
+
+Successful loadDraft (line ~415):
+
+```typescript
+      set({ pendingDraft: parsed, draftLoadError: null, draftLoadErrorHint: null });
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```bash
+cd gui && npm test -- --run metadataStore.test.ts 2>&1 | tail -30
+```
+
+Expected: 6 new tests PASS. Existing tests still pass (regression check).
+
+### Task 3.3: Remove legacy `startsWith('conflict:')` fallback + rewrite affected tests
+
+**Files:**
+
+- Modify: `gui/src/state/metadataStore.ts` (the line was already touched in Task 3.2, but verify the legacy clause is fully gone)
+- Modify: `gui/src/state/metadataStore.test.ts`
+- Modify: `gui/src/components/ConflictModal.test.tsx`
+
+- [ ] **Step 1: Verify legacy fallback is gone**
+
+```bash
+grep -n "startsWith('conflict:')" gui/src/state/metadataStore.ts
+```
+
+Expected: no matches (already removed in Task 3.2 step 4a).
+
+```bash
+grep -n "msg.startsWith\|conflict:" gui/src/state/metadataStore.ts
+```
+
+Expected: only references in comments referring to the old behavior (e.g. "PR #665 で全 23 commands が AppError 化済のため、legacy raw String fallback (msg.startsWith('conflict:')) は廃止"). No production guard remains.
+
+- [ ] **Step 2: Rewrite legacy `'conflict: ...'` test cases in metadataStore.test.ts**
+
+```bash
+grep -n "'conflict:" gui/src/state/metadataStore.test.ts
+```
+
+For each match, the legacy form is one of:
+
+```typescript
+// pattern A: mock invoke rejecting with raw Error
+apply_changes_error: new Error('conflict: external modification detected (expected mtime 1700, got 1800)'),
+
+// pattern B: direct setState for ConflictModal-type tests
+useMetadataStore.setState({ conflictError: 'conflict: x', dirty: true });
+```
+
+Convert pattern A to AppError-shaped reject object:
+
+```typescript
+apply_changes_error: { code: 'state.mtime_conflict', message: 'external modification detected (expected mtime 1700, got 1800)' },
+```
+
+Convert pattern B by removing the `'conflict:'` prefix from the message:
+
+```typescript
+useMetadataStore.setState({ conflictError: 'x', dirty: true });
+```
+
+The matching `expect(state.conflictError).toContain('conflict:')` assertions should change to assert the message body (e.g. `expect(state.conflictError).toContain('external modification')`).
+
+Walk through every grep'd line, applying the transform. Also handle the `apply_changes_error: new Error('conflict: stale')` patterns identically.
+
+- [ ] **Step 3: Run tests to verify metadataStore.test.ts passes**
+
+```bash
+cd gui && npm test -- --run metadataStore.test.ts 2>&1 | tail -30
+```
+
+Expected: all tests PASS. If a test still fails because the conflict branch is taken on a non-conflict mock, double-check that the mock's reject shape is `{ code: 'state.mtime_conflict', message: ... }` and not the legacy raw string.
+
+- [ ] **Step 4: Fix ConflictModal.test.tsx test data**
+
+```bash
+grep -n "'conflict:" gui/src/components/ConflictModal.test.tsx
+```
+
+For each match like `conflictError: 'conflict: external modification detected'`, drop the `conflict:` prefix:
+
+```typescript
+// before
+useMetadataStore.setState({ conflictError: 'conflict: external modification detected' });
+expect(screen.getByText(/conflict: external/)).toBeInTheDocument();
+
+// after
+useMetadataStore.setState({ conflictError: 'external modification detected' });
+expect(screen.getByText(/external/)).toBeInTheDocument();
+```
+
+(The modal renders the message verbatim — the test was simply asserting on a string substring.)
+
+- [ ] **Step 5: Run ConflictModal tests**
+
+```bash
+cd gui && npm test -- --run ConflictModal.test.tsx 2>&1 | tail -20
+```
+
+Expected: all PASS.
+
+### Task 3.4: TDD recentStore hint pair
+
+**Files:**
+
+- Modify: `gui/src/state/recentStore.ts`
+- Modify or create: `gui/src/state/recentStore.test.ts`
+
+- [ ] **Step 1: Write 2 failing tests**
+
+Add to `gui/src/state/recentStore.test.ts` (new tests at end of file):
+
+```typescript
+describe('AppError hint pair (#663)', () => {
+  beforeEach(() => {
+    useRecentStore.getState().reset();
+  });
+
+  it('load path: loadErrorHint is set when AppError carries hint', async () => {
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockImplementation(async () => {
+      throw {
+        code: 'io.read_failed',
+        message: 'broken recent.json',
+        hint: 'delete the file and restart',
+      };
+    });
+    await useRecentStore.getState().load();
+    const s = useRecentStore.getState();
+    expect(s.loadError).toBe('broken recent.json');
+    expect(s.loadErrorHint).toBe('delete the file and restart');
+  });
+
+  it('add path: addErrorHint is set when AppError carries hint', async () => {
+    const mockInvoke = vi.mocked(invoke);
+    mockInvoke.mockImplementation(async () => {
+      throw {
+        code: 'io.write_failed',
+        message: 'recent.json write failed',
+        hint: 'check disk space',
+      };
+    });
+    await useRecentStore.getState().add('/tmp/x.mp4');
+    const s = useRecentStore.getState();
+    expect(s.addError).toBe('recent.json write failed');
+    expect(s.addErrorHint).toBe('check disk space');
+  });
+});
+```
+
+If `recentStore.test.ts` already exists, append these inside (or alongside) existing describe blocks. If not, create the file with the necessary imports (`vi`, `useRecentStore`, `invoke`, etc — pattern from `metadataStore.test.ts`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd gui && npm test -- --run recentStore.test.ts 2>&1 | tail -20
+```
+
+Expected: 2 FAIL (`addErrorHint` / `loadErrorHint` not in state).
+
+- [ ] **Step 3: Add hint pair to recentStore.ts**
+
+Modify `gui/src/state/recentStore.ts`:
+
+a) Update import (line 4):
+
+```typescript
+import { appErrorHint, appErrorMessage } from '../lib/appError';
+```
+
+b) Update `RecentState` interface to add `loadErrorHint` / `addErrorHint`:
+
+```typescript
+export interface RecentState {
+  entries: RecentEntry[];
+  loaded: boolean;
+  loadError: string | null;
+  /** #663: hint for loadError, if AppError carried one. */
+  loadErrorHint: string | null;
+  addError: string | null;
+  /** #663: hint for addError. */
+  addErrorHint: string | null;
+
+  load: () => Promise<void>;
+  add: (path: string) => Promise<void>;
+  clear: () => Promise<void>;
+  reset: () => void;
+}
+```
+
+c) Update default state in `create<RecentState>((set) => ({ ... }))` (line ~43):
+
+```typescript
+  entries: [],
+  loaded: false,
+  loadError: null,
+  loadErrorHint: null,    // ← 新規
+  addError: null,
+  addErrorHint: null,     // ← 新規
+```
+
+d) Update `load` catch (line ~59-64):
+
+```typescript
+    } catch (e) {
+      set({
+        loadError: appErrorMessage(e),
+        loadErrorHint: appErrorHint(e),
+        loaded: true,
+      });
+    }
+```
+
+e) Update `add` catch (line ~74-76):
+
+```typescript
+    } catch (e) {
+      set({ addError: appErrorMessage(e), addErrorHint: appErrorHint(e) });
+    }
+```
+
+f) Update success paths to clear hint (line ~58 for load, ~73 for add):
+
+```typescript
+      set({ entries, loaded: true, loadError: null, loadErrorHint: null });
+      // ...
+      set({ entries, addError: null, addErrorHint: null });
+```
+
+g) Update `clear` (line ~80) and `reset` (line ~84) to clear hint:
+
+```typescript
+  async clear() {
+    await invoke<void>('clear_recent');
+    set({ entries: [], loadError: null, loadErrorHint: null, addError: null, addErrorHint: null });
+  },
+
+  reset() {
+    set({ entries: [], loaded: false, loadError: null, loadErrorHint: null, addError: null, addErrorHint: null });
+  },
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+cd gui && npm test -- --run recentStore.test.ts 2>&1 | tail -20
+```
+
+Expected: 2 new tests PASS, existing tests still PASS.
+
+### Task 3.5: Phase 3 full test pass + commit
+
+- [ ] **Step 1: Run full vitest**
+
+```bash
+cd gui && npm test -- --run 2>&1 | tail -30
+```
+
+Expected: all tests PASS (existing ~566 + new ~13 = ~580). If any failing, identify by name and fix.
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+cd gui && npm run typecheck 2>&1 | tail -10
+```
+
+Expected: exit 0, no errors.
+
+- [ ] **Step 3: Commit Phase 3**
+
+```bash
+cd ..
+git add gui/src/state/metadataStore.ts gui/src/state/metadataStore.test.ts gui/src/state/recentStore.ts gui/src/state/recentStore.test.ts gui/src/components/ConflictModal.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(gui): metadataStore / recentStore に *ErrorHint state を追加 + legacy fallback 削除 (Refs #663)
+
+PR #665 で全 23 commands が Result<T, AppError> 化済のため、
+metadataStore.ts:209 の legacy raw String fallback
+`|| msg.startsWith('conflict:')` を撤去。code === 'state.mtime_conflict'
+のみで ConflictModal 経路に分岐するシンプルな state machine に。
+
+主な変更:
+
+- metadataStore: loadErrorHint / applyErrorHint / restoreErrorHint /
+  draftSaveErrorHint / draftLoadErrorHint の 5 state field を追加。
+  各 catch block で appErrorHint(e) を取り込み、success path で null clear
+- recentStore: loadErrorHint / addErrorHint を追加 (同パターン)
+- conflictError には hint pair を追加しない (ConflictModal は spec § 3 で
+  scope 外、modal 既存 compose hint と概念衝突回避)
+- TDD red→green: metadataStore に新規 6 件 + recentStore に新規 2 件
+- 既存 conflict 文字列ベース test (metadataStore.test.ts 8 件 +
+  ConflictModal.test.tsx 6 件) を AppError object 形式 / prefix 削除版に書き換え
+
+Phase 3/5 (spec §7)。
+
+Refs #663
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit success, 5 files changed.
+
+---
+
+## Phase 4: Frontend UI (5 screens + RestoreButton + CSS)
+
+### Task 4.1: Add `.errorHint` shared CSS class
+
+**Files:**
+
+- Modify: `gui/src/styles/tokens.css` (token-only, no new selectors) — ALREADY has `--ae-text-dim`, no change needed
+- Modify: `gui/src/components/RestoreButton.module.css` (new `.errorHint` class)
+- (各 screen の `.module.css` でも同様の `.errorHint` を追加)
+
+The pattern: each component defines its own `.errorHint` selector that uses the existing `--ae-text-dim` token. We do NOT introduce a new global utility class — keep CSS module isolation.
+
+- [ ] **Step 1: Add `.errorHint` to RestoreButton.module.css**
+
+Edit `gui/src/components/RestoreButton.module.css`. Append after the existing `.error` class (line 30-35):
+
+```css
+.errorHint {
+  font-family: var(--ae-font-body);
+  font-size: 10px;
+  color: var(--ae-text-dim);
+  margin-left: 8px;
+  margin-top: 2px;
+  display: block;
+  line-height: 1.5;
+}
+```
+
+- [ ] **Step 2: Add `.errorHint` to other module.css files used by error display**
+
+For each of the following files, add a similar `.errorHint` class (style harmonized with the file's existing `.error` / `.errorMessage` selectors):
+
+| File | Place after | Exact addition |
+| --- | --- | --- |
+| `gui/src/screens/DropScreen.module.css` | existing `.error` selector | `.errorHint { color: var(--ae-text-dim); font-size: 12px; margin-top: 6px; line-height: 1.5; }` |
+| `gui/src/screens/DetectingScreen.module.css` | existing `.errorMessage` | `.errorHint { color: var(--ae-text-dim); font-size: 12px; margin-top: 8px; line-height: 1.5; }` |
+| `gui/src/screens/PreviewScreen.module.css` | existing `.applyError` | `.applyErrorHint { color: var(--ae-text-dim); font-size: 11px; margin-left: 8px; line-height: 1.5; }` |
+| `gui/src/screens/ExportScreen.module.css` | existing `.listError` | `.listErrorHint { color: var(--ae-text-dim); font-size: 11px; line-height: 1.5; display: block; margin-top: 2px; }` |
+
+If any of these `.module.css` files lacks the "place after" anchor selector, search for `role="alert"` usage in the corresponding `.tsx` file and add the new class with a sensible local style.
+
+- [ ] **Step 3: Verify lint passes**
+
+```bash
+cd gui && npm run lint 2>&1 | tail -10
+```
+
+Expected: exit 0.
+
+### Task 4.2: TDD RestoreButton hint 2nd line
+
+**Files:**
+
+- Modify: `gui/src/components/RestoreButton.tsx`
+- Modify: `gui/src/components/RestoreButton.test.tsx`
+
+- [ ] **Step 1: Write 2 failing tests**
+
+Add to `gui/src/components/RestoreButton.test.tsx`:
+
+```typescript
+describe('hint rendering (#663)', () => {
+  it('renders restoreErrorHint as 2nd line when present', () => {
+    useMetadataStore.setState({
+      hasBackup: true,
+      restoring: false,
+      restoreError: 'backup not found',
+      restoreErrorHint: 'create backup first',
+    });
+    render(<RestoreButton />);
+    expect(screen.getByText('backup not found')).toBeInTheDocument();
+    expect(screen.getByText(/create backup first/)).toBeInTheDocument();
+  });
+
+  it('does not render hint when restoreErrorHint is null', () => {
+    useMetadataStore.setState({
+      hasBackup: true,
+      restoring: false,
+      restoreError: 'plain message',
+      restoreErrorHint: null,
+    });
+    render(<RestoreButton />);
+    expect(screen.getByText('plain message')).toBeInTheDocument();
+    expect(screen.queryByText(/💡/)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd gui && npm test -- --run RestoreButton.test.tsx 2>&1 | tail -15
+```
+
+Expected: 2 FAIL.
+
+- [ ] **Step 3: Update RestoreButton.tsx to render hint as 2nd line**
+
+In `gui/src/components/RestoreButton.tsx`, change line 53 (`const restoreError = ...`) and the bottom render block:
+
+```typescript
+  const restoreError = useMetadataStore((s) => s.restoreError);
+  const restoreErrorHint = useMetadataStore((s) => s.restoreErrorHint);
+```
+
+Update the JSX (line 92-97):
+
+```tsx
+      {restoreError && (
+        <span className={styles.error} role="alert">
+          {restoreError}
+          {restoreErrorHint && (
+            <span className={styles.errorHint}>💡 {restoreErrorHint}</span>
+          )}
+        </span>
+      )}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+cd gui && npm test -- --run RestoreButton.test.tsx 2>&1 | tail -15
+```
+
+Expected: 2 PASS, existing tests still PASS.
+
+### Task 4.3: TDD DropScreen hint 2nd line + local errorHint state
+
+**Files:**
+
+- Modify: `gui/src/screens/DropScreen.tsx`
+- Modify: `gui/src/screens/DropScreen.test.tsx`
+
+- [ ] **Step 1: Write 1 failing test**
+
+Add to `gui/src/screens/DropScreen.test.tsx` (in an existing describe or a new "hint rendering (#663)"):
+
+```typescript
+it('renders error hint as 2nd line when probe rejects with AppError', async () => {
+  const mockInvoke = vi.mocked(invoke);
+  mockInvoke.mockImplementation(async (cmd) => {
+    if (cmd === 'probe_video') {
+      throw {
+        code: 'parse.ffprobe_output_invalid',
+        message: 'ffprobe failed',
+        hint: 'check ffmpeg version',
+      };
+    }
+    throw new Error('unexpected');
+  });
+
+  render(<DropScreen />);
+  // (simulate the probe trigger — adapt to existing test helpers; this may
+  // require `await user.upload(...)` or calling the underlying handler.)
+  // For brevity, we directly call setError analog by rendering the error card:
+  //   alternative: test ErrorCard component in isolation if exposed.
+
+  // Skeleton:
+  await waitFor(() => {
+    expect(screen.getByText('ffprobe failed')).toBeInTheDocument();
+    expect(screen.getByText(/check ffmpeg version/)).toBeInTheDocument();
+  });
+});
+```
+
+Adapt to whatever test helpers DropScreen.test.tsx already uses for triggering probe failure.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd gui && npm test -- --run DropScreen.test.tsx 2>&1 | tail -20
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Update DropScreen.tsx**
+
+In `gui/src/screens/DropScreen.tsx`:
+
+a) Add import for `appErrorHint`:
+
+```typescript
+import { appErrorHint, appErrorMessage } from '../lib/appError';
+```
+
+b) Add local `errorHint` state next to the existing `error` state (line ~129):
+
+```typescript
+const [error, setError] = useState<string | null>(null);
+const [errorHint, setErrorHint] = useState<string | null>(null);
+```
+
+c) Update the catch blocks at lines ~142, ~164 (the patterns `setError(e instanceof Error ? e.message : String(e))`) to also set `errorHint`:
+
+```typescript
+} catch (e) {
+  setError(appErrorMessage(e));
+  setErrorHint(appErrorHint(e));
+}
+```
+
+d) Update `setError(null)` calls (lines 133, 159, 265) to also reset `errorHint`:
+
+```typescript
+setError(null);
+setErrorHint(null);
+```
+
+e) Update `ErrorCardProps` to receive `errorHint` and render it (line ~475):
+
+```typescript
+interface ErrorCardProps {
+  error: string | null;
+  errorHint: string | null;          // ← 新規
+  onDismiss: () => void;
+  onRetry: () => void;
+}
+
+function ErrorCard({ error, errorHint, onDismiss, onRetry }: ErrorCardProps) {
+  // ... existing hooks ...
+  return (
+    <div ref={cardRef} className={styles.selectedCard} role="alert" data-testid="drop-error-card">
+      <div className={styles.selectedHeading}>エラー</div>
+      <div className={styles.error}>{error ?? 'probe failed'}</div>
+      {errorHint && (
+        <div className={styles.errorHint}>💡 {errorHint}</div>
+      )}
+      <div className={styles.actions}>
+        {/* existing buttons */}
+      </div>
+    </div>
+  );
+}
+```
+
+f) Update the `ErrorCard` callsite in DropScreen to pass `errorHint`:
+
+```typescript
+<ErrorCard error={error} errorHint={errorHint} onDismiss={...} onRetry={...} />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd gui && npm test -- --run DropScreen.test.tsx 2>&1 | tail -20
+```
+
+Expected: new test PASS, existing tests still PASS.
+
+### Task 4.4: TDD DetectingScreen hint 2nd line + local errorHint state
+
+**Files:**
+
+- Modify: `gui/src/screens/DetectingScreen.tsx`
+- Modify: `gui/src/screens/DetectingScreen.test.tsx`
+
+- [ ] **Step 1: Write 1 failing test**
+
+Add to `gui/src/screens/DetectingScreen.test.tsx`:
+
+```typescript
+it('renders error hint as 2nd line when start_detect rejects with AppError', async () => {
+  const mockInvoke = vi.mocked(invoke);
+  mockInvoke.mockImplementation(async (cmd) => {
+    if (cmd === 'start_detect') {
+      throw {
+        code: 'subprocess.spawn_failed',
+        message: 'failed to spawn allaganeye CLI',
+        hint: 'verify Python install',
+      };
+    }
+    throw new Error('unexpected');
+  });
+
+  // (render DetectingScreen with a fixture videoPath and let useEffect trigger the start_detect call.)
+  render(<DetectingScreen video={...} />);
+  await waitFor(() => {
+    expect(screen.getByText(/failed to spawn/)).toBeInTheDocument();
+    expect(screen.getByText(/verify Python/)).toBeInTheDocument();
+  });
+});
+```
+
+Adapt to existing test helpers / fixture pattern.
+
+- [ ] **Step 2: Run to verify FAIL**
+
+```bash
+cd gui && npm test -- --run DetectingScreen.test.tsx 2>&1 | tail -20
+```
+
+- [ ] **Step 3: Update DetectingScreen.tsx**
+
+a) Import `appErrorHint`:
+
+```typescript
+import { appErrorHint, appErrorMessage } from '../lib/appError';
+```
+
+b) Add local `errorHint` state next to `error` (line ~274):
+
+```typescript
+const [error, setError] = useState<string | null>(null);
+const [errorHint, setErrorHint] = useState<string | null>(null);
+```
+
+c) Update the catch / setError sites (line ~322, 349 etc.) to set `errorHint`:
+
+```typescript
+setError(null);
+setErrorHint(null);
+// ...
+} catch (e) {
+  const msg = appErrorMessage(e);
+  setError(msg);
+  setErrorHint(appErrorHint(e));
+}
+```
+
+d) Update the error render block (line ~733-741):
+
+```tsx
+<div className={styles.errorScreen} data-testid="detecting-error" role="alert">
+  <div className={styles.errorHeading}>検知に失敗しました</div>
+  <div className={styles.errorFile}>{displayFile}</div>
+  <pre className={styles.errorMessage} data-testid="detecting-error-message">
+    {error ?? 'unknown error'}
+  </pre>
+  {errorHint && (
+    <div className={styles.errorHint} data-testid="detecting-error-hint">
+      💡 {errorHint}
+    </div>
+  )}
+  <div className={styles.actions}>
+    {/* existing retry / back buttons */}
+  </div>
+</div>
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+```bash
+cd gui && npm test -- --run DetectingScreen.test.tsx 2>&1 | tail -20
+```
+
+### Task 4.5: TDD PreviewScreen hint 2nd line (uses store)
+
+**Files:**
+
+- Modify: `gui/src/screens/PreviewScreen.tsx`
+- Modify: `gui/src/screens/PreviewScreen.test.tsx`
+
+- [ ] **Step 1: Write 1 failing test**
+
+Add to `gui/src/screens/PreviewScreen.test.tsx`:
+
+```typescript
+it('renders applyErrorHint inline when present', () => {
+  useMetadataStore.setState({
+    metadata: { source: 'x', matches: [] } as never,
+    filePath: '/tmp/m.json',
+    applyError: 'disk full',
+    applyErrorHint: 'free up space',
+  });
+  render(<PreviewScreen />);
+  expect(screen.getByText('disk full')).toBeInTheDocument();
+  expect(screen.getByText(/free up space/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+- [ ] **Step 3: Update PreviewScreen.tsx**
+
+a) Subscribe to `applyErrorHint` (next to existing `applyError` subscription on line 91):
+
+```typescript
+const applyError = useMetadataStore((s) => s.applyError);
+const applyErrorHint = useMetadataStore((s) => s.applyErrorHint);
+```
+
+b) Update the inline error render (line 649-653):
+
+```tsx
+{applyError && (
+  <span className={styles.applyError} role="alert">
+    {applyError}
+    {applyErrorHint && (
+      <span className={styles.applyErrorHint}>💡 {applyErrorHint}</span>
+    )}
+  </span>
+)}
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+```bash
+cd gui && npm test -- --run PreviewScreen.test.tsx 2>&1 | tail -15
+```
+
+### Task 4.6: TDD ExportScreen per-match hint + reducer update
+
+**Files:**
+
+- Modify: `gui/src/screens/ExportScreen.tsx`
+- Modify: `gui/src/screens/ExportScreen.test.tsx`
+
+- [ ] **Step 1: Write 1 failing test**
+
+Add to `gui/src/screens/ExportScreen.test.tsx`:
+
+```typescript
+it('renders per-match error hint when export rejects with AppError', async () => {
+  const mockInvoke = vi.mocked(invoke);
+  mockInvoke.mockImplementation(async (cmd) => {
+    if (cmd === 'export_match') {
+      throw {
+        code: 'subprocess.spawn_failed',
+        message: 'ffmpeg spawn failed',
+        hint: 'reinstall ffmpeg',
+      };
+    }
+    throw new Error('unexpected');
+  });
+
+  // (render ExportScreen with a single-match fixture and trigger the export.)
+  // Skeleton — adapt to existing patterns:
+  // ...
+  await waitFor(() => {
+    expect(screen.getByText(/ffmpeg spawn failed/)).toBeInTheDocument();
+    expect(screen.getByText(/reinstall ffmpeg/)).toBeInTheDocument();
+  });
+});
+```
+
+Adapt to ExportScreen's existing test setup (it uses a `matchStates` reducer with a per-match `error` field; the test should hit the catch at line ~358).
+
+- [ ] **Step 2: Run to verify FAIL**
+
+- [ ] **Step 3: Update ExportScreen.tsx**
+
+a) Import `appErrorHint`:
+
+```typescript
+import { appErrorHint, appErrorMessage } from '../lib/appError';
+```
+
+b) Extend the per-match state row type with `errorHint: string | null`. Find the type definition (search `error?:` or `status:` near line 250) and add:
+
+```typescript
+interface MatchExportState {
+  status: 'idle' | 'running' | 'done' | 'error';
+  percent: number;
+  error?: string;
+  errorHint?: string;     // ← 新規
+  fallbackNotice?: string;
+  outputPath?: string;
+}
+```
+
+c) Update the reducer / event handler at line ~258-260 (event-driven path):
+
+```typescript
+return {
+  ...prev,
+  [p.match_index]: {
+    ...prior,
+    status,
+    percent: p.percent,
+    error: p.stage === 'error' ? p.message : prior.error,
+    errorHint: p.stage === 'error' ? (p.hint ?? null) : prior.errorHint,  // ← 新規 (event from Rust may include hint)
+    fallbackNotice,
+  },
+};
+```
+
+(If the `export-progress` event payload doesn't include `hint`, this falls back to `null`. Future Rust-side enhancement can attach hint to event payloads — out of #663 scope.)
+
+d) Update the `catch (e)` block at line ~352-359:
+
+```typescript
+} catch (e) {
+  failureCount += 1;
+  const msg = appErrorMessage(e);
+  const hint = appErrorHint(e);
+  setMatchStates((prev) => ({
+    ...prev,
+    [m.index]: { status: 'error', percent: 0, error: msg, errorHint: hint ?? undefined },
+  }));
+}
+```
+
+e) Update the per-match render at line ~859-861:
+
+```tsx
+{s.status === 'error' && s.error && (
+  <span className={styles.listError} role="alert">
+    {s.error.slice(0, 120)}
+    {s.errorHint && (
+      <span className={styles.listErrorHint}>💡 {s.errorHint}</span>
+    )}
+  </span>
+)}
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+```bash
+cd gui && npm test -- --run ExportScreen.test.tsx 2>&1 | tail -15
+```
+
+### Task 4.7: Phase 4 full test pass + commit
+
+- [ ] **Step 1: Run full vitest, lint, typecheck, build**
+
+```bash
+cd gui && npm run lint && npm run typecheck && npm test -- --run && npm run build 2>&1 | tail -30
+```
+
+Expected: all pass. If any failure, identify and fix.
+
+- [ ] **Step 2: Commit Phase 4**
+
+```bash
+cd ..
+git add gui/src/components/RestoreButton.tsx gui/src/components/RestoreButton.module.css gui/src/components/RestoreButton.test.tsx gui/src/screens/DropScreen.tsx gui/src/screens/DropScreen.module.css gui/src/screens/DropScreen.test.tsx gui/src/screens/DetectingScreen.tsx gui/src/screens/DetectingScreen.module.css gui/src/screens/DetectingScreen.test.tsx gui/src/screens/PreviewScreen.tsx gui/src/screens/PreviewScreen.module.css gui/src/screens/PreviewScreen.test.tsx gui/src/screens/ExportScreen.tsx gui/src/screens/ExportScreen.module.css gui/src/screens/ExportScreen.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(gui): 各 screen の inline error に hint 2 行目を追加 (Refs #663)
+
+Phase 3 で frontend store に追加した *ErrorHint state を、各 screen の
+inline error 表示で 2 行目として render する。`var(--ae-text-dim)` 色で
+1 行目 (赤系 error message) と区別され、user に対処方法を示す UX。
+
+主な変更:
+
+- RestoreButton: restoreErrorHint を span に追加 render
+- DropScreen: local errorHint state を追加、ErrorCard に渡す
+- DetectingScreen: local errorHint state、 errorScreen 内で render
+- PreviewScreen: store applyErrorHint を inline error に追加
+- ExportScreen: per-match reducer state を errorHint 拡張、listError 内で render
+- 各 .module.css に `.errorHint` (or 派生) class を追加 (var(--ae-text-dim) 利用)
+- TDD red→green: 各 screen + RestoreButton で計 6 件の新規 test
+
+a11y: role="alert" は wrapper に維持、hint は補足情報として 2 行目に
+連続させる (jest-axe で violation なし)。
+
+Phase 4/5 (spec §8)。
+
+Refs #663
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit success.
+
+---
+
+## Phase 5: Docs + Issue body
+
+### Task 5.1: Update docs/tauri-commands.md
+
+**Files:**
+
+- Modify: `docs/tauri-commands.md`
+
+- [ ] **Step 1: Add hint mapping table at end of file**
+
+Append the following section after the existing master command table (verify exact insertion point with `tail -20 docs/tauri-commands.md`):
+
+```markdown
+## AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)
+
+> 本 table の文言は `gui/src-tauri/src/error.rs` の `default_hint_for_code()` と
+> 完全一致させる (CI integrity check は今回入れないが、文言変更時は両方を
+> 同 PR で更新する規約)。
+
+| code | hint |
+| --- | --- |
+| `state.mtime_conflict` | metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください |
+| `io.file_not_found` | ファイルが見つかりません。パスを確認するか、allaganeye split を再実行してください |
+| `io.read_failed` | ファイルの読み込みに失敗しました。ディスク状況・ファイルロック状態を確認してください |
+| `io.write_failed` | ファイルの書き込みに失敗しました。空き容量と書き込み権限 (Portable ZIP の install dir が user-writable か) を確認してください |
+| `io.delete_failed` | ファイル / フォルダの削除に失敗しました。他プロセスでロックされていないか確認してください |
+| `io.backup_failed` | バックアップファイルの作成に失敗しました。allaganeye 出力フォルダの空き容量と書き込み権限を確認してください |
+| `io.permission_denied` | ファイルへのアクセス権限がありません。Portable ZIP install dir が user-writable な場所か、ファイル / フォルダが読み取り専用でないか確認してください |
+| `io.already_exists` | ファイルが既に存在します。出力先を変更するか既存ファイルを削除してください |
+| `io.would_block` / `io.timed_out` | I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください |
+| `io.error` | I/O エラーが発生しました。詳細は logs フォルダを確認してください |
+| `parse.json_invalid` | JSON ファイルが破損しています。バックアップ (.bak) からの復元か allaganeye split のやり直しを検討してください |
+| `parse.json_serialize_failed` | JSON 書き出しに失敗しました。同梱 issue テンプレートでバグ報告してください |
+| `parse.schema_invalid` | metadata.json の構造が期待形式と異なります。allaganeye のバージョンと metadata 生成バージョンが一致しているか確認してください |
+| `parse.ffprobe_output_invalid` | ffprobe の出力を解釈できませんでした。ffmpeg / ffprobe を最新の BtbN LGPL ビルドに更新してください |
+| `subprocess.spawn_failed` | 外部プロセスの起動に失敗しました。ffmpeg / Python / 同梱 runtime が壊れていないか確認してください |
+| `subprocess.exit_failed` | 外部プロセスが異常終了しました。logs フォルダの最新ログから詳細を確認してください |
+| `subprocess.cancelled` | (hint なし: ユーザー操作によるキャンセルは UI 側で十分な情報を出す) |
+| `validation.path_invalid` | 入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v) |
+| `validation.not_a_file` | 指定されたパスはファイルではありません (フォルダや symlink ではなく動画ファイルを選択してください) |
+| `validation.range_invalid` | 入力された数値が許容範囲外です。フォーム下のヒント表示を確認してください |
+| `path.install_dir_unresolved` | Portable ZIP の install dir を特定できませんでした。allaganeye-gui.exe を ZIP 展開後の元のフォルダ構成のまま起動してください |
+| `platform.unsupported` | 本機能は現在の OS では未対応です。Windows での起動が必要です |
+| `internal.error` | (hint なし: 内部エラーで具体的アクションがない、message 側で logs 参照を案内) |
+```
+
+### Task 5.2: Update docs/ui-architecture.md § 4
+
+**Files:**
+
+- Modify: `docs/ui-architecture.md`
+
+- [ ] **Step 1: Append §4.x at end of section §4 (line ~53)**
+
+Locate the existing `## 4. エラー伝搬フロー (#614)` section. Append a new sub-section at the end of it (before the next `## 5.` section):
+
+```markdown
+### 4.x AppError code 体系と inline error の使い分け (#663)
+
+Tauri command の `Result<T, AppError>` で frontend に届く構造化 error は、
+`docs/tauri-commands.md` で master 一覧化されている。inline error 表示時は
+`appErrorMessage(e)` を 1 行目に、`appErrorHint(e)` を 2 行目 (`var(--ae-text-dim)`)
+に render する規約。code → default hint の mapping は
+`gui/src-tauri/src/error.rs::default_hint_for_code` で一元管理。
+
+#### 主な分岐ルール
+
+- `code === 'state.mtime_conflict'` → ConflictModal を出す (apply path のみ)
+- それ以外の `code` → inline error (2 行目に hint があれば render)
+- legacy raw String (= AppError 化前の commands) → `appErrorMessage` で
+  message のみ取得、hint は null になる (PR #663 で legacy raw を返す
+  command は存在しないが、helper の互換性として温存)
+```
+
+### Task 5.3: Update docs/ui-interaction-spec.md § 1.5
+
+**Files:**
+
+- Modify: `docs/ui-interaction-spec.md`
+
+- [ ] **Step 1: Append §1.5.x at end of section §1.5 (line ~80-100)**
+
+Locate the existing `### 1.5 エラー表示の一貫性 (inline + toast)` section. Append a new sub-section after the existing content but before §1.6 (or the next top-level §2):
+
+```markdown
+#### 1.5.x AppError `code` ベースの分岐ルール (#663)
+
+Tauri command 失敗時の error 表示は以下を厳守する:
+
+1. `appErrorCodeIs(e, 'state.mtime_conflict')` で apply path → ConflictModal (modal 表示)
+2. その他の AppError code → inline error
+   - 1 行目: `appErrorMessage(e)` (赤系: `var(--ae-text-error)` ないし screen 固有 error 色)
+   - 2 行目: `appErrorHint(e)` (灰系: `var(--ae-text-dim)`、`💡` 等の prefix で
+     アクション提示と分かるように)
+3. catch ブロック以外で error を扱わない (`alert()` / `console.error` のみは禁止)
+4. globalErrorListener が拾うのは uncaught (window.error / unhandledrejection /
+   panic) のみ。catch 済 Tauri command error は ErrorModal に出さない (規約)
+```
+
+### Task 5.4: Run markdownlint
+
+- [ ] **Step 1: Run markdownlint**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | tail -10
+```
+
+Expected: `Summary: 0 error(s)`. Fix any reported issues inline.
+
+### Task 5.5: Update issue #663 body
+
+**Files:**
+
+- External: `gh issue edit 663`
+
+- [ ] **Step 1: Compose new issue body**
+
+Use `printf` + `--body-file -` to avoid Japanese inline encoding issues (per `feedback_gh_command_ja_heredoc.md`):
+
+```bash
+printf '%s' '## 概要
+
+PR #665 (`ea9bca9`) で `gui/src-tauri/src/lib.rs` の全 23 Tauri commands が
+`Result<T, String>` → `Result<T, AppError>` に migration 完了済み。本 issue
+ではその仕上げとして以下 4 軸を完遂する。
+
+## 残作業 (4 軸)
+
+### (A) Legacy `startsWith('conflict:')` fallback 撤去
+
+`gui/src/state/metadataStore.ts:209` の `appErrorCodeIs(e, '"'"'state.mtime_conflict'"'"') || msg.startsWith('"'"'conflict:'"'"')` から後半 (legacy raw String fallback) を削除する。`code === '"'"'state.mtime_conflict'"'"'` のみで分岐する。
+
+### (B) Per-code default hint helper 追加と全 80 site への適用
+
+`gui/src-tauri/src/error.rs` に `default_hint_for_code()` + `with_default_hint()` を追加し、全 80 site の `AppError::new(...)` で chain する。`From<io::Error>` / `From<serde_json::Error>` も hint chain 経路に乗せる。
+
+### (C) Frontend での hint 表示
+
+各 store (metadataStore / recentStore) に `*ErrorHint` state pair を追加し、各 inline error の 2 行目に hint を render (`var(--ae-text-dim)` 色、`💡` prefix)。
+
+### (D) docs / issue body 整合
+
+- `docs/tauri-commands.md` に AppError default hint mapping table を追加
+- `docs/ui-architecture.md` § 4 に AppError code 体系と使い分け追記
+- `docs/ui-interaction-spec.md` § 1.5 に error.code ベース分岐ルール追記
+- 本 issue body を更新 (本 update)
+
+## 受け入れ条件
+
+- [ ] (A) `metadataStore.ts:209` の `|| msg.startsWith('"'"'conflict:'"'"')` が削除されている
+- [ ] (A) `metadataStore.test.ts` の `'"'"'conflict: ...'"'"'` raw String テストが AppError object 形式に書き換わっている
+- [ ] (A) `ConflictModal.test.tsx` の test data から `'"'"'conflict:'"'"'` prefix が消えている
+- [ ] (B) `error.rs` に `default_hint_for_code()` + `with_default_hint()` が追加され、22 codes 分の日本語 hint が table に存在する
+- [ ] (B) `From<std::io::Error>` / `From<serde_json::Error>` の impl 内で `.with_default_hint()` が呼ばれている
+- [ ] (B) `lib.rs` の全 80 site の `AppError::new(code, msg)` に `.with_default_hint()` が chain されている
+- [ ] (C) `metadataStore` に `loadErrorHint` / `applyErrorHint` / `restoreErrorHint` / `draftSaveErrorHint` / `draftLoadErrorHint` の 5 state が追加されている
+- [ ] (C) `recentStore` に `loadErrorHint` / `addErrorHint` が追加されている
+- [ ] (C) 5 screen + RestoreButton の inline error が hint があれば 2 行目を `var(--ae-text-dim)` で render する
+- [ ] (D) `docs/tauri-commands.md` に AppError default hint mapping table が追加されている
+- [ ] (D) `docs/ui-architecture.md` § 4 に `code` 体系と使い分け節 (§4.x) が追加されている
+- [ ] (D) `docs/ui-interaction-spec.md` § 1.5 に `error.code` ベース分岐ルール節 (§1.5.x) が追加されている
+- [ ] cargo check / cargo test --lib (新 6 件 + 既存 149 件 = 155 件 pass)
+- [ ] npm run lint / typecheck / test (新 13-15 件 + 既存 ~566 件 = ~580 件 pass) / build
+- [ ] CI 全 8 job pass (gui-rust / gui-frontend / build-windows / installer-pester / python / markdownlint / validate-checklist / version-check)
+- [ ] Iron Law 6 実機検証 5 経路 (state.mtime_conflict / io.permission_denied / io.file_not_found / parse.json_invalid / subprocess.spawn_failed) を Idios が PASS 確認
+
+## スコープ外
+
+- ErrorModal (#614) への AppError 統合
+- `globalErrorListener.ts` への AppError parse 追加
+- `ConflictModal` での AppError hint 表示 (modal 既存 compose hint と概念衝突回避)
+- 新規 Tauri command の追加 / 削除
+- 自動 telemetry / Sentry crash reporter 統合
+- 関連 issue (#619 / #614 等 CLOSED 群) の body 修正
+
+## 関連
+
+- 派生元: #614 (PR #661、AppError struct 導入)、#619 (PR #665、`Result<T, AppError>` migration)
+- 親 plan: `docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md` (Lane I-A)
+- spec: `docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md`
+' | gh issue edit 663 --body-file -
+```
+
+- [ ] **Step 2: Verify the issue body update**
+
+```bash
+gh issue view 663 --json body | head -50
+```
+
+Expected: new body content visible.
+
+### Task 5.6: Phase 5 commit
+
+- [ ] **Step 1: Commit Phase 5 (docs only — issue body update is via gh CLI, not in repo)**
+
+```bash
+git add docs/tauri-commands.md docs/ui-architecture.md docs/ui-interaction-spec.md
+git commit -m "$(cat <<'EOF'
+docs: AppError default hint mapping を docs に整合させる (Refs #663)
+
+Phase 1-4 で追加した default_hint_for_code mapping (22 codes) と frontend
+hint 表示規約を docs に明文化。docs/tauri-commands.md は error.rs の
+mapping を mirror、ui-architecture.md / ui-interaction-spec.md は
+inline error の 2 行構成と code-based 分岐ルールを規定。
+
+主な追加:
+
+- docs/tauri-commands.md: 末尾に AppError default hint mapping table
+  (22 entries、`error.rs::default_hint_for_code` と完全一致)
+- docs/ui-architecture.md §4.x: AppError code 体系と inline error の
+  使い分け、ConflictModal 経路と inline 経路の分岐ルール
+- docs/ui-interaction-spec.md §1.5.x: appErrorCodeIs / appErrorMessage /
+  appErrorHint の使用パターンと 1 行目 / 2 行目の色規約
+
+Issue #663 body も同 PR で gh issue edit を通して update 済 (実態に整合)。
+
+Phase 5/5 (spec §10-§11)。
+
+Refs #663
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit success, 3 files changed.
+
+---
+
+## Phase 6: PR Pre-flight + 実機検証 + PR creation (no commit)
+
+### Task 6.1: PR Pre-flight checks (Iron Law 6 完全準拠)
+
+- [ ] **Step 1: base 同期確認**
+
+```bash
+git fetch origin develop-0.2.0
+git log HEAD..origin/develop-0.2.0 --oneline
+```
+
+If output is non-empty AND any commit touches `gui/src-tauri/src/error.rs|lib.rs|gui/src/state/*|gui/src/components/*|gui/src/screens/*|docs/tauri-commands.md|docs/ui-architecture.md|docs/ui-interaction-spec.md`, run:
+
+```bash
+git merge origin/develop-0.2.0
+# resolve any conflicts
+```
+
+Then re-run automated checks below.
+
+- [ ] **Step 2: 並行 worktree PR 重複確認**
+
+```bash
+gh pr list --search "#663" --state all
+gh pr list --state open --search "claude/"
+```
+
+Expected: no other open PR claiming #663. If exists, halt and ask Idios via `AskUserQuestion`.
+
+### Task 6.2: 自動チェック (path 別 / Iron Law 6 — 失敗パターン A 防止)
+
+- [ ] **Step 1: Rust check**
+
+```bash
+cd gui/src-tauri && cargo check && cargo test --lib 2>&1 | tail -10
+```
+
+Expected: 155 件 pass.
+
+- [ ] **Step 2: GUI frontend check**
+
+```bash
+cd ../.. && cd gui && npm run lint && npm run typecheck && npm test -- --run && npm run build 2>&1 | tail -20
+```
+
+Expected: lint / typecheck / vitest (~580 件 pass) / build all green.
+
+- [ ] **Step 3: Markdownlint**
+
+```bash
+cd .. && bash scripts/check-markdownlint.sh 2>&1 | tail -5
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 4: Python regression check**
+
+```bash
+ruff check . && ruff format --check . && pyright && pytest 2>&1 | tail -10
+```
+
+Expected: pass (本 PR は GUI / docs のみで Python に影響なし。regression check)。
+
+### Task 6.3: 実機検証依頼 (Iron Law 6 — 失敗パターン B 防止)
+
+**Files:**
+
+- Tool: `AskUserQuestion`
+
+- [ ] **Step 1: Ask Idios for 5-route 実機検証**
+
+Use `AskUserQuestion` with the following spec:
+
+```text
+Question: 実機検証 5 経路の結果を教えてください (allaganeye-gui を Tauri dev で起動して各 route を再現)。
+Options:
+
+- 全 5 PASS (PR 作成可)
+- 一部 FAIL (詳細を Idios が記述)
+- 後で実施 (PR 作成は保留、後続でアップデート)
+- やめる
+```
+
+Provide the 5 routes inline:
+
+1. `state.mtime_conflict`: metadata.json を 2 つの allaganeye-gui プロセスで同時 edit → apply、ConflictModal 表示 + AppError hint は modal に出ない
+2. `io.permission_denied`: read-only な metadata.json を編集→apply、inline error 2 行目に "Portable ZIP install dir が user-writable な..." hint
+3. `io.file_not_found`: metadata.json を削除して GUI から再 load、inline error 2 行目に "ファイルが見つかりません..." hint
+4. `parse.json_invalid`: metadata.json を破損させて load、inline error 2 行目に "JSON ファイルが破損..." hint
+5. `subprocess.spawn_failed`: ffprobe を一時 rename して probe、inline error 2 行目に "外部プロセスの起動に失敗..." hint
+
+Wait for response before proceeding.
+
+### Task 6.4: PR 作成 (Self-Test Report 添付)
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push origin claude/tender-khayyam-03d618 2>&1 | tail -5
+```
+
+Expected: push success.
+
+- [ ] **Step 2: Compose PR body and create PR**
+
+```bash
+printf '%s' '## Summary
+
+[#663](https://github.com/Idios/kobutachan-allaganeye/issues/663) (PR #665 後の AppError migration 完遂) の実装。
+
+Lane I-A (wave 0 起点)。spec [docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md](docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md)。session-id: `tender-khayyam-03d618`。
+
+## 主な変更 (5 phase / 5 commit)
+
+### Phase 1: Rust `error.rs` (default hint helper)
+
+- `default_hint_for_code(code)` (22 entries) + `with_default_hint()` 追加
+- `From<io::Error>` / `From<serde_json::Error>` impl で hint chain
+- 6 件の TDD 新 test (155 件 pass)
+
+### Phase 2: Rust `lib.rs` mechanical
+
+- 全 80 site の `AppError::new(...)` に `.with_default_hint()` chain
+- regression なし
+
+### Phase 3: Frontend stores
+
+- `metadataStore`: `*ErrorHint` 5 state 追加 (load / apply / restore / draftSave / draftLoad)
+- `recentStore`: `loadErrorHint` / `addErrorHint` 追加
+- `metadataStore.ts:209` の legacy `|| msg.startsWith('"'"'conflict:'"'"')` を削除
+- 既存 conflict 文字列 test (8 + 6 件) を AppError object 形式 / prefix 削除版に書き換え
+
+### Phase 4: Frontend UI
+
+- 5 screen + RestoreButton の inline error に hint 2 行目を追加 (`var(--ae-text-dim)` 色)
+- 各 module.css に `.errorHint` (or 派生) class
+- 各 screen / component test に hint 表示 test を追加
+
+### Phase 5: Docs + issue body
+
+- `docs/tauri-commands.md`: AppError default hint mapping table (22 entries)
+- `docs/ui-architecture.md` §4.x: AppError code 体系と inline 使い分け
+- `docs/ui-interaction-spec.md` §1.5.x: error.code ベース分岐ルール
+- Issue #663 body を実態に合わせて update (gh issue edit)
+
+## 受け入れ条件 (issue #663 全 14 項目)
+
+- [x] (A) `metadataStore.ts:209` の `|| msg.startsWith('"'"'conflict:'"'"')` が削除されている
+- [x] (A) `metadataStore.test.ts` の `'"'"'conflict: ...'"'"'` raw String テストが AppError object 形式に書き換え
+- [x] (A) `ConflictModal.test.tsx` の test data から `'"'"'conflict:'"'"'` prefix が消えている
+- [x] (B) `error.rs` に `default_hint_for_code()` + `with_default_hint()` 追加、22 codes 日本語 hint
+- [x] (B) `From<std::io::Error>` / `From<serde_json::Error>` で `.with_default_hint()`
+- [x] (B) `lib.rs` 全 80 site の `AppError::new(...)` に `.with_default_hint()`
+- [x] (C) `metadataStore` に 5 `*ErrorHint` state、`recentStore` に 2 hint pair 追加
+- [x] (C) 5 screen + RestoreButton の inline error が hint を 2 行目に render
+- [x] (D) docs 3 ファイル更新
+- [x] (D) issue body 更新
+
+## Self-Test Report
+
+### Machine-verified (Iron Law 6 PR 作成 Pre-flight)
+
+- [x] `git fetch origin develop-0.2.0` + `git log HEAD..origin/develop-0.2.0` (取り込み未済 commit なし、または merge 完了)
+- [x] `gh pr list --search "#663"` 並行 worktree PR 重複なし
+- [x] `cd gui/src-tauri && cargo check` (warning なし)
+- [x] `cd gui/src-tauri && cargo test --lib` (155 件 pass、新 6 件 + 既存 149 件)
+- [x] `cd gui && npm run lint` (exit 0)
+- [x] `cd gui && npm run typecheck` (exit 0)
+- [x] `cd gui && npm test -- --run` (~580 件 pass、新 13-15 件 + 既存 ~566 件)
+- [x] `cd gui && npm run build` (exit 0)
+- [x] `bash scripts/check-markdownlint.sh` (0 errors)
+- [x] `ruff check . && ruff format --check . && pyright && pytest` (Python regression なし)
+
+### Machine-unverifiable (Iron Law 6 実機検証 — 失敗パターン B 防止)
+
+- E2E #1: `state.mtime_conflict` 経路 (2 プロセス同時 edit → apply、ConflictModal 表示 + modal 既存 hint 維持、AppError hint は modal に出ない)
+- E2E #2: `io.permission_denied` 経路 (read-only metadata.json apply、inline 2 行目に "Portable ZIP install dir..." hint)
+- E2E #3: `io.file_not_found` 経路 (metadata.json 削除して再 load、inline 2 行目に "ファイルが見つかりません..." hint)
+- E2E #4: `parse.json_invalid` 経路 (metadata.json 破損 load、inline 2 行目に "JSON ファイルが破損..." hint)
+- E2E #5: `subprocess.spawn_failed` 経路 (ffprobe rename して probe、inline 2 行目に "外部プロセスの起動に失敗..." hint)
+
+## 関連
+
+Refs #663 #665 #661 #614 #619 #514
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+' | gh pr create --base develop-0.2.0 --head claude/tender-khayyam-03d618 --title 'refactor(gui): #663 AppError migration 完遂 (legacy fallback 撤去 + per-code default hint 全 80 site 適用) (Lane I-A)' --body-file -
+```
+
+Expected: PR created with link printed. Note the PR number for follow-up.
+
+---
+
+## Self-review
+
+Spec coverage check (against `docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md`):
+
+- ✅ §5 (Layer 1) — Task 1.1 / 1.2 / 1.3 cover `default_hint_for_code`, `with_default_hint`, From impl chains
+- ✅ §6 (Layer 2) — Task 2.1 covers 80 sites mechanical migration
+- ✅ §7 (Layer 3) — Task 3.2 / 3.3 / 3.4 cover store state, legacy fallback removal, recentStore
+- ✅ §8 (Layer 4) — Task 4.1-4.6 cover CSS + RestoreButton + 4 screens
+- ✅ §9 (Tests) — TDD red→green at every modification, regression check at end of each phase
+- ✅ §9.3 (実機検証 5 経路) — Task 6.3 explicitly invokes `AskUserQuestion`
+- ✅ §10 (Docs) — Task 5.1-5.4 cover all 3 doc files + markdownlint
+- ✅ §11 (Issue body update) — Task 5.5 with `printf | gh issue edit` (per `feedback_gh_command_ja_heredoc.md`)
+- ✅ §12 (受け入れ条件) — All 14 items mapped to specific tasks
+- ✅ §13 (Risks) — Pre-flight (Task 6.1), automated checks (Task 6.2), 実機検証 (Task 6.3) all addressed
+- ✅ §14 (実装順序 5 phase / 5 commit) — Phases 1-5 → 5 commits, Phase 6 = PR creation no commit
+- ✅ §15 (PR Pre-flight) — Task 6.1 / 6.2
+- ✅ §16 (PR 規約) — Task 6.4 PR body shows `Refs #663` only, session-id, Self-Test Report
+
+Placeholder scan: No "TBD" / "TODO" / "implement later" remain. Each step has explicit code or commands. Some screen test skeletons (`render(<DropScreen />); /* simulate the probe trigger */`) are intentionally adaptive because they depend on existing test helpers — the executor reads the file first to mirror the established pattern.
+
+Type consistency: `appErrorMessage` / `appErrorHint` / `appErrorCodeIs` are consistent across phases. `default_hint_for_code` / `with_default_hint` consistent. `*ErrorHint` field naming consistent (`loadErrorHint`, `applyErrorHint`, etc.) — no `loadHint` / `applyHintMessage` divergence.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-08-l2-appError-migration-completion.md`.** Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md
+++ b/docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md
@@ -1,0 +1,708 @@
+# L2 Lane I-A: AppError migration 完遂 (legacy fallback 撤去 + per-code default hint 全 80 site 適用) 設計
+
+> **Status**: v0.2.0 リリースゲート Lane I-A (Group A) — wave 0 起点 (Lane I-B = Group B の前提)
+> **Scope**: [#663](https://github.com/Idios/kobutachan-allaganeye/issues/663) 単独 (1 spec / 1 章 / 1 PR)
+> **session**: `tender-khayyam-03d618` (2026-05-08 brainstorming、Idios + Claude Opus 4.7)
+> **依存元 PR**: [#661](https://github.com/Idios/kobutachan-allaganeye/pull/661) (`AppError` struct 導入) / [#665](https://github.com/Idios/kobutachan-allaganeye/pull/665) (`Result<T, AppError>` 23 commands migration、本 spec の前提として `ea9bca9` で完了済)
+
+## §0 関連 issue / PR の状態整理
+
+| 参照先 | 状態 | 本 spec への関与 |
+| --- | --- | --- |
+| [#663](https://github.com/Idios/kobutachan-allaganeye/issues/663) | OPEN | **本 spec で対応** (issue body は実態に合わせて PR 内で更新) |
+| [#614](https://github.com/Idios/kobutachan-allaganeye/issues/614) | CLOSED (PR #661 で完了) | `AppError` struct + `install_panic_hook` + `ErrorModal` 導入元、本 spec で再 open しない |
+| [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) | CLOSED (PR #665 で完了) | `Result<T, AppError>` 23 commands migration を Round 1 review (`ea9bca9`) で完遂、本 spec はこの上に乗る |
+| [#514](https://github.com/Idios/kobutachan-allaganeye/issues/514) | CLOSED | `state.mtime_conflict` で ConflictModal を出す経路、本 spec の legacy fallback 撤去で「`startsWith('conflict:')`」も削除 |
+| [#624](https://github.com/Idios/kobutachan-allaganeye/issues/624) | OPEN (Lane IV-b) | pr-checklist CI bug、本 spec の Self-Test Report 記法 (bullet) で回避 (本 spec で修正対象ではない) |
+
+## §1 Background — PR #665 で核心 migration は完了済み
+
+[#663](https://github.com/Idios/kobutachan-allaganeye/issues/663) の元 issue body は「legacy 17 Tauri command の `Result<T, String>` を `AppError::to_wire_string()` で返す形に migrate」と書かれているが、実際には PR #665 (`ea9bca9: 23 commands を Result<T, AppError> に migrate`) で **23 commands の `Result<T, String>` → `Result<T, AppError>` migration が既に完遂**している。`to_wire_string()` 自体は production 未使用で削除され ([gui/src-tauri/src/error.rs](gui/src-tauri/src/error.rs) のテストコメント参照)、現在は Tauri が `serde::Serialize` 経由で structured object を直接 frontend に届ける形。
+
+そのため本 spec が扱う #663 の残作業は次の 4 軸に整理される。
+
+- **(A) Legacy `startsWith('conflict:')` fallback 撤去**
+  ([gui/src/state/metadataStore.ts:209](gui/src/state/metadataStore.ts:209) の `appErrorCodeIs(e, 'state.mtime_conflict') || msg.startsWith('conflict:')` から後半削除)
+- **(B) Per-code default hint helper 追加と全 80 site への適用**
+  (Rust `AppError` に `default_hint_for_code()` + `with_default_hint()` を追加、lib.rs 全 80 site で chain)
+- **(C) Frontend での hint 表示**
+  (各 store の error フィールドに `*ErrorHint` ペアを追加、各 inline error の 2 行目に hint を render)
+- **(D) docs / issue body 整合**
+  (`docs/tauri-commands.md` / `docs/ui-architecture.md` / `docs/ui-interaction-spec.md` 更新 + 元 issue body 書き換え)
+
+## §2 Goals
+
+1. legacy raw String error を許容する `startsWith('conflict:')` fallback を完全に撤去し、`appErrorCodeIs(e, 'state.mtime_conflict')` のみで分岐させる (PR #663 の核心受け入れ条件)
+2. 22 個の AppError code に対する default 日本語 hint を `error.rs` の 1 つの mapping table に集約し、全 80 site の `AppError::new(...)` に `.with_default_hint()` を chain する (= site 個別の hint 揺れを発生させずに 80 site 網羅)
+3. frontend が AppError の `code` で error 種別を判定し、hint があれば inline error の 2 行目に表示する規約を確立する
+4. AppError code 体系と使い分けを `docs/tauri-commands.md` / `ui-architecture.md` § 4 / `ui-interaction-spec.md` § 1.5 に明文化し、新規 command 追加時の指針を残す
+5. 元 issue 本文を「PR #665 後の残作業として何を完遂したか」が読み取れる形に書き換える (Iron Law 4 整合: PR / commit には Closes/Fixes 禁止、issue 本体に記録を残す)
+
+## §3 Non-goals (scope 外明記)
+
+- **ErrorModal (#614) への AppError 統合**: `ErrorModal` は uncaught panic / React error 用の経路であり、Tauri command 経路は catch ブロックで処理する規約を維持する
+- **`globalErrorListener.ts` への AppError parse 追加**: Tauri command の reject は invoke 側 catch で処理する設計、`'tauri-command'` errorCategory は将来別 issue (handle 漏れ統合観測等) に備える reservation のままとする
+- **`ConflictModal` での AppError hint 表示**: modal 内に既に compose hint テキスト (`「上書き」で外部変更を破棄...`) があるため、AppError の `state.mtime_conflict` default hint は「modal の表示には乗せない」として scope 外
+- **新規 Tauri command の追加 / 削除**: 機能拡張は別 issue (Lane I-B = Group B 等)
+- **自動 telemetry / Sentry crash reporter 統合**: 元 issue scope 外明記
+- **関連 issue (#619 / #614 等 CLOSED 群) の body 修正**: 本 spec では触らない
+- **Lane I-B (Group B) の作業先取り**: lib.rs 共有 issue (`#679` / `#648` / `#644`) は Lane I-A merge 後に着手の規約を厳守
+
+## §4 Architecture (4-layer)
+
+```text
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Layer 1: Rust error.rs (pure helper module)                              │
+│   - default_hint_for_code(code: &str) -> Option<&'static str>             │
+│   - AppError::with_default_hint(self) -> Self                             │
+│   - 22 codes への日本語 hint mapping table                                │
+└──────────────────────────────────────────────────────────────────────────┘
+                              ↓ chain
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Layer 2: Rust lib.rs (mechanical migration)                              │
+│   - 全 80 site で `AppError::new(code, msg).with_default_hint()` 形式に    │
+│   - From<io::Error> / From<serde_json::Error> も hint chain 経路に乗る   │
+└──────────────────────────────────────────────────────────────────────────┘
+                              ↓ Tauri serialize → invoke reject (frontend)
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Layer 3: Frontend state (per-store error+hint pair)                      │
+│   - metadataStore: 5 error / 5 errorHint state                            │
+│   - recentStore: addError + addErrorHint 等                               │
+│   - 各 catch site で `appErrorMessage(e)` + `appErrorHint(e)` 併用       │
+│   - metadataStore:209 の `|| msg.startsWith('conflict:')` を削除          │
+└──────────────────────────────────────────────────────────────────────────┘
+                              ↓ subscribe
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Layer 4: Frontend UI (inline error 2-line render)                        │
+│   - 5 screen + RestoreButton で hint があれば 2 行目を `var(--ae-text-dim)` で render│
+│   - hint 専用 CSS class (`.errorHint`)                                    │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+各 layer は独立したテスト可能ユニット。Layer 1 は pure (no I/O)、Layer 2 は mechanical (compile check + 既存 cargo test 全 pass で全 site 通過保証)、Layer 3 は store unit test、Layer 4 は component test。
+
+## §5 Layer 1 設計: Rust `error.rs`
+
+### §5.1 既存 API の温存と修正
+
+```rust
+impl AppError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self { ... }   // 温存
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self { ... }                // #[allow(dead_code)] 削除
+    #[allow(dead_code)] pub fn with_stacktrace(mut self, stacktrace: impl Into<String>) -> Self { ... } // 温存 (将来 Sentry 用)
+}
+impl From<std::io::Error> for AppError { ... }      // 内部に hint chain 追加 (§5.3)
+impl From<serde_json::Error> for AppError { ... }   // 同上
+impl From<String> for AppError { ... }              // 温存 (`internal.error` で hint None)
+```
+
+**`with_hint` の `#[allow(dead_code)]` は温存する** (production code は `with_default_hint` を使い、`with_default_hint` 内部で `self.hint` に直接代入するため `with_hint` は経由しない。`with_hint` は test (`error.rs::tests::serialize_app_error_roundtrips` および本 spec § 5.4 の `with_default_hint_does_not_overwrite_explicit_hint`) と将来 Approach C への hybrid 移行時の override 用 API として温存する。test 経路でしか使われないため、非 test build (`cargo build`) で dead code warning が出ないよう `#[allow(dead_code)]` を保持する)。
+
+### §5.2 新規 API — `with_default_hint()` と `default_hint_for_code()`
+
+```rust
+impl AppError {
+    /// code に対する default hint を attach する。すでに hint が設定されている場合は
+    /// 上書きせず保持する (call site で `.with_hint("...")` を先に書いた場合の override
+    /// が効く設計、将来 Approach C への hybrid 移行時に必要)。
+    pub fn with_default_hint(mut self) -> Self {
+        if self.hint.is_some() {
+            return self;
+        }
+        self.hint = default_hint_for_code(&self.code).map(String::from);
+        self
+    }
+}
+
+/// AppError code に対する日本語 default hint を返す。未登録 code は None。
+/// 22 entries (現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
+/// validation.* / path.* / platform.* / internal.*)。
+fn default_hint_for_code(code: &str) -> Option<&'static str> {
+    match code {
+        // state
+        "state.mtime_conflict" => Some(
+            "metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください"
+        ),
+        // io (manual call site)
+        "io.file_not_found" => Some(
+            "ファイルが見つかりません。パスを確認するか、allaganeye split を再実行してください"
+        ),
+        "io.read_failed" => Some(
+            "ファイルの読み込みに失敗しました。ディスク状況・ファイルロック状態を確認してください"
+        ),
+        "io.write_failed" => Some(
+            "ファイルの書き込みに失敗しました。空き容量と書き込み権限 (Portable ZIP の install dir が user-writable か) を確認してください"
+        ),
+        "io.delete_failed" => Some(
+            "ファイル / フォルダの削除に失敗しました。他プロセスでロックされていないか確認してください"
+        ),
+        "io.backup_failed" => Some(
+            "バックアップファイルの作成に失敗しました。allaganeye 出力フォルダの空き容量と書き込み権限を確認してください"
+        ),
+        // io (auto from std::io::Error::ErrorKind via From impl)
+        "io.permission_denied" => Some(
+            "ファイルへのアクセス権限がありません。Portable ZIP install dir が user-writable な場所か、ファイル / フォルダが読み取り専用でないか確認してください"
+        ),
+        "io.already_exists" => Some(
+            "ファイルが既に存在します。出力先を変更するか既存ファイルを削除してください"
+        ),
+        "io.would_block" | "io.timed_out" => Some(
+            "I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください"
+        ),
+        "io.error" => Some(
+            "I/O エラーが発生しました。詳細は logs フォルダを確認してください"
+        ),
+        // parse
+        "parse.json_invalid" => Some(
+            "JSON ファイルが破損しています。バックアップ (.bak) からの復元か allaganeye split のやり直しを検討してください"
+        ),
+        "parse.json_serialize_failed" => Some(
+            "JSON 書き出しに失敗しました。同梱 issue テンプレートでバグ報告してください"
+        ),
+        "parse.schema_invalid" => Some(
+            "metadata.json の構造が期待形式と異なります。allaganeye のバージョンと metadata 生成バージョンが一致しているか確認してください"
+        ),
+        "parse.ffprobe_output_invalid" => Some(
+            "ffprobe の出力を解釈できませんでした。ffmpeg / ffprobe を最新の BtbN LGPL ビルドに更新してください"
+        ),
+        // subprocess
+        "subprocess.spawn_failed" => Some(
+            "外部プロセスの起動に失敗しました。ffmpeg / Python / 同梱 runtime が壊れていないか確認してください"
+        ),
+        "subprocess.exit_failed" => Some(
+            "外部プロセスが異常終了しました。logs フォルダの最新ログから詳細を確認してください"
+        ),
+        "subprocess.cancelled" => None, // ユーザー操作によるキャンセルは hint 不要 (UI 側で「キャンセルされました」を表示で十分)
+        // validation
+        "validation.path_invalid" => Some(
+            "入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v)"
+        ),
+        "validation.not_a_file" => Some(
+            "指定されたパスはファイルではありません (フォルダや symlink ではなく動画ファイルを選択してください)"
+        ),
+        "validation.range_invalid" => Some(
+            "入力された数値が許容範囲外です。フォーム下のヒント表示を確認してください"
+        ),
+        // path / platform / internal
+        "path.install_dir_unresolved" => Some(
+            "Portable ZIP の install dir を特定できませんでした。allaganeye-gui.exe を ZIP 展開後の元のフォルダ構成のまま起動してください"
+        ),
+        "platform.unsupported" => Some(
+            "本機能は現在の OS では未対応です。Windows での起動が必要です"
+        ),
+        "internal.error" => None, // 内部エラーで具体的アクションがない (詳細は logs 参照を message 側で示す方針)
+        _ => None,
+    }
+}
+```
+
+### §5.3 `From<...>` impl の hint chain
+
+`From<io::Error>` と `From<serde_json::Error>` は `?` 演算子で自動変換され call site で `.with_default_hint()` が呼ばれない。impl 内で自動 hint 付与する (= 設計選択 (i)、§設計セクション 2 で承認済)。
+
+```rust
+impl From<std::io::Error> for AppError {
+    fn from(e: std::io::Error) -> Self {
+        let code = match e.kind() { /* 既存 */ };
+        AppError::new(code, e.to_string()).with_default_hint()  // ← 追加
+    }
+}
+impl From<serde_json::Error> for AppError {
+    fn from(e: serde_json::Error) -> Self {
+        AppError::new("parse.json_invalid", e.to_string()).with_default_hint()  // ← 追加
+    }
+}
+impl From<String> for AppError {
+    fn from(message: String) -> Self {
+        AppError::new("internal.error", message)
+        // hint None で問題ない (default_hint_for_code でも internal.error は None マップ)
+    }
+}
+```
+
+### §5.4 Layer 1 の test (TDD red 起点、cargo test --lib)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // 既存 2 件 (serialize_app_error_roundtrips / app_error_display_format) は温存
+
+    #[test]
+    fn default_hint_covers_all_known_codes() {
+        let with_hint = [
+            "state.mtime_conflict",
+            "io.file_not_found", "io.read_failed", "io.write_failed",
+            "io.delete_failed", "io.backup_failed",
+            "io.permission_denied", "io.already_exists",
+            "io.would_block", "io.timed_out", "io.error",
+            "parse.json_invalid", "parse.json_serialize_failed",
+            "parse.schema_invalid", "parse.ffprobe_output_invalid",
+            "subprocess.spawn_failed", "subprocess.exit_failed",
+            "validation.path_invalid", "validation.not_a_file", "validation.range_invalid",
+            "path.install_dir_unresolved", "platform.unsupported",
+        ];
+        for code in with_hint {
+            assert!(default_hint_for_code(code).is_some(), "missing hint for code: {}", code);
+        }
+        // 意図的 None 群
+        assert!(default_hint_for_code("subprocess.cancelled").is_none());
+        assert!(default_hint_for_code("internal.error").is_none());
+        assert!(default_hint_for_code("unknown.code").is_none());
+    }
+
+    #[test]
+    fn with_default_hint_attaches_known_code() {
+        let e = AppError::new("io.read_failed", "could not read").with_default_hint();
+        assert!(e.hint.is_some());
+        assert!(e.hint.unwrap().contains("ディスク状況"));
+    }
+
+    #[test]
+    fn with_default_hint_does_not_overwrite_explicit_hint() {
+        let e = AppError::new("io.read_failed", "msg")
+            .with_hint("custom hint")
+            .with_default_hint();
+        assert_eq!(e.hint.as_deref(), Some("custom hint"));
+    }
+
+    #[test]
+    fn with_default_hint_returns_no_hint_for_unknown_code() {
+        let e = AppError::new("unknown.code", "msg").with_default_hint();
+        assert!(e.hint.is_none());
+    }
+
+    #[test]
+    fn from_io_error_attaches_default_hint() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "x");
+        let e: AppError = io_err.into();
+        assert_eq!(e.code, "io.file_not_found");
+        assert!(e.hint.is_some());
+    }
+
+    #[test]
+    fn from_serde_json_error_attaches_default_hint() {
+        let json_err = serde_json::from_str::<serde_json::Value>("{ invalid").unwrap_err();
+        let e: AppError = json_err.into();
+        assert_eq!(e.code, "parse.json_invalid");
+        assert!(e.hint.is_some());
+    }
+}
+```
+
+## §6 Layer 2 設計: Rust `lib.rs` (mechanical migration)
+
+全 80 site の `AppError::new(code, format!("..."))` を `AppError::new(code, format!("...")).with_default_hint()` chain に変更する。
+
+- mechanical 操作なので site ごとの個別判断は不要
+- `cargo check` で type 整合確認、`cargo test --lib` で既存 149 件 + Layer 1 新 6 件 = 155 件 pass を担保
+- `with_hint` の `#[allow(dead_code)]` は §5.1 の決定通り温存 (削除しない)
+
+### §6.1 例 (apply_changes 周辺、`state.mtime_conflict` の `AppError::new(...)` 呼び出し箇所)
+
+```rust
+// before
+return Err(AppError::new(
+    "state.mtime_conflict",
+    format!("expected mtime {} got {}", expected, actual),
+));
+
+// after
+return Err(AppError::new(
+    "state.mtime_conflict",
+    format!("expected mtime {} got {}", expected, actual),
+).with_default_hint());
+```
+
+## §7 Layer 3 設計: Frontend state (per-store error+hint pair)
+
+### §7.1 metadataStore.ts の state field 拡張
+
+| 既存 | 新規 (hint pair 追加) | 用途 |
+| --- | --- | --- |
+| `loadError: string \| null` | `loadErrorHint: string \| null` | DropScreen の load 失敗 |
+| `applyError: string \| null` | `applyErrorHint: string \| null` | apply path |
+| `restoreError: string \| null` | `restoreErrorHint: string \| null` | RestoreButton (#516) |
+| `draftSaveError: string \| null` | `draftSaveErrorHint: string \| null` | draft save |
+| `draftLoadError: string \| null` | `draftLoadErrorHint: string \| null` | draft load |
+| `conflictError: string \| null` | (追加なし) | ConflictModal は scope 外 |
+
+`DEFAULT_STATE` / `dismissError` 系も対応。
+
+### §7.2 catch block の変更 pattern
+
+```typescript
+// before
+try {
+  ...
+} catch (e) {
+  set({ applying: false, applyError: appErrorMessage(e) });
+}
+
+// after
+try {
+  ...
+} catch (e) {
+  set({
+    applying: false,
+    applyError: appErrorMessage(e),
+    applyErrorHint: appErrorHint(e),
+  });
+}
+```
+
+### §7.3 legacy `startsWith('conflict:')` fallback の撤去
+
+```typescript
+// metadataStore.ts:209 (before)
+if (appErrorCodeIs(e, 'state.mtime_conflict') || msg.startsWith('conflict:')) {
+  set({ applying: false, conflictError: msg });
+  return;
+}
+
+// after
+if (appErrorCodeIs(e, 'state.mtime_conflict')) {
+  set({ applying: false, conflictError: msg });
+  return;
+}
+```
+
+直前 line 206-208 のコメント (「#619: structured AppError 化以後は code-based 判定を優先...」) も以下の趣旨に書き換え:
+
+> #663: PR #665 で全 23 commands が AppError 化済のため、legacy raw String fallback は廃止する。code === 'state.mtime_conflict' のみで分岐する。
+
+### §7.4 recentStore.ts の対応
+
+`add_recent` / `clear_recent` / `read_recent` の catch path で同パターンを適用 (state field 名は実コード参照、追加方針は metadataStore と同じ「error + errorHint pair」)。
+
+## §8 Layer 4 設計: Frontend UI (inline error 2-line render)
+
+### §8.1 影響 component と変更内容
+
+| component | 変更内容 |
+| --- | --- |
+| [DropScreen.tsx](gui/src/screens/DropScreen.tsx) | 既存 `setError(e.message)` を `setError(message)` + `setErrorHint(hint)` に拡張、card 内で 2 行目 render |
+| [DetectingScreen.tsx](gui/src/screens/DetectingScreen.tsx) | `start_detect` 失敗時の inline error に hint 行追加 |
+| [CompleteScreen.tsx](gui/src/screens/CompleteScreen.tsx) | RestoreButton 経由なので screen レベルでは追加変更不要 |
+| [PreviewScreen.tsx](gui/src/screens/PreviewScreen.tsx) | preview load / apply error 等で hint 行追加 |
+| [ExportScreen.tsx](gui/src/screens/ExportScreen.tsx) | per-match export error に hint 行追加 |
+| [RestoreButton.tsx](gui/src/components/RestoreButton.tsx) | inline `role="alert"` 内で hint を 2 行目 render |
+
+### §8.2 render pattern (例)
+
+```tsx
+{applyError && (
+  <div role="alert" className={styles.errorBox}>
+    <p className={styles.errorMessage}>{applyError}</p>
+    {applyErrorHint && (
+      <p className={styles.errorHint}>💡 {applyErrorHint}</p>
+    )}
+  </div>
+)}
+```
+
+a11y: `role="alert"` は wrapper に維持、hint は補足情報として `<p>` を続ける (`docs/a11y-policy.md` の Modal / inline error 規約に整合させる; `aria-describedby` の追加は jest-axe テストで violation の有無を確認した上で判断)。
+
+### §8.3 CSS
+
+`gui/src/styles/tokens.css` (or 各 module.css) に共通 hint スタイルを追加:
+
+```css
+.errorHint {
+  margin-top: var(--ae-spacing-xs);
+  color: var(--ae-text-dim);
+  font-size: var(--ae-text-sm);
+  line-height: 1.5;
+}
+```
+
+`var(--ae-text-dim)` は既存の補助色 token。red 系 error と区別される。
+
+## §9 Test 戦略
+
+### §9.1 Rust (cargo test --lib)
+
+| test name | 検証内容 |
+| --- | --- |
+| `default_hint_covers_all_known_codes` (新) | 22 codes 全部 + 例外で None |
+| `with_default_hint_attaches_known_code` (新) | hint chain 成功 |
+| `with_default_hint_does_not_overwrite_explicit_hint` (新) | guard logic |
+| `with_default_hint_returns_no_hint_for_unknown_code` (新) | 未登録 code |
+| `from_io_error_attaches_default_hint` (新) | From impl の hint chain |
+| `from_serde_json_error_attaches_default_hint` (新) | From impl の hint chain |
+| 既存 149 件 | regression check (hint をテストしていない既存に影響なし) |
+
+### §9.2 Frontend (vitest)
+
+| test file | 追加 / 変更 | 検証内容 |
+| --- | --- | --- |
+| [gui/src/lib/appError.test.ts](gui/src/lib/appError.test.ts) | 影響なし | 既存 helper test 既に網羅済 |
+| [gui/src/state/metadataStore.test.ts](gui/src/state/metadataStore.test.ts) | 既存 8 件書き換え + 新規 5 件 | (a) AppError 形式 reject で `applyError` + `applyErrorHint` 設定、(b) `state.mtime_conflict` で conflictError 振り分け、(c) legacy raw String reject で `applyError` のみ (hint=null)、(d-f) load/restore/draftSave/draftLoad の hint pair |
+| `gui/src/state/recentStore.test.ts` | 新規 2 件 | addError + addErrorHint 設定 |
+| [gui/src/components/ConflictModal.test.tsx](gui/src/components/ConflictModal.test.tsx) | 既存 6 件の test data 修正 | `'conflict: x'` → `'x'` (legacy prefix 撤去後の form) |
+| `gui/src/components/RestoreButton.test.tsx` | 新規 2 件 | hint 表示時 2 行目 render / hint=null 時 2 行目非表示 |
+| `gui/src/screens/DropScreen.test.tsx` | 新規 1 件 | error card で hint 表示 |
+| `gui/src/screens/DetectingScreen.test.tsx` | 新規 1 件 | start_detect 失敗時 hint 表示 |
+| `gui/src/screens/PreviewScreen.test.tsx` | 新規 1 件 | preview load error の hint 表示 |
+| `gui/src/screens/ExportScreen.test.tsx` | 新規 1 件 | per-match error の hint 表示 |
+| jest-axe a11y チェック (該当 component) | 既存 + 必要に応じ新規 | hint 含む alert で a11y violation がないこと |
+
+合計: 既存 ~566 件 + 新規 13-15 件 + 既存修正 ~14 件 = ~595 件。
+
+### §9.3 実機検証 (Iron Law 6 — `gui/src-tauri/**` + state 系変更につき必須)
+
+5 経路を `AskUserQuestion` で Idios に手動依頼:
+
+1. `state.mtime_conflict` 経路 — metadata.json を 2 つの allaganeye-gui プロセスで同時 edit → apply、ConflictModal 表示 + scope 外宣言通り AppError hint は modal に出ない
+2. `io.permission_denied` 経路 — read-only な metadata.json を編集→apply、inline error 2 行目に "Portable ZIP install dir が user-writable な..." hint
+3. `io.file_not_found` 経路 — metadata.json を削除して GUI から再 load、inline error 2 行目に "ファイルが見つかりません..." hint
+4. `parse.json_invalid` 経路 — metadata.json を破損させて load、inline error 2 行目に "JSON ファイルが破損..." hint
+5. `subprocess.spawn_failed` 経路 — ffprobe を一時 rename して probe、inline error 2 行目に "外部プロセスの起動に失敗..." hint
+
+## §10 Doc 整合 (3 ファイル)
+
+### §10.1 [docs/tauri-commands.md](docs/tauri-commands.md)
+
+既存 master table に hint 列を加えるか、末尾に「AppError default hint mapping」 section を追加し、22 codes 全件を 1 表にまとめる (本 spec § 5.2 が source of truth、tauri-commands.md はその外部 mirror)。
+
+```markdown
+## AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)
+
+> 本 table の文言は `gui/src-tauri/src/error.rs` の `default_hint_for_code()` と
+> 完全一致させる (CI で integrity check は今回入れないが、文言変更時は両方を
+> 同 PR で更新する規約)。
+
+| code | hint |
+| --- | --- |
+| `state.mtime_conflict` | metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください |
+| `io.file_not_found` | ファイルが見つかりません。パスを確認するか、allaganeye split を再実行してください |
+| `io.read_failed` | ファイルの読み込みに失敗しました。ディスク状況・ファイルロック状態を確認してください |
+| `io.write_failed` | ファイルの書き込みに失敗しました。空き容量と書き込み権限 (Portable ZIP の install dir が user-writable か) を確認してください |
+| `io.delete_failed` | ファイル / フォルダの削除に失敗しました。他プロセスでロックされていないか確認してください |
+| `io.backup_failed` | バックアップファイルの作成に失敗しました。allaganeye 出力フォルダの空き容量と書き込み権限を確認してください |
+| `io.permission_denied` | ファイルへのアクセス権限がありません。Portable ZIP install dir が user-writable な場所か、ファイル / フォルダが読み取り専用でないか確認してください |
+| `io.already_exists` | ファイルが既に存在します。出力先を変更するか既存ファイルを削除してください |
+| `io.would_block` / `io.timed_out` | I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください |
+| `io.error` | I/O エラーが発生しました。詳細は logs フォルダを確認してください |
+| `parse.json_invalid` | JSON ファイルが破損しています。バックアップ (.bak) からの復元か allaganeye split のやり直しを検討してください |
+| `parse.json_serialize_failed` | JSON 書き出しに失敗しました。同梱 issue テンプレートでバグ報告してください |
+| `parse.schema_invalid` | metadata.json の構造が期待形式と異なります。allaganeye のバージョンと metadata 生成バージョンが一致しているか確認してください |
+| `parse.ffprobe_output_invalid` | ffprobe の出力を解釈できませんでした。ffmpeg / ffprobe を最新の BtbN LGPL ビルドに更新してください |
+| `subprocess.spawn_failed` | 外部プロセスの起動に失敗しました。ffmpeg / Python / 同梱 runtime が壊れていないか確認してください |
+| `subprocess.exit_failed` | 外部プロセスが異常終了しました。logs フォルダの最新ログから詳細を確認してください |
+| `subprocess.cancelled` | (hint なし: ユーザー操作によるキャンセルは UI 側で十分な情報を出す) |
+| `validation.path_invalid` | 入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v) |
+| `validation.not_a_file` | 指定されたパスはファイルではありません (フォルダや symlink ではなく動画ファイルを選択してください) |
+| `validation.range_invalid` | 入力された数値が許容範囲外です。フォーム下のヒント表示を確認してください |
+| `path.install_dir_unresolved` | Portable ZIP の install dir を特定できませんでした。allaganeye-gui.exe を ZIP 展開後の元のフォルダ構成のまま起動してください |
+| `platform.unsupported` | 本機能は現在の OS では未対応です。Windows での起動が必要です |
+| `internal.error` | (hint なし: 内部エラーで具体的アクションがない、message 側で logs 参照を案内) |
+```
+
+### §10.2 [docs/ui-architecture.md](docs/ui-architecture.md) § 4 「エラー伝搬フロー (#614)」
+
+末尾に AppError code 一覧 + 使い分けを §4.x として追記:
+
+```markdown
+### 4.x AppError code 体系と inline error の使い分け (#663)
+
+Tauri command の `Result<T, AppError>` で frontend に届く構造化 error は、
+`docs/tauri-commands.md` で master 一覧化されている。inline error 表示時は
+`appErrorMessage(e)` を 1 行目に、`appErrorHint(e)` を 2 行目 (`var(--ae-text-dim)`)
+に render する規約。code → default hint の mapping は
+`gui/src-tauri/src/error.rs::default_hint_for_code` で一元管理。
+
+#### 主な分岐ルール
+- `code === 'state.mtime_conflict'` → ConflictModal を出す (apply path のみ)
+- それ以外の `code` → inline error (2 行目に hint があれば render)
+- legacy raw String (= AppError 化前の commands) → `appErrorMessage` で
+  message のみ取得、hint は null (PR #663 で legacy raw を返す command は
+  存在しないが、helper の互換性は温存)
+```
+
+### §10.3 [docs/ui-interaction-spec.md](docs/ui-interaction-spec.md) § 1.5 「エラー表示の一貫性」
+
+§ 1.5.x として追記:
+
+```markdown
+### 1.5.x AppError `code` ベースの分岐ルール (#663)
+
+Tauri command 失敗時の error 表示は以下を厳守する:
+
+1. `appErrorCodeIs(e, 'state.mtime_conflict')` で apply path → ConflictModal (modal 表示)
+2. その他の AppError code → inline error
+   - 1 行目: `appErrorMessage(e)` (赤系: `var(--ae-text-error)`)
+   - 2 行目: `appErrorHint(e)` (灰系: `var(--ae-text-dim)`、`💡` 等の prefix で
+     アクション提示と分かるように)
+3. catch ブロック以外で error を扱わない (`alert()` / `console.error` のみは禁止)
+4. globalErrorListener が拾うのは uncaught (window.error / unhandledrejection /
+   panic) のみ。catch 済 Tauri command error は ErrorModal に出さない (規約)
+```
+
+## §11 Issue body 更新
+
+`gh issue edit 663 --body-file -` で update。書き換え方針:
+
+- **概要**: 「PR #665 で 23 commands が `Result<T, AppError>` に migrate 済。本 issue は仕上げ部分 (legacy fallback 撤去 / hint production 適用 / docs 整合) を扱う」
+- **背景**: 旧 body の `to_wire_string()` 表記を削除し、現実態 (Tauri serde Serialize 経由) に書き換え
+- **作業内容**: 4 軸 (A/B/C/D) で再構成
+- **受け入れ条件**: §12 と同期させる
+- **スコープ外**: §3 と同期させる
+
+`feedback_gh_command_ja_heredoc.md` 準拠で `printf | --body-file -` または HEREDOC を使う (inline 引数日本語禁止)。
+
+## §12 受け入れ条件 (本 spec で確定する list)
+
+- [ ] (A) [gui/src/state/metadataStore.ts:209](gui/src/state/metadataStore.ts:209) の `|| msg.startsWith('conflict:')` が削除されている
+- [ ] (A) `metadataStore.test.ts` の `'conflict: ...'` raw String テストが AppError object 形式に書き換わっている
+- [ ] (A) `ConflictModal.test.tsx` の test data から `'conflict:'` prefix が消えている
+- [ ] (B) [gui/src-tauri/src/error.rs](gui/src-tauri/src/error.rs) に `default_hint_for_code()` + `with_default_hint()` が追加され、22 codes 分の日本語 hint が table に存在する
+- [ ] (B) `From<std::io::Error>` / `From<serde_json::Error>` の impl 内で `.with_default_hint()` が呼ばれている
+- [ ] (B) [gui/src-tauri/src/lib.rs](gui/src-tauri/src/lib.rs) の全 80 site の `AppError::new(code, msg)` に `.with_default_hint()` が chain されている
+- [ ] (C) `metadataStore` に `loadErrorHint` / `applyErrorHint` / `restoreErrorHint` / `draftSaveErrorHint` / `draftLoadErrorHint` の 5 state が追加されている
+- [ ] (C) `recentStore` に対応する hint pair が追加されている
+- [ ] (C) 5 screen + RestoreButton の inline error が hint があれば 2 行目を `var(--ae-text-dim)` で render する
+- [ ] (D) [docs/tauri-commands.md](docs/tauri-commands.md) に AppError default hint mapping table が追加されている
+- [ ] (D) [docs/ui-architecture.md](docs/ui-architecture.md) § 4 に `code` 体系と使い分け節 (§4.x) が追加されている
+- [ ] (D) [docs/ui-interaction-spec.md](docs/ui-interaction-spec.md) § 1.5 に `error.code` ベース分岐ルール節 (§1.5.x) が追加されている
+- [ ] (D) issue #663 body が PR #665 後の状態を反映する形に書き換わっている
+- [ ] cargo check / cargo test --lib (新 6 件 + 既存 149 件 = 155 件 pass)
+- [ ] npm run lint / typecheck / test (新 13-15 件 + 既存 ~566 件 = ~580 件 pass) / build
+- [ ] CI 全 8 job pass (gui-rust / gui-frontend / build-windows / installer-pester / python / markdownlint / validate-checklist / version-check)
+- [ ] Iron Law 6 実機検証 5 経路 (§9.3) を Idios が PASS 確認
+
+## §13 Risks & 対策
+
+| Risk | 対策 |
+| --- | --- |
+| **80 site への chain 追加で diff 大きい (lib.rs +80 行)** | mechanical change なのでレビュー負担は文言の方に集中。`docs/tauri-commands.md` の hint table で文言を 1 ヶ所に集約 |
+| **22 codes の日本語 hint 文言の言い回し review が散在する** | spec self-review で文言を 1 表に集約、user review で一括承認/差し戻し、本 spec § 5.2 が source of truth |
+| **既存 metadataStore.test.ts / ConflictModal.test.tsx の rewrite で regression リスク** | TDD 順序 (red→green) で書き換え、削除前後で test 件数が同等以上であることを確認 |
+| **Iron Law 3 scope creep**: hint 文言を整える過程で「ついでに message も整える」誘惑 | scope-guard skill 適用、message 変更は別 issue 起票 |
+| **Iron Law 6 PR Pre-flight**: Lane I-A 起点だが他 lane と並行する可能性 | base merge 取り込み + `gh pr list --search "#663"` 並行確認、PR 作成時に再確認 |
+| **Iron Law 6 実機検証**: gui/src-tauri/** + state 系の変更で実機検証必要 | §9.3 5 経路を `AskUserQuestion` で Idios に依頼 |
+| **CI 全 8 job pass**: gui-rust / gui-frontend / build-windows / installer-pester / python / markdownlint / validate-checklist / version-check | PR pre-flight で全 job のローカル相当チェックを通す |
+| **legacy fallback の test 削除で「想定外 input でも動いていた挙動」を失う** | issue body に明記 (string prefix 判定撤廃 = legacy form は明示的に非サポート)。helper の `appErrorMessage` / `appErrorHint` が legacy raw String / Error instance を null hint で受け流す互換性は温存 |
+| **`with_hint` 直接呼び出しの混在**: production 全 site は `.with_default_hint()` chain を使うため `with_hint` は test と将来 hybrid 移行用 API として残る | §5.1 で `#[allow(dead_code)]` 温存と確定。test (`error.rs::tests`) では `with_hint` を使い続ける |
+
+## §14 実装順序 (TDD-driven、5 phase / 5 commit)
+
+### Phase 1: Rust error.rs (pure helper)
+
+1. test 6 件 red — `cargo test --lib` で fail
+2. `default_hint_for_code` 実装 → green
+3. `with_default_hint` 実装 → green
+4. `From<io::Error>` / `From<serde_json::Error>` の hint chain 追加 → green
+5. `with_hint` の `#[allow(dead_code)]` は温存 (§5.1 参照)、`with_stacktrace` も同様に温存
+
+**commit**: `feat(gui): AppError::default_hint_for_code helper を追加 (Refs #663)`
+
+### Phase 2: Rust lib.rs (mechanical migration)
+
+1. 全 80 site の `AppError::new(code, msg)` を `.with_default_hint()` chain に書き換え
+2. `cargo check` / `cargo test --lib` で 155 件 pass 確認 (cargo check で warning なし、特に `with_hint` 関連 warning が出ないことを確認)
+
+**commit**: `refactor(gui): lib.rs 全 80 site に .with_default_hint() を適用 (Refs #663)`
+
+### Phase 3: Frontend state stores (test 先行)
+
+1. `metadataStore.test.ts` に hint pair の failing test 追加 (5 種類)
+2. `metadataStore.ts` に `*ErrorHint` state 追加 → green
+3. catch block で `appErrorHint(e)` 取り込み → green
+4. legacy `|| msg.startsWith('conflict:')` 削除 → 既存 test red
+5. 既存 test (8 件) の AppError 化リライト → green
+6. `recentStore.ts` も同パターン
+7. `npm run typecheck` / `npm test -- --run` 全 pass
+
+**commit**: `feat(gui): metadataStore / recentStore に *ErrorHint state を追加 + legacy fallback 削除 (Refs #663)`
+
+### Phase 4: Frontend UI (各 screen の inline error 2 行目)
+
+1. `RestoreButton.test.tsx` に hint 表示 failing test 追加
+2. `RestoreButton.tsx` で hint 2 行目 render → green
+3. 各 screen test に hint 表示 failing test 追加
+4. 各 screen の `*Error` render を 2 行目構造に拡張 → green
+5. CSS (`tokens.css` / module.css) に `.errorHint` class 追加
+6. `npm run lint` / `typecheck` / `test` / `build` 全 pass
+
+**commit**: `feat(gui): 各 screen の inline error に hint 2 行目を追加 (Refs #663)`
+
+### Phase 5: Docs + Issue body
+
+1. `docs/tauri-commands.md` に hint mapping table 追加
+2. `docs/ui-architecture.md` § 4 に AppError code 一覧 + 使い分け追記
+3. `docs/ui-interaction-spec.md` § 1.5 に error.code ベース分岐ルール追記
+4. `bash scripts/check-markdownlint.sh` 全 pass
+5. `gh issue edit 663 --body-file -` で issue body 書き換え (`feedback_gh_command_ja_heredoc.md` 準拠)
+
+**commit**: `docs: AppError default hint mapping を docs に整合させる (Refs #663)`
+
+## §15 PR 作成 Pre-flight (Iron Law 6 完全準拠)
+
+```bash
+# 1. base 同期
+git fetch origin develop-0.2.0
+git log HEAD..origin/develop-0.2.0 --oneline
+# 取り込み未済 commit が touched files (gui/src-tauri/src/error.rs / lib.rs /
+# gui/src/state/* / gui/src/components/* / gui/src/screens/* / docs/*) と交差するなら
+git merge origin/develop-0.2.0
+# CI 該当 job のローカル相当を再実行
+
+# 2. 並行 worktree 確認
+gh pr list --search "#663" --state all
+gh pr list --state open --search "claude/"
+
+# 3. 自動チェック (path 別)
+cd gui/src-tauri && cargo check && cargo test --lib
+cd gui && npm run lint && npm run typecheck && npm test -- --run && npm run build
+bash scripts/check-markdownlint.sh
+ruff check . && ruff format --check . && pyright && pytest
+
+# 4. PR 本文に Self-Test Report (machine-verified [x] + machine-unverifiable plain bullet)
+# 5. 実機検証 5 経路 (§9.3) を AskUserQuestion で Idios に依頼 → PASS 確認後にレビュー依頼
+```
+
+## §16 PR 規約
+
+- ベース branch: `develop-0.2.0`
+- 1 PR = 1 issue (#663)、`Refs #663` のみ (Closes/Fixes 禁止 = Iron Law 4)
+- Self-Test Report 規約 (`docs/l2-workflow.md`)
+- session-id: `tender-khayyam-03d618` を PR 本文に明記
+- マージ後 `/close-issue` skill で base ブランチで実測再検証 + 手動 close
+- (A) PR 内修正優先 (`docs/l2-workflow.md`)、レビュー摘出は原則 PR 内追加修正
+
+## §17 Diff 規模見積もり (final)
+
+| 領域 | 追加 | 削除 |
+| --- | --- | --- |
+| Rust (`gui/src-tauri/src/error.rs` + `lib.rs`) | +210 | -2 |
+| Frontend state | +40 | -3 |
+| Frontend UI (screens / components / CSS) | +90 | 0 |
+| Frontend tests | +120 | -25 |
+| Docs (`tauri-commands.md` / `ui-architecture.md` / `ui-interaction-spec.md`) | +90 | -10 |
+| Issue body (`gh issue edit`、code diff には含まれない) | +30 | -50 |
+| **合計 (code diff)** | **+550** | **-40** |
+
+## §18 References
+
+- [docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md](docs/superpowers/plans/2026-05-07-l2-v020-roadmap.md) — Lane I-A 位置付け (wave 0 起点)
+- [docs/l2-workflow.md](docs/l2-workflow.md) — PR Pre-flight / Self-Test Report / (A) PR 内修正優先 / 実機検証 trigger
+- [docs/tauri-commands.md](docs/tauri-commands.md) — Tauri command master 一覧 (PR #665 で新設)
+- [docs/ui-architecture.md](docs/ui-architecture.md) § 4 — エラー伝搬フロー
+- [docs/ui-interaction-spec.md](docs/ui-interaction-spec.md) § 1.5 — エラー表示の一貫性
+- [docs/a11y-policy.md](docs/a11y-policy.md) — Modal / inline error の a11y 規約
+- [gui/src-tauri/src/error.rs](gui/src-tauri/src/error.rs) — `AppError` struct 本体 (PR #661 で導入)
+- [gui/src-tauri/src/lib.rs](gui/src-tauri/src/lib.rs) — 80 site の AppError::new 呼び出し
+- [gui/src/lib/appError.ts](gui/src/lib/appError.ts) — frontend narrowing helper (PR #665 で新設)
+- [gui/src/state/metadataStore.ts](gui/src/state/metadataStore.ts) — legacy fallback の所在
+- PR [#661](https://github.com/Idios/kobutachan-allaganeye/pull/661) — `AppError` struct 導入
+- PR [#665](https://github.com/Idios/kobutachan-allaganeye/pull/665) — `Result<T, AppError>` 23 commands migration (本 spec の前提)
+- Iron Law (`.claude/hooks/session-start.sh`) — 1 (受け入れ条件) / 3 (scope creep) / 4 (Closes 禁止) / 5 (曖昧 AskUserQuestion) / 6 (PR Pre-flight + 実機検証)
+
+## §19 Memory feedback / 関連メモ
+
+本 spec 関連で実行時に参照すべきメモ:
+
+- `feedback_gh_command_ja_heredoc.md` — `gh issue edit` の日本語本文は `printf | --body-file -` または HEREDOC
+- `feedback_taskstop_child_process_leak.md` — `npm run tauri dev` 等を `run_in_background` した後の child プロセス残留対策 (実機検証時に該当)
+- `feedback_skill_revision_empirical.md` — skill 改修時 (`/review-pr` 等) は empirical-prompt-tuning が有効

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -76,6 +76,38 @@ try {
 
 `.github/workflows/ci.yml` の `doc-tauri-commands-drift` job が `gui/src-tauri/src/lib.rs` 内の `#[tauri::command]` 数と本 doc の table 行数を比較し、不一致時に CI を fail させる (本 doc 漏れ防止、issue [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) 受け入れ条件 2)。command を追加・削除した場合は本 doc の table 行も同時に更新すること。
 
+## AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)
+
+> 本 table の文言は `gui/src-tauri/src/error.rs` の `default_hint_for_code()` と
+> 完全一致させる (CI integrity check は今回入れないが、文言変更時は両方を
+> 同 PR で更新する規約)。
+
+| code | hint |
+| --- | --- |
+| `state.mtime_conflict` | metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください |
+| `io.file_not_found` | ファイルが見つかりません。パスを確認するか、allaganeye split を再実行してください |
+| `io.read_failed` | ファイルの読み込みに失敗しました。ディスク状況・ファイルロック状態を確認してください |
+| `io.write_failed` | ファイルの書き込みに失敗しました。空き容量と書き込み権限 (Portable ZIP の install dir が user-writable か) を確認してください |
+| `io.delete_failed` | ファイル / フォルダの削除に失敗しました。他プロセスでロックされていないか確認してください |
+| `io.backup_failed` | バックアップファイルの作成に失敗しました。allaganeye 出力フォルダの空き容量と書き込み権限を確認してください |
+| `io.permission_denied` | ファイルへのアクセス権限がありません。Portable ZIP install dir が user-writable な場所か、ファイル / フォルダが読み取り専用でないか確認してください |
+| `io.already_exists` | ファイルが既に存在します。出力先を変更するか既存ファイルを削除してください |
+| `io.would_block` / `io.timed_out` | I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください |
+| `io.error` | I/O エラーが発生しました。詳細は logs フォルダを確認してください |
+| `parse.json_invalid` | JSON ファイルが破損しています。バックアップ (.bak) からの復元か allaganeye split のやり直しを検討してください |
+| `parse.json_serialize_failed` | JSON 書き出しに失敗しました。同梱 issue テンプレートでバグ報告してください |
+| `parse.schema_invalid` | metadata.json の構造が期待形式と異なります。allaganeye のバージョンと metadata 生成バージョンが一致しているか確認してください |
+| `parse.ffprobe_output_invalid` | ffprobe の出力を解釈できませんでした。ffmpeg / ffprobe を最新の BtbN LGPL ビルドに更新してください |
+| `subprocess.spawn_failed` | 外部プロセスの起動に失敗しました。ffmpeg / Python / 同梱 runtime が壊れていないか確認してください |
+| `subprocess.exit_failed` | 外部プロセスが異常終了しました。logs フォルダの最新ログから詳細を確認してください |
+| `subprocess.cancelled` | (hint なし: ユーザー操作によるキャンセルは UI 側で十分な情報を出す) |
+| `validation.path_invalid` | 入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v) |
+| `validation.not_a_file` | 指定されたパスはファイルではありません (フォルダや symlink ではなく動画ファイルを選択してください) |
+| `validation.range_invalid` | 入力された数値が許容範囲外です。フォーム下のヒント表示を確認してください |
+| `path.install_dir_unresolved` | Portable ZIP の install dir を特定できませんでした。allaganeye-gui.exe を ZIP 展開後の元のフォルダ構成のまま起動してください |
+| `platform.unsupported` | 本機能は現在の OS では未対応です。Windows での起動が必要です |
+| `internal.error` | (hint なし: 内部エラーで具体的アクションがない、message 側で logs 参照を案内) |
+
 ## 関連
 
 - 派生元: [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) 本 doc 新設 + 全 23 command の AppError migration (PR #665)

--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -102,6 +102,22 @@ GUI 内部で発生する想定外エラー (Rust panic / React 例外 / unhandl
 
 ErrorModal は [`docs/bug-report-guide.md`](bug-report-guide.md) §1.4 の「ログ取得」と連動する。ユーザーは ErrorModal の「ログフォルダを開く」→ 該当 `.log` ファイル → issue 添付という流れで bug report を提出する。詳細手順は bug-report-guide.md を参照。
 
+### AppError code 体系と inline error の使い分け (#663)
+
+Tauri command の `Result<T, AppError>` で frontend に届く構造化 error は、
+[`docs/tauri-commands.md`](tauri-commands.md) で master 一覧化されている。inline error 表示時は
+`appErrorMessage(e)` を 1 行目に、`appErrorHint(e)` を 2 行目 (`var(--ae-text-dim)`)
+に render する規約。code → default hint の mapping は
+[`gui/src-tauri/src/error.rs`](../gui/src-tauri/src/error.rs) の `default_hint_for_code` で一元管理。
+
+#### 主な分岐ルール
+
+- `code === 'state.mtime_conflict'` → ConflictModal を出す (apply path のみ)
+- それ以外の `code` → inline error (2 行目に hint があれば render)
+- legacy raw String (= AppError 化前の commands) → `appErrorMessage` で
+  message のみ取得、hint は null になる (PR #663 で legacy raw を返す
+  command は存在しないが、helper の互換性として温存)
+
 ## 5. 各画面の phase state
 
 ### drop (動画ファイル選択)

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -97,6 +97,19 @@
 
 **ErrorModal との分離 (#614)**: `ErrorModal` は **想定外エラー (Rust panic / unhandled JS exception / React 内部例外) 専用** で、`isRecoverable=false` がデフォルト。recoverable error (`load_metadata` の I/O 失敗、`apply_changes` のネットワーク失敗等) は **本節で規定する inline + toast** に流す。両者は排他で、同一画面内に重複しない。詳細は [`ui-architecture.md` §4 エラー伝搬フロー](ui-architecture.md#4-エラー伝搬フロー-614) を参照。
 
+#### AppError `code` ベースの分岐ルール (#663)
+
+Tauri command 失敗時の error 表示は以下を厳守する:
+
+1. `appErrorCodeIs(e, 'state.mtime_conflict')` で apply path → ConflictModal (modal 表示)
+2. その他の AppError code → inline error
+   - 1 行目: `appErrorMessage(e)` (赤系: `var(--ae-danger)` ないし screen 固有 error 色)
+   - 2 行目: `appErrorHint(e)` (灰系: `var(--ae-text-dim)`、`💡` 等の prefix で
+     アクション提示と分かるように)
+3. catch ブロック以外で error を扱わない (`alert()` / `console.error` のみは禁止)
+4. globalErrorListener が拾うのは uncaught (window.error / unhandledrejection /
+   panic) のみ。catch 済 Tauri command error は ErrorModal に出さない (規約)
+
 ## 2. 画面別 UI 部品状態機械
 
 §2 は 5 画面それぞれを **1 画面 = 1 PR** で順次追加する (#590 着手フローに従う)。

--- a/gui/src-tauri/src/error.rs
+++ b/gui/src-tauri/src/error.rs
@@ -98,9 +98,14 @@ impl From<serde_json::Error> for AppError {
 /// を `Result<_, AppError>` を返す Tauri command 内で `?` 経由で呼び出すケース
 /// で使われる。code は `internal.error` 固定。新規コードでは call site で
 /// `AppError::new("domain.error_kind", message)` を構築するのが望ましい。
+///
+/// `.with_default_hint()` chain は future-proof のため (`From<io::Error>` /
+/// `From<serde_json::Error>` と同 contract で integrity を保つ。現状
+/// `internal.error` は hint None だが、将来 hint を追加した場合の silent
+/// bypass を防ぐ)。lib.rs 全 80 site の hint chain 規律と整合 (#663)。
 impl From<String> for AppError {
     fn from(message: String) -> Self {
-        AppError::new("internal.error", message)
+        AppError::new("internal.error", message).with_default_hint()
     }
 }
 

--- a/gui/src-tauri/src/error.rs
+++ b/gui/src-tauri/src/error.rs
@@ -44,6 +44,17 @@ impl AppError {
         self
     }
 
+    /// code に対する default hint を attach する。すでに hint が設定されている場合は
+    /// 上書きせず保持する (call site で `.with_hint("...")` を先に書いた場合の override
+    /// が効く設計、将来 Approach C への hybrid 移行時に必要)。
+    pub fn with_default_hint(mut self) -> Self {
+        if self.hint.is_some() {
+            return self;
+        }
+        self.hint = default_hint_for_code(&self.code).map(String::from);
+        self
+    }
+
 }
 
 impl fmt::Display for AppError {
@@ -70,7 +81,7 @@ impl From<std::io::Error> for AppError {
             std::io::ErrorKind::TimedOut => "io.timed_out",
             _ => "io.error",
         };
-        AppError::new(code, e.to_string())
+        AppError::new(code, e.to_string()).with_default_hint()
     }
 }
 
@@ -78,7 +89,7 @@ impl From<std::io::Error> for AppError {
 /// `parse.json_invalid` 固定。message は `e.to_string()` で line/column 情報を含む。
 impl From<serde_json::Error> for AppError {
     fn from(e: serde_json::Error) -> Self {
-        AppError::new("parse.json_invalid", e.to_string())
+        AppError::new("parse.json_invalid", e.to_string()).with_default_hint()
     }
 }
 
@@ -90,6 +101,89 @@ impl From<serde_json::Error> for AppError {
 impl From<String> for AppError {
     fn from(message: String) -> Self {
         AppError::new("internal.error", message)
+    }
+}
+
+/// AppError code に対する日本語 default hint を返す。未登録 code は None。
+/// 22 entries (現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
+/// validation.* / path.* / platform.* / internal.*)。
+/// 文言は `docs/tauri-commands.md` の AppError default hint mapping table と一致させる
+/// (本 fn が source of truth、docs は mirror)。
+fn default_hint_for_code(code: &str) -> Option<&'static str> {
+    match code {
+        // state
+        "state.mtime_conflict" => Some(
+            "metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください"
+        ),
+        // io (manual call site)
+        "io.file_not_found" => Some(
+            "ファイルが見つかりません。パスを確認するか、allaganeye split を再実行してください"
+        ),
+        "io.read_failed" => Some(
+            "ファイルの読み込みに失敗しました。ディスク状況・ファイルロック状態を確認してください"
+        ),
+        "io.write_failed" => Some(
+            "ファイルの書き込みに失敗しました。空き容量と書き込み権限 (Portable ZIP の install dir が user-writable か) を確認してください"
+        ),
+        "io.delete_failed" => Some(
+            "ファイル / フォルダの削除に失敗しました。他プロセスでロックされていないか確認してください"
+        ),
+        "io.backup_failed" => Some(
+            "バックアップファイルの作成に失敗しました。allaganeye 出力フォルダの空き容量と書き込み権限を確認してください"
+        ),
+        // io (auto from std::io::Error::ErrorKind via From impl)
+        "io.permission_denied" => Some(
+            "ファイルへのアクセス権限がありません。Portable ZIP install dir が user-writable な場所か、ファイル / フォルダが読み取り専用でないか確認してください"
+        ),
+        "io.already_exists" => Some(
+            "ファイルが既に存在します。出力先を変更するか既存ファイルを削除してください"
+        ),
+        "io.would_block" | "io.timed_out" => Some(
+            "I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください"
+        ),
+        "io.error" => Some(
+            "I/O エラーが発生しました。詳細は logs フォルダを確認してください"
+        ),
+        // parse
+        "parse.json_invalid" => Some(
+            "JSON ファイルが破損しています。バックアップ (.bak) からの復元か allaganeye split のやり直しを検討してください"
+        ),
+        "parse.json_serialize_failed" => Some(
+            "JSON 書き出しに失敗しました。同梱 issue テンプレートでバグ報告してください"
+        ),
+        "parse.schema_invalid" => Some(
+            "metadata.json の構造が期待形式と異なります。allaganeye のバージョンと metadata 生成バージョンが一致しているか確認してください"
+        ),
+        "parse.ffprobe_output_invalid" => Some(
+            "ffprobe の出力を解釈できませんでした。ffmpeg / ffprobe を最新の BtbN LGPL ビルドに更新してください"
+        ),
+        // subprocess
+        "subprocess.spawn_failed" => Some(
+            "外部プロセスの起動に失敗しました。ffmpeg / Python / 同梱 runtime が壊れていないか確認してください"
+        ),
+        "subprocess.exit_failed" => Some(
+            "外部プロセスが異常終了しました。logs フォルダの最新ログから詳細を確認してください"
+        ),
+        "subprocess.cancelled" => None, // ユーザー操作によるキャンセルは hint 不要 (UI 側で「キャンセルされました」を表示で十分)
+        // validation
+        "validation.path_invalid" => Some(
+            "入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v)"
+        ),
+        "validation.not_a_file" => Some(
+            "指定されたパスはファイルではありません (フォルダや symlink ではなく動画ファイルを選択してください)"
+        ),
+        "validation.range_invalid" => Some(
+            "入力された数値が許容範囲外です。フォーム下のヒント表示を確認してください"
+        ),
+        // path / platform / internal
+        "path.install_dir_unresolved" => Some(
+            "Portable ZIP の install dir を特定できませんでした。allaganeye-gui.exe を ZIP 展開後の元のフォルダ構成のまま起動してください"
+        ),
+        "platform.unsupported" => Some(
+            "本機能は現在の OS では未対応です。Windows での起動が必要です"
+        ),
+        "internal.error" => None, // 内部エラーで具体的アクションがない (詳細は logs 参照を message 側で示す方針)
+        _ => None,
     }
 }
 
@@ -186,5 +280,64 @@ mod tests {
     fn app_error_display_format() {
         let e = AppError::new("net.timeout", "request timed out");
         assert_eq!(format!("{}", e), "[net.timeout] request timed out");
+    }
+
+    #[test]
+    fn default_hint_covers_all_known_codes() {
+        let with_hint = [
+            "state.mtime_conflict",
+            "io.file_not_found", "io.read_failed", "io.write_failed",
+            "io.delete_failed", "io.backup_failed",
+            "io.permission_denied", "io.already_exists",
+            "io.would_block", "io.timed_out", "io.error",
+            "parse.json_invalid", "parse.json_serialize_failed",
+            "parse.schema_invalid", "parse.ffprobe_output_invalid",
+            "subprocess.spawn_failed", "subprocess.exit_failed",
+            "validation.path_invalid", "validation.not_a_file", "validation.range_invalid",
+            "path.install_dir_unresolved", "platform.unsupported",
+        ];
+        for code in with_hint {
+            assert!(default_hint_for_code(code).is_some(), "missing hint for code: {}", code);
+        }
+        assert!(default_hint_for_code("subprocess.cancelled").is_none());
+        assert!(default_hint_for_code("internal.error").is_none());
+        assert!(default_hint_for_code("unknown.code").is_none());
+    }
+
+    #[test]
+    fn with_default_hint_attaches_known_code() {
+        let e = AppError::new("io.read_failed", "could not read").with_default_hint();
+        assert!(e.hint.is_some());
+        assert!(e.hint.unwrap().contains("ディスク状況"));
+    }
+
+    #[test]
+    fn with_default_hint_does_not_overwrite_explicit_hint() {
+        let e = AppError::new("io.read_failed", "msg")
+            .with_hint("custom hint")
+            .with_default_hint();
+        assert_eq!(e.hint.as_deref(), Some("custom hint"));
+    }
+
+    #[test]
+    fn with_default_hint_returns_no_hint_for_unknown_code() {
+        let e = AppError::new("unknown.code", "msg").with_default_hint();
+        assert!(e.hint.is_none());
+    }
+
+    #[test]
+    fn from_io_error_attaches_default_hint() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "x");
+        let e: AppError = io_err.into();
+        assert_eq!(e.code, "io.file_not_found");
+        assert!(e.hint.is_some());
+    }
+
+    #[test]
+    fn from_serde_json_error_attaches_default_hint() {
+        let json_err = serde_json::from_str::<serde_json::Value>("{ invalid").unwrap_err();
+        let e: AppError = json_err.into();
+        assert_eq!(e.code, "parse.json_invalid");
+        assert!(e.hint.is_some());
     }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -79,19 +79,22 @@ fn load_metadata_sync(meta_path: &Path) -> Result<Value, AppError> {
         return Err(AppError::new(
             "io.file_not_found",
             format!("metadata file not found: {}", meta_path.display()),
-        ));
+        )
+        .with_default_hint());
     }
     let content = fs::read_to_string(meta_path).map_err(|e| {
         AppError::new(
             "io.read_failed",
             format!("read failed ({}): {}", meta_path.display(), e),
         )
+        .with_default_hint()
     })?;
     let value: Value = serde_json::from_str(&content).map_err(|e| {
         AppError::new(
             "parse.json_invalid",
             format!("invalid JSON in {}: {}", meta_path.display(), e),
         )
+        .with_default_hint()
     })?;
     if !value.is_object() {
         return Err(AppError::new(
@@ -100,7 +103,8 @@ fn load_metadata_sync(meta_path: &Path) -> Result<Value, AppError> {
                 "metadata file {} root must be a JSON object",
                 meta_path.display()
             ),
-        ));
+        )
+        .with_default_hint());
     }
     Ok(value)
 }
@@ -137,6 +141,7 @@ async fn apply_changes(
                 meta_path.display()
             ),
         )
+        .with_default_hint()
     })
 }
 
@@ -167,6 +172,7 @@ fn draft_path_for(meta_path: &Path) -> Result<PathBuf, AppError> {
             "validation.path_invalid",
             format!("metadata path has no parent: {}", meta_path.display()),
         )
+        .with_default_hint()
     })?;
     Ok(parent.join("metadata.draft.json"))
 }
@@ -186,12 +192,14 @@ fn load_draft_sync(meta_path: &Path) -> Result<Option<Value>, AppError> {
             "io.read_failed",
             format!("read draft failed ({}): {}", draft_path.display(), e),
         )
+        .with_default_hint()
     })?;
     let value: Value = serde_json::from_str(&content).map_err(|e| {
         AppError::new(
             "parse.json_invalid",
             format!("invalid JSON in draft {}: {}", draft_path.display(), e),
         )
+        .with_default_hint()
     })?;
     Ok(Some(value))
 }
@@ -208,6 +216,7 @@ fn clear_draft_sync(meta_path: &Path) -> Result<(), AppError> {
             "io.delete_failed",
             format!("remove draft failed ({}): {}", draft_path.display(), e),
         )
+        .with_default_hint()
     })
 }
 
@@ -223,25 +232,29 @@ fn restore_from_original_sync(meta_path: &Path) -> Result<(), AppError> {
             "validation.path_invalid",
             format!("metadata path has no parent: {}", meta_path.display()),
         )
+        .with_default_hint()
     })?;
     let original_path = parent.join("metadata.original.json");
     if !original_path.exists() {
         return Err(AppError::new(
             "io.file_not_found",
             format!("no backup to restore: {}", original_path.display()),
-        ));
+        )
+        .with_default_hint());
     }
     let content = fs::read_to_string(&original_path).map_err(|e| {
         AppError::new(
             "io.read_failed",
             format!("read backup failed ({}): {}", original_path.display(), e),
         )
+        .with_default_hint()
     })?;
     let value: Value = serde_json::from_str(&content).map_err(|e| {
         AppError::new(
             "parse.json_invalid",
             format!("parse backup failed ({}): {}", original_path.display(), e),
         )
+        .with_default_hint()
     })?;
     write_metadata_atomic(meta_path, &value)
 }
@@ -256,6 +269,7 @@ async fn check_backup_exists(path: String) -> Result<bool, AppError> {
             "validation.path_invalid",
             format!("metadata path has no parent: {}", meta_path.display()),
         )
+        .with_default_hint()
     })?;
     Ok(parent.join("metadata.original.json").exists())
 }
@@ -319,12 +333,14 @@ fn recent_path() -> Result<PathBuf, AppError> {
             "path.install_dir_unresolved",
             format!("failed to resolve current_exe: {}", e),
         )
+        .with_default_hint()
     })?;
     let dir = exe.parent().ok_or_else(|| {
         AppError::new(
             "path.install_dir_unresolved",
             format!("current_exe has no parent: {}", exe.display()),
         )
+        .with_default_hint()
     })?;
     Ok(dir.join("recent.json"))
 }
@@ -390,6 +406,7 @@ fn clear_recent_sync(path: &Path) -> Result<(), AppError> {
             "io.delete_failed",
             format!("remove recent.json failed ({}): {}", path.display(), e),
         )
+        .with_default_hint()
     })
 }
 
@@ -399,6 +416,7 @@ fn write_recent_atomic(path: &Path, list: &[RecentEntry]) -> Result<(), AppError
             "validation.path_invalid",
             format!("recent path has no parent: {}", path.display()),
         )
+        .with_default_hint()
     })?;
     if !parent.exists() {
         fs::create_dir_all(parent).map_err(|e| {
@@ -406,6 +424,7 @@ fn write_recent_atomic(path: &Path, list: &[RecentEntry]) -> Result<(), AppError
                 "io.write_failed",
                 format!("create dir {} failed: {}", parent.display(), e),
             )
+            .with_default_hint()
         })?;
     }
     let mut tmp_path = path.to_path_buf();
@@ -415,7 +434,8 @@ fn write_recent_atomic(path: &Path, list: &[RecentEntry]) -> Result<(), AppError
             return Err(AppError::new(
                 "validation.path_invalid",
                 format!("recent path has no file name: {}", path.display()),
-            ))
+            )
+            .with_default_hint())
         }
     };
     tmp_path.set_file_name(tmp_name);
@@ -424,12 +444,14 @@ fn write_recent_atomic(path: &Path, list: &[RecentEntry]) -> Result<(), AppError
             "parse.json_serialize_failed",
             format!("serialize recent failed: {}", e),
         )
+        .with_default_hint()
     })?;
     fs::write(&tmp_path, serialized).map_err(|e| {
         AppError::new(
             "io.write_failed",
             format!("write tmp {} failed: {}", tmp_path.display(), e),
         )
+        .with_default_hint()
     })?;
     if let Err(e) = fs::rename(&tmp_path, path) {
         let _ = fs::remove_file(&tmp_path);
@@ -441,7 +463,8 @@ fn write_recent_atomic(path: &Path, list: &[RecentEntry]) -> Result<(), AppError
                 path.display(),
                 e
             ),
-        ));
+        )
+        .with_default_hint());
     }
     Ok(())
 }
@@ -482,13 +505,15 @@ async fn add_recent(path: String) -> Result<Vec<RecentEntry>, AppError> {
         return Err(AppError::new(
             "io.file_not_found",
             format!("file not found: {}", video_path.display()),
-        ));
+        )
+        .with_default_hint());
     }
     let meta = fs::metadata(&video_path).map_err(|e| {
         AppError::new(
             "io.read_failed",
             format!("stat failed ({}): {}", video_path.display(), e),
         )
+        .with_default_hint()
     })?;
     let size_bytes = meta.len();
     let mtime_ms = meta
@@ -618,6 +643,7 @@ async fn probe_video_with(
                 "io.read_failed",
                 format!("stat failed ({}): {}", path.display(), e),
             )
+            .with_default_hint()
         })?
         .len();
 
@@ -636,6 +662,7 @@ async fn probe_video_with(
                 "subprocess.spawn_failed",
                 format!("ffprobe spawn failed: {e}"),
             )
+            .with_default_hint()
         })?;
 
     if !output.status.success() {
@@ -647,7 +674,8 @@ async fn probe_video_with(
                 output.status.code(),
                 stderr.trim()
             ),
-        ));
+        )
+        .with_default_hint());
     }
 
     let json: Value = serde_json::from_slice(&output.stdout).map_err(|e| {
@@ -655,6 +683,7 @@ async fn probe_video_with(
             "parse.ffprobe_output_invalid",
             format!("ffprobe json parse failed: {e}"),
         )
+        .with_default_hint()
     })?;
 
     let streams = json
@@ -665,6 +694,7 @@ async fn probe_video_with(
                 "parse.ffprobe_output_invalid",
                 "ffprobe output missing 'streams' array",
             )
+            .with_default_hint()
         })?;
     let video_stream = streams
         .iter()
@@ -674,6 +704,7 @@ async fn probe_video_with(
                 "parse.ffprobe_output_invalid",
                 "no video stream in ffprobe output",
             )
+            .with_default_hint()
         })?;
 
     let width = video_stream
@@ -684,6 +715,7 @@ async fn probe_video_with(
                 "parse.ffprobe_output_invalid",
                 "video stream missing width",
             )
+            .with_default_hint()
         })? as u32;
     let height = video_stream
         .get("height")
@@ -693,6 +725,7 @@ async fn probe_video_with(
                 "parse.ffprobe_output_invalid",
                 "video stream missing height",
             )
+            .with_default_hint()
         })? as u32;
     let codec = video_stream
         .get("codec_name")
@@ -715,6 +748,7 @@ async fn probe_video_with(
             "parse.ffprobe_output_invalid",
             "cannot determine frame rate",
         )
+        .with_default_hint()
     })?;
 
     let duration_seconds = json
@@ -727,12 +761,14 @@ async fn probe_video_with(
                 "parse.ffprobe_output_invalid",
                 "format.duration missing or unparseable",
             )
+            .with_default_hint()
         })?;
     if duration_seconds <= 0.0 {
         return Err(AppError::new(
             "validation.range_invalid",
             "duration is non-positive",
-        ));
+        )
+        .with_default_hint());
     }
 
     let file_name = path
@@ -777,25 +813,29 @@ fn validate_video_path(path: &Path) -> Result<PathBuf, AppError> {
         return Err(AppError::new(
             "io.file_not_found",
             format!("video file not found: {}", path.display()),
-        ));
+        )
+        .with_default_hint());
     }
     let meta = fs::metadata(path).map_err(|e| {
         AppError::new(
             "io.read_failed",
             format!("stat failed ({}): {}", path.display(), e),
         )
+        .with_default_hint()
     })?;
     if !meta.is_file() {
         return Err(AppError::new(
             "validation.not_a_file",
             format!("video path is not a regular file: {}", path.display()),
-        ));
+        )
+        .with_default_hint());
     }
     fs::canonicalize(path).map_err(|e| {
         AppError::new(
             "io.read_failed",
             format!("canonicalize failed ({}): {}", path.display(), e),
         )
+        .with_default_hint()
     })
 }
 
@@ -822,6 +862,7 @@ async fn ensure_server_started() -> Result<u16, AppError> {
             "subprocess.spawn_failed",
             format!("bind 127.0.0.1:0 failed: {}", e),
         )
+        .with_default_hint()
     })?;
     let addr = listener
         .local_addr()
@@ -893,6 +934,7 @@ fn apply_changes_sync(
                     "io.read_failed",
                     format!("cannot read mtime of {}", meta_path.display()),
                 )
+                .with_default_hint()
             })?;
             if actual != expected {
                 return Err(AppError::new(
@@ -903,7 +945,8 @@ fn apply_changes_sync(
                         expected,
                         actual
                     ),
-                ));
+                )
+                .with_default_hint());
             }
         }
     }
@@ -914,6 +957,7 @@ fn apply_changes_sync(
             "validation.path_invalid",
             format!("metadata path has no parent: {}", meta_path.display()),
         )
+        .with_default_hint()
     })?;
     let original_path = parent.join("metadata.original.json");
 
@@ -928,6 +972,7 @@ fn apply_changes_sync(
                     e
                 ),
             )
+            .with_default_hint()
         })?;
     }
 
@@ -940,6 +985,7 @@ fn write_metadata_atomic(path: &Path, payload: &Value) -> Result<(), AppError> {
             "validation.path_invalid",
             format!("metadata path has no parent: {}", path.display()),
         )
+        .with_default_hint()
     })?;
     if !parent.exists() {
         fs::create_dir_all(parent).map_err(|e| {
@@ -947,6 +993,7 @@ fn write_metadata_atomic(path: &Path, payload: &Value) -> Result<(), AppError> {
                 "io.write_failed",
                 format!("create dir {} failed: {}", parent.display(), e),
             )
+            .with_default_hint()
         })?;
     }
     let mut tmp_path = path.to_path_buf();
@@ -956,7 +1003,8 @@ fn write_metadata_atomic(path: &Path, payload: &Value) -> Result<(), AppError> {
             return Err(AppError::new(
                 "validation.path_invalid",
                 format!("metadata path has no file name: {}", path.display()),
-            ))
+            )
+            .with_default_hint())
         }
     };
     tmp_path.set_file_name(tmp_name);
@@ -966,12 +1014,14 @@ fn write_metadata_atomic(path: &Path, payload: &Value) -> Result<(), AppError> {
             "parse.json_serialize_failed",
             format!("serialize failed: {}", e),
         )
+        .with_default_hint()
     })?;
     fs::write(&tmp_path, serialized).map_err(|e| {
         AppError::new(
             "io.write_failed",
             format!("write tmp {} failed: {}", tmp_path.display(), e),
         )
+        .with_default_hint()
     })?;
     if let Err(e) = fs::rename(&tmp_path, path) {
         let _ = fs::remove_file(&tmp_path);
@@ -983,7 +1033,8 @@ fn write_metadata_atomic(path: &Path, payload: &Value) -> Result<(), AppError> {
                 path.display(),
                 e
             ),
-        ));
+        )
+        .with_default_hint());
     }
     Ok(())
 }
@@ -1032,12 +1083,14 @@ fn thumb_cache_dir(video_hash: &str) -> Result<PathBuf, AppError> {
             "path.install_dir_unresolved",
             format!("failed to resolve current_exe: {}", e),
         )
+        .with_default_hint()
     })?;
     let dir = exe.parent().ok_or_else(|| {
         AppError::new(
             "path.install_dir_unresolved",
             format!("current_exe has no parent: {}", exe.display()),
         )
+        .with_default_hint()
     })?;
     Ok(dir.join("cache").join(video_hash).join("thumbs"))
 }
@@ -1097,13 +1150,15 @@ async fn generate_match_thumbnails(
         return Err(AppError::new(
             "io.file_not_found",
             format!("video file not found: {}", video.display()),
-        ));
+        )
+        .with_default_hint());
     }
     let meta = fs::metadata(&video).map_err(|e| {
         AppError::new(
             "io.read_failed",
             format!("stat failed ({}): {}", video.display(), e),
         )
+        .with_default_hint()
     })?;
     let mtime_ms = meta
         .modified()
@@ -1112,6 +1167,7 @@ async fn generate_match_thumbnails(
                 "io.read_failed",
                 format!("mtime failed ({}): {}", video.display(), e),
             )
+            .with_default_hint()
         })?
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
@@ -1120,12 +1176,14 @@ async fn generate_match_thumbnails(
                 "io.read_failed",
                 format!("mtime before epoch ({}): {}", video.display(), e),
             )
+            .with_default_hint()
         })?;
     let canonical = fs::canonicalize(&video).map_err(|e| {
         AppError::new(
             "io.read_failed",
             format!("canonicalize failed ({}): {}", video.display(), e),
         )
+        .with_default_hint()
     })?;
 
     let video_hash = compute_video_cache_hash(&canonical, mtime_ms);
@@ -1135,6 +1193,7 @@ async fn generate_match_thumbnails(
             "io.write_failed",
             format!("create cache dir {} failed: {}", cache_dir.display(), e),
         )
+        .with_default_hint()
     })?;
 
     let timestamps = compute_candidate_timestamps(boundary_t_seconds, window_seconds, count);
@@ -1152,6 +1211,7 @@ async fn generate_match_thumbnails(
                     "internal.error",
                     format!("semaphore closed: {}", e),
                 )
+                .with_default_hint()
             })?;
             ensure_thumbnail_exists(&video_for_task, t, &out_path).await?;
             Ok::<ThumbnailEntry, AppError>(ThumbnailEntry {
@@ -1189,6 +1249,7 @@ async fn ensure_thumbnail_exists(
                     "io.write_failed",
                     format!("create dir {} failed: {}", parent.display(), e),
                 )
+                .with_default_hint()
             })?;
         }
     }
@@ -1218,6 +1279,7 @@ async fn ensure_thumbnail_exists(
                 "subprocess.spawn_failed",
                 format!("spawn ffmpeg failed at t={}: {}", t_arg, e),
             )
+            .with_default_hint()
         })?;
 
     if !output.status.success() {
@@ -1230,7 +1292,8 @@ async fn ensure_thumbnail_exists(
                 output.status.code(),
                 stderr.trim()
             ),
-        ));
+        )
+        .with_default_hint());
     }
     Ok(())
 }
@@ -1536,25 +1599,29 @@ fn validate_export_request(
         return Err(AppError::new(
             "io.file_not_found",
             format!("video file not found: {}", video_path.display()),
-        ));
+        )
+        .with_default_hint());
     }
     let meta = fs::metadata(video_path).map_err(|e| {
         AppError::new(
             "io.read_failed",
             format!("stat failed ({}): {}", video_path.display(), e),
         )
+        .with_default_hint()
     })?;
     if !meta.is_file() {
         return Err(AppError::new(
             "validation.not_a_file",
             format!("video path is not a regular file: {}", video_path.display()),
-        ));
+        )
+        .with_default_hint());
     }
     if !start_seconds.is_finite() || start_seconds < 0.0 {
         return Err(AppError::new(
             "validation.range_invalid",
             format!("start_seconds must be >= 0 (got {})", start_seconds),
-        ));
+        )
+        .with_default_hint());
     }
     if !end_seconds.is_finite() || end_seconds <= start_seconds {
         return Err(AppError::new(
@@ -1563,7 +1630,8 @@ fn validate_export_request(
                 "end_seconds must be > start_seconds (got start={}, end={})",
                 start_seconds, end_seconds
             ),
-        ));
+        )
+        .with_default_hint());
     }
     Ok(())
 }
@@ -1590,7 +1658,8 @@ fn validate_output_parent_exists(output_path: &Path) -> Result<(), AppError> {
             return Err(AppError::new(
                 "io.file_not_found",
                 format!("output directory does not exist: {}", parent.display()),
-            ));
+            )
+            .with_default_hint());
         }
     }
     Ok(())
@@ -1607,14 +1676,16 @@ fn validate_open_folder_request(path: &str) -> Result<(), AppError> {
         return Err(AppError::new(
             "io.file_not_found",
             format!("path does not exist: {}", path),
-        ));
+        )
+        .with_default_hint());
     }
     #[cfg(not(target_os = "windows"))]
     {
         return Err(AppError::new(
             "platform.unsupported",
             "open_folder_in_explorer is only supported on Windows",
-        ));
+        )
+        .with_default_hint());
     }
     #[cfg(target_os = "windows")]
     {
@@ -1649,6 +1720,7 @@ fn open_folder_in_explorer(path: String) -> Result<(), AppError> {
                     "subprocess.spawn_failed",
                     format!("failed to launch explorer: {}", e),
                 )
+                .with_default_hint()
             })?;
     }
 
@@ -2058,7 +2130,7 @@ async fn export_match(
                 fallback_from: None,
             },
         );
-        return Err(AppError::new("subprocess.exit_failed", msg));
+        return Err(AppError::new("subprocess.exit_failed", msg).with_default_hint());
     }
 
     // No retry -- surface the primary failure.
@@ -2078,7 +2150,7 @@ async fn export_match(
             fallback_from: None,
         },
     );
-    Err(AppError::new("subprocess.exit_failed", msg))
+    Err(AppError::new("subprocess.exit_failed", msg).with_default_hint())
 }
 
 fn build_export_result(output: &Path, match_index: u32, started: Instant) -> ExportResult {
@@ -2389,7 +2461,8 @@ async fn start_detect(
         return Err(AppError::new(
             "io.file_not_found",
             format!("video file not found: {}", video.display()),
-        ));
+        )
+        .with_default_hint());
     }
     let output_buf = PathBuf::from(&output_dir);
     if let Err(e) = fs::create_dir_all(&output_buf) {
@@ -2400,7 +2473,8 @@ async fn start_detect(
                 output_buf.display(),
                 e
             ),
-        ));
+        )
+        .with_default_hint());
     }
 
     let cmd_spec = resolve_allaganeye_command(&app);
@@ -2549,7 +2623,7 @@ async fn start_detect(
                     ..Default::default()
                 },
             );
-            return Err(AppError::new("subprocess.cancelled", "detect cancelled"));
+            return Err(AppError::new("subprocess.cancelled", "detect cancelled").with_default_hint());
         }
     };
 
@@ -2578,7 +2652,7 @@ async fn start_detect(
                 ..Default::default()
             },
         );
-        return Err(AppError::new("subprocess.exit_failed", msg));
+        return Err(AppError::new("subprocess.exit_failed", msg).with_default_hint());
     }
 
     let metadata_path = metadata_path.ok_or_else(|| {
@@ -2586,6 +2660,7 @@ async fn start_detect(
             "internal.error",
             "detect completed but no metadata_path was emitted",
         )
+        .with_default_hint()
     })?;
 
     Ok(DetectResult {
@@ -2605,6 +2680,7 @@ fn get_log_dir() -> Result<String, AppError> {
                 "path.install_dir_unresolved",
                 format!("could not resolve log dir: {}", e),
             )
+            .with_default_hint()
         })
 }
 

--- a/gui/src/components/ConflictModal.test.tsx
+++ b/gui/src/components/ConflictModal.test.tsx
@@ -57,12 +57,14 @@ describe('ConflictModal', () => {
   });
 
   it('renders dialog + 3 action buttons when conflictError is set', () => {
+    // #663: structured AppError 化以後、conflictError には raw message
+    // (prefix 無し) が入る。
     useMetadataStore.setState({
-      conflictError: 'conflict: external modification detected',
+      conflictError: 'external modification detected',
     });
     render(<ConflictModal />);
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByText(/conflict: external/)).toBeInTheDocument();
+    expect(screen.getByText(/external modification/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '上書き' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'リロード' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'キャンセル' })).toBeInTheDocument();
@@ -70,7 +72,7 @@ describe('ConflictModal', () => {
 
   it('cancel dismisses the modal without side effects', async () => {
     useMetadataStore.setState({
-      conflictError: 'conflict: x',
+      conflictError: 'x',
       dirty: true,
     });
     render(<ConflictModal />);
@@ -84,7 +86,7 @@ describe('ConflictModal', () => {
 
   it('overwrite invokes apply_changes with expectedMtimeMs=null', async () => {
     useMetadataStore.setState({
-      conflictError: 'conflict: x',
+      conflictError: 'x',
       metadata: seedMetadata(),
       filePath: '/tmp/metadata.json',
       loadedMtimeMs: 1700,
@@ -108,7 +110,7 @@ describe('ConflictModal', () => {
 
   it('reload re-invokes load_metadata + get_metadata_mtime', async () => {
     useMetadataStore.setState({
-      conflictError: 'conflict: x',
+      conflictError: 'x',
       metadata: seedMetadata(),
       filePath: '/tmp/metadata.json',
       loadedMtimeMs: 1700,
@@ -131,7 +133,7 @@ describe('ConflictModal', () => {
   });
 
   it('Escape dismisses the modal (#587)', async () => {
-    useMetadataStore.setState({ conflictError: 'conflict: x' });
+    useMetadataStore.setState({ conflictError: 'x' });
     render(<ConflictModal />);
     const user = userEvent.setup();
     await user.keyboard('{Escape}');
@@ -140,7 +142,7 @@ describe('ConflictModal', () => {
   });
 
   it('focus is trapped inside the modal panel (#587)', async () => {
-    useMetadataStore.setState({ conflictError: 'conflict: x' });
+    useMetadataStore.setState({ conflictError: 'x' });
     render(<ConflictModal />);
     const dialog = screen.getByRole('dialog');
     // After mount, focus must have moved into the panel.
@@ -148,7 +150,7 @@ describe('ConflictModal', () => {
   });
 
   it('has no axe violations when shown (#587)', async () => {
-    useMetadataStore.setState({ conflictError: 'conflict: x' });
+    useMetadataStore.setState({ conflictError: 'x' });
     const { container } = render(<ConflictModal />);
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/gui/src/components/DraftRestoreModal.test.tsx
+++ b/gui/src/components/DraftRestoreModal.test.tsx
@@ -129,7 +129,7 @@ describe('DraftRestoreModal', () => {
   it('does not render while conflictError is set (ConflictModal takes priority)', () => {
     useMetadataStore.setState({
       pendingDraft: seedMetadata(),
-      conflictError: 'conflict: external modification detected',
+      conflictError: 'external modification detected',
       filePath: '/tmp/metadata.json',
     });
     const { container } = render(<DraftRestoreModal />);

--- a/gui/src/components/RestoreButton.module.css
+++ b/gui/src/components/RestoreButton.module.css
@@ -33,3 +33,15 @@
   color: var(--ae-danger);
   margin-left: 8px;
 }
+
+/* #663 — 2nd-line hint shown after `.error`. Uses the dim text token so it
+   visually de-emphasises the corrective hint below the red error message. */
+.errorHint {
+  font-family: var(--ae-font-body);
+  font-size: 10px;
+  color: var(--ae-text-dim);
+  margin-left: 8px;
+  margin-top: 2px;
+  display: block;
+  line-height: 1.5;
+}

--- a/gui/src/components/RestoreButton.test.tsx
+++ b/gui/src/components/RestoreButton.test.tsx
@@ -117,4 +117,52 @@ describe('RestoreButton', () => {
     const button = screen.getByRole('button', { name: '元に戻す' });
     expect(button.hasAttribute('title')).toBe(false);
   });
+
+  // #663 — Phase 4: render the AppError hint as a 2nd line after the
+  // existing inline error message so the user sees both the failure and
+  // the recommended next step. Hint stays inside the role="alert"
+  // wrapper to avoid double-announcement by screen readers.
+  describe('hint rendering (#663)', () => {
+    it('renders restoreErrorHint as 2nd line when present', () => {
+      useMetadataStore.setState({
+        filePath: '/x',
+        hasBackup: true,
+        restoring: false,
+        restoreError: 'backup not found',
+        restoreErrorHint: 'create backup first',
+      });
+      render(<RestoreButton />);
+      expect(screen.getByText('backup not found')).toBeInTheDocument();
+      expect(screen.getByText(/create backup first/)).toBeInTheDocument();
+    });
+
+    it('does not render hint when restoreErrorHint is null', () => {
+      useMetadataStore.setState({
+        filePath: '/x',
+        hasBackup: true,
+        restoring: false,
+        restoreError: 'plain message',
+        restoreErrorHint: null,
+      });
+      render(<RestoreButton />);
+      expect(screen.getByText('plain message')).toBeInTheDocument();
+      expect(screen.queryByText(/💡/)).not.toBeInTheDocument();
+    });
+
+    it('hint stays inside the role="alert" wrapper for screen-reader continuity (#663)', () => {
+      useMetadataStore.setState({
+        filePath: '/x',
+        hasBackup: true,
+        restoring: false,
+        restoreError: 'backup not found',
+        restoreErrorHint: 'create backup first',
+      });
+      render(<RestoreButton />);
+      const alert = screen.getByRole('alert');
+      // Both message and hint should be DOM-descendants of the same alert region,
+      // so the screen reader announces them as one update.
+      expect(alert).toHaveTextContent('backup not found');
+      expect(alert).toHaveTextContent(/create backup first/);
+    });
+  });
 });

--- a/gui/src/components/RestoreButton.tsx
+++ b/gui/src/components/RestoreButton.tsx
@@ -52,6 +52,10 @@ export function RestoreButton({
   const hasBackup = useMetadataStore((s) => s.hasBackup);
   const restoring = useMetadataStore((s) => s.restoring);
   const restoreError = useMetadataStore((s) => s.restoreError);
+  // #663: hint rendered as a 2nd line below the error message. Kept
+  // inside the same role="alert" wrapper so screen readers announce
+  // message + hint as a single update.
+  const restoreErrorHint = useMetadataStore((s) => s.restoreErrorHint);
   const restore = useMetadataStore((s) => s.restore);
 
   const disabled = !hasBackup || restoring;
@@ -93,6 +97,9 @@ export function RestoreButton({
       {restoreError && (
         <span className={styles.error} role="alert">
           {restoreError}
+          {restoreErrorHint && (
+            <span className={styles.errorHint}>💡 {restoreErrorHint}</span>
+          )}
         </span>
       )}
     </>

--- a/gui/src/screens/DetectingScreen.module.css
+++ b/gui/src/screens/DetectingScreen.module.css
@@ -292,6 +292,16 @@
   overflow-y: auto;
 }
 
+/* #663 — 2nd-line hint rendered after `.errorMessage` in the error view.
+   Dim text token de-emphasises the corrective hint relative to the
+   primary failure message above. */
+.errorHint {
+  color: var(--ae-text-dim);
+  font-size: 12px;
+  margin-top: 8px;
+  line-height: 1.5;
+}
+
 /*
  * #646 review Round 2 課題 2 — error view の [再試行] ボタン。
  * gold tint で「次の操作を促す」プライマリ寄りに見せ、隣の

--- a/gui/src/screens/DetectingScreen.test.tsx
+++ b/gui/src/screens/DetectingScreen.test.tsx
@@ -461,6 +461,33 @@ describe('DetectingScreen', () => {
     expect(msg.textContent).toContain('python -m allaganeye');
   });
 
+  // #663 — Phase 4: when start_detect rejects with an AppError-shaped
+  // object (`{ code, message, hint }`), the error view renders the hint
+  // as a 2nd line below `errorMessage`. Bare Error throws keep the
+  // existing single-line UX (appErrorHint returns null).
+  it('renders error hint as 2nd line when start_detect rejects with AppError (#663)', async () => {
+    invokeMock.mockImplementation((cmd) => {
+      if (cmd === 'start_detect') {
+        return Promise.reject({
+          code: 'subprocess.spawn_failed',
+          message: 'failed to spawn allaganeye CLI',
+          hint: 'verify Python install',
+        });
+      }
+      return Promise.resolve(null);
+    });
+    render(<DetectingScreen />);
+    await waitFor(() => {
+      expect(screen.getByTestId('detecting-error')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId('detecting-error-message').textContent,
+    ).toContain('failed to spawn allaganeye CLI');
+    expect(screen.getByTestId('detecting-error-hint').textContent).toContain(
+      'verify Python install',
+    );
+  });
+
   it('back button on error view returns to drop (#646)', async () => {
     invokeMock.mockImplementation((cmd) => {
       if (cmd === 'start_detect') {

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -4,6 +4,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { AllaganSigil } from '../components/AllaganSigil';
 import { DisabledTooltip } from '../components/DisabledTooltip';
+import { appErrorHint, appErrorMessage } from '../lib/appError';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
 import { toStartDetectParams } from '../utils/detection';
@@ -272,6 +273,10 @@ export function DetectingScreen() {
     'running' as DetectingPhase,
   );
   const [error, setError] = useState<string | null>(null);
+  // #663 — AppError hint rendered as 2nd line under the primary message
+  // in `DetectingErrorView`. Kept on the parent (alongside `error`) so the
+  // child running view's `onError` callback can stamp both at once.
+  const [errorHint, setErrorHint] = useState<string | null>(null);
   // #646 review Round 4 補足 #6 -- run-scoped state (progress / log /
   // probeInfo / phaseLabel / elapsed / startedAt) は `DetectingRunningView`
   // 内部に閉じ込め、retry 時は `key={runCount}` で remount して initial
@@ -320,6 +325,7 @@ export function DetectingScreen() {
   // による子 component remount で達成する。
   function handleRetry(): void {
     setError(null);
+    setErrorHint(null);
     dispatch({ type: 'RETRY' });
     setRunCount((c) => c + 1);
   }
@@ -328,6 +334,7 @@ export function DetectingScreen() {
     return (
       <DetectingErrorView
         error={error}
+        errorHint={errorHint}
         displayFile={displayFile}
         onRetry={handleRetry}
         onBack={() => navigate('drop')}
@@ -345,8 +352,9 @@ export function DetectingScreen() {
       loadSample={loadSample}
       navigate={navigate}
       onCancelClick={() => dispatch({ type: 'CANCEL_CLICKED' })}
-      onError={(msg) => {
+      onError={(msg, hint) => {
         setError(msg);
+        setErrorHint(hint);
         dispatch({ type: 'DETECT_ERROR' });
       }}
       onComplete={() => dispatch({ type: 'PROGRESS_COMPLETE' })}
@@ -362,7 +370,11 @@ interface DetectingRunningViewProps {
   loadSample: ReturnType<typeof useMetadataStore.getState>['loadSample'];
   navigate: ReturnType<typeof useAppStateStore.getState>['navigate'];
   onCancelClick: () => void;
-  onError: (message: string) => void;
+  /**
+   * #663 — `hint` is the AppError corrective hint (null when the error came
+   * from a `phase=error` progress event or a non-AppError throw).
+   */
+  onError: (message: string, hint: string | null) => void;
   onComplete: () => void;
 }
 
@@ -489,7 +501,10 @@ function DetectingRunningView({
             }
 
             if (payload.phase === 'error') {
-              onError(payload.message ?? 'unknown error');
+              // #663 — progress events from the CLI carry no AppError hint
+              // (`phase=error` only conveys `message`). Pass null so the
+              // error view shows just the primary message.
+              onError(payload.message ?? 'unknown error', null);
               return;
             }
 
@@ -513,7 +528,9 @@ function DetectingRunningView({
         onComplete();
       } catch (e) {
         if (cancelled) return;
-        onError(e instanceof Error ? e.message : String(e));
+        // #663 — AppError-shaped throws (Tauri command rejection) carry
+        // a corrective hint that we render as the error view's 2nd line.
+        onError(appErrorMessage(e), appErrorHint(e));
       }
     }
 
@@ -699,6 +716,12 @@ function PhaseRow({ name, jp, pct, sub }: PhaseRowProps) {
  */
 interface DetectingErrorViewProps {
   error: string | null;
+  /**
+   * #663 — corrective hint rendered as a 2nd line below the primary
+   * error message. Sourced from AppError throw sites; null for legacy
+   * progress-event errors and bare `Error` instances.
+   */
+  errorHint: string | null;
   displayFile: string;
   onRetry: () => void;
   onBack: () => void;
@@ -706,6 +729,7 @@ interface DetectingErrorViewProps {
 
 function DetectingErrorView({
   error,
+  errorHint,
   displayFile,
   onRetry,
   onBack,
@@ -737,6 +761,11 @@ function DetectingErrorView({
       <pre className={styles.errorMessage} data-testid="detecting-error-message">
         {error ?? 'unknown error'}
       </pre>
+      {errorHint && (
+        <div className={styles.errorHint} data-testid="detecting-error-hint">
+          💡 {errorHint}
+        </div>
+      )}
       <div className={styles.actions}>
         <button
           type="button"

--- a/gui/src/screens/DropScreen.module.css
+++ b/gui/src/screens/DropScreen.module.css
@@ -287,6 +287,15 @@
   font-size: 11px;
 }
 
+/* #663 — 2nd-line hint rendered below `.error` inside the ErrorCard.
+   Dim text token de-emphasises the corrective hint vs the red message. */
+.errorHint {
+  color: var(--ae-text-dim);
+  font-size: 12px;
+  margin-top: 6px;
+  line-height: 1.5;
+}
+
 .loading {
   font-family: var(--ae-font-mono);
   font-size: 11px;

--- a/gui/src/screens/DropScreen.test.tsx
+++ b/gui/src/screens/DropScreen.test.tsx
@@ -166,6 +166,27 @@ describe('DropScreen', () => {
     expect(screen.getByTestId('drop-screen').dataset.phase).toBe('idle');
   });
 
+  // #663 — Phase 4: when the probe rejects with an AppError-shaped object
+  // (`{ code, message, hint }`), the ErrorCard renders the hint as a 2nd
+  // line below the message so users get a recommended next action. Bare
+  // Error instances (`new Error(...)`) keep the existing single-line UX
+  // because `appErrorHint` returns null for them.
+  it('renders probe error hint as 2nd line when probe rejects with AppError (#663)', async () => {
+    const openDialog = vi.fn().mockResolvedValue('C:/videos/x.mkv');
+    const probeFn = vi.fn().mockRejectedValue({
+      code: 'parse.ffprobe_output_invalid',
+      message: 'ffprobe failed',
+      hint: 'check ffmpeg version',
+    });
+    render(<DropScreen openDialogFn={openDialog} probeFn={probeFn} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /参照/ }));
+    await waitFor(() => {
+      expect(screen.getByText('ffprobe failed')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/check ffmpeg version/)).toBeInTheDocument();
+  });
+
   it('Escape on the SelectedCard dismisses it (#587)', async () => {
     const openDialog = vi.fn().mockResolvedValue('C:/videos/x.mkv');
     render(<DropScreen openDialogFn={openDialog} />);

--- a/gui/src/screens/DropScreen.tsx
+++ b/gui/src/screens/DropScreen.tsx
@@ -9,6 +9,7 @@ import { AllaganSigil } from '../components/AllaganSigil';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { appErrorHint, appErrorMessage } from '../lib/appError';
 import { useAppStateStore } from '../state/appStateStore';
 import {
   type RecentEntry,
@@ -127,10 +128,15 @@ export function DropScreen({
   const [phase, dispatch] = useReducer(dropReducer, 'idle' as DropPhase);
   const [probeInfo, setProbeInfo] = useState<VideoProbeInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // #663: AppError hint rendered as a 2nd line below `error` inside
+  // the ErrorCard. `appErrorHint` returns null for legacy `new Error()`
+  // throws so the existing single-line UX is preserved.
+  const [errorHint, setErrorHint] = useState<string | null>(null);
   const [dragState, setDragState] = useState<DragState>('idle');
 
   async function probeAndDispatch(path: string): Promise<void> {
     setError(null);
+    setErrorHint(null);
     try {
       const info = await (probeFn ?? probeVideo)(path);
       setProbeInfo(info);
@@ -139,7 +145,8 @@ export function DropScreen({
       // with paths that turned out to be unreadable.
       void addRecent(info.path);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(appErrorMessage(e));
+      setErrorHint(appErrorHint(e));
       dispatch({ type: 'PROBE_FAIL' });
     }
   }
@@ -157,11 +164,13 @@ export function DropScreen({
   async function pickAndProbe() {
     dispatch({ type: 'BROWSE_CLICKED' });
     setError(null);
+    setErrorHint(null);
     let selected: string | null;
     try {
       selected = await (openDialogFn ?? defaultOpenDialog)();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(appErrorMessage(e));
+      setErrorHint(appErrorHint(e));
       dispatch({ type: 'PROBE_FAIL' });
       return;
     }
@@ -263,6 +272,7 @@ export function DropScreen({
 
   function dismissError() {
     setError(null);
+    setErrorHint(null);
     dispatch({ type: 'DISMISS_ERROR' });
   }
 
@@ -297,7 +307,12 @@ export function DropScreen({
       {phase === 'selected' && probeInfo ? (
         <SelectedCard info={probeInfo} onConfirm={confirm} onCancel={cancelSelection} />
       ) : phase === 'probeError' ? (
-        <ErrorCard error={error} onDismiss={dismissError} onRetry={pickAndProbe} />
+        <ErrorCard
+          error={error}
+          errorHint={errorHint}
+          onDismiss={dismissError}
+          onRetry={pickAndProbe}
+        />
       ) : (
         <>
           <AllaganFrame style={{ width: '78%', padding: 2, zIndex: 2 }}>
@@ -468,11 +483,13 @@ function SelectedCard({ info, onConfirm, onCancel }: SelectedCardProps) {
 
 interface ErrorCardProps {
   error: string | null;
+  /** #663 — corrective hint rendered as a 2nd line below `error` when non-null. */
+  errorHint: string | null;
   onDismiss: () => void;
   onRetry: () => void;
 }
 
-function ErrorCard({ error, onDismiss, onRetry }: ErrorCardProps) {
+function ErrorCard({ error, errorHint, onDismiss, onRetry }: ErrorCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   // #587: same dialog-like behavior as SelectedCard. Escape = dismiss.
   // We keep the existing role="alert" for backward compat with tests
@@ -488,6 +505,9 @@ function ErrorCard({ error, onDismiss, onRetry }: ErrorCardProps) {
     >
       <div className={styles.selectedHeading}>エラー</div>
       <div className={styles.error}>{error ?? 'probe failed'}</div>
+      {errorHint && (
+        <div className={styles.errorHint}>💡 {errorHint}</div>
+      )}
       <div className={styles.actions}>
         <button type="button" className={styles.cancelButton} onClick={onDismiss}>
           閉じる

--- a/gui/src/screens/ExportScreen.module.css
+++ b/gui/src/screens/ExportScreen.module.css
@@ -386,6 +386,23 @@
   white-space: nowrap;
 }
 
+/* #663 — 2nd-line hint rendered after `.listError`. Stays inside the
+   alert wrapper so screen readers read message + hint as one announcement.
+   The parent `.listError` clamps message text to a single line via
+   `max-width: 240px; overflow: hidden; text-overflow: ellipsis;
+   white-space: nowrap`. The hint must override all three so multi-line
+   Japanese hints are not truncated mid-character. */
+.listErrorHint {
+  display: block;
+  color: var(--ae-text-dim);
+  font-size: 11px;
+  line-height: 1.5;
+  margin-top: 2px;
+  white-space: normal;
+  max-width: 100%;
+  overflow: visible;
+}
+
 .listName {
   flex: 1;
   overflow: hidden;

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -526,6 +526,34 @@ describe('ExportScreen (Phase 4 #466)', () => {
     expect(screen.getByTestId('export-screen').dataset.phase).toBe('idle');
   });
 
+  // #663 — Phase 4: when export_match rejects with an AppError-shaped
+  // object (`{ code, message, hint }`), the per-match list error renders
+  // the hint as a 2nd line below the primary message. The sample
+  // metadata has 9 matches and the mock fails every export, so we expect
+  // 9 message + 9 hint nodes. Asserting on getAllByText keeps the test
+  // robust to fixture-size changes (just checks ≥1).
+  it('renders per-match error hint when export_match rejects with AppError (#663)', async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'export_match') {
+        return Promise.reject({
+          code: 'subprocess.spawn_failed',
+          message: 'ffmpeg spawn failed',
+          hint: 'reinstall ffmpeg',
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    render(<ExportScreen />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /書き出し開始/ }));
+    await waitFor(() => {
+      expect(screen.getAllByText(/ffmpeg spawn failed/).length).toBeGreaterThan(
+        0,
+      );
+    });
+    expect(screen.getAllByText(/reinstall ffmpeg/).length).toBeGreaterThan(0);
+  });
+
   // #545 review #7: 進捗バー直下に「経過 0:00 / 残り —」が出る (running 中)。
   // 完了後は両方の表示が残るが setInterval は止まる。
   it('shows elapsed / remaining time line during running', async () => {

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -4,6 +4,7 @@ import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { DisabledTooltip } from '../components/DisabledTooltip';
+import { appErrorHint, appErrorMessage } from '../lib/appError';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
 import { joinPath, stripExtendedPathPrefix } from '../utils/path';
@@ -20,6 +21,12 @@ interface MatchState {
   status: MatchStatus;
   percent: number;
   error?: string;
+  /**
+   * #663 — corrective hint rendered as a 2nd line below `error` in the
+   * per-match list. Sourced from AppError throw sites; absent for
+   * progress-event errors and bare `Error` instances.
+   */
+  errorHint?: string;
   outputPath?: string;
   /**
    * #591 -- non-null when the GPU encoder failed and the export was
@@ -257,6 +264,11 @@ export function ExportScreen() {
               status,
               percent: p.percent,
               error: p.stage === 'error' ? p.message : prior.error,
+              // #663 — `export-progress` event payload does not currently
+              // carry an AppError hint (Rust-side enhancement is future
+              // work); keep whatever the prior catch-block stamped so the
+              // event handler does not clear it on stage transitions.
+              errorHint: prior.errorHint,
               fallbackNotice,
             },
           };
@@ -352,10 +364,20 @@ export function ExportScreen() {
         }));
       } catch (e) {
         failureCount += 1;
-        const msg = e instanceof Error ? e.message : String(e);
+        // #663 — AppError-shaped throws (Tauri command rejection) carry
+        // a corrective hint that we render as the per-match list's 2nd
+        // error line. `appErrorHint` returns null for legacy `new Error`,
+        // which we collapse to undefined so MatchState stays clean.
+        const msg = appErrorMessage(e);
+        const hint = appErrorHint(e);
         setMatchStates((prev) => ({
           ...prev,
-          [m.index]: { status: 'error', percent: 0, error: msg },
+          [m.index]: {
+            status: 'error',
+            percent: 0,
+            error: msg,
+            errorHint: hint ?? undefined,
+          },
         }));
       }
     }
@@ -859,6 +881,11 @@ export function ExportScreen() {
                   {s.status === 'error' && s.error && (
                     <span className={styles.listError} role="alert">
                       {s.error.slice(0, 120)}
+                      {s.errorHint && (
+                        <span className={styles.listErrorHint}>
+                          💡 {s.errorHint}
+                        </span>
+                      )}
                     </span>
                   )}
                   {s.fallbackNotice && (

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -266,8 +266,11 @@ export function ExportScreen() {
               error: p.stage === 'error' ? p.message : prior.error,
               // #663 — `export-progress` event payload does not currently
               // carry an AppError hint (Rust-side enhancement is future
-              // work); keep whatever the prior catch-block stamped so the
-              // event handler does not clear it on stage transitions.
+              // work). errorHint の最終 source of truth は catch handler
+              // (catch handler が MatchState を全置換するため、progress
+              // event 時点では prior.errorHint は基本 undefined のまま
+              // preserved。この event handler は errorHint を能動的に
+              // セットせず、catch handler の結果が後から確定する形)。
               errorHint: prior.errorHint,
               fallbackNotice,
             },

--- a/gui/src/screens/PreviewScreen.module.css
+++ b/gui/src/screens/PreviewScreen.module.css
@@ -326,6 +326,18 @@
   margin-left: 8px;
 }
 
+/* #663 — 2nd-line hint rendered after `.applyError`. Uses the dim text
+   token so corrective hints are visually subordinate to the red message.
+   `display: block` forces the hint onto a new line; without it the parent
+   span renders message + hint on a single line. */
+.applyErrorHint {
+  display: block;
+  color: var(--ae-text-dim);
+  font-size: 11px;
+  margin-left: 8px;
+  line-height: 1.5;
+}
+
 .emptyNote {
   padding: 24px;
   text-align: center;

--- a/gui/src/screens/PreviewScreen.test.tsx
+++ b/gui/src/screens/PreviewScreen.test.tsx
@@ -51,6 +51,20 @@ describe('PreviewScreen', () => {
     expect(screen.getByText(/#004 · of 9/)).toBeInTheDocument();
   });
 
+  // #663 — Phase 4: when applyError is set in the store, render the
+  // companion applyErrorHint as a 2nd line so the user sees the
+  // recommended next step. Hint stays inside the existing role="alert"
+  // wrapper so a screen reader announces message + hint as one update.
+  it('renders applyErrorHint inline when present (#663)', () => {
+    useMetadataStore.setState({
+      applyError: 'disk full',
+      applyErrorHint: 'free up space',
+    });
+    render(<PreviewScreen />);
+    expect(screen.getByText('disk full')).toBeInTheDocument();
+    expect(screen.getByText(/free up space/)).toBeInTheDocument();
+  });
+
   it('renders 2 panes (IN, OUT) with IN active by default', () => {
     render(<PreviewScreen />);
     const inPane = screen.getByRole('button', { name: /IN \(start\)/ });

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -89,6 +89,9 @@ export function PreviewScreen() {
   const dirty = useMetadataStore((s) => s.dirty);
   const applying = useMetadataStore((s) => s.applying);
   const applyError = useMetadataStore((s) => s.applyError);
+  // #663 — corrective hint rendered as a 2nd line under `applyError` so
+  // the user sees both the failure and the recommended next step.
+  const applyErrorHint = useMetadataStore((s) => s.applyErrorHint);
   const filePath = useMetadataStore((s) => s.filePath);
   const updateMatch = useMetadataStore((s) => s.updateMatch);
   const apply = useMetadataStore((s) => s.apply);
@@ -649,6 +652,11 @@ export function PreviewScreen() {
         {applyError && (
           <span className={styles.applyError} role="alert">
             {applyError}
+            {applyErrorHint && (
+              <span className={styles.applyErrorHint}>
+                💡 {applyErrorHint}
+              </span>
+            )}
           </span>
         )}
         <RestoreButton onRestored={() => navigate('complete')} />

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -56,25 +56,29 @@ function validMetadata(): Metadata {
  * Set up an invoke mock that dispatches per command name. Tests can override
  * specific commands via .mockImplementationOnce(...) or by configuring this
  * map further.
+ *
+ * #663: `*_error` fields accept arbitrary reject values (Error instances or
+ * AppError-shaped objects `{ code, message, hint? }`) so tests can simulate
+ * the structured error path that Tauri uses post PR #665.
  */
 interface MockConfig {
   load_metadata?: unknown;
-  load_metadata_error?: Error;
+  load_metadata_error?: unknown;
   get_metadata_mtime?: number | null;
-  get_metadata_mtime_error?: Error;
+  get_metadata_mtime_error?: unknown;
   apply_changes?: number;
-  apply_changes_error?: Error;
+  apply_changes_error?: unknown;
   restore_from_original?: unknown;
-  restore_from_original_error?: Error;
+  restore_from_original_error?: unknown;
   check_backup_exists?: boolean;
-  check_backup_exists_error?: Error;
+  check_backup_exists_error?: unknown;
   // #517
   save_draft?: unknown;
-  save_draft_error?: Error;
+  save_draft_error?: unknown;
   load_draft?: unknown;
-  load_draft_error?: Error;
+  load_draft_error?: unknown;
   clear_draft?: unknown;
-  clear_draft_error?: Error;
+  clear_draft_error?: unknown;
 }
 
 function configureInvoke(cfg: MockConfig) {
@@ -431,12 +435,16 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
   });
 
   it('surfaces conflict errors in conflictError, not applyError', async () => {
+    // #663: PR #665 で全 23 commands が AppError 化済のため、conflict は
+    // structured AppError ({ code: 'state.mtime_conflict', ... }) として届く。
     configureInvoke({
       load_metadata: validMetadata(),
       get_metadata_mtime: 1700,
-      apply_changes_error: new Error(
-        'conflict: external modification detected (expected mtime 1700, got 1800)',
-      ),
+      apply_changes_error: {
+        code: 'state.mtime_conflict',
+        message:
+          'external modification detected (expected mtime 1700, got 1800)',
+      },
       check_backup_exists: false,
     });
     await useMetadataStore.getState().load('p');
@@ -446,7 +454,7 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
     const state = useMetadataStore.getState();
     expect(state.applying).toBe(false);
     expect(state.applyError).toBeNull();
-    expect(state.conflictError).toContain('conflict:');
+    expect(state.conflictError).toContain('external modification');
     // Store retains dirty edits so the user can choose to overwrite.
     expect(state.dirty).toBe(true);
   });
@@ -487,16 +495,17 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
 
   it('reloadAfterConflict re-loads metadata.json from disk', async () => {
     // First load with mtime 1700, then `conflictError` is set.
+    // #663: structured AppError ({ code: 'state.mtime_conflict', ... }) で reject
     configureInvoke({
       load_metadata: validMetadata(),
       get_metadata_mtime: 1700,
-      apply_changes_error: new Error('conflict: stale'),
+      apply_changes_error: { code: 'state.mtime_conflict', message: 'stale' },
       check_backup_exists: false,
     });
     await useMetadataStore.getState().load('p');
     useMetadataStore.getState().updateMatch(1, { name: 'dirty' });
     await useMetadataStore.getState().apply();
-    expect(useMetadataStore.getState().conflictError).toContain('conflict');
+    expect(useMetadataStore.getState().conflictError).toContain('stale');
 
     // Reload now returns a fresh validMetadata (no `name` edit) + new mtime.
     configureInvoke({
@@ -520,7 +529,7 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
   });
 
   it('dismissConflict clears the modal state without reloading or reapplying', () => {
-    useMetadataStore.setState({ conflictError: 'conflict: x', dirty: true });
+    useMetadataStore.setState({ conflictError: 'x', dirty: true });
     useMetadataStore.getState().dismissConflict();
     const state = useMetadataStore.getState();
     expect(state.conflictError).toBeNull();
@@ -543,18 +552,20 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
   // proves the next apply completes with the rotated mtime (regression guard).
   it('conflict → reload → apply completes the full recovery flow', async () => {
     // Step 1: initial load + apply triggers conflict.
+    // #663: structured AppError ({ code: 'state.mtime_conflict', ... }) で reject
     configureInvoke({
       load_metadata: validMetadata(),
       get_metadata_mtime: 1700,
-      apply_changes_error: new Error(
-        'conflict: external modification detected (expected 1700, got 1800)',
-      ),
+      apply_changes_error: {
+        code: 'state.mtime_conflict',
+        message: 'external modification detected (expected 1700, got 1800)',
+      },
       check_backup_exists: false,
     });
     await useMetadataStore.getState().load('p');
     useMetadataStore.getState().updateMatch(1, { name: 'pending-edit' });
     await useMetadataStore.getState().apply();
-    expect(useMetadataStore.getState().conflictError).toContain('conflict');
+    expect(useMetadataStore.getState().conflictError).toContain('external');
 
     // Step 2: reload → fresh mtime, conflictError cleared.
     configureInvoke({
@@ -620,6 +631,21 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
     };
     expect(args.expectedMtimeMs).toBe(2500);
     expect(useMetadataStore.getState().loadedMtimeMs).toBe(3300);
+  });
+
+  it('legacy raw-string Error("conflict: ...") routes to applyError, not conflictError (#663)', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      get_metadata_mtime: 1700,
+      apply_changes_error: new Error('conflict: legacy raw string'),
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, { name: 'x' });
+    await useMetadataStore.getState().apply();
+    const s = useMetadataStore.getState();
+    expect(s.conflictError).toBeNull();
+    expect(s.applyError).toContain('conflict:');
   });
 });
 
@@ -942,7 +968,7 @@ describe('useMetadataStore (#514 × #517 interaction)', () => {
     });
     await useMetadataStore.getState().load('p');
     // conflict 発火を simulate
-    useMetadataStore.setState({ conflictError: 'conflict: external' });
+    useMetadataStore.setState({ conflictError: 'external' });
     await useMetadataStore.getState().reloadAfterConflict();
     expect(useMetadataStore.getState().pendingDraft?.matches[0].name).toBe(
       'rescued',
@@ -963,7 +989,7 @@ describe('useMetadataStore (#514 × #517 interaction)', () => {
     });
     await useMetadataStore.getState().load('p');
     expect(useMetadataStore.getState().pendingDraft).not.toBeNull();
-    useMetadataStore.setState({ conflictError: 'conflict: external' });
+    useMetadataStore.setState({ conflictError: 'external' });
     expect(useMetadataStore.getState().conflictError).toBeTruthy();
     expect(useMetadataStore.getState().pendingDraft).not.toBeNull();
   });
@@ -1051,5 +1077,121 @@ describe('useMetadataStore.discardEdits (#589)', () => {
 
     expect(useMetadataStore.getState().dirty).toBe(false);
     expect(useMetadataStore.getState().loadedMtimeMs).toBe(2000);
+  });
+});
+
+// #663 — AppError hint pair. Each error-state field gains a sibling `*Hint`
+// that carries the AppError.hint when the underlying invoke rejected with a
+// structured AppError object. legacy raw Error rejection keeps the hint null.
+describe('AppError hint pair (#663)', () => {
+  beforeEach(() => {
+    useMetadataStore.getState().clear();
+  });
+
+  it('apply path: applyErrorHint is set when AppError carries hint', async () => {
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'apply_changes') {
+        // Tauri rejects with the AppError-shaped object directly
+        throw {
+          code: 'io.write_failed',
+          message: 'disk full',
+          hint: 'check free disk space',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+    useMetadataStore.setState({
+      metadata: { source: 'x', matches: [] } as never,
+      filePath: '/tmp/m.json',
+      loadedMtimeMs: 1000,
+    });
+    await useMetadataStore.getState().apply();
+    const s = useMetadataStore.getState();
+    expect(s.applyError).toBe('disk full');
+    expect(s.applyErrorHint).toBe('check free disk space');
+  });
+
+  it('load path: loadErrorHint is set when AppError carries hint', async () => {
+    invokeMock.mockImplementation(async () => {
+      throw {
+        code: 'io.file_not_found',
+        message: 'no such file',
+        hint: 'check path',
+      };
+    });
+    await useMetadataStore.getState().load('/tmp/missing.json');
+    const s = useMetadataStore.getState();
+    expect(s.loadError).toBe('no such file');
+    expect(s.loadErrorHint).toBe('check path');
+  });
+
+  it('restore path: restoreErrorHint is set', async () => {
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'restore_from_original') {
+        throw {
+          code: 'io.backup_failed',
+          message: 'no backup',
+          hint: 'create backup first',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+    useMetadataStore.setState({ filePath: '/tmp/m.json' });
+    await useMetadataStore.getState().restore();
+    const s = useMetadataStore.getState();
+    expect(s.restoreError).toBe('no backup');
+    expect(s.restoreErrorHint).toBe('create backup first');
+  });
+
+  it('saveDraft path: draftSaveErrorHint is set', async () => {
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'save_draft') {
+        throw {
+          code: 'io.write_failed',
+          message: 'disk full',
+          hint: 'free space',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+    useMetadataStore.setState({
+      filePath: '/tmp/m.json',
+      metadata: { source: 'x', matches: [] } as never,
+    });
+    await useMetadataStore.getState().saveDraft();
+    const s = useMetadataStore.getState();
+    expect(s.draftSaveError).toBe('disk full');
+    expect(s.draftSaveErrorHint).toBe('free space');
+  });
+
+  it('loadDraft path: draftLoadErrorHint is set', async () => {
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'load_draft') {
+        throw {
+          code: 'parse.json_invalid',
+          message: 'bad json',
+          hint: 'corrupt draft',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+    useMetadataStore.setState({
+      filePath: '/tmp/m.json',
+      metadata: { source: 'x', matches: [] } as never,
+    });
+    await useMetadataStore.getState().loadDraft();
+    const s = useMetadataStore.getState();
+    expect(s.draftLoadError).toBe('bad json');
+    expect(s.draftLoadErrorHint).toBe('corrupt draft');
+  });
+
+  it('legacy raw-Error reject keeps hint null', async () => {
+    invokeMock.mockImplementation(async () => {
+      throw new Error('plain error string');
+    });
+    await useMetadataStore.getState().load('/tmp/x.json');
+    const s = useMetadataStore.getState();
+    expect(s.loadError).toBe('plain error string');
+    expect(s.loadErrorHint).toBeNull();
   });
 });

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -1,7 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { create } from 'zustand';
 
-import { appErrorCodeIs, appErrorMessage } from '../lib/appError';
+import { appErrorCodeIs, appErrorHint, appErrorMessage } from '../lib/appError';
 import { sampleMetadata } from '../data/sampleMetadata';
 import type { Match, Metadata, TypeOverride } from '../types/metadata';
 import { MetadataSchema } from '../types/metadata.schema';
@@ -28,8 +28,12 @@ export interface MetadataState {
   filePath: string | null;
   dirty: boolean;
   loadError: string | null;
+  /** #663: hint for loadError, if AppError carried one. */
+  loadErrorHint: string | null;
   applying: boolean;
   applyError: string | null;
+  /** #663: hint for applyError, if AppError carried one. */
+  applyErrorHint: string | null;
 
   /** #516: flips true after a successful `apply()` that created metadata.original.json. */
   hasBackup: boolean;
@@ -37,6 +41,8 @@ export interface MetadataState {
   restoring: boolean;
   /** #516: last restore error message, if any. */
   restoreError: string | null;
+  /** #663: hint for restoreError, if AppError carried one. */
+  restoreErrorHint: string | null;
 
   /**
    * #514: mtime (ms since epoch) of metadata.json recorded at load time.
@@ -60,6 +66,8 @@ export interface MetadataState {
   pendingDraft: Metadata | null;
   /** #517: last draft load error (corrupt draft / parse failure). */
   draftLoadError: string | null;
+  /** #663: hint for draftLoadError, if AppError carried one. */
+  draftLoadErrorHint: string | null;
   /** #517: true while an auto-save (debounced saveDraft) is in flight. */
   draftSaving: boolean;
   /**
@@ -70,6 +78,8 @@ export interface MetadataState {
    * (a save that never landed cannot be restored).
    */
   draftSaveError: string | null;
+  /** #663: hint for draftSaveError, if AppError carried one. */
+  draftSaveErrorHint: string | null;
 
   load: (path: string) => Promise<void>;
   updateMatch: (index: number, patch: MatchEditPatch) => void;
@@ -180,7 +190,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
   async function runApply(overwrite: boolean): Promise<void> {
     const { metadata, filePath, loadedMtimeMs } = get();
     if (!metadata || !filePath) return;
-    set({ applying: true, applyError: null, conflictError: null });
+    set({ applying: true, applyError: null, applyErrorHint: null, conflictError: null });
     try {
       const normalized = normalizeForPersistence(metadata);
       const newMtime = await invoke<number>('apply_changes', {
@@ -193,6 +203,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         dirty: false,
         applying: false,
         applyError: null,
+        applyErrorHint: null,
         loadedMtimeMs: newMtime,
         conflictError: null,
       });
@@ -203,13 +214,14 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       await get().clearDraft();
     } catch (e) {
       const msg = appErrorMessage(e);
-      // #619: structured AppError 化以後は code-based 判定を優先。legacy raw
-      // String fallback として `msg.startsWith('conflict:')` も残す
-      // (古い command が migration 漏れしていても conflict UI を出せるよう)。
-      if (appErrorCodeIs(e, 'state.mtime_conflict') || msg.startsWith('conflict:')) {
+      const hint = appErrorHint(e);
+      // #663: PR #665 で全 23 commands が AppError 化済のため、legacy raw String
+      // fallback (msg.startsWith('conflict:')) は廃止する。code === 'state.mtime_conflict'
+      // のみで分岐する。
+      if (appErrorCodeIs(e, 'state.mtime_conflict')) {
         set({ applying: false, conflictError: msg });
       } else {
-        set({ applying: false, applyError: msg });
+        set({ applying: false, applyError: msg, applyErrorHint: hint });
       }
     }
   }
@@ -219,19 +231,24 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
   filePath: null,
   dirty: false,
   loadError: null,
+  loadErrorHint: null,
   applying: false,
   applyError: null,
+  applyErrorHint: null,
 
   hasBackup: false,
   restoring: false,
   restoreError: null,
+  restoreErrorHint: null,
 
   loadedMtimeMs: null,
   conflictError: null,
   pendingDraft: null,
   draftLoadError: null,
+  draftLoadErrorHint: null,
   draftSaving: false,
   draftSaveError: null,
+  draftSaveErrorHint: null,
 
   load: async (path) => {
     try {
@@ -246,13 +263,18 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         filePath: path,
         dirty: false,
         loadError: null,
+        loadErrorHint: null,
         applyError: null,
+        applyErrorHint: null,
         restoreError: null,
+        restoreErrorHint: null,
         loadedMtimeMs: mtime ?? null,
         conflictError: null,
         pendingDraft: null,
         draftLoadError: null,
+        draftLoadErrorHint: null,
         draftSaveError: null,
+        draftSaveErrorHint: null,
       });
       await get().refreshBackupStatus();
       // #517: automatically probe for a draft after a successful load. If one
@@ -265,12 +287,15 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         filePath: null,
         dirty: false,
         loadError: appErrorMessage(e),
+        loadErrorHint: appErrorHint(e),
         hasBackup: false,
         loadedMtimeMs: null,
         conflictError: null,
         pendingDraft: null,
         draftLoadError: null,
+        draftLoadErrorHint: null,
         draftSaveError: null,
+        draftSaveErrorHint: null,
       });
     }
   },
@@ -309,24 +334,29 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       filePath: null,
       dirty: false,
       loadError: null,
+      loadErrorHint: null,
       applying: false,
       applyError: null,
+      applyErrorHint: null,
       hasBackup: false,
       restoring: false,
       restoreError: null,
+      restoreErrorHint: null,
       loadedMtimeMs: null,
       conflictError: null,
       pendingDraft: null,
       draftLoadError: null,
+      draftLoadErrorHint: null,
       draftSaving: false,
       draftSaveError: null,
+      draftSaveErrorHint: null,
     });
   },
 
   restore: async () => {
     const { filePath } = get();
     if (!filePath) return;
-    set({ restoring: true, restoreError: null });
+    set({ restoring: true, restoreError: null, restoreErrorHint: null });
     try {
       await invoke('restore_from_original', { path: filePath });
       // Reload metadata from disk; load() also refreshes hasBackup.
@@ -336,6 +366,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       set({
         restoring: false,
         restoreError: appErrorMessage(e),
+        restoreErrorHint: appErrorHint(e),
       });
     }
   },
@@ -378,13 +409,16 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
     const { filePath, metadata } = get();
     if (!filePath || !metadata) return;
     // Clear any prior save error up-front so consumers see a fresh attempt.
-    set({ draftSaving: true, draftSaveError: null });
+    set({ draftSaving: true, draftSaveError: null, draftSaveErrorHint: null });
     try {
       await invoke('save_draft', { path: filePath, draft: metadata });
     } catch (e) {
       // Surface the failure via state — scheduleDraftSave's fire-and-forget
       // call would otherwise swallow the rejection silently (see F1 review).
-      set({ draftSaveError: appErrorMessage(e) });
+      set({
+        draftSaveError: appErrorMessage(e),
+        draftSaveErrorHint: appErrorHint(e),
+      });
     } finally {
       set({ draftSaving: false });
     }
@@ -396,7 +430,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
     try {
       const raw = await invoke<unknown>('load_draft', { path: filePath });
       if (raw === null || raw === undefined) {
-        set({ pendingDraft: null, draftLoadError: null });
+        set({ pendingDraft: null, draftLoadError: null, draftLoadErrorHint: null });
         return;
       }
       const parsed = MetadataSchema.parse(raw) as unknown as Metadata;
@@ -409,14 +443,15 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         normalizeSourcePath(metadata.source)
       ) {
         await invoke('clear_draft', { path: filePath });
-        set({ pendingDraft: null, draftLoadError: null });
+        set({ pendingDraft: null, draftLoadError: null, draftLoadErrorHint: null });
         return;
       }
-      set({ pendingDraft: parsed, draftLoadError: null });
+      set({ pendingDraft: parsed, draftLoadError: null, draftLoadErrorHint: null });
     } catch (e) {
       set({
         pendingDraft: null,
         draftLoadError: appErrorMessage(e),
+        draftLoadErrorHint: appErrorHint(e),
       });
     }
   },
@@ -475,17 +510,22 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       filePath: null,
       dirty: false,
       loadError: null,
+      loadErrorHint: null,
       applying: false,
       applyError: null,
+      applyErrorHint: null,
       hasBackup: false,
       restoring: false,
       restoreError: null,
+      restoreErrorHint: null,
       loadedMtimeMs: null,
       conflictError: null,
       pendingDraft: null,
       draftLoadError: null,
+      draftLoadErrorHint: null,
       draftSaving: false,
       draftSaveError: null,
+      draftSaveErrorHint: null,
     });
   },
   };

--- a/gui/src/state/recentStore.test.ts
+++ b/gui/src/state/recentStore.test.ts
@@ -115,3 +115,40 @@ describe('useRecentStore.reset (#571)', () => {
     expect(invokeMock).not.toHaveBeenCalled();
   });
 });
+
+// #663 — AppError hint pair. `loadError` / `addError` gain sibling `*Hint`
+// fields populated from AppError.hint when invoke rejects with a structured
+// AppError object.
+describe('AppError hint pair (#663)', () => {
+  beforeEach(() => {
+    useRecentStore.getState().reset();
+  });
+
+  it('load path: loadErrorHint is set when AppError carries hint', async () => {
+    invokeMock.mockImplementation(async () => {
+      throw {
+        code: 'io.read_failed',
+        message: 'broken recent.json',
+        hint: 'delete the file and restart',
+      };
+    });
+    await useRecentStore.getState().load();
+    const s = useRecentStore.getState();
+    expect(s.loadError).toBe('broken recent.json');
+    expect(s.loadErrorHint).toBe('delete the file and restart');
+  });
+
+  it('add path: addErrorHint is set when AppError carries hint', async () => {
+    invokeMock.mockImplementation(async () => {
+      throw {
+        code: 'io.write_failed',
+        message: 'recent.json write failed',
+        hint: 'check disk space',
+      };
+    });
+    await useRecentStore.getState().add('/tmp/x.mp4');
+    const s = useRecentStore.getState();
+    expect(s.addError).toBe('recent.json write failed');
+    expect(s.addErrorHint).toBe('check disk space');
+  });
+});

--- a/gui/src/state/recentStore.ts
+++ b/gui/src/state/recentStore.ts
@@ -1,7 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { create } from 'zustand';
 
-import { appErrorMessage } from '../lib/appError';
+import { appErrorHint, appErrorMessage } from '../lib/appError';
 
 /**
  * #571 — single entry in the persisted recent-videos history. Mirrors the
@@ -27,8 +27,12 @@ export interface RecentState {
   loaded: boolean;
   /** Last load failure, surfaced for tests / debug log; the drop screen ignores it (history is best-effort). */
   loadError: string | null;
+  /** #663: hint for loadError, if AppError carried one. */
+  loadErrorHint: string | null;
   /** Last add failure, e.g. when the user dropped a file that was deleted before we could stat it. */
   addError: string | null;
+  /** #663: hint for addError, if AppError carried one. */
+  addErrorHint: string | null;
 
   /** Read history from disk. Idempotent — safe to call on every DropScreen mount. */
   load: () => Promise<void>;
@@ -44,7 +48,9 @@ export const useRecentStore = create<RecentState>((set) => ({
   entries: [],
   loaded: false,
   loadError: null,
+  loadErrorHint: null,
   addError: null,
+  addErrorHint: null,
 
   async load() {
     try {
@@ -55,10 +61,11 @@ export const useRecentStore = create<RecentState>((set) => ({
       const entries: RecentEntry[] = Array.isArray(result)
         ? (result as RecentEntry[])
         : [];
-      set({ entries, loaded: true, loadError: null });
+      set({ entries, loaded: true, loadError: null, loadErrorHint: null });
     } catch (e) {
       set({
         loadError: appErrorMessage(e),
+        loadErrorHint: appErrorHint(e),
         loaded: true,
       });
     }
@@ -70,18 +77,31 @@ export const useRecentStore = create<RecentState>((set) => ({
       const entries: RecentEntry[] = Array.isArray(result)
         ? (result as RecentEntry[])
         : [];
-      set({ entries, addError: null });
+      set({ entries, addError: null, addErrorHint: null });
     } catch (e) {
-      set({ addError: appErrorMessage(e) });
+      set({ addError: appErrorMessage(e), addErrorHint: appErrorHint(e) });
     }
   },
 
   async clear() {
     await invoke<void>('clear_recent');
-    set({ entries: [], loadError: null, addError: null });
+    set({
+      entries: [],
+      loadError: null,
+      loadErrorHint: null,
+      addError: null,
+      addErrorHint: null,
+    });
   },
 
   reset() {
-    set({ entries: [], loaded: false, loadError: null, addError: null });
+    set({
+      entries: [],
+      loaded: false,
+      loadError: null,
+      loadErrorHint: null,
+      addError: null,
+      addErrorHint: null,
+    });
   },
 }));


### PR DESCRIPTION
## Summary

[#663](https://github.com/Idios/kobutachan-allaganeye/issues/663) (PR #665 後の AppError migration 完遂) の実装。

Lane I-A (wave 0 起点)。spec [docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md](docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md)。session-id: `tender-khayyam-03d618`。

## 主な変更 (5 phase / 5 commit)

### Phase 1 (`af44ace`): Rust `error.rs` (default hint helper)

- `default_hint_for_code(code)` (22 entries) + `with_default_hint()` 追加
- `From<io::Error>` / `From<serde_json::Error>` impl で hint chain
- 6 件の TDD 新 test (156 件 pass: 150 baseline + 6 new)

### Phase 2 (`5bef51b`): Rust `lib.rs` mechanical

- 全 80 site の `AppError::new(...)` に `.with_default_hint()` chain
- regression なし (156 件継続 pass)

### Phase 3 (`25ff2dd`): Frontend stores

- `metadataStore`: `*ErrorHint` 5 state 追加 (load / apply / restore / draftSave / draftLoad)
- `recentStore`: `loadErrorHint` / `addErrorHint` 追加
- [`gui/src/state/metadataStore.ts:209`](gui/src/state/metadataStore.ts#L209) の legacy `|| msg.startsWith('conflict:')` を削除
- 既存 conflict 文字列 test (3 metadataStore + 6 ConflictModal + 1 DraftRestoreModal stale prefix) を AppError object 形式 / prefix 削除版に書き換え
- 6 + 2 = 8 件 TDD 新 test + 1 件 legacy raw-string regression test (598 vitest)

### Phase 4 (`91363a3`): Frontend UI

- 5 screen + RestoreButton の inline error に hint 2 行目を追加 (`var(--ae-text-dim)` 色、`💡` prefix)
- 各 module.css に `.errorHint` (or `.applyErrorHint` / `.listErrorHint`) class
- `PreviewScreen.module.css::.applyErrorHint` で `display: block` (1 行目との改行担保)
- `ExportScreen.module.css::.listErrorHint` で `white-space: normal` + `max-width: 100%` + `overflow: visible` (parent `.listError` の `nowrap` / `overflow: hidden` を override、長い日本語 hint の truncation 防止)
- 6 + 1 = 7 件 TDD 新 test (RestoreButton a11y test 含む、605 vitest)
- a11y: hint は `role="alert"` wrapper の **内側** に nest (jest-axe で violation なし)

### Phase 5 (`a4b003c`): Docs + issue body

- [docs/tauri-commands.md](docs/tauri-commands.md): AppError default hint mapping table (22 entries、`error.rs::default_hint_for_code` と完全一致 mirror)
- [docs/ui-architecture.md](docs/ui-architecture.md) §4: AppError code 体系と inline error の使い分け節を追加 (`code === 'state.mtime_conflict'` → ConflictModal / その他 → inline 2 行目 hint)
- [docs/ui-interaction-spec.md](docs/ui-interaction-spec.md) §1.5: `error.code` ベース分岐ルール節を追加 (`appErrorCodeIs` / `appErrorMessage` / `appErrorHint` の使用パターンと `var(--ae-danger)` / `var(--ae-text-dim)` 色規約)
- Issue #663 body を実態に合わせて update (`gh issue edit` 経由、4 軸 (A)(B)(C)(D) 構成 + 16 受け入れ条件 checkbox + scope 外明記)

## 受け入れ条件 (issue #663 body の 16 項目)

- [x] (A) [`metadataStore.ts:209`](gui/src/state/metadataStore.ts#L209) の `|| msg.startsWith('conflict:')` が削除されている
- [x] (A) `metadataStore.test.ts` の `'conflict: ...'` raw String テストが AppError object 形式に書き換え (Phase 3 で `Error('conflict: ...')` → `{ code: 'state.mtime_conflict', message: '...' }`)
- [x] (A) `ConflictModal.test.tsx` の test data から `'conflict:'` prefix が消えている (6 setState calls + 1 getByText 修正)
- [x] (A) Phase 3 fix で発見した `DraftRestoreModal.test.tsx:132` の stale prefix も同 PR で修正済 (sweep results)
- [x] (B) [`error.rs`](gui/src-tauri/src/error.rs) に `default_hint_for_code()` + `with_default_hint()` 追加、22 codes 日本語 hint
- [x] (B) `From<std::io::Error>` / `From<serde_json::Error>` で `.with_default_hint()` chain
- [x] (B) [`lib.rs`](gui/src-tauri/src/lib.rs) 全 80 site の `AppError::new(...)` に `.with_default_hint()`
- [x] (C) `metadataStore` に 5 `*ErrorHint` state 追加、`recentStore` に 2 hint pair 追加
- [x] (C) 5 screen + RestoreButton の inline error が hint を 2 行目に render
- [x] (C) PreviewScreen / ExportScreen で hint が新規行 / 折り返し対応で表示 (CSS overrides 済)
- [x] (C) RestoreButton で hint が `role="alert"` 内側に存在することを test で pinning
- [x] (D) [docs/tauri-commands.md](docs/tauri-commands.md) AppError hint mapping table 追加 (22 entries mirror)
- [x] (D) [docs/ui-architecture.md](docs/ui-architecture.md) §4 に code 体系と使い分け節
- [x] (D) [docs/ui-interaction-spec.md](docs/ui-interaction-spec.md) §1.5 に error.code ベース分岐ルール節
- [x] (D) Issue #663 body を `gh issue edit` で実態に合わせて update
- [x] CI 全 8 job pass + Iron Law 6 実機検証 5 経路 PASS (本 PR 作成時に Idios 確認済、下記 Self-Test Report 参照)

## Self-Test Report

### Machine-verified (Iron Law 6 PR 作成 Pre-flight)

- [x] `git fetch origin develop-0.2.0` + `git log HEAD..origin/develop-0.2.0` (取り込み未済 commit なし)
- [x] `gh pr list --search "#663"` 並行 worktree PR 重複なし (#683 = roadmap、merged)
- [x] 他の open `claude/` PR (#688 / #686 / #684 / #687) は別 lane (Group G / #616 / #643 / #365) で本 PR scope と非干渉
- [x] `cd gui/src-tauri && cargo check` (clean、incremental cache の Windows OS warning は本 PR 無関係)
- [x] `cd gui/src-tauri && cargo test --lib` (**156 件 pass**、新 6 件 + 既存 150 件)
- [x] `cd gui && npm run lint` (exit 0、既存 `errorStore.ts` 1 warning 本 PR 無関係)
- [x] `cd gui && npm run typecheck` (exit 0)
- [x] `cd gui && npm test -- --run` (**605 件 pass**、新 16 件 + 既存 589 件)
- [x] `cd gui && npm run build` (success、`gui/dist/` 生成 366KB JS / 41KB CSS)
- [x] `bash scripts/check-markdownlint.sh` (本 PR 修正 5 docs について 0 errors、`gui/node_modules/**/*.md` の pre-existing baseline 7712 errors は CI 範囲外)
- [x] `python -m ruff check . && python -m ruff format --check . && python -m pyright && python -m pytest` (Python regression なし、895 passed / 1 skipped)
- [x] Final code review (entire branch) PASS — "Ready to merge: Yes"

### Machine-unverifiable (Iron Law 6 実機検証 — 失敗パターン B 防止、5 経路を Idios 確認済)

- E2E #1: `state.mtime_conflict` 経路 (2 プロセス同時 edit → apply、ConflictModal 表示 + modal 既存 hint 維持、AppError hint は modal に出ない / scope-out 通り) ✅ PASS
- E2E #2: `io.permission_denied` 経路 (read-only metadata.json apply、PreviewScreen `applyError` の inline 2 行目に "Portable ZIP install dir..." hint) ✅ PASS
- E2E #3: `io.file_not_found` 経路 (metadata.json 削除して再 load、DropScreen ErrorCard の inline 2 行目に "ファイルが見つかりません..." hint) ✅ PASS
- E2E #4: `parse.json_invalid` 経路 (metadata.json 破損 load、DropScreen ErrorCard の inline 2 行目に "JSON ファイルが破損..." hint) ✅ PASS
- E2E #5: `subprocess.spawn_failed` 経路 (ffprobe rename / ALLAGANEYE_FFMPEG 不正 path、DropScreen ErrorCard の inline 2 行目に "外部プロセスの起動に失敗..." hint) ✅ PASS

## scope 外 (派生 issue 候補)

- ConflictModal hint 表示拡張 (modal 既存 compose hint と概念衝突回避、spec §3 で scope 外明記)
- ErrorModal への AppError 統合 / globalErrorListener への AppError parse 追加 (spec §3 scope 外)
- DraftRestoreModal への hint 表示 (Phase 3 で `draftLoadErrorHint` state は追加済、UI 追加は別 PR / 別 issue)
- recentStore error UI 表示 (DropScreen は recentStore error 表示しない設計、別 issue で再検討)
- Stale docstring 更新 (`gui/src/lib/appError.ts:57-62` / `gui/src-tauri/src/error.rs:28-34`、final reviewer Minor 指摘、別 PR 候補)
- markdownlint script の `gui/node_modules/**` ignore 不足 (`.markdownlint-cli2.yaml`、pre-existing CI 影響なし、別 issue)

## 関連

Refs #663 #665 #661 #614 #619 #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
