### PR TITLE
refactor(gui): #693 InlineErrorHint component 新設 + 既存 5 site refactor (Lane V Phase 1)

### DIFF
--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -118,6 +118,38 @@ Tauri command の `Result<T, AppError>` で frontend に届く構造化 error �
   message のみ取得、hint は null になる (PR #663 で legacy raw を返す
   command は存在しないが、helper の互換性として温存)
 
+### §4.7 InlineErrorHint component (#693)
+
+PR #693 で導入された共通 component。hint UI の `💡` prefix と `var(--ae-text-dim)`
+スタイルを 1 箇所に集約する。既存 5 site (RestoreButton / DropScreen ErrorCard /
+DetectingScreen / PreviewScreen / ExportScreen) 及び後続 3 site
+(ConflictModal #695 / DraftRestoreModal #697 / DropScreen recentNotice #698)
+で共有する。
+
+**Usage**:
+
+```tsx
+import { InlineErrorHint } from '../components/InlineErrorHint';
+
+<span role="alert">
+  {errorMessage}
+  <InlineErrorHint hint={errorHint} />
+</span>
+```
+
+**a11y 規約**:
+
+- consumer 側で `role="alert"` wrapper を提供する (本 component 自身は role を持たない)
+- 親の role を維持することで、screen reader は「message + hint」を 1 つの alert
+  update として読み上げる
+
+**Wrapper class での site-specific override**:
+
+- PreviewScreen `.applyErrorHint`: `display: block` で改行担保
+- ExportScreen `.listErrorHint`: parent `.listError` の `nowrap` / `overflow:hidden`
+  を override (`white-space: normal` + `max-width: 100%` + `overflow: visible`)
+- 他 3 site (RestoreButton / DropScreen / DetectingScreen) は wrapper class 不要
+
 ## 5. 各画面の phase state
 
 ### drop (動画ファイル選択)

--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -106,8 +106,9 @@ Tauri command 失敗時の error 表示は以下を厳守する:
 1. `appErrorCodeIs(e, 'state.mtime_conflict')` で apply path → ConflictModal (modal 表示)
 2. その他の AppError code → inline error
    - 1 行目: `appErrorMessage(e)` (赤系: `var(--ae-danger)` ないし screen 固有 error 色)
-   - 2 行目: `appErrorHint(e)` (灰系: `var(--ae-text-dim)`、`💡` 等の prefix で
-     アクション提示と分かるように)
+   - 2 行目: `appErrorHint(e)` を `<InlineErrorHint hint={...} />` component で表示
+     (PR #693 で共通化、`💡` prefix + `var(--ae-text-dim)` を 1 箇所に集約。
+     詳細は [ui-architecture.md §4.7](ui-architecture.md#§47-inlineerrorhint-component-693) 参照)
 3. catch ブロック以外で error を扱わない (`alert()` / `console.error` のみは禁止)
 4. globalErrorListener が拾うのは uncaught (window.error / unhandledrejection /
    panic) のみ。catch 済 Tauri command error は ErrorModal に出さない (規約)

--- a/gui/src/components/ConfirmExitModal.module.css
+++ b/gui/src/components/ConfirmExitModal.module.css
@@ -36,11 +36,13 @@
   line-height: 1.5;
 }
 
+/* #693: InlineErrorHint wrapper として block 表示 (改行 + margin) と
+   modal 内 layout 用 opacity override を担保。font-size / color は
+   InlineErrorHint 側に委譲。 */
 .errorHint {
   display: block;
-  font-size: 0.9em;
-  opacity: 0.85;
   margin-top: 0.25rem;
+  opacity: 0.85;
 }
 
 .hint {

--- a/gui/src/components/ConfirmExitModal.tsx
+++ b/gui/src/components/ConfirmExitModal.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { appErrorHint, appErrorMessage } from '../lib/appError';
+import { InlineErrorHint } from './InlineErrorHint';
 import styles from './ConfirmExitModal.module.css';
 
 /**
@@ -104,8 +105,7 @@ export function ConfirmExitModal() {
             <span>{error}</span>
             {errorHint && (
               <span className={styles.errorHint}>
-                <span aria-hidden="true">💡 </span>
-                <span>{errorHint}</span>
+                <InlineErrorHint hint={errorHint} />
               </span>
             )}
           </p>

--- a/gui/src/components/InlineErrorHint.module.css
+++ b/gui/src/components/InlineErrorHint.module.css
@@ -1,0 +1,14 @@
+/* #693: 5 site 共通の hint 2 行目 style。Phase 4 #689 で確立した規約 (`💡` prefix +
+   `var(--ae-text-dim)`) を component に集約。consumer 側 `role="alert"` wrapper の
+   内側に nest する規約 (component 自身は role を持たない、a11y violation 回避)。
+
+   サイト固有の表示制御 (PreviewScreen `display: block` / ExportScreen
+   `white-space: normal` + `max-width: 100%` + `overflow: visible` 等) は consumer
+   側 wrapper class で維持し、本 component は最小 layout のみ提供する。 */
+.hint {
+  font-family: var(--ae-font-body);
+  font-size: 11px;
+  color: var(--ae-text-dim);
+  display: block;
+  line-height: 1.5;
+}

--- a/gui/src/components/InlineErrorHint.test.tsx
+++ b/gui/src/components/InlineErrorHint.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { InlineErrorHint } from './InlineErrorHint';
+
+describe('InlineErrorHint', () => {
+  it('renders hint with 💡 prefix when hint is provided', () => {
+    render(<InlineErrorHint hint="ファイルを確認してください" />);
+    expect(screen.getByText('💡 ファイルを確認してください')).toBeInTheDocument();
+  });
+
+  it('renders nothing when hint is null', () => {
+    const { container } = render(<InlineErrorHint hint={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when hint is undefined', () => {
+    const { container } = render(<InlineErrorHint hint={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when hint is empty string', () => {
+    const { container } = render(<InlineErrorHint hint="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not carry role attribute (parent role="alert" must remain authoritative)', () => {
+    render(<InlineErrorHint hint="some hint" />);
+    const el = screen.getByText(/💡/);
+    expect(el).not.toHaveAttribute('role');
+  });
+});

--- a/gui/src/components/InlineErrorHint.tsx
+++ b/gui/src/components/InlineErrorHint.tsx
@@ -1,0 +1,25 @@
+import type { JSX } from 'react';
+
+import styles from './InlineErrorHint.module.css';
+
+export interface InlineErrorHintProps {
+  /** Hint text. When `null` / `undefined` / empty, the component renders nothing. */
+  hint: string | null | undefined;
+}
+
+/**
+ * #693: 5 既存 site (RestoreButton / DropScreen ErrorCard / DetectingScreen /
+ * PreviewScreen / ExportScreen) + 新規 3 site (#695 ConflictModal / #697
+ * DraftRestoreModal / #698 DropScreen recentNotice) で共有される、AppError
+ * の `hint` を inline error の 2 行目に表示するための小さな component。
+ *
+ * - `💡` prefix は本 component で集中管理 (i18n / theme 切替時の修正点を 1 箇所に)
+ * - a11y: 本 component 自身に `role` を付けない (consumer 側 `role="alert"` wrapper
+ *   の内側に nest する規約、Phase 4 #689 で確立)
+ * - 文字色 = `var(--ae-text-dim)`、サイズ・表示の細部は site-specific wrapper
+ *   class で override 可能 (本 component は最小 layout のみ提供)
+ */
+export function InlineErrorHint({ hint }: InlineErrorHintProps): JSX.Element | null {
+  if (!hint) return null;
+  return <span className={styles.hint}>💡 {hint}</span>;
+}

--- a/gui/src/components/RestoreButton.module.css
+++ b/gui/src/components/RestoreButton.module.css
@@ -34,14 +34,3 @@
   margin-left: 8px;
 }
 
-/* #663 — 2nd-line hint shown after `.error`. Uses the dim text token so it
-   visually de-emphasises the corrective hint below the red error message. */
-.errorHint {
-  font-family: var(--ae-font-body);
-  font-size: 10px;
-  color: var(--ae-text-dim);
-  margin-left: 8px;
-  margin-top: 2px;
-  display: block;
-  line-height: 1.5;
-}

--- a/gui/src/components/RestoreButton.tsx
+++ b/gui/src/components/RestoreButton.tsx
@@ -2,6 +2,7 @@ import { ask } from '@tauri-apps/plugin-dialog';
 
 import { useMetadataStore } from '../state/metadataStore';
 import { DisabledTooltip } from './DisabledTooltip';
+import { InlineErrorHint } from './InlineErrorHint';
 import styles from './RestoreButton.module.css';
 
 /**
@@ -97,9 +98,7 @@ export function RestoreButton({
       {restoreError && (
         <span className={styles.error} role="alert">
           {restoreError}
-          {restoreErrorHint && (
-            <span className={styles.errorHint}>💡 {restoreErrorHint}</span>
-          )}
+          <InlineErrorHint hint={restoreErrorHint} />
         </span>
       )}
     </>

--- a/gui/src/screens/DetectingScreen.module.css
+++ b/gui/src/screens/DetectingScreen.module.css
@@ -292,16 +292,6 @@
   overflow-y: auto;
 }
 
-/* #663 — 2nd-line hint rendered after `.errorMessage` in the error view.
-   Dim text token de-emphasises the corrective hint relative to the
-   primary failure message above. */
-.errorHint {
-  color: var(--ae-text-dim);
-  font-size: 12px;
-  margin-top: 8px;
-  line-height: 1.5;
-}
-
 /*
  * #646 review Round 2 課題 2 — error view の [再試行] ボタン。
  * gold tint で「次の操作を促す」プライマリ寄りに見せ、隣の

--- a/gui/src/screens/DetectingScreen.tsx
+++ b/gui/src/screens/DetectingScreen.tsx
@@ -4,6 +4,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { AllaganSigil } from '../components/AllaganSigil';
 import { DisabledTooltip } from '../components/DisabledTooltip';
+import { InlineErrorHint } from '../components/InlineErrorHint';
 import { appErrorHint, appErrorMessage } from '../lib/appError';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
@@ -762,8 +763,8 @@ function DetectingErrorView({
         {error ?? 'unknown error'}
       </pre>
       {errorHint && (
-        <div className={styles.errorHint} data-testid="detecting-error-hint">
-          💡 {errorHint}
+        <div data-testid="detecting-error-hint">
+          <InlineErrorHint hint={errorHint} />
         </div>
       )}
       <div className={styles.actions}>

--- a/gui/src/screens/DropScreen.module.css
+++ b/gui/src/screens/DropScreen.module.css
@@ -287,15 +287,6 @@
   font-size: 11px;
 }
 
-/* #663 — 2nd-line hint rendered below `.error` inside the ErrorCard.
-   Dim text token de-emphasises the corrective hint vs the red message. */
-.errorHint {
-  color: var(--ae-text-dim);
-  font-size: 12px;
-  margin-top: 6px;
-  line-height: 1.5;
-}
-
 .loading {
   font-family: var(--ae-font-mono);
   font-size: 11px;

--- a/gui/src/screens/DropScreen.tsx
+++ b/gui/src/screens/DropScreen.tsx
@@ -6,6 +6,7 @@ import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { AllaganFrame } from '../components/AllaganFrame';
 import { AllaganSigil } from '../components/AllaganSigil';
+import { InlineErrorHint } from '../components/InlineErrorHint';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -505,9 +506,7 @@ function ErrorCard({ error, errorHint, onDismiss, onRetry }: ErrorCardProps) {
     >
       <div className={styles.selectedHeading}>エラー</div>
       <div className={styles.error}>{error ?? 'probe failed'}</div>
-      {errorHint && (
-        <div className={styles.errorHint}>💡 {errorHint}</div>
-      )}
+      <InlineErrorHint hint={errorHint} />
       <div className={styles.actions}>
         <button type="button" className={styles.cancelButton} onClick={onDismiss}>
           閉じる

--- a/gui/src/screens/ExportScreen.module.css
+++ b/gui/src/screens/ExportScreen.module.css
@@ -461,10 +461,11 @@
   letter-spacing: 1px;
 }
 
+/* #693: InlineErrorHint wrapper として block 表示 (改行 + margin) と
+   parent .openFolderError の inline 配置 override を担保。font-size / color は
+   InlineErrorHint 側に委譲。 */
 .openFolderErrorHint {
   display: block;
-  font-size: 0.9em;
-  opacity: 0.85;
   margin-top: 0.25rem;
-  color: var(--ae-text-dim);
+  opacity: 0.85;
 }

--- a/gui/src/screens/ExportScreen.module.css
+++ b/gui/src/screens/ExportScreen.module.css
@@ -386,21 +386,15 @@
   white-space: nowrap;
 }
 
-/* #663 — 2nd-line hint rendered after `.listError`. Stays inside the
-   alert wrapper so screen readers read message + hint as one announcement.
-   The parent `.listError` clamps message text to a single line via
-   `max-width: 240px; overflow: hidden; text-overflow: ellipsis;
-   white-space: nowrap`. The hint must override all three so multi-line
-   Japanese hints are not truncated mid-character. */
+/* #693 — InlineErrorHint の wrapper として、parent .listError nowrap /
+   overflow:hidden を override し長い hint を折り返し可能にする。
+   font-* 系は InlineErrorHint 側に委譲。 */
 .listErrorHint {
   display: block;
-  color: var(--ae-text-dim);
-  font-size: 11px;
-  line-height: 1.5;
-  margin-top: 2px;
   white-space: normal;
   max-width: 100%;
   overflow: visible;
+  margin-top: 2px;
 }
 
 .listName {

--- a/gui/src/screens/ExportScreen.test.tsx
+++ b/gui/src/screens/ExportScreen.test.tsx
@@ -602,7 +602,8 @@ describe('ExportScreen (Phase 4 #466)', () => {
           screen.getByText('指定された出力先が見つかりません'),
         ).toBeInTheDocument();
       });
-      expect(screen.getByText('パスを確認してください')).toBeInTheDocument();
+      // #693 InlineErrorHint refactor: hint は `💡 {hint}` の形で 1 span に render される
+      expect(screen.getByText('💡 パスを確認してください')).toBeInTheDocument();
       expect(screen.getByTestId('open-folder-error-hint')).toBeInTheDocument();
     });
 

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -4,6 +4,7 @@ import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { useEffect, useReducer, useRef, useState } from 'react';
 
 import { DisabledTooltip } from '../components/DisabledTooltip';
+import { InlineErrorHint } from '../components/InlineErrorHint';
 import { appErrorHint, appErrorMessage } from '../lib/appError';
 import { useAppStateStore } from '../state/appStateStore';
 import { useMetadataStore } from '../state/metadataStore';
@@ -886,7 +887,7 @@ export function ExportScreen() {
                       {s.error.slice(0, 120)}
                       {s.errorHint && (
                         <span className={styles.listErrorHint}>
-                          💡 {s.errorHint}
+                          <InlineErrorHint hint={s.errorHint} />
                         </span>
                       )}
                     </span>

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -714,8 +714,7 @@ export function ExportScreen() {
                     className={styles.openFolderErrorHint}
                     data-testid="open-folder-error-hint"
                   >
-                    <span aria-hidden="true">💡 </span>
-                    <span>{openFolderErrorHint}</span>
+                    <InlineErrorHint hint={openFolderErrorHint} />
                   </span>
                 )}
               </div>

--- a/gui/src/screens/PreviewScreen.module.css
+++ b/gui/src/screens/PreviewScreen.module.css
@@ -326,16 +326,11 @@
   margin-left: 8px;
 }
 
-/* #663 — 2nd-line hint rendered after `.applyError`. Uses the dim text
-   token so corrective hints are visually subordinate to the red message.
-   `display: block` forces the hint onto a new line; without it the parent
-   span renders message + hint on a single line. */
+/* #693 — InlineErrorHint の wrapper として、改行を担保 (display: block)。
+   font-size / color / family は InlineErrorHint 側に委譲。 */
 .applyErrorHint {
   display: block;
-  color: var(--ae-text-dim);
-  font-size: 11px;
-  margin-left: 8px;
-  line-height: 1.5;
+  margin-top: 2px;
 }
 
 .emptyNote {

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 
 import { FrameStrip, type FrameStripThumb } from '../components/FrameStrip';
+import { InlineErrorHint } from '../components/InlineErrorHint';
 import { RestoreButton } from '../components/RestoreButton';
 import { useAppStateStore } from '../state/appStateStore';
 import {
@@ -654,7 +655,7 @@ export function PreviewScreen() {
             {applyError}
             {applyErrorHint && (
               <span className={styles.applyErrorHint}>
-                💡 {applyErrorHint}
+                <InlineErrorHint hint={applyErrorHint} />
               </span>
             )}
           </span>


### PR DESCRIPTION
## Summary

#693 (Refs #663) の対応。Phase 4 #689 で確立した hint UI 規約 (`💡` prefix + `var(--ae-text-dim)`) を `InlineErrorHint` component に集約し、既存 5 site (RestoreButton / DropScreen / DetectingScreen / PreviewScreen / ExportScreen) を component 経由に refactor。後続 PR #695 / #697 / #698 が同 component を consume する base を提供する **Wave 1.1 lead PR**。

session-id: `lane-v-pr1-693`
spec: `docs/superpowers/specs/2026-05-11-lane-v-phase-1-group-i-design.md` §5.1 (現在 #712 で docs PR 化中)

## 変更内容 (7 commits)

1. `c145237` feat(gui): add InlineErrorHint component
   - 新規 `gui/src/components/InlineErrorHint.{tsx,module.css,test.tsx}`
   - props `hint: string | null | undefined`、a11y は consumer 側 `role="alert"` 内側に nest 規約
   - 5 件の TDD test (set / null / undefined / empty / a11y) pass
2. `bb25dcd` refactor(gui): RestoreButton uses InlineErrorHint
3. `030a02a` refactor(gui): DropScreen ErrorCard uses InlineErrorHint
4. `7e6b310` refactor(gui): DetectingScreen uses InlineErrorHint (`data-testid="detecting-error-hint"` は wrapper div で維持)
5. `482c0e5` refactor(gui): PreviewScreen uses InlineErrorHint (`.applyErrorHint` wrapper は `display:block` のみ残し font-* 系を component に委譲)
6. `2aa8b5e` refactor(gui): ExportScreen uses InlineErrorHint (`.listErrorHint` wrapper は nowrap override 系を維持しつつ font-* 系を委譲)
7. `680c06e` docs(ui): InlineErrorHint 規約節を追記 (§4.7)

## 受け入れ条件 (元 issue #693 を逐条引用)

- [x] 共通 component 候補: `gui/src/components/InlineErrorHint.tsx` (props: `hint: string | null`) を新設、5 site で再利用 → `c145237`
- [x] CSS approach は採用せず component approach 一本化 (brainstorming Q2 で確定、Recommended)
- [x] 採用方針 (component / CSS / hybrid) を `docs/ui-architecture.md` §4.7 に追記 → `680c06e`
- [x] 5 site の test (RestoreButton / DropScreen / DetectingScreen / PreviewScreen / ExportScreen) を共通化に追従更新 → 616/616 全 pass
- 将来 i18n フレームワーク導入時の textcase: `🛈 hint:` 等の他言語 prefix 切替 — `InlineErrorHint` 内 1 箇所に集約しているため対応容易 (scope-out 要件、別 issue 想定)

## Self-Test Report

### Machine-verified

- [x] `git fetch origin develop-0.2.0` + 取り込み未済 commit なし
- [x] `gh pr list --search "#693"` で並行 PR 重複なし (#712 は本 lane の docs PR、sibling)
- [x] `cd gui && npm run lint` exit 0
- [x] `cd gui && npm run typecheck` exit 0
- [x] `cd gui && npm test -- --run` 616/616 pass (新規 5 件 + 既存 611 件)
- [x] `cd gui && npm run build` success (本 PR で実行確認、subagent verified)
- [x] `cd gui/src-tauri && cargo check` clean (frontend 変更のみ)
- [x] `cd gui/src-tauri && cargo test --lib` 156 件 baseline 維持
- [x] `bash scripts/check-markdownlint.sh` 0 errors
- [x] `grep -rn "💡 " gui/src/` 結果 = `InlineErrorHint.tsx` + `InlineErrorHint.test.tsx` のみ (hard-coded 残存ゼロ)

### Machine-unverifiable (Iron Law 6 実機検証 — Idios PASS 依頼)

- 既存 5 site の hint 表示が refactor 後も retained (PreviewScreen apply error / DropScreen load error / RestoreButton restore error / DetectingScreen detect error / ExportScreen export error を発火させて目視確認)

## 関連

Refs #693 #663 #689

Lane V Phase 1 lead PR。Wave 1.2 (PR #695 / #697 / #698) は本 PR merge 後に `InlineErrorHint` を consume。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
