### PR TITLE
feat(ci): error.rs hint table drift check job 追加 (Refs #692)

### DIFF
--- a/.github/scripts/check-error-hint-drift.sh
+++ b/.github/scripts/check-error-hint-drift.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Check drift between gui/src-tauri/src/error.rs::default_hint_for_code
+# and docs/tauri-commands.md §「AppError default hint mapping」 table.
+#
+# Source of truth: error.rs (docstring states "本 fn が source of truth、docs は mirror")
+# Mirror:          docs/tauri-commands.md
+# Both must agree on (code, hint) pairs after normalization.
+#
+# Exit codes:
+#   0 — no drift detected
+#   1 — drift detected (or input files missing)
+#
+# Refs: https://github.com/Idios/kobutachan-allaganeye/issues/692
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RUST_FILE="${RUST_FILE:-$REPO_ROOT/gui/src-tauri/src/error.rs}"
+DOC_FILE="${DOC_FILE:-$REPO_ROOT/docs/tauri-commands.md}"
+
+if [[ ! -f "$RUST_FILE" ]]; then
+    echo "ERROR: Rust source not found: $RUST_FILE" >&2
+    exit 1
+fi
+if [[ ! -f "$DOC_FILE" ]]; then
+    echo "ERROR: Docs file not found: $DOC_FILE" >&2
+    exit 1
+fi
+
+RUST_PAIRS=$(awk -f "$SCRIPT_DIR/extract-rust-hints.awk" "$RUST_FILE" | sort)
+DOC_PAIRS=$(awk -f "$SCRIPT_DIR/extract-doc-hints.awk" "$DOC_FILE" | sort)
+
+if diff -u <(echo "$RUST_PAIRS") <(echo "$DOC_PAIRS") > /dev/null; then
+    echo "OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync ($(echo "$RUST_PAIRS" | wc -l) entries)"
+    exit 0
+fi
+
+cat >&2 <<'EOF'
+
+ERROR: error.rs ↔ docs/tauri-commands.md hint drift detected.
+
+Source of truth: gui/src-tauri/src/error.rs::default_hint_for_code
+Mirror:          docs/tauri-commands.md §「AppError default hint mapping」 table
+
+Both must be updated in the same PR. See docs/tauri-commands.md docstring +
+gui/src-tauri/src/error.rs::default_hint_for_code docstring for the contract.
+
+Diff (- = error.rs side, + = docs side):
+EOF
+diff -u <(echo "$RUST_PAIRS") <(echo "$DOC_PAIRS") >&2 || true
+exit 1

--- a/.github/scripts/extract-doc-hints.awk
+++ b/.github/scripts/extract-doc-hints.awk
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S awk -f
+# Extract (code, hint_normalized) pairs from
+# docs/tauri-commands.md §「AppError default hint mapping」 table rows.
+#
+# Output format: <code>\t<hint_normalized>
+#   - code: from `code` (backtick-wrapped) in the first cell; cell may contain
+#     multiple codes separated by " / " (e.g. `io.would_block` / `io.timed_out`)
+#   - hint: second cell, whitespace-collapsed to single space
+#   - None entry: hint cell starts with "(hint なし:" → <<NONE>> sentinel
+#
+# Approach: state-machine on lines. Enter target section when seeing
+# "## AppError default hint mapping" header, exit on next "## " header or EOF.
+# Inside section, parse rows that start with "| `".
+
+BEGIN {
+    in_section = 0
+}
+
+# Enter target section
+/^## AppError default hint mapping/ {
+    in_section = 1
+    next
+}
+
+# Exit on next ## heading (other than entering line)
+in_section && /^## / {
+    in_section = 0
+}
+
+# Parse table row: | `code` ... | hint |
+in_section && /^\| `/ {
+    process_row($0)
+}
+
+function process_row(line,    code_cell, hint_cell, codes, code, hint, pipe_idx, second_pipe_idx, third_pipe_idx, rest, rest2) {
+    pipe_idx = index(line, "|")
+    if (pipe_idx != 1) return  # row must start with |
+    rest = substr(line, 2)
+    second_pipe_idx = index(rest, "|")
+    if (second_pipe_idx == 0) return
+    code_cell = substr(rest, 1, second_pipe_idx - 1)
+    rest2 = substr(rest, second_pipe_idx + 1)
+    third_pipe_idx = index(rest2, "|")
+    if (third_pipe_idx == 0) {
+        hint_cell = rest2
+    } else {
+        hint_cell = substr(rest2, 1, third_pipe_idx - 1)
+    }
+
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", hint_cell)
+    if (hint_cell ~ /^\(hint なし:/) {
+        hint = "<<NONE>>"
+    } else {
+        hint = hint_cell
+        gsub(/[[:space:]]+/, " ", hint)
+        sub(/^ /, "", hint)
+        sub(/ $/, "", hint)
+    }
+
+    while (match(code_cell, /`[a-zA-Z0-9_.]+`/)) {
+        code = substr(code_cell, RSTART + 1, RLENGTH - 2)
+        print code "\t" hint
+        code_cell = substr(code_cell, RSTART + RLENGTH)
+    }
+}

--- a/.github/scripts/extract-doc-hints.awk
+++ b/.github/scripts/extract-doc-hints.awk
@@ -32,7 +32,7 @@ in_section && /^\| `/ {
     process_row($0)
 }
 
-function process_row(line,    code_cell, hint_cell, codes, code, hint, pipe_idx, second_pipe_idx, third_pipe_idx, rest, rest2) {
+function process_row(line,    code_cell, hint_cell, code, hint, pipe_idx, second_pipe_idx, third_pipe_idx, rest, rest2) {
     pipe_idx = index(line, "|")
     if (pipe_idx != 1) return  # row must start with |
     rest = substr(line, 2)

--- a/.github/scripts/extract-rust-hints.awk
+++ b/.github/scripts/extract-rust-hints.awk
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S awk -f
+# Extract (code, hint_normalized) pairs from
+# gui/src-tauri/src/error.rs::default_hint_for_code match arms.
+#
+# Output format: <code>\t<hint_normalized>
+#   - code: from string literal "code" in the arm's left side
+#   - hint: from Some("...") string literal, whitespace-collapsed to single space
+#   - or-pattern ("a" | "b" => Some(...)) emits one row per code
+#   - None entries (=> None,) emit <<NONE>> as the hint
+#   - catch-all (_ => None,) is skipped (no quoted code literal)
+#
+# Approach: accumulate fn body into a single buffer (newlines -> space),
+# then scan with regex for each match arm and emit pairs.
+
+BEGIN {
+    in_fn = 0
+    buf = ""
+}
+
+/^fn default_hint_for_code/ {
+    in_fn = 1
+    next
+}
+
+in_fn && /^\}/ {
+    in_fn = 0
+}
+
+in_fn {
+    buf = buf " " $0
+}
+
+END {
+    while (match(buf, /"[a-zA-Z0-9_.]+"([[:space:]]*\|[[:space:]]*"[a-zA-Z0-9_.]+")*[[:space:]]*=>[[:space:]]*(Some\([[:space:]]*"[^"]*"[[:space:]]*\)|None)[[:space:]]*,/)) {
+        arm = substr(buf, RSTART, RLENGTH)
+        buf = substr(buf, RSTART + RLENGTH)
+        process_arm(arm)
+    }
+}
+
+function process_arm(arm,    sep_idx, left, right, hint, code, raw) {
+    sep_idx = index(arm, "=>")
+    if (sep_idx == 0) return
+    left = substr(arm, 1, sep_idx - 1)
+    right = substr(arm, sep_idx + 2)
+
+    if (right ~ /None/) {
+        hint = "<<NONE>>"
+    } else {
+        if (!match(right, /Some\([[:space:]]*"[^"]*"[[:space:]]*\)/)) return
+        raw = substr(right, RSTART, RLENGTH)
+        sub(/^Some\([[:space:]]*"/, "", raw)
+        sub(/"[[:space:]]*\)$/, "", raw)
+        hint = raw
+        gsub(/[[:space:]]+/, " ", hint)
+        sub(/^ /, "", hint)
+        sub(/ $/, "", hint)
+    }
+
+    while (match(left, /"[a-zA-Z0-9_.]+"/)) {
+        code = substr(left, RSTART + 1, RLENGTH - 2)
+        print code "\t" hint
+        left = substr(left, RSTART + RLENGTH)
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,18 @@ jobs:
         shell: bash
         run: bash .github/scripts/check-error-hint-drift.sh
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck on all .sh files
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          severity: warning
+          scandir: '.'
+          additional_files: '.github/scripts/*.sh tests/scripts/*.sh scripts/*.sh'
+
   installer-pester:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,15 @@ jobs:
           LIB_COUNT=$(wc -l < /tmp/lib_commands.txt)
           echo "OK: $LIB_COUNT tauri commands documented (name-level match)"
 
+  doc-error-hint-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check error.rs ↔ docs/tauri-commands.md hint mapping drift
+        shell: bash
+        run: bash .github/scripts/check-error-hint-drift.sh
+
   installer-pester:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,6 @@ jobs:
         with:
           severity: warning
           scandir: '.'
-          additional_files: '.github/scripts/*.sh tests/scripts/*.sh scripts/*.sh'
 
   installer-pester:
     runs-on: windows-latest

--- a/.shellcheckignore
+++ b/.shellcheckignore
@@ -1,0 +1,11 @@
+# shellcheck で scan しない path (CI .github/workflows/ci.yml shellcheck job 用)
+#
+# 本 file は `ludeeus/action-shellcheck@2.0.0` (`scandir: '.'`) が repo 全体を
+# scan する際の除外指定。Q5 (Lane IV-b' brainstorming session) で確定した
+# 「repo 全体 .sh」の意図は、本 lane で追加・既存の作業 script (.github/scripts/,
+# tests/scripts/, scripts/) を CI で守ることに限定する。
+#
+# .claude/hooks/*.sh は Claude Code agent infrastructure で本 PR の scope 外。
+# 個別に shellcheck warning level に揃える作業は別 lane で扱う。
+
+.claude/hooks/

--- a/docs/superpowers/plans/2026-05-08-l2-appError-migration-completion.md
+++ b/docs/superpowers/plans/2026-05-08-l2-appError-migration-completion.md
@@ -89,7 +89,7 @@ git status
 
 - [ ] **Step 2: Read the spec for full context**
 
-Read `docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md` end-to-end. The spec is the source of truth for all design decisions (22 hint codes, 4-layer architecture, scope boundaries).
+Read `docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md` end-to-end. The spec is the source of truth for all design decisions (24 codes (or-pattern 展開後 #692) を hint mapping に集約, 4-layer architecture, scope boundaries).
 
 - [ ] **Step 3: Verify Iron Law base sync**
 
@@ -421,7 +421,7 @@ git add gui/src-tauri/src/error.rs
 git commit -m "$(cat <<'EOF'
 feat(gui): AppError::default_hint_for_code helper を追加 (Refs #663)
 
-PR #665 で Result<T, AppError> migration が完了済の状態を踏まえ、22 codes
+PR #665 で Result<T, AppError> migration が完了済の状態を踏まえ、24 codes (or-pattern 展開後 #692)
 (state / io.manual / io.auto / parse / subprocess / validation / path /
 platform / internal) に対する日本語 default hint を error.rs の 1 mapping
 table に集約。
@@ -2022,7 +2022,7 @@ PR #665 (`ea9bca9`) で `gui/src-tauri/src/lib.rs` の全 23 Tauri commands が
 - [ ] (A) `metadataStore.ts:209` の `|| msg.startsWith('"'"'conflict:'"'"')` が削除されている
 - [ ] (A) `metadataStore.test.ts` の `'"'"'conflict: ...'"'"'` raw String テストが AppError object 形式に書き換わっている
 - [ ] (A) `ConflictModal.test.tsx` の test data から `'"'"'conflict:'"'"'` prefix が消えている
-- [ ] (B) `error.rs` に `default_hint_for_code()` + `with_default_hint()` が追加され、22 codes 分の日本語 hint が table に存在する
+- [ ] (B) `error.rs` に `default_hint_for_code()` + `with_default_hint()` が追加され、24 codes (or-pattern 展開後 #692) 分の日本語 hint が table に存在する
 - [ ] (B) `From<std::io::Error>` / `From<serde_json::Error>` の impl 内で `.with_default_hint()` が呼ばれている
 - [ ] (B) `lib.rs` の全 80 site の `AppError::new(code, msg)` に `.with_default_hint()` が chain されている
 - [ ] (C) `metadataStore` に `loadErrorHint` / `applyErrorHint` / `restoreErrorHint` / `draftSaveErrorHint` / `draftLoadErrorHint` の 5 state が追加されている
@@ -2070,7 +2070,7 @@ git add docs/tauri-commands.md docs/ui-architecture.md docs/ui-interaction-spec.
 git commit -m "$(cat <<'EOF'
 docs: AppError default hint mapping を docs に整合させる (Refs #663)
 
-Phase 1-4 で追加した default_hint_for_code mapping (22 codes) と frontend
+Phase 1-4 で追加した default_hint_for_code mapping (24 codes (or-pattern 展開後 #692)) と frontend
 hint 表示規約を docs に明文化。docs/tauri-commands.md は error.rs の
 mapping を mirror、ui-architecture.md / ui-interaction-spec.md は
 inline error の 2 行構成と code-based 分岐ルールを規定。
@@ -2249,7 +2249,7 @@ Lane I-A (wave 0 起点)。spec [docs/superpowers/specs/2026-05-08-l2-appError-m
 - [x] (A) `metadataStore.ts:209` の `|| msg.startsWith('"'"'conflict:'"'"')` が削除されている
 - [x] (A) `metadataStore.test.ts` の `'"'"'conflict: ...'"'"'` raw String テストが AppError object 形式に書き換え
 - [x] (A) `ConflictModal.test.tsx` の test data から `'"'"'conflict:'"'"'` prefix が消えている
-- [x] (B) `error.rs` に `default_hint_for_code()` + `with_default_hint()` 追加、22 codes 日本語 hint
+- [x] (B) `error.rs` に `default_hint_for_code()` + `with_default_hint()` 追加、24 codes (or-pattern 展開後 #692) 日本語 hint
 - [x] (B) `From<std::io::Error>` / `From<serde_json::Error>` で `.with_default_hint()`
 - [x] (B) `lib.rs` 全 80 site の `AppError::new(...)` に `.with_default_hint()`
 - [x] (C) `metadataStore` に 5 `*ErrorHint` state、`recentStore` に 2 hint pair 追加

--- a/docs/superpowers/plans/2026-05-08-l2-appError-migration-completion.md
+++ b/docs/superpowers/plans/2026-05-08-l2-appError-migration-completion.md
@@ -161,10 +161,11 @@ Add the following just before the existing `#[derive(Debug, Clone, Serialize)] p
 
 ```rust
 /// AppError code に対する日本語 default hint を返す。未登録 code は None。
-/// 22 entries (現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
-/// validation.* / path.* / platform.* / internal.*)。
+/// 24 codes (or-pattern `io.would_block | io.timed_out` を 2 codes に展開後、22 hint
+/// + 2 None = 24)。現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
+/// validation.* / path.* / platform.* / internal.*。
 /// 文言は `docs/tauri-commands.md` の AppError default hint mapping table と一致させる
-/// (本 fn が source of truth、docs は mirror)。
+/// (本 fn が source of truth、docs は mirror、#692 で CI integrity check 化済)。
 fn default_hint_for_code(code: &str) -> Option<&'static str> {
     match code {
         // state
@@ -427,7 +428,7 @@ table に集約。
 
 主な追加:
 
-- default_hint_for_code(code: &str) -> Option<&'static str> (22 entries)
+- default_hint_for_code(code: &str) -> Option<&'static str> (24 codes、or-pattern 展開後 #692)
 - AppError::with_default_hint(self) -> Self (既存 hint があれば上書きしない)
 - From<std::io::Error> / From<serde_json::Error> impl 内で
   .with_default_hint() を chain (?演算子で自動 hint 付与)
@@ -1885,8 +1886,8 @@ Append the following section after the existing master command table (verify exa
 ## AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)
 
 > 本 table の文言は `gui/src-tauri/src/error.rs` の `default_hint_for_code()` と
-> 完全一致させる (CI integrity check は今回入れないが、文言変更時は両方を
-> 同 PR で更新する規約)。
+> 完全一致させる (#692 で CI integrity check 化済 = `.github/scripts/check-error-hint-drift.sh`
+> + `doc-error-hint-drift` job、文言変更時は両方を同 PR で更新する規約)。
 
 | code | hint |
 | --- | --- |
@@ -2077,7 +2078,7 @@ inline error の 2 行構成と code-based 分岐ルールを規定。
 主な追加:
 
 - docs/tauri-commands.md: 末尾に AppError default hint mapping table
-  (22 entries、`error.rs::default_hint_for_code` と完全一致)
+  (24 codes、or-pattern 展開後 #692、`error.rs::default_hint_for_code` と完全一致)
 - docs/ui-architecture.md §4.x: AppError code 体系と inline error の
   使い分け、ConflictModal 経路と inline 経路の分岐ルール
 - docs/ui-interaction-spec.md §1.5.x: appErrorCodeIs / appErrorMessage /
@@ -2214,7 +2215,7 @@ Lane I-A (wave 0 起点)。spec [docs/superpowers/specs/2026-05-08-l2-appError-m
 
 ### Phase 1: Rust `error.rs` (default hint helper)
 
-- `default_hint_for_code(code)` (22 entries) + `with_default_hint()` 追加
+- `default_hint_for_code(code)` (24 codes、or-pattern 展開後 #692) + `with_default_hint()` 追加
 - `From<io::Error>` / `From<serde_json::Error>` impl で hint chain
 - 6 件の TDD 新 test (155 件 pass)
 
@@ -2238,7 +2239,7 @@ Lane I-A (wave 0 起点)。spec [docs/superpowers/specs/2026-05-08-l2-appError-m
 
 ### Phase 5: Docs + issue body
 
-- `docs/tauri-commands.md`: AppError default hint mapping table (22 entries)
+- `docs/tauri-commands.md`: AppError default hint mapping table (24 codes、or-pattern 展開後 #692)
 - `docs/ui-architecture.md` §4.x: AppError code 体系と inline 使い分け
 - `docs/ui-interaction-spec.md` §1.5.x: error.code ベース分岐ルール
 - Issue #663 body を実態に合わせて update (gh issue edit)

--- a/docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update-implementation-plan.md
+++ b/docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update-implementation-plan.md
@@ -216,7 +216,7 @@ Use Write tool:
 
 | # | priority | 概要 |
 | --- | --- | --- |
-| #692 | P3 | error.rs hint table drift check job 追加 (CI で `error.rs::default_hint_for_code` 22 entries と `docs/tauri-commands.md` の文言一致を保証) |
+| #692 | P3 | error.rs hint table drift check job 追加 (CI で `error.rs::default_hint_for_code` 24 codes (or-pattern 展開後) と `docs/tauri-commands.md` の文言一致を保証) |
 | #700 | P3 (bug) | markdownlint ignore で nested `gui/node_modules` を除外 (`.markdownlint-cli2.yaml`) |
 
 **並行安全度**: high (CI yml + markdownlint config 独立) / **brainstorming 単位**: Lane IV-b' で Group G #458 と統合 (1 spec / 3 章)

--- a/docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
+++ b/docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
@@ -78,7 +78,9 @@
 | --- | --- | --- |
 | #458 | P2 | bug_report.yml (同意チェック付き) 新設 — 外部ユーザー受け入れ準備 |
 
-**並行安全度**: high (`.github/ISSUE_TEMPLATE/bug_report.yml` 独立) / **brainstorming 単位**: 本 issue は Lane IV-b' から scope-out (PR #497 + PR #688 で実装完了済、残るは L2 release 後の UI 実測のみ、release gate 後に `/close-issue` で handoff)。Lane IV-b' は Group J 単独 (1 spec / 2 章)
+**本 release (v0.2.0) Wave 1 での実装作業なし** — §4 参照 (実装完了済 PR #497 + PR #688、残作業は release gate 後の `/close-issue` handoff のみ)。
+
+**並行安全度**: high (`.github/ISSUE_TEMPLATE/bug_report.yml` 独立) / **brainstorming 単位**: Lane IV-b' から scope-out。Lane IV-b' は Group J 単独 (1 spec / 2 章)
 
 ### Group I: post-#663 GUI cleanup (7 件、新規、Lane V 3 phase)
 

--- a/docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
+++ b/docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
@@ -21,7 +21,7 @@
 
 - 旧 plan 「Group A AppError 起点」(Lane I-A) が DONE。Group B (Lane I-B) は `with_default_hint()` chain 経由で AppError 経路に乗る前提が成立
 - 旧 plan 「Group F l2b 配布 4 件」全件 DONE。`allaganeye.bat` GUI 起動 / portable ZIP versioned 名 / 同梱物 integrity check / `get-pip.py` SHA pin が production
-- 旧 plan 「Group G workflow 3 件」のうち 2 件 DONE。残 #458 (bug_report.yml) は本 plan で Lane IV-b' に統合
+- 旧 plan 「Group G workflow 3 件」のうち 2 件 DONE。残 #458 (bug_report.yml) は当初 Lane IV-b' に統合予定だったが本 plan 確定時に scope-out (実装完了済、release gate 後 handoff)
 - 旧 plan 「Group H lint/CLI 2 件」DONE。ESLint window.confirm/alert/prompt block + CLI 進捗バー ETA 表示改善が production
 - 旧 plan 注釈「[#365](https://github.com/Idios/kobutachan-allaganeye/issues/365) は v0.2.0 内取り込み disposition」消化済 (#365 closed via PR #687)
 
@@ -72,13 +72,13 @@
 **並行安全度**: low (全画面 path レイアウト) / **brainstorming 単位**: 1 spec / 1 章
 **注**: #680 は Group D に fold 済 (旧 plan 「Group E #680」)
 
-### Group G: l2-workflow 残 (1 件、Lane IV-b' で Group J と統合)
+### Group G: l2-workflow 残 (1 件、Lane IV-b' から scope-out)
 
 | # | priority | 概要 |
 | --- | --- | --- |
 | #458 | P2 | bug_report.yml (同意チェック付き) 新設 — 外部ユーザー受け入れ準備 |
 
-**並行安全度**: high (`.github/ISSUE_TEMPLATE/bug_report.yml` 独立) / **brainstorming 単位**: Lane IV-b' で Group J と統合 (1 spec / 3 章)
+**並行安全度**: high (`.github/ISSUE_TEMPLATE/bug_report.yml` 独立) / **brainstorming 単位**: 本 issue は Lane IV-b' から scope-out (PR #497 + PR #688 で実装完了済、残るは L2 release 後の UI 実測のみ、release gate 後に `/close-issue` で handoff)。Lane IV-b' は Group J 単独 (1 spec / 2 章)
 
 ### Group I: post-#663 GUI cleanup (7 件、新規、Lane V 3 phase)
 
@@ -100,14 +100,14 @@
 - Phase 2 (Wave 1 main 3 lanes merge 後): #694 unified ErrorState refactor (5 screen + 3 modal consumer 一括 refactor)
 - Phase 3 (#694 merge 後): #699 docstring (refactor 結果反映)
 
-### Group J: post-#663 workflow polish (2 件、新規、Lane IV-b' 統合)
+### Group J: post-#663 workflow polish (2 件、新規、Lane IV-b' 単独)
 
 | # | priority | 概要 |
 | --- | --- | --- |
 | #692 | P3 | error.rs hint table drift check job 追加 (CI で `error.rs::default_hint_for_code` 22 entries と `docs/tauri-commands.md` の文言一致を保証) |
 | #700 | P3 (bug) | markdownlint ignore で nested `gui/node_modules` を除外 (`.markdownlint-cli2.yaml`) |
 
-**並行安全度**: high (CI yml + markdownlint config 独立) / **brainstorming 単位**: Lane IV-b' で Group G #458 と統合 (1 spec / 3 章)
+**並行安全度**: high (CI yml + markdownlint config 独立) / **brainstorming 単位**: Lane IV-b' 単独 (1 spec / 2 章、#458 は scope-out)
 
 ### Group K: l2b cleanup (2 件、新規、Lane IV-e)
 
@@ -157,10 +157,12 @@ WAVE 1  (CURRENT — 最大 6 lane 並行可、bandwidth に応じて選択)
                 #699 docstring 更新 (refactor 結果反映)
               1 spec / 7 章 (3 phase 構成)
 
-  Lane IV-b'  Group G remainder + Group J 統合 (workflow / CI / docs polish)
-              #458 (P2、bug_report.yml) // #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
+  Lane IV-b'  Group J 単独 (workflow / CI / docs polish)
+              #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
               file 完全独立、PR 並行可
-              1 spec / 3 章
+              1 spec / 2 章
+
+              ※ Group G #458 は本 lane から scope-out (実装完了済、release gate 後 /close-issue handoff)
 
   Lane IV-e   Group K (l2b cleanup)
               #704 (Pester PS5.1 BOM) // #705 (BtbN URL 陳腐化対策、旧 plan 「5 章目」消化)
@@ -197,7 +199,7 @@ WAVE 3  (release gate)
 /superpowers:brainstorming Lane V Phase 3: Group I #699 docstring 更新 (#694 merge 後)
 
 # Wave 1 polish - Lane IV (workflow / CI / installer)
-/superpowers:brainstorming Lane IV-b': Group G #458 + Group J #692 #700 (workflow / CI / docs polish)
+/superpowers:brainstorming Lane IV-b': Group J #692 #700 (workflow / CI / docs polish、#458 は scope-out)
 /superpowers:brainstorming Lane IV-e: Group K の問題を解決したい (#704 #705 l2b cleanup)
 
 # Wave 2 (Wave 1 完走後)
@@ -218,7 +220,7 @@ WAVE 3  (release gate)
 | V Phase 1 (5 件) | | ✓ #691 | | | | | ✓ #695 | ✓ #697 | ✓ #698 | | | | | | | |
 | V Phase 2 (#694) | | ✓ refactor | (consumer) | (consumer) | | (consumer) | (consumer) | (consumer) | (consumer) | ✓ refactor | | | | | | |
 | V Phase 3 (#699) | | | | | | | | | | | | | | | | (docstring) |
-| IV-b' (#458 #692 #700) | | | | | | | | | | | ✓ #692 | ✓ #692 | ✓ #458 | ✓ #700 | | |
+| IV-b' (#692 #700) | | | | | | | | | | | ✓ #692 | ✓ #692 | | ✓ #700 | | |
 | IV-e (#704 #705) | | | | | | | | | | | | | | | ✓ #704 | ✓ #705 |
 | III (#676) | | | (path) | (path) | | 全画面 path | | | (path) | | | | | | | |
 
@@ -253,6 +255,12 @@ WAVE 3  (release gate)
 6. **Lane V Phase 1 #698 / Lane II-a #633 の DropScreen 衝突**: 先着優先 + rebase で吸収
 
 ## 4. deferred / v0.2.0 対象外
+
+### Group G #458 — Lane IV-b' から scope-out (handoff)
+
+[#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) (P2、bug_report.yml) は本 plan 公開時点で実装作業完了済 (PR #497 + PR #688)、残る受け入れ条件 1 件「New issue UI からテンプレ選択可能」は L2 release (`develop-0.2.0 → main` マージ) 後に main 反映済みの環境で実測する必要があるため、Lane IV-b' (Wave 1) から scope-out した。
+
+release gate (Wave 3) 後、L3 初期に `/close-issue` skill で実測 → close する handoff path で運用する。
 
 ### v0.2.0 外確定 (deferred ラベル維持、6 件)
 

--- a/docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
+++ b/docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
@@ -106,7 +106,7 @@
 
 | # | priority | 概要 |
 | --- | --- | --- |
-| #692 | P3 | error.rs hint table drift check job 追加 (CI で `error.rs::default_hint_for_code` 22 entries と `docs/tauri-commands.md` の文言一致を保証) |
+| #692 | P3 | error.rs hint table drift check job 追加 (CI で `error.rs::default_hint_for_code` 24 codes (or-pattern 展開後) と `docs/tauri-commands.md` の文言一致を保証) |
 | #700 | P3 (bug) | markdownlint ignore で nested `gui/node_modules` を除外 (`.markdownlint-cli2.yaml`) |
 
 **並行安全度**: high (CI yml + markdownlint config 独立) / **brainstorming 単位**: Lane IV-b' 単独 (1 spec / 2 章、#458 は scope-out)

--- a/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
+++ b/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
@@ -1472,12 +1472,19 @@ Expected: 全 CI job pass。
 
 実装フェーズで追記する記録。各 task 完了時に状況を memo。
 
-### Task 0 結果
+### Task 0 結果 (2026-05-11 session `tender-moore-2a5d2f`)
 
-- 取り込み未済 commit: [TBD - 実装時記入]
-- 並行 worktree PR: [TBD]
-- shellcheck pass 状況: [TBD - pass / 軽微 N 件 / 多数 N 件、各 file 別の件数]
-- 多数の場合の AskUserQuestion 結果: [該当時のみ TBD]
+- 取り込み未済 commit: **なし** (worktree は `origin/develop-0.2.0` と同期)
+- 並行 worktree PR: **なし** (`gh pr list --state open --search "#692 OR #700 OR Lane IV-b"` 出力 `[]`)
+- shellcheck install: **NOT_INSTALLED** (Windows local + sandbox 制限で winget / WSL apt の install attempt 不可)
+- shellcheck local 実行: **skip** (未 install のため、subagent 環境では install できず)
+- Manual static analysis (代替):
+  - `scripts/check-markdownlint.sh` (27 lines): 0 issues estimated (set -euo pipefail / BASH_SOURCE / quote 全て clean)
+  - `scripts/cleanup-worktrees.sh` (108 lines): 1 warning estimated (line 94 `[[ -z "$(ls -A "$d" 2>/dev/null)" ]]` で SC2012 `Use find instead of ls`)
+  - 合計 estimated: 1 warning (軽微 1-3 範囲)
+- **判定: 軽微 1-3 件 branch を採用** — Task 7 で shellcheck job 追加 + 既存 script に必要最小限の修正 (SC2012 pragma or `find` 置換、本 PR 内で透明化)
+- shellcheck CI 上動作: `ludeeus/action-shellcheck@master` (または pinned version) が `ubuntu-latest` で shellcheck を auto-install して実行するため、local 未 install は CI 動作に影響なし。Task 7 「local shellcheck で repo 全体 .sh が pass」step は CI 実証 (PR-1 push 時) で代替する
+- 多数 (4+) でなかったため AskUserQuestion 発動なし
 
 ### Task 4 結果 (実機 drift run)
 

--- a/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
+++ b/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
@@ -1,0 +1,1516 @@
+# L2 Lane IV-b' (Group J + Group G remainder 調整) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lane IV-b' polish lane の実装 — (1) error.rs ↔ docs/tauri-commands.md の AppError hint mapping drift を CI で防ぐ (#692) / (2) `.markdownlint-cli2.yaml` で nested `gui/node_modules/` を ignore する (#700) / (3) roadmap doc を 2 件 / 2 章構造に縮小 (#458 scope-out 反映)。2 並行 PR (PR-1 = #692 + adjacency / PR-2 = #700)。
+
+**Architecture:** PR-1 は `.github/scripts/` に bash + awk 3 file (main script + 2 awk parser) を新規追加し、ci.yml に `doc-error-hint-drift` + `shellcheck` の 2 job を追加。並行で本 spec doc 同梱 + roadmap doc/design doc を §5.1 表通り 4 ヶ所修正。PR-2 は `.markdownlint-cli2.yaml` の `ignores` に `**/node_modules/**` を 1 行追加。
+
+**Tech Stack:** bash + GNU awk / GitHub Actions / shellcheck / markdownlint-cli2 / gh CLI
+
+**Spec:** [docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md](../specs/2026-05-11-lane-iv-b-prime-design.md)
+
+---
+
+## File Structure
+
+| Path | 種類 | 責務 | 担当 task |
+| --- | --- | --- | --- |
+| `.github/scripts/extract-rust-hints.awk` | 新規 | error.rs の `default_hint_for_code` match arm から (code, hint) pair を抽出。or-pattern → 各 code に展開、None entry → `<<NONE>>` sentinel | Task 1 |
+| `.github/scripts/extract-doc-hints.awk` | 新規 | tauri-commands.md の §「AppError default hint mapping」 table から (code, hint) pair を抽出。code cell の or-pattern (`/` 区切り) → 各 code に展開、`(hint なし: ...)` → `<<NONE>>` sentinel | Task 2 |
+| `.github/scripts/check-error-hint-drift.sh` | 新規 | 上 2 parser を呼び sort + diff -u で照合、drift → exit 1 | Task 3 |
+| `tests/fixtures/error-hints/sample-error.rs` | 新規 | Task 1-3 用 fixture (or-pattern + None + 通常 hint 計 6 arm) | Task 1 |
+| `tests/fixtures/error-hints/sample-tauri-commands.md` | 新規 | Task 2-3 用 fixture (or-pattern / 区切り + None + 通常 hint) | Task 2 |
+| `tests/fixtures/error-hints/expected.tsv` | 新規 | 期待出力 (code\thint normalized、sort 済) | Task 1 |
+| `tests/scripts/test_error_hint_drift.sh` | 新規 | bash test harness (fixture vs expected) | Task 1-3 |
+| `.github/workflows/ci.yml` | 修正 | `doc-error-hint-drift` job + `shellcheck` job 追加 | Task 6, 7 |
+| `docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md` | 修正 | Lane IV-b' 4 ヶ所 + deferred 表追記 (§5.1) | Task 8 |
+| `docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md` | 修正 | Lane IV-b' 4 ヶ所 (§5.1 相当) | Task 9 |
+| `.markdownlint-cli2.yaml` | 修正 | `ignores` に `**/node_modules/**` 1 行追加 | Task 11 |
+
+---
+
+## Task 0: Pre-flight & shellcheck pass 状況確認
+
+**Goal:** 着手前の状態確認。shellcheck pass 状況を §7.4.2 (spec) の 3 分岐 (pass / 軽微 1-3 件 / 多数) で確定する。
+
+**Files:**
+
+- Check: `scripts/check-markdownlint.sh`, `scripts/cleanup-worktrees.sh`
+
+- [ ] **Step 1: 着手 worktree の git fetch + 取り込み未済 commit 確認 (Iron Law 6)**
+
+```bash
+git fetch origin develop-0.2.0
+git log HEAD..origin/develop-0.2.0 --oneline | head -20
+```
+
+Expected: 出力なし (= 取り込み未済 commit なし) or 数件 (取り込み未済あれば次 step で merge)。
+
+- [ ] **Step 2: 取り込み未済 commit ある場合 → merge**
+
+```bash
+# Step 1 で commit が出ていた場合のみ
+git merge origin/develop-0.2.0
+# conflict なければそのまま進む。conflict あれば手動解決。
+```
+
+Expected: clean merge or no-op。
+
+- [ ] **Step 3: 並行 worktree PR 重複確認 (Iron Law 6)**
+
+```bash
+gh pr list --state open --search "#692 OR #700 OR Lane IV-b" --json number,title,headRefName 2>&1
+```
+
+Expected: 該当なし (本 lane で初の PR、Wave 0 で merge 済の #688 など close 状態の PR は --state open フィルタで除外される)。万一 open で既存 PR あれば user に判断仰ぐ。
+
+- [ ] **Step 4: shellcheck がローカルで利用可能か確認**
+
+```bash
+which shellcheck 2>&1 || echo "NOT_INSTALLED"
+```
+
+Expected: `/usr/bin/shellcheck` 等の path、または `NOT_INSTALLED`。
+
+- [ ] **Step 5: 未インストールなら install 案内**
+
+```bash
+# Windows local の場合
+# winget install --id koalaman.shellcheck
+# または scoop install shellcheck
+# または GitHub Releases から static binary を取得
+# Linux/macOS: apt install shellcheck / brew install shellcheck
+```
+
+Expected: shellcheck v0.9+ が which で見えるようになる。
+
+- [ ] **Step 6: 既存 .sh script の shellcheck 実行**
+
+```bash
+shellcheck -S warning scripts/check-markdownlint.sh scripts/cleanup-worktrees.sh 2>&1 | tee /tmp/shellcheck-baseline.log
+```
+
+Expected: 出力を `/tmp/shellcheck-baseline.log` に記録。issue 件数を確認 (0 / 1-3 / 多数 で次の分岐判定)。
+
+- [ ] **Step 7: 分岐判定**
+
+| 件数 | 対応 |
+| --- | --- |
+| 0 (pass) | Task 7 で shellcheck job を素直に追加。既存 script 修正不要 |
+| 1-3 (軽微) | Task 7 で shellcheck job 追加 + 既存 script を最小修正 (pragma 追加 or quote 修正)。修正点を PR-1 本文 §「scope creep 透明化」節に記述 |
+| 4+ (多数 / structural) | **AskUserQuestion を発動** — 「(a) 本 PR で全件修正、(b) shellcheck job 追加を保留して別 issue 起票、(c) shellcheck warning level → error level を `\|\|true` で許容に変更」の 3 択を user に問う |
+
+判定結果を memo (本 plan 末尾の「Pre-flight log」節に追記)、Task 7 の動作分岐で参照。
+
+---
+
+## Task 1: extract-rust-hints.awk TDD
+
+**Goal:** error.rs の `default_hint_for_code` match arm から `(code, hint_normalized)` pair を抽出する awk script を TDD で作成。or-pattern (`"a" | "b" =>`) を 2 code に展開、None entry を `<<NONE>>` sentinel に変換。
+
+**Files:**
+
+- Create: `.github/scripts/extract-rust-hints.awk`
+- Create: `tests/fixtures/error-hints/sample-error.rs`
+- Create: `tests/fixtures/error-hints/expected-rust.tsv`
+- Create: `tests/scripts/test_extract_rust_hints.sh`
+
+- [ ] **Step 1: fixture sample-error.rs を作成**
+
+`tests/fixtures/error-hints/sample-error.rs`:
+
+```rust
+// Minimal fixture for extract-rust-hints.awk TDD.
+// Includes: single-line hint, multi-line hint, or-pattern, None entry, catch-all.
+
+fn default_hint_for_code(code: &str) -> Option<&'static str> {
+    match code {
+        "state.mtime_conflict" => Some(
+            "metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください"
+        ),
+        "io.file_not_found" => Some(
+            "ファイルが見つかりません。パスを確認してください"
+        ),
+        "io.would_block" | "io.timed_out" => Some(
+            "I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください"
+        ),
+        "subprocess.cancelled" => None,
+        "internal.error" => None,
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 2: 期待出力 expected-rust.tsv を作成 (sort 済)**
+
+`tests/fixtures/error-hints/expected-rust.tsv` (各行は `<code>\t<hint>` 形式で間の `\t` は TAB 文字 1 個。下記 code block は MD010 を一時的に許容):
+
+<!-- markdownlint-disable MD010 -->
+```text
+internal.error	<<NONE>>
+io.file_not_found	ファイルが見つかりません。パスを確認してください
+io.timed_out	I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください
+io.would_block	I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください
+state.mtime_conflict	metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください
+subprocess.cancelled	<<NONE>>
+```
+<!-- markdownlint-enable MD010 -->
+
+Note: catch-all `_` arm は emit しない (codes に `_` literal 含まれないため、後述 awk 実装で除外)。
+
+- [ ] **Step 3: test harness test_extract_rust_hints.sh を作成**
+
+`tests/scripts/test_extract_rust_hints.sh`:
+
+```bash
+#!/usr/bin/env bash
+# TDD harness for .github/scripts/extract-rust-hints.awk
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AWK_FILE="$SCRIPT_DIR/.github/scripts/extract-rust-hints.awk"
+FIXTURE="$SCRIPT_DIR/tests/fixtures/error-hints/sample-error.rs"
+EXPECTED="$SCRIPT_DIR/tests/fixtures/error-hints/expected-rust.tsv"
+
+if [[ ! -f "$AWK_FILE" ]]; then
+  echo "FAIL: awk script not found: $AWK_FILE" >&2
+  exit 1
+fi
+
+actual=$(awk -f "$AWK_FILE" "$FIXTURE" | sort)
+expected=$(sort "$EXPECTED")
+
+if [[ "$actual" == "$expected" ]]; then
+  echo "PASS: extract-rust-hints.awk matches expected"
+  exit 0
+else
+  echo "FAIL: drift detected"
+  diff -u <(echo "$expected") <(echo "$actual")
+  exit 1
+fi
+```
+
+```bash
+chmod +x tests/scripts/test_extract_rust_hints.sh
+```
+
+- [ ] **Step 4: red 確認 (awk script なし)**
+
+```bash
+bash tests/scripts/test_extract_rust_hints.sh
+```
+
+Expected: `FAIL: awk script not found: .../.github/scripts/extract-rust-hints.awk` で exit 1。
+
+- [ ] **Step 5: extract-rust-hints.awk を実装**
+
+`.github/scripts/extract-rust-hints.awk`:
+
+```awk
+#!/usr/bin/env -S awk -f
+# Extract (code, hint_normalized) pairs from
+# gui/src-tauri/src/error.rs::default_hint_for_code match arms.
+#
+# Output format: <code>\t<hint_normalized>
+#   - code: from string literal "code" in the arm's left side
+#   - hint: from Some("...") string literal, whitespace-collapsed to single space
+#   - or-pattern ("a" | "b" => Some(...)) emits one row per code
+#   - None entries (=> None,) emit <<NONE>> as the hint
+#   - catch-all (_ => None,) is skipped (no quoted code literal)
+#
+# Approach: accumulate fn body into a single buffer (newlines → space),
+# then scan with regex for each match arm and emit pairs.
+
+BEGIN {
+    in_fn = 0
+    buf = ""
+}
+
+/^fn default_hint_for_code/ {
+    in_fn = 1
+    next
+}
+
+in_fn && /^\}/ {
+    in_fn = 0
+}
+
+in_fn {
+    buf = buf " " $0
+}
+
+END {
+    # Scan buf for match arms. Each arm matches:
+    #   "code1" ( | "code2" )* => ( Some( "hint" ) | None ) ,
+    # We extract them one at a time, shrinking buf as we go.
+    while (match(buf, /"[a-zA-Z0-9_.]+"([[:space:]]*\|[[:space:]]*"[a-zA-Z0-9_.]+")*[[:space:]]*=>[[:space:]]*(Some\([[:space:]]*"[^"]*"[[:space:]]*\)|None)[[:space:]]*,/)) {
+        arm = substr(buf, RSTART, RLENGTH)
+        buf = substr(buf, RSTART + RLENGTH)
+        process_arm(arm)
+    }
+}
+
+function process_arm(arm,    sep_idx, left, right, hint, n, i, code, raw) {
+    sep_idx = index(arm, "=>")
+    if (sep_idx == 0) return
+    left = substr(arm, 1, sep_idx - 1)
+    right = substr(arm, sep_idx + 2)
+
+    if (right ~ /None/) {
+        hint = "<<NONE>>"
+    } else {
+        # Extract Some("...") arg between first " and last " inside Some(...)
+        if (!match(right, /Some\([[:space:]]*"[^"]*"[[:space:]]*\)/)) return
+        raw = substr(right, RSTART, RLENGTH)
+        # strip Some(   "...")
+        sub(/^Some\([[:space:]]*"/, "", raw)
+        sub(/"[[:space:]]*\)$/, "", raw)
+        hint = raw
+        gsub(/[[:space:]]+/, " ", hint)
+        sub(/^ /, "", hint)
+        sub(/ $/, "", hint)
+    }
+
+    # Extract codes from left side ("a" | "b" | ...)
+    while (match(left, /"[a-zA-Z0-9_.]+"/)) {
+        code = substr(left, RSTART + 1, RLENGTH - 2)
+        print code "\t" hint
+        left = substr(left, RSTART + RLENGTH)
+    }
+}
+```
+
+- [ ] **Step 6: green 確認**
+
+```bash
+bash tests/scripts/test_extract_rust_hints.sh
+```
+
+Expected: `PASS: extract-rust-hints.awk matches expected`、exit 0。
+
+もし FAIL の場合: diff 出力を確認し、awk 実装を修正。よくある修正点:
+
+- regex の POSIX vs gawk 差異: `[[:space:]]` は POSIX 互換、`[a-zA-Z0-9_.]+` も互換
+- `match()` 関数の戻り値: 0 = no match、>0 = byte position
+- `RSTART` / `RLENGTH` のリセット: 別 `match()` 後に更新される
+- 改行を含む `Some("...")` の hint normalize で改行→space 変換が効いているか
+
+- [ ] **Step 7: commit**
+
+```bash
+git add .github/scripts/extract-rust-hints.awk \
+        tests/fixtures/error-hints/sample-error.rs \
+        tests/fixtures/error-hints/expected-rust.tsv \
+        tests/scripts/test_extract_rust_hints.sh
+git -c commit.gpgsign=false commit -m "feat(ci): extract-rust-hints.awk TDD (or-pattern + None entry handling) (Refs #692)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: extract-doc-hints.awk TDD
+
+**Goal:** `docs/tauri-commands.md` の §「AppError default hint mapping」 table 行から `(code, hint_normalized)` pair を抽出する awk script を TDD で作成。code cell 内の or-pattern (例: `` `io.would_block` / `io.timed_out` ``) を 2 code に展開、`(hint なし: ...)` を `<<NONE>>` sentinel に変換。
+
+**Files:**
+
+- Create: `.github/scripts/extract-doc-hints.awk`
+- Create: `tests/fixtures/error-hints/sample-tauri-commands.md`
+- Create: `tests/fixtures/error-hints/expected-doc.tsv`
+- Create: `tests/scripts/test_extract_doc_hints.sh`
+
+- [ ] **Step 1: fixture sample-tauri-commands.md を作成**
+
+`tests/fixtures/error-hints/sample-tauri-commands.md`:
+
+```markdown
+# Sample tauri-commands.md (fixture for extract-doc-hints.awk TDD)
+
+## 他の section (本 awk は処理しない)
+
+| col | val |
+| --- | --- |
+| `not.a.code` | should be ignored |
+
+## AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)
+
+> 本 table の文言は ... と完全一致させる (規約)。
+
+| code | hint |
+| --- | --- |
+| `state.mtime_conflict` | metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください |
+| `io.file_not_found` | ファイルが見つかりません。パスを確認してください |
+| `io.would_block` / `io.timed_out` | I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください |
+| `subprocess.cancelled` | (hint なし: ユーザー操作によるキャンセルは UI 側で十分な情報を出す) |
+| `internal.error` | (hint なし: 内部エラーで具体的アクションがない、message 側で logs 参照を案内) |
+
+## 関連 (本 awk は処理しない)
+
+- See spec ...
+```
+
+- [ ] **Step 2: 期待出力 expected-doc.tsv を作成 (sort 済)**
+
+`tests/fixtures/error-hints/expected-doc.tsv` (Task 1 と同様、間の `\t` は TAB 1 個):
+
+<!-- markdownlint-disable MD010 -->
+```text
+internal.error	<<NONE>>
+io.file_not_found	ファイルが見つかりません。パスを確認してください
+io.timed_out	I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください
+io.would_block	I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください
+state.mtime_conflict	metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください
+subprocess.cancelled	<<NONE>>
+```
+<!-- markdownlint-enable MD010 -->
+
+(Task 1 expected-rust.tsv と同一形式 + 同一 sorted ordering。drift check で diff -u が空になる前提)
+
+- [ ] **Step 3: test harness test_extract_doc_hints.sh を作成**
+
+`tests/scripts/test_extract_doc_hints.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AWK_FILE="$SCRIPT_DIR/.github/scripts/extract-doc-hints.awk"
+FIXTURE="$SCRIPT_DIR/tests/fixtures/error-hints/sample-tauri-commands.md"
+EXPECTED="$SCRIPT_DIR/tests/fixtures/error-hints/expected-doc.tsv"
+
+if [[ ! -f "$AWK_FILE" ]]; then
+  echo "FAIL: awk script not found: $AWK_FILE" >&2
+  exit 1
+fi
+
+actual=$(awk -f "$AWK_FILE" "$FIXTURE" | sort)
+expected=$(sort "$EXPECTED")
+
+if [[ "$actual" == "$expected" ]]; then
+  echo "PASS: extract-doc-hints.awk matches expected"
+  exit 0
+else
+  echo "FAIL: drift detected"
+  diff -u <(echo "$expected") <(echo "$actual")
+  exit 1
+fi
+```
+
+```bash
+chmod +x tests/scripts/test_extract_doc_hints.sh
+```
+
+- [ ] **Step 4: red 確認 (awk なし)**
+
+```bash
+bash tests/scripts/test_extract_doc_hints.sh
+```
+
+Expected: `FAIL: awk script not found: .../.github/scripts/extract-doc-hints.awk`。
+
+- [ ] **Step 5: extract-doc-hints.awk を実装**
+
+`.github/scripts/extract-doc-hints.awk`:
+
+```awk
+#!/usr/bin/env -S awk -f
+# Extract (code, hint_normalized) pairs from
+# docs/tauri-commands.md §「AppError default hint mapping」 table rows.
+#
+# Output format: <code>\t<hint_normalized>
+#   - code: from `code` (backtick-wrapped) in the first cell; cell may contain
+#     multiple codes separated by " / " (e.g. `io.would_block` / `io.timed_out`)
+#   - hint: second cell, whitespace-collapsed to single space
+#   - None entry: hint cell starts with "(hint なし:" → <<NONE>> sentinel
+#
+# Approach: state-machine on lines. Enter target section when seeing
+# "## AppError default hint mapping" header, exit on next "## " header or EOF.
+# Inside section, parse rows that start with "| `".
+
+BEGIN {
+    in_section = 0
+}
+
+# Enter target section
+/^## AppError default hint mapping/ {
+    in_section = 1
+    next
+}
+
+# Exit on next ## heading (other than entering line)
+in_section && /^## / {
+    in_section = 0
+}
+
+# Parse table row: | `code` ... | hint |
+in_section && /^\| `/ {
+    process_row($0)
+}
+
+function process_row(line,    code_cell, hint_cell, codes, n, i, code, hint, pipe_idx, second_pipe_idx, third_pipe_idx) {
+    # Find pipe boundaries. Format: | cell1 | cell2 |
+    # Note: cells may contain " / " or backticks but not literal |.
+    pipe_idx = index(line, "|")
+    if (pipe_idx != 1) return  # row must start with |
+    rest = substr(line, 2)
+    second_pipe_idx = index(rest, "|")
+    if (second_pipe_idx == 0) return
+    code_cell = substr(rest, 1, second_pipe_idx - 1)
+    rest2 = substr(rest, second_pipe_idx + 1)
+    third_pipe_idx = index(rest2, "|")
+    if (third_pipe_idx == 0) {
+        hint_cell = rest2
+    } else {
+        hint_cell = substr(rest2, 1, third_pipe_idx - 1)
+    }
+
+    # Extract hint
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", hint_cell)
+    if (hint_cell ~ /^\(hint なし:/) {
+        hint = "<<NONE>>"
+    } else {
+        hint = hint_cell
+        gsub(/[[:space:]]+/, " ", hint)
+        sub(/^ /, "", hint)
+        sub(/ $/, "", hint)
+    }
+
+    # Extract codes from code_cell — find all `...` patterns
+    while (match(code_cell, /`[a-zA-Z0-9_.]+`/)) {
+        code = substr(code_cell, RSTART + 1, RLENGTH - 2)
+        print code "\t" hint
+        code_cell = substr(code_cell, RSTART + RLENGTH)
+    }
+}
+```
+
+- [ ] **Step 6: green 確認**
+
+```bash
+bash tests/scripts/test_extract_doc_hints.sh
+```
+
+Expected: `PASS: extract-doc-hints.awk matches expected`、exit 0。
+
+- [ ] **Step 7: commit**
+
+```bash
+git add .github/scripts/extract-doc-hints.awk \
+        tests/fixtures/error-hints/sample-tauri-commands.md \
+        tests/fixtures/error-hints/expected-doc.tsv \
+        tests/scripts/test_extract_doc_hints.sh
+git -c commit.gpgsign=false commit -m "feat(ci): extract-doc-hints.awk TDD (or-pattern '/' split + None handling) (Refs #692)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: check-error-hint-drift.sh implementation
+
+**Goal:** Task 1-2 で作成した 2 awk parser を呼び、sort + diff -u で照合して drift → exit 1 する bash script を実装。fixture vs fixture で互いに一致することを確認。
+
+**Files:**
+
+- Create: `.github/scripts/check-error-hint-drift.sh`
+- Create: `tests/scripts/test_check_error_hint_drift.sh`
+
+- [ ] **Step 1: check-error-hint-drift.sh を実装**
+
+`.github/scripts/check-error-hint-drift.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Check drift between gui/src-tauri/src/error.rs::default_hint_for_code
+# and docs/tauri-commands.md §「AppError default hint mapping」 table.
+#
+# Source of truth: error.rs (docstring states "本 fn が source of truth、docs は mirror")
+# Mirror:          docs/tauri-commands.md
+# Both must agree on (code, hint) pairs after normalization.
+#
+# Exit codes:
+#   0 — no drift detected
+#   1 — drift detected (or input files missing)
+#
+# Refs: https://github.com/Idios/kobutachan-allaganeye/issues/692
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RUST_FILE="${RUST_FILE:-$REPO_ROOT/gui/src-tauri/src/error.rs}"
+DOC_FILE="${DOC_FILE:-$REPO_ROOT/docs/tauri-commands.md}"
+
+if [[ ! -f "$RUST_FILE" ]]; then
+    echo "ERROR: Rust source not found: $RUST_FILE" >&2
+    exit 1
+fi
+if [[ ! -f "$DOC_FILE" ]]; then
+    echo "ERROR: Docs file not found: $DOC_FILE" >&2
+    exit 1
+fi
+
+RUST_PAIRS=$(awk -f "$SCRIPT_DIR/extract-rust-hints.awk" "$RUST_FILE" | sort)
+DOC_PAIRS=$(awk -f "$SCRIPT_DIR/extract-doc-hints.awk" "$DOC_FILE" | sort)
+
+if diff -u <(echo "$RUST_PAIRS") <(echo "$DOC_PAIRS") > /dev/null; then
+    echo "OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync ($(echo "$RUST_PAIRS" | wc -l) entries)"
+    exit 0
+fi
+
+cat >&2 <<'EOF'
+
+ERROR: error.rs ↔ docs/tauri-commands.md hint drift detected.
+
+Source of truth: gui/src-tauri/src/error.rs::default_hint_for_code
+Mirror:          docs/tauri-commands.md §「AppError default hint mapping」 table
+
+Both must be updated in the same PR. See docs/tauri-commands.md docstring +
+gui/src-tauri/src/error.rs::default_hint_for_code docstring for the contract.
+
+Diff (- = error.rs side, + = docs side):
+EOF
+diff -u <(echo "$RUST_PAIRS") <(echo "$DOC_PAIRS") >&2 || true
+exit 1
+```
+
+```bash
+chmod +x .github/scripts/check-error-hint-drift.sh
+```
+
+- [ ] **Step 2: test_check_error_hint_drift.sh を作成 (fixture vs fixture)**
+
+`tests/scripts/test_check_error_hint_drift.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Integration test: check-error-hint-drift.sh against fixture files.
+# Fixtures are designed to match (expected pairs identical), so the
+# script should exit 0.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export RUST_FILE="$SCRIPT_DIR/tests/fixtures/error-hints/sample-error.rs"
+export DOC_FILE="$SCRIPT_DIR/tests/fixtures/error-hints/sample-tauri-commands.md"
+
+if bash "$SCRIPT_DIR/.github/scripts/check-error-hint-drift.sh"; then
+    echo "PASS: fixtures match"
+    exit 0
+else
+    echo "FAIL: fixtures should match but drift detected" >&2
+    exit 1
+fi
+```
+
+```bash
+chmod +x tests/scripts/test_check_error_hint_drift.sh
+```
+
+- [ ] **Step 3: red 確認 → 即 green 確認 (fixture 設計上一致するので即 green になる)**
+
+```bash
+bash tests/scripts/test_check_error_hint_drift.sh
+```
+
+Expected: `OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync (6 entries)` + `PASS: fixtures match`、exit 0。
+
+(本 task は Task 1-2 で fixture を一致するよう設計しているので、新規 awk parser が正しければ即 PASS。awk 実装の bug があれば FAIL → Task 1 or 2 に戻って修正。)
+
+- [ ] **Step 4: local shellcheck で .sh を lint**
+
+```bash
+shellcheck -S warning .github/scripts/check-error-hint-drift.sh \
+                     tests/scripts/test_extract_rust_hints.sh \
+                     tests/scripts/test_extract_doc_hints.sh \
+                     tests/scripts/test_check_error_hint_drift.sh
+```
+
+Expected: 0 warning。warning あれば即修正。
+
+- [ ] **Step 5: commit**
+
+```bash
+git add .github/scripts/check-error-hint-drift.sh \
+        tests/scripts/test_check_error_hint_drift.sh
+git -c commit.gpgsign=false commit -m "feat(ci): check-error-hint-drift.sh integration (Refs #692)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 実機 (error.rs + tauri-commands.md) で run → drift なし確認
+
+**Goal:** real file (project の現状) で drift なし (= source of truth と mirror が一致) を確認。drift があれば、それは本 lane 着手前から存在する問題で、別途 spec で扱う判断が必要 (本 lane scope 外なので AskUserQuestion 発動)。
+
+- [ ] **Step 1: 実機 run**
+
+```bash
+bash .github/scripts/check-error-hint-drift.sh
+```
+
+Expected: `OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync (24 entries)`、exit 0。
+
+(error.rs の or-pattern を 2 code に展開した結果、合計 24 codes。docs も `/` 区切り展開後で 24 codes。)
+
+- [ ] **Step 2: もし drift 検出された場合 → AskUserQuestion**
+
+drift がある場合、それは PR #689 (Group A AppError migration) または別 PR で混入した文言不一致。本 lane の責務範囲を超える可能性あり。
+
+```text
+AskUserQuestion:
+"check-error-hint-drift.sh の初回実機 run で drift が検出された。
+原因 1: PR #689 以降の commit で error.rs か docs/tauri-commands.md の片側のみ更新された
+原因 2: awk parser の bug (Task 1-2 の implementation)
+原因 3: その他
+
+対応案:
+(a) 本 lane で docs/tauri-commands.md を error.rs に揃える修正を同梱 (scope creep を §6.4 で透明化)
+(b) 別 issue 起票して本 lane scope 外、drift check job 自体は本 PR で merge し、修正 PR を別途
+(c) awk parser を再点検 (Task 1-2 に戻る)
+"
+```
+
+選択結果を本 plan の「Pre-flight log」節に追記。
+
+- [ ] **Step 3: 確認結果を memo**
+
+drift なし (exit 0) なら本 plan 「Pre-flight log」に `Task 4: real-run PASS (24 entries in sync)` を追記。
+
+---
+
+## Task 5: TDD red×3 (§3.4 故意 drift)
+
+**Goal:** spec §3.4 の red×3 ケース (文言変更 / or-pattern code 削除 / None sentinel 変更) で drift check が正しく fail することを実証。Self-Test Report のエビデンスとして commit log にも残す。
+
+**Files:**
+
+- Touch (temporary): `docs/tauri-commands.md` (revert 必須)
+
+- [ ] **Step 1: red 1 — 文言変更**
+
+```bash
+# `io.file_not_found` の hint cell を一時的に変更
+git diff --quiet docs/tauri-commands.md  # 事前に clean 確認
+sed -i.bak 's/パスを確認するか/パスを再確認するか/' docs/tauri-commands.md
+bash .github/scripts/check-error-hint-drift.sh && echo "UNEXPECTED PASS" || echo "EXPECTED FAIL (exit code: $?)"
+```
+
+Expected: `ERROR: error.rs ↔ docs/tauri-commands.md hint drift detected.` + diff 出力、exit 1。
+
+- [ ] **Step 2: revert (red 1)**
+
+```bash
+mv docs/tauri-commands.md.bak docs/tauri-commands.md
+bash .github/scripts/check-error-hint-drift.sh
+```
+
+Expected: `OK: ...`、exit 0。
+
+- [ ] **Step 3: red 2 — or-pattern code 削除**
+
+```bash
+# `io.would_block` / `io.timed_out` 行を一時的に `io.would_block` のみに変更
+cp docs/tauri-commands.md docs/tauri-commands.md.bak
+sed -i 's/`io.would_block` \/ `io.timed_out`/`io.would_block`/' docs/tauri-commands.md
+bash .github/scripts/check-error-hint-drift.sh && echo "UNEXPECTED PASS" || echo "EXPECTED FAIL (io.timed_out missing)"
+```
+
+Expected: 出力で `+ io.timed_out<TAB>I/O 処理が...` (docs 側に欠ける code) が `-` 行として error.rs 側に存在する diff となり exit 1。`<TAB>` は TAB 文字 1 個。
+
+- [ ] **Step 4: revert (red 2)**
+
+```bash
+mv docs/tauri-commands.md.bak docs/tauri-commands.md
+bash .github/scripts/check-error-hint-drift.sh
+```
+
+Expected: `OK: ...`、exit 0。
+
+- [ ] **Step 5: red 3 — None sentinel 変更**
+
+```bash
+# `subprocess.cancelled` の `(hint なし: ...)` を実際の文言に変更
+cp docs/tauri-commands.md docs/tauri-commands.md.bak
+sed -i 's/(hint なし: ユーザー操作.*)/キャンセルされました/' docs/tauri-commands.md
+bash .github/scripts/check-error-hint-drift.sh && echo "UNEXPECTED PASS" || echo "EXPECTED FAIL (None sentinel mismatch)"
+```
+
+Expected: `subprocess.cancelled` の hint が `<<NONE>>` (error.rs 側) vs `キャンセルされました` (docs 側) で diff、exit 1。
+
+- [ ] **Step 6: revert (red 3)**
+
+```bash
+mv docs/tauri-commands.md.bak docs/tauri-commands.md
+bash .github/scripts/check-error-hint-drift.sh
+git diff --quiet docs/tauri-commands.md  # 完全 revert 確認
+```
+
+Expected: `OK: ...`、exit 0、`git diff --quiet` も exit 0 (差分なし)。
+
+- [ ] **Step 7: TDD log を保存 (Self-Test Report 用)**
+
+```bash
+mkdir -p docs/superpowers/specs/lane-iv-b-prime-evidence
+cat > docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md <<'EOF'
+# TDD red×3 verification log (Lane IV-b' #692)
+
+Spec: docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md §3.4
+
+## red 1: 文言変更
+- 変更: `io.file_not_found` hint cell を「パスを確認」→「パスを再確認」
+- 結果: exit 1、diff 出力で文言 mismatch を明示
+
+## red 2: or-pattern code 削除
+- 変更: docs から `io.timed_out` を削除 (or-pattern を `io.would_block` のみに)
+- 結果: exit 1、`+ io.timed_out\t...` 行が docs side に欠落
+
+## red 3: None sentinel 変更
+- 変更: `subprocess.cancelled` の cell を `(hint なし: ...)` → 「キャンセルされました」
+- 結果: exit 1、Rust side `<<NONE>>` vs docs side 実文言 mismatch
+
+## green (revert 後)
+- すべての revert 後で `OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync (24 entries)`
+- `git diff --quiet docs/tauri-commands.md` exit 0
+EOF
+```
+
+- [ ] **Step 8: commit**
+
+```bash
+git add docs/superpowers/specs/lane-iv-b-prime-evidence/
+git -c commit.gpgsign=false commit -m "test: TDD red×3 verification log for hint drift check (Refs #692)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: ci.yml に doc-error-hint-drift job 追加
+
+**Goal:** `.github/workflows/ci.yml` に `doc-error-hint-drift` job を追加し、push / pull_request トリガで drift check を自動実行。precedent は同 file の `doc-tauri-commands-drift` (行 157+)。
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: ci.yml の `doc-tauri-commands-drift` job の直後に doc-error-hint-drift job を挿入**
+
+`.github/workflows/ci.yml` の `doc-tauri-commands-drift` job (現在 157-178 行付近、`installer-pester:` の前) の直後に以下を追加:
+
+```yaml
+  doc-error-hint-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check error.rs ↔ docs/tauri-commands.md hint mapping drift
+        shell: bash
+        run: bash .github/scripts/check-error-hint-drift.sh
+```
+
+実装時の参考: `doc-tauri-commands-drift` job 構造 (現状):
+
+```yaml
+  doc-tauri-commands-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check tauri-commands.md drift vs lib.rs (name-level set-diff)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # ... inline awk + sort -u + diff -u ...
+```
+
+本 task の job は同等の構造で、inline ではなく外部 script (`.github/scripts/check-error-hint-drift.sh`) を呼ぶ点が異なる。
+
+- [ ] **Step 2: ci.yml の yaml syntax を local 確認**
+
+```bash
+# Python の場合
+python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML OK"
+
+# または yq があれば
+# yq eval '.jobs.doc-error-hint-drift' .github/workflows/ci.yml
+```
+
+Expected: `YAML OK`、または yq 出力で新 job が見える。
+
+- [ ] **Step 3: act / GH Actions local runner で動作確認 (option、skip 可)**
+
+```bash
+# act がインストールされていれば
+# act -j doc-error-hint-drift
+```
+
+act 未インストールなら skip。CI 上の実証は PR-1 push 時に行う (Task 10)。
+
+- [ ] **Step 4: commit**
+
+```bash
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "feat(ci): doc-error-hint-drift job 追加 (Refs #692)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: ci.yml に shellcheck job 追加 + 既存 script 対応
+
+**Goal:** ci.yml に shellcheck job を新規追加 (Q5 確定、repo 全体 .sh 対象)。Task 0 で確認した既存 script の shellcheck 状況に応じて修正も同梱。
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+- Possibly modify: `scripts/check-markdownlint.sh`, `scripts/cleanup-worktrees.sh` (Task 0 結果による)
+
+- [ ] **Step 1: ci.yml に shellcheck job 追加**
+
+Task 6 で追加した `doc-error-hint-drift` job の直後に挿入:
+
+```yaml
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck on all .sh files
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          severity: warning
+          scandir: '.'
+          additional_files: '.github/scripts/*.sh tests/scripts/*.sh scripts/*.sh'
+```
+
+注: `ludeeus/action-shellcheck@2.0.0` のバージョン pin。 `@master` は再現性に難。`2.0.0` の存在は実装時に `gh api /repos/ludeeus/action-shellcheck/releases` で確認、最新 stable に合わせる。
+
+- [ ] **Step 2: Task 0 結果分岐**
+
+| Task 0 結果 | 本 step の対応 |
+| --- | --- |
+| pass (0 件) | 次 step (yaml verify) へ |
+| 軽微 (1-3 件) | 既存 script に shellcheck pragma または quote 修正を最小限で追加。ファイル単位で commit を分けて track |
+| 多数 (4+ 件) | Task 0 で AskUserQuestion 済の判断結果に従う (本 PR で全件修正 / 別 issue 起票 / `\|\|true` 許容) |
+
+軽微修正の例 (`scripts/check-markdownlint.sh` で SC2086 想定):
+
+```bash
+# 修正前
+markdownlint-cli2 $files
+# 修正後
+markdownlint-cli2 "$files"
+# または shellcheck disable 行追加 (やむを得ない場合)
+# shellcheck disable=SC2086
+```
+
+- [ ] **Step 3: local shellcheck で repo 全体 .sh が pass することを確認**
+
+```bash
+shellcheck -S warning .github/scripts/*.sh tests/scripts/*.sh scripts/*.sh
+echo "exit: $?"
+```
+
+Expected: 出力なし、exit 0。
+
+- [ ] **Step 4: ci.yml yaml syntax 確認**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`。
+
+- [ ] **Step 5: commit (修正があれば 2 commit に分割)**
+
+```bash
+# ci.yml shellcheck job 追加分
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "feat(ci): shellcheck job 追加 (repo 全体 .sh) (Refs #692)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+
+# 既存 script の shellcheck 対応分 (該当あれば)
+git add scripts/*.sh
+git -c commit.gpgsign=false commit -m "fix(scripts): shellcheck warnings 対応 (Refs #692)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: roadmap plan.md (§5.1 表通り 4 ヶ所修正)
+
+**Goal:** `docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md` の Lane IV-b' 関連記述を 2 件 / 2 章 (#692 / #700) に縮小、#458 は handoff として明記。spec §5.1 表通り。
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md`
+
+- [ ] **Step 1: 修正対象 hit を grep で全列挙**
+
+```bash
+grep -n "Lane IV-b'\|#458\|Group J" docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
+```
+
+Expected: spec §5.1 表で示した 4 ヶ所 (行 81 付近、行 110 付近、行 162 付近、行 200 付近) + 関連の hit (§4 deferred 表追記対象、255 付近)。実際の行番号は本 task 実行時の git HEAD 状態に依存。
+
+- [ ] **Step 2: 行 81 付近を修正 (Group G 並行安全度行)**
+
+該当箇所 (現状):
+
+```markdown
+**並行安全度**: high (`.github/ISSUE_TEMPLATE/bug_report.yml` 独立) / **brainstorming 単位**: Lane IV-b' で Group J と統合 (1 spec / 3 章)
+```
+
+修正後:
+
+```markdown
+**並行安全度**: high (`.github/ISSUE_TEMPLATE/bug_report.yml` 独立) / **brainstorming 単位**: 本 issue は Lane IV-b' から scope-out (PR #497 + PR #688 で実装完了済、残るは L2 release 後の UI 実測のみ、release gate 後に `/close-issue` で handoff)。Lane IV-b' は Group J 単独 (1 spec / 2 章)
+```
+
+- [ ] **Step 3: 行 110 付近を修正 (Lane IV-b' description)**
+
+該当箇所 (現状):
+
+```markdown
+  Lane IV-b'  Group G remainder + Group J 統合 (workflow / CI / docs polish)
+              #458 (P2、bug_report.yml) // #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
+              file 完全独立、PR 並行可
+              1 spec / 3 章
+```
+
+修正後:
+
+```markdown
+  Lane IV-b'  Group J 単独 (workflow / CI / docs polish)
+              #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
+              file 完全独立、PR 並行可
+              1 spec / 2 章
+
+              ※ Group G #458 は本 lane から scope-out (実装完了済、release gate 後 /close-issue handoff)
+```
+
+- [ ] **Step 4: 行 162 付近を修正 (Wave 1 ASCII 図)**
+
+該当箇所 (現状):
+
+```markdown
+  Lane IV-b'  Group G remainder + Group J 統合 (workflow / CI / docs polish)
+              #458 (P2、bug_report.yml) // #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
+              file 完全独立、PR 並行可
+              1 spec / 3 章
+```
+
+修正後: Step 3 と同一に修正 (本 doc は ASCII 図と説明文で 2 ヶ所同記述あり、grep -n で 2 件 hit するため両方修正)。
+
+- [ ] **Step 5: 行 200 付近を修正 (brainstorming 入り口)**
+
+該当箇所 (現状):
+
+```markdown
+/superpowers:brainstorming Lane IV-b': Group G #458 + Group J #692 #700 (workflow / CI / docs polish)
+```
+
+修正後:
+
+```markdown
+/superpowers:brainstorming Lane IV-b': Group J #692 #700 (workflow / CI / docs polish、#458 は scope-out)
+```
+
+- [ ] **Step 6: §4 deferred 表に #458 handoff 追記**
+
+該当箇所 (現状の §「v0.2.0 外確定 (deferred ラベル維持、6 件)」 直前):
+
+```markdown
+## 4. deferred / v0.2.0 対象外
+```
+
+修正方針: §「v0.2.0 外確定」の表の直下、または別 sub-section として追加:
+
+```markdown
+### Group G #458 — Lane IV-b' から scope-out (handoff)
+
+[#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) (P2、bug_report.yml) は本 plan 公開時点で実装作業完了済 (PR #497 + PR #688)、残る受け入れ条件 1 件「New issue UI からテンプレ選択可能」は L2 release (`develop-0.2.0 → main` マージ) 後に main 反映済みの環境で実測する必要があるため、Lane IV-b' (Wave 1) から scope-out した。
+
+release gate (Wave 3) 後、L3 初期に `/close-issue` skill で実測 → close する handoff path で運用する。
+```
+
+- [ ] **Step 7: markdownlint pass 確認**
+
+```bash
+bash scripts/check-markdownlint.sh docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
+```
+
+Expected: `0 error(s)`。
+
+- [ ] **Step 8: commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
+git -c commit.gpgsign=false commit -m "docs(roadmap): Lane IV-b' を Group J 単独に縮小 (#458 scope-out) (Refs #458 #692 #700)
+
+本 brainstorming session (spec docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md §5)
+で確定した Lane IV-b' scope 縮小を roadmap plan に反映。
+
+- Lane IV-b' = Group J 単独 (1 spec / 2 章、#692 + #700)
+- Group G #458 は Lane IV-b' から scope-out (実装完了済、release gate 後
+  /close-issue handoff)
+- §4 deferred 表に #458 handoff path を追記
+
+Refs #458 #692 #700
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: roadmap design.md (§5.1 相当 4 ヶ所修正)
+
+**Goal:** `docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md` の Lane IV-b' 関連記述も整合修正。Task 8 の plan.md と同じ趣旨。
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md`
+
+- [ ] **Step 1: 修正対象 hit を grep で列挙**
+
+```bash
+grep -n "Lane IV-b'\|#458\|Group J" docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md
+```
+
+Expected: spec §5.1 表で示した 4 ヶ所相当 (§4.1 Group G 行、§4.2 Lane IV-b' 行、§4.3 file matrix 行、§4.6 brainstorming 入り口)。
+
+- [ ] **Step 2: §4.1 Group G 行を修正**
+
+該当箇所 (現状):
+
+```markdown
+| **G** | **l2-workflow 残** | **1** | OPEN | [#458](...) (P2) |
+```
+
+修正後 (notes column の追加またはコメント):
+
+```markdown
+| **G** | **l2-workflow 残** | **1** | OPEN | [#458](...) (P2) — Lane IV-b' から scope-out (release gate 後 handoff) |
+```
+
+- [ ] **Step 3: §4.2 Lane IV-b' 行を修正 (Wave 1 lane 表内)**
+
+該当箇所 (現状、Wave 1 ASCII 図内):
+
+```markdown
+  Lane IV-b'  Group G remainder + Group J 統合 (workflow / CI / docs polish)
+              #458 (P2、bug_report.yml) // #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
+              file 完全独立、PR 並行可
+              1 spec / 3 章
+```
+
+修正後:
+
+```markdown
+  Lane IV-b'  Group J 単独 (workflow / CI / docs polish)
+              #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
+              file 完全独立、PR 並行可
+              1 spec / 2 章
+
+              ※ Group G #458 は本 lane から scope-out (実装完了済、release gate 後 /close-issue handoff)
+```
+
+- [ ] **Step 4: §4.3 file 衝突 matrix 行を修正**
+
+該当箇所 (現状):
+
+```markdown
+| IV-b' (#458 #692 #700) | ... | ✓ #692 | ✓ #692 | ✓ #458 | ✓ #700 | | |
+```
+
+修正後 (issue template 列の ✓ #458 を削除し、lane ラベルから #458 を外す):
+
+```markdown
+| IV-b' (#692 #700) | ... | ✓ #692 | ✓ #692 | | ✓ #700 | | |
+```
+
+- [ ] **Step 5: §4.6 brainstorming 入り口を修正**
+
+該当箇所 (現状):
+
+```markdown
+/superpowers:brainstorming Lane IV-b': Group G #458 + Group J #692 #700 (workflow / CI / docs polish)
+```
+
+修正後:
+
+```markdown
+/superpowers:brainstorming Lane IV-b': Group J #692 #700 (workflow / CI / docs polish、#458 は scope-out)
+```
+
+- [ ] **Step 6: markdownlint pass 確認**
+
+```bash
+bash scripts/check-markdownlint.sh docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md
+```
+
+Expected: `0 error(s)`。
+
+- [ ] **Step 7: commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md
+git -c commit.gpgsign=false commit -m "docs(roadmap-spec): Lane IV-b' design doc を Group J 単独に縮小 (Refs #458 #692 #700)
+
+Task 8 で更新した roadmap plan.md と整合する形で base design doc も修正。
+Lane IV-b' = Group J 単独 (#692 + #700)、Group G #458 は scope-out + handoff。
+
+Refs #458 #692 #700
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: PR-1 作成
+
+**Goal:** PR-1 (#692 + adjacency: spec doc + roadmap doc 修正 + drift CI job + shellcheck job + 既存 script 修正) を作成し、CI を pass させる。
+
+**Files:** (touch なし)
+
+- [ ] **Step 1: PR-1 Pre-flight 再実行 (Iron Law 6)**
+
+```bash
+git fetch origin develop-0.2.0
+git log HEAD..origin/develop-0.2.0 --oneline | head -20
+```
+
+Expected: 出力なし (取り込み未済 commit なし) または数件 (取り込み未済あれば次 step で merge)。
+
+```bash
+# 取り込み未済 commit あれば
+# git merge origin/develop-0.2.0
+# conflict なければ続行、conflict あれば手動解決
+```
+
+- [ ] **Step 2: 並行 worktree PR 重複確認**
+
+```bash
+gh pr list --state open --json number,title,headRefName \
+  | jq '.[] | select(.title | test("#692|#700|Lane IV-b") )'
+```
+
+Expected: 該当なし。万一 open で並行 PR あれば user 判断仰ぐ。
+
+- [ ] **Step 3: 本 worktree branch を push**
+
+```bash
+git push -u origin claude/tender-moore-2a5d2f
+```
+
+Expected: branch が origin に push される。
+
+- [ ] **Step 4: PR-1 本文を作成 (printf | gh pr create --body-file -)**
+
+```bash
+printf '%s\n' \
+'## スコープ' \
+'' \
+'Lane IV-b'\'' (Group J #692 hint drift CI) を実装。' \
+'' \
+'- `.github/scripts/check-error-hint-drift.sh` + 2 awk file (extract-rust-hints.awk / extract-doc-hints.awk) 新規作成' \
+'- `.github/workflows/ci.yml` に `doc-error-hint-drift` job 追加 (`doc-tauri-commands-drift` precedent 踏襲)' \
+'- `.github/workflows/ci.yml` に `shellcheck` job 新規追加 (repo 全体 .sh 対象、Q5)' \
+'- 本 brainstorming session で確定した Lane IV-b'\'' scope 縮小 (#458 scope-out、release gate 後 handoff) を `docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md` + `docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md` に反映 (fact 訂正、§5)' \
+'- 本 Lane IV-b'\'' spec doc を新規追加: `docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md`' \
+'' \
+'Refs #692' \
+'' \
+'## 受け入れ条件 (#692)' \
+'' \
+'- [x] error.rs から (code, hint) 抽出 script (`.github/scripts/extract-rust-hints.awk`)' \
+'- [x] docs/tauri-commands.md から (code, hint) 抽出 script (`.github/scripts/extract-doc-hints.awk`)' \
+'- [x] sort + diff -u で drift → CI fail (ci.yml に `doc-error-hint-drift` job 追加)' \
+'- [x] or-pattern (`io.would_block | io.timed_out`) / None entries (`subprocess.cancelled` / `internal.error`) の handling' \
+'- [x] 故意 drift → red → fix → green の TDD 検証 (`docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md`)' \
+'' \
+'## Test plan (本 PR 提出前にローカルで実行済)' \
+'' \
+'- [x] `bash tests/scripts/test_extract_rust_hints.sh` → PASS' \
+'- [x] `bash tests/scripts/test_extract_doc_hints.sh` → PASS' \
+'- [x] `bash tests/scripts/test_check_error_hint_drift.sh` → PASS' \
+'- [x] `bash .github/scripts/check-error-hint-drift.sh` → OK (24 entries in sync)' \
+'- [x] §3.4 red×3 (文言変更 / or-pattern code 削除 / None sentinel 変更) → 3 ケース exit 1、revert で exit 0' \
+'- [x] `shellcheck -S warning .github/scripts/*.sh tests/scripts/*.sh scripts/*.sh` → 0 warning' \
+'- [x] `bash scripts/check-markdownlint.sh` → 0 error' \
+'- [x] `python -c "import yaml; yaml.safe_load(open('\''.github/workflows/ci.yml'\''))"` → YAML OK' \
+'' \
+'## scope creep 透明化' \
+'' \
+'本 PR は (a) #692 実装 / (b) shellcheck job + 既存 script 軽微修正 / (c) Lane IV-b'\'' scope 縮小の roadmap doc fact 訂正 / (d) Lane IV-b'\'' spec doc 新規追加 を含む。Iron Law 3 (1 PR = 1 scope) との整合は spec [§5.3](docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md#L53-scope-creep-警戒の透明化) で「Lane IV-b'\'' 事実訂正 = scope 内」と判断、(d) は spec doc 同梱の慣習に従う。' \
+'' \
+'## 実機検証 (machine-unverifiable)' \
+'' \
+'- 該当なし (CI workflow / lint config / docs のみの変更、GPU / audio / video detector / GUI Tauri touch なし)' \
+'' \
+'session-id: tender-moore-2a5d2f' \
+  | gh pr create --base develop-0.2.0 --title "feat(ci): error.rs hint table drift check job 追加 (Refs #692)" --body-file -
+```
+
+Expected: PR URL が出力される。memo (本 plan 末尾の Pre-flight log に追記)。
+
+- [ ] **Step 5: PR 番号を取得して CI watch**
+
+```bash
+PR_NUM=$(gh pr view --json number --jq .number)
+echo "PR-1: #$PR_NUM"
+gh pr checks "$PR_NUM" --watch
+```
+
+Expected: 全 CI job が pass (markdownlint / shellcheck / doc-error-hint-drift / 既存 全 job)。
+
+- [ ] **Step 6: CI 失敗時の対応**
+
+`/iterate-review` skill を起動するか、CI log を確認して inline 修正:
+
+- markdownlint fail: 該当 file を bash scripts/check-markdownlint.sh で local 確認、修正
+- shellcheck fail: local で再 lint、修正
+- doc-error-hint-drift fail: error.rs と docs/tauri-commands.md の drift を解消
+- yaml syntax fail: ci.yml の structure 確認
+
+各修正 commit → push → CI 再 watch。
+
+- [ ] **Step 7: PR-1 メタ情報を本 plan に記録**
+
+```bash
+# 本 plan の末尾「Pre-flight log」節に追記:
+# - PR-1 URL
+# - PR-1 番号
+# - PR-1 作成時刻
+```
+
+---
+
+## Task 11: PR-2 — .markdownlint-cli2.yaml 修正 + local 検証 + commit
+
+**Goal:** PR-2 (#700) の実装。`.markdownlint-cli2.yaml` の `ignores` に `**/node_modules/**` を 1 行追加、local で 7712 → 0 を確認。
+
+**Files:**
+
+- Modify: `.markdownlint-cli2.yaml`
+
+**Note:** Task 11-12 は PR-1 と独立、並行作業可。実行環境としては **同 worktree で PR-1 の branch を base に作業すると merge 順序問題が出るため、別 worktree (新規 session) で PR-2 を作るのが望ましい**。本 plan は同 worktree 直列実行を想定 (説明簡素化)、subagent dispatch なら別 worktree dispatch を推奨。
+
+- [ ] **Step 1: PR-1 完了確認 (または別 worktree 切り替え)**
+
+```bash
+# Option A: 同 worktree 直列 — PR-1 が merge されてから PR-2 着手
+gh pr view --json number,state --jq '{number: .number, state: .state}'
+# state: "MERGED" なら次へ。"OPEN" なら待機 or 別 worktree で PR-2 を並行
+
+# Option B: 別 worktree (新 session) で PR-2 作成
+# git worktree add .claude/worktrees/<auto-name>-pr2 develop-0.2.0
+# cd .claude/worktrees/<auto-name>-pr2
+```
+
+- [ ] **Step 2: pre-install で gui/node_modules/ を生成 (red 確認用)**
+
+```bash
+cd gui && npm install
+cd ..
+ls gui/node_modules | head -5
+```
+
+Expected: `gui/node_modules/` 配下に大量の package directory。
+
+- [ ] **Step 3: red 確認 — 修正前の markdownlint 結果**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | tail -5
+```
+
+Expected: 7000+ errors (issue #700 報告では 7712、依存 package 更新で前後する)。
+
+- [ ] **Step 4: .markdownlint-cli2.yaml を修正**
+
+`.markdownlint-cli2.yaml` の `ignores` セクションを以下に変更:
+
+```yaml
+ignores:
+  - "node_modules/**"
+  - "**/node_modules/**"  # nested (gui/node_modules 等) も除外 (#700)
+  - ".venv/**"
+  - ".git/**"
+  - ".pytest_cache/**"
+  - ".ruff_cache/**"
+  - "**/kobutachan_allaganeye.egg-info/**"
+```
+
+- [ ] **Step 5: green 確認 — 修正後の markdownlint 結果**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | tail -5
+```
+
+Expected: `0 error(s)`。
+
+- [ ] **Step 6: CI 無影響確認 — .markdownlint-cli2.yaml の glob 仕様を ad-hoc に確認**
+
+```bash
+# CI は npm install 未実行のため gui/node_modules/ 不在、挙動変化なし
+# 念のため: cwd 直下の hypothetical node_modules も引き続き ignore されることを確認
+# (node_modules/** glob が残っているので OK、目視で .markdownlint-cli2.yaml 確認)
+cat .markdownlint-cli2.yaml | grep -A 7 "^ignores:"
+```
+
+Expected: `node_modules/**` と `**/node_modules/**` の両 entry が見える。
+
+- [ ] **Step 7: commit**
+
+```bash
+git add .markdownlint-cli2.yaml
+git -c commit.gpgsign=false commit -m "fix(markdownlint): nested gui/node_modules を ignore に追加 (Refs #700)
+
+.markdownlint-cli2.yaml の ignores glob を node_modules/** から
+{node_modules/**, **/node_modules/**} の併記に変更。markdownlint-cli2 の
+glob 仕様で node_modules/** は cwd 直下のみ match し nested (gui/node_modules/)
+に届かない問題を解消。
+
+検証:
+- 修正前: bash scripts/check-markdownlint.sh で 7712 errors
+- 修正後: bash scripts/check-markdownlint.sh で 0 errors
+- CI 影響なし (CI は npm install しないため gui/node_modules/ 不在)
+
+Refs #700
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: PR-2 作成
+
+**Goal:** PR-2 (#700) を作成、CI pass を確認。
+
+- [ ] **Step 1: PR-2 Pre-flight (Iron Law 6)**
+
+```bash
+git fetch origin develop-0.2.0
+git log HEAD..origin/develop-0.2.0 --oneline | head -20
+gh pr list --state open --json number,title --jq '.[] | select(.title | test("#700|markdownlint") )'
+```
+
+Expected: 取り込み未済 commit なし、並行 PR なし (PR-1 は #692 で別 issue なので重複に該当しない)。
+
+- [ ] **Step 2: branch を push**
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+- [ ] **Step 3: PR-2 本文作成**
+
+```bash
+printf '%s\n' \
+'## スコープ' \
+'' \
+'Lane IV-b'\'' (Group J #700 markdownlint nested ignore) を実装。' \
+'' \
+'- `.markdownlint-cli2.yaml` の `ignores` に `**/node_modules/**` を 1 行追加' \
+'- `markdownlint-cli2` の glob 仕様で `node_modules/**` は cwd 直下のみ match し nested (`gui/node_modules/`) に届かない問題を解消' \
+'- CI は `npm install` 未実行のため `gui/node_modules/` 不在、CI 挙動変化なし' \
+'' \
+'spec doc は PR-1 に同梱: [docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md §4](docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md)' \
+'' \
+'Refs #700' \
+'' \
+'## 受け入れ条件 (#700)' \
+'' \
+'- [x] `.markdownlint-cli2.yaml` の ignores glob 修正' \
+'- [x] `gui/node_modules/**/*.md` の誤検出 7712 → 0 (local 検証済)' \
+'- [x] CI markdownlint job pass 維持 (npm install 不要のため挙動変化なし)' \
+'' \
+'## Test plan (本 PR 提出前にローカルで実行済)' \
+'' \
+'- [x] `cd gui && npm install` で gui/node_modules/ を用意' \
+'- [x] 修正前 `bash scripts/check-markdownlint.sh` → 7712 errors (red 確認)' \
+'- [x] `.markdownlint-cli2.yaml` に `**/node_modules/**` を追加' \
+'- [x] 修正後 `bash scripts/check-markdownlint.sh` → 0 errors (green)' \
+'- [x] `.markdownlint-cli2.yaml` の syntax (yaml load) OK' \
+'' \
+'## 実機検証 (machine-unverifiable)' \
+'' \
+'- 該当なし (lint config 1 行修正のみ、GPU / audio / video detector / GUI Tauri touch なし)' \
+'' \
+'session-id: tender-moore-2a5d2f' \
+  | gh pr create --base develop-0.2.0 --title "fix(markdownlint): nested gui/node_modules を ignore に追加 (Refs #700)" --body-file -
+```
+
+Expected: PR URL 出力。
+
+- [ ] **Step 4: CI watch**
+
+```bash
+PR_NUM=$(gh pr view --json number --jq .number)
+echo "PR-2: #$PR_NUM"
+gh pr checks "$PR_NUM" --watch
+```
+
+Expected: 全 CI job pass。
+
+- [ ] **Step 5: PR-2 メタ情報を本 plan に記録**
+
+本 plan 末尾「Pre-flight log」節に PR-2 URL / 番号 / 作成時刻を追記。
+
+---
+
+## Pre-flight log (実装中追記用)
+
+実装フェーズで追記する記録。各 task 完了時に状況を memo。
+
+### Task 0 結果
+
+- 取り込み未済 commit: [TBD - 実装時記入]
+- 並行 worktree PR: [TBD]
+- shellcheck pass 状況: [TBD - pass / 軽微 N 件 / 多数 N 件、各 file 別の件数]
+- 多数の場合の AskUserQuestion 結果: [該当時のみ TBD]
+
+### Task 4 結果 (実機 drift run)
+
+- exit code: [TBD - 0 (sync) or 1 (drift)]
+- entries 数: [TBD - 24 entries 想定]
+- drift 検出時の AskUserQuestion 結果: [該当時のみ TBD]
+
+### PR-1 メタ情報
+
+- PR URL: [TBD]
+- PR 番号: [TBD]
+- 作成時刻: [TBD]
+- CI 結果: [TBD]
+- merge 時刻: [TBD]
+
+### PR-2 メタ情報
+
+- PR URL: [TBD]
+- PR 番号: [TBD]
+- 作成時刻: [TBD]
+- CI 結果: [TBD]
+- merge 時刻: [TBD]
+
+---
+
+## 完了後の handoff (本 plan 外、参考)
+
+各 PR merge 後の手順:
+
+1. `/close-issue` skill 起動 (PR-1 ↔ #692、PR-2 ↔ #700 を個別 close)
+   - 受け入れ条件の merge 後 base ブランチでの実測再検証
+   - 未消化チェックボックスや残タスクのトリアージ
+   - 個別 issue を Idios 確認後 `gh issue close`
+2. **#458 は本 lane では touch なし** — release gate (Wave 3、`/release` skill) 後の L3 初期に別 session で:
+   - `develop-0.2.0 → main` マージ後の New issue UI で「[bug] バグ報告」テンプレ選択を実測
+   - `/close-issue` で #458 を close

--- a/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
+++ b/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
@@ -1504,11 +1504,12 @@ Expected: 全 CI job pass。
 
 ### PR-2 メタ情報
 
-- PR URL: [TBD]
-- PR 番号: [TBD]
-- 作成時刻: [TBD]
-- CI 結果: [TBD]
-- merge 時刻: [TBD]
+- PR URL: <https://github.com/Idios/kobutachan-allaganeye/pull/717>
+- PR 番号: #717
+- 作成時刻: 2026-05-11 (worktree `lane-iv-b-prime-pr2`、session `tender-moore-2a5d2f` derived)
+- CI 結果: **全 7 jobs PASS** ✅ (`markdownlint` 7s / `gui-frontend` 58s / `gui-rust` 4m46s / `installer-pester` 42s / `python` 1m7s / `validate-checklist` 4s / `doc-tauri-commands-drift` 6s)
+- merge 時刻: [TBD — レビュー後]
+- 注: PR-2 は `develop-0.2.0` base のため、PR-1 #715 で追加した `doc-error-hint-drift` / `shellcheck` job は本 PR-2 の CI ではまだ動かない (PR-1 マージ後に rebase すれば動く)。本 PR-2 scope (markdownlint config 1 行) は既存 `markdownlint` job で pass 確認済
 
 ---
 

--- a/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
+++ b/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
@@ -1496,11 +1496,11 @@ Expected: 全 CI job pass。
 
 ### PR-1 メタ情報
 
-- PR URL: [TBD]
-- PR 番号: [TBD]
-- 作成時刻: [TBD]
-- CI 結果: [TBD]
-- merge 時刻: [TBD]
+- PR URL: <https://github.com/Idios/kobutachan-allaganeye/pull/715>
+- PR 番号: #715
+- 作成時刻: 2026-05-11 (session `tender-moore-2a5d2f`)
+- CI 結果: **全 9 jobs PASS** ✅ (`doc-error-hint-drift` 6s / `shellcheck` 7s / `markdownlint` 8s / `validate-checklist` 7s / `doc-tauri-commands-drift` 6s / `gui-frontend` 1m5s / `gui-rust` 4m12s / `installer-pester` 33s / `python` 1m0s)
+- merge 時刻: [TBD — レビュー後]
 
 ### PR-2 メタ情報
 

--- a/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
+++ b/docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md
@@ -1486,11 +1486,13 @@ Expected: 全 CI job pass。
 - shellcheck CI 上動作: `ludeeus/action-shellcheck@master` (または pinned version) が `ubuntu-latest` で shellcheck を auto-install して実行するため、local 未 install は CI 動作に影響なし。Task 7 「local shellcheck で repo 全体 .sh が pass」step は CI 実証 (PR-1 push 時) で代替する
 - 多数 (4+) でなかったため AskUserQuestion 発動なし
 
-### Task 4 結果 (実機 drift run)
+### Task 4 結果 (実機 drift run、2026-05-11)
 
-- exit code: [TBD - 0 (sync) or 1 (drift)]
-- entries 数: [TBD - 24 entries 想定]
-- drift 検出時の AskUserQuestion 結果: [該当時のみ TBD]
+- exit code: **0 (sync)**
+- 出力: `OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync (24 entries)`
+- entries 数: **24** (or-pattern `io.would_block | io.timed_out` を 2 code に展開した結果、22 hint + 2 None = 24 codes)
+- drift 検出なし、AskUserQuestion 発動なし
+- 確認 commit base: `405c3c6` (Task 3 完了時点)
 
 ### PR-1 メタ情報
 

--- a/docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md
+++ b/docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md
@@ -33,7 +33,7 @@
 ## §2 Goals
 
 1. legacy raw String error を許容する `startsWith('conflict:')` fallback を完全に撤去し、`appErrorCodeIs(e, 'state.mtime_conflict')` のみで分岐させる (PR #663 の核心受け入れ条件)
-2. 22 個の AppError code に対する default 日本語 hint を `error.rs` の 1 つの mapping table に集約し、全 80 site の `AppError::new(...)` に `.with_default_hint()` を chain する (= site 個別の hint 揺れを発生させずに 80 site 網羅)
+2. 24 codes (or-pattern 展開後 #692) の AppError code に対する default 日本語 hint を `error.rs` の 1 つの mapping table に集約し、全 80 site の `AppError::new(...)` に `.with_default_hint()` を chain する (= site 個別の hint 揺れを発生させずに 80 site 網羅)
 3. frontend が AppError の `code` で error 種別を判定し、hint があれば inline error の 2 行目に表示する規約を確立する
 4. AppError code 体系と使い分けを `docs/tauri-commands.md` / `ui-architecture.md` § 4 / `ui-interaction-spec.md` § 1.5 に明文化し、新規 command 追加時の指針を残す
 5. 元 issue 本文を「PR #665 後の残作業として何を完遂したか」が読み取れる形に書き換える (Iron Law 4 整合: PR / commit には Closes/Fixes 禁止、issue 本体に記録を残す)
@@ -55,7 +55,7 @@
 │ Layer 1: Rust error.rs (pure helper module)                              │
 │   - default_hint_for_code(code: &str) -> Option<&'static str>             │
 │   - AppError::with_default_hint(self) -> Self                             │
-│   - 22 codes への日本語 hint mapping table                                │
+│   - 24 codes (or-pattern 展開後 #692) への日本語 hint mapping table                                │
 └──────────────────────────────────────────────────────────────────────────┘
                               ↓ chain
 ┌──────────────────────────────────────────────────────────────────────────┐
@@ -425,7 +425,7 @@ a11y: `role="alert"` は wrapper に維持、hint は補足情報として `<p>`
 
 | test name | 検証内容 |
 | --- | --- |
-| `default_hint_covers_all_known_codes` (新) | 22 codes 全部 + 例外で None |
+| `default_hint_covers_all_known_codes` (新) | 24 codes (or-pattern 展開後 #692) 全部 + 例外で None |
 | `with_default_hint_attaches_known_code` (新) | hint chain 成功 |
 | `with_default_hint_does_not_overwrite_explicit_hint` (新) | guard logic |
 | `with_default_hint_returns_no_hint_for_unknown_code` (新) | 未登録 code |
@@ -464,7 +464,7 @@ a11y: `role="alert"` は wrapper に維持、hint は補足情報として `<p>`
 
 ### §10.1 [docs/tauri-commands.md](docs/tauri-commands.md)
 
-既存 master table に hint 列を加えるか、末尾に「AppError default hint mapping」 section を追加し、22 codes 全件を 1 表にまとめる (本 spec § 5.2 が source of truth、tauri-commands.md はその外部 mirror)。
+既存 master table に hint 列を加えるか、末尾に「AppError default hint mapping」 section を追加し、24 codes (or-pattern 展開後 #692) 全件を 1 表にまとめる (本 spec § 5.2 が source of truth、tauri-commands.md はその外部 mirror)。
 
 ```markdown
 ## AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)
@@ -557,7 +557,7 @@ Tauri command 失敗時の error 表示は以下を厳守する:
 - [ ] (A) [gui/src/state/metadataStore.ts:209](gui/src/state/metadataStore.ts:209) の `|| msg.startsWith('conflict:')` が削除されている
 - [ ] (A) `metadataStore.test.ts` の `'conflict: ...'` raw String テストが AppError object 形式に書き換わっている
 - [ ] (A) `ConflictModal.test.tsx` の test data から `'conflict:'` prefix が消えている
-- [ ] (B) [gui/src-tauri/src/error.rs](gui/src-tauri/src/error.rs) に `default_hint_for_code()` + `with_default_hint()` が追加され、22 codes 分の日本語 hint が table に存在する
+- [ ] (B) [gui/src-tauri/src/error.rs](gui/src-tauri/src/error.rs) に `default_hint_for_code()` + `with_default_hint()` が追加され、24 codes (or-pattern 展開後 #692) 分の日本語 hint が table に存在する
 - [ ] (B) `From<std::io::Error>` / `From<serde_json::Error>` の impl 内で `.with_default_hint()` が呼ばれている
 - [ ] (B) [gui/src-tauri/src/lib.rs](gui/src-tauri/src/lib.rs) の全 80 site の `AppError::new(code, msg)` に `.with_default_hint()` が chain されている
 - [ ] (C) `metadataStore` に `loadErrorHint` / `applyErrorHint` / `restoreErrorHint` / `draftSaveErrorHint` / `draftLoadErrorHint` の 5 state が追加されている
@@ -577,7 +577,7 @@ Tauri command 失敗時の error 表示は以下を厳守する:
 | Risk | 対策 |
 | --- | --- |
 | **80 site への chain 追加で diff 大きい (lib.rs +80 行)** | mechanical change なのでレビュー負担は文言の方に集中。`docs/tauri-commands.md` の hint table で文言を 1 ヶ所に集約 |
-| **22 codes の日本語 hint 文言の言い回し review が散在する** | spec self-review で文言を 1 表に集約、user review で一括承認/差し戻し、本 spec § 5.2 が source of truth |
+| **24 codes (or-pattern 展開後 #692) の日本語 hint 文言の言い回し review が散在する** | spec self-review で文言を 1 表に集約、user review で一括承認/差し戻し、本 spec § 5.2 が source of truth |
 | **既存 metadataStore.test.ts / ConflictModal.test.tsx の rewrite で regression リスク** | TDD 順序 (red→green) で書き換え、削除前後で test 件数が同等以上であることを確認 |
 | **Iron Law 3 scope creep**: hint 文言を整える過程で「ついでに message も整える」誘惑 | scope-guard skill 適用、message 変更は別 issue 起票 |
 | **Iron Law 6 PR Pre-flight**: Lane I-A 起点だが他 lane と並行する可能性 | base merge 取り込み + `gh pr list --search "#663"` 並行確認、PR 作成時に再確認 |

--- a/docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md
+++ b/docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md
@@ -115,8 +115,9 @@ impl AppError {
 }
 
 /// AppError code に対する日本語 default hint を返す。未登録 code は None。
-/// 22 entries (現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
-/// validation.* / path.* / platform.* / internal.*)。
+/// 24 codes (or-pattern `io.would_block | io.timed_out` を 2 codes に展開後、22 hint
+/// + 2 None = 24)。現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
+/// validation.* / path.* / platform.* / internal.*。
 fn default_hint_for_code(code: &str) -> Option<&'static str> {
     match code {
         // state

--- a/docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md
+++ b/docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md
@@ -11,7 +11,7 @@
 - **Wave 0 完走** (4 lane / 9 issue 完了): Lane I-A (Group A) / Lane IV-a (Group F 4 件) / Lane IV-b 部分 (Group G 2/3) / Lane IV-c (Group H 2 件) が merge 済 (PR #684 #686 #687 #688 #689 #701 #702 #703 #706)
 - **post-#663 cleanup 12 件発生** (PR #689 review 派生): Group I (post-#663 GUI cleanup, 当初 8 件 → §2 採用方針 (a) で #696 を Group D に fold した結果 7 件) / Group J (post-#663 workflow polish, 2 件) / Group K (l2b cleanup, 2 件) が新規 issue として登録済 ([#691](https://github.com/Idios/kobutachan-allaganeye/issues/691) [#692](https://github.com/Idios/kobutachan-allaganeye/issues/692) [#693](https://github.com/Idios/kobutachan-allaganeye/issues/693) [#694](https://github.com/Idios/kobutachan-allaganeye/issues/694) [#695](https://github.com/Idios/kobutachan-allaganeye/issues/695) [#696](https://github.com/Idios/kobutachan-allaganeye/issues/696) [#697](https://github.com/Idios/kobutachan-allaganeye/issues/697) [#698](https://github.com/Idios/kobutachan-allaganeye/issues/698) [#699](https://github.com/Idios/kobutachan-allaganeye/issues/699) [#700](https://github.com/Idios/kobutachan-allaganeye/issues/700) [#704](https://github.com/Idios/kobutachan-allaganeye/issues/704) [#705](https://github.com/Idios/kobutachan-allaganeye/issues/705))
 - **Wave 1 未着手**: 旧 plan の Wave 1 (Lane I-B / II-a / II-b、main 3 lane) は未開始
-- **Group G 残**: [#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) (P2、bug_report.yml 同意チェック付き) が OPEN のまま
+- **Group G 残**: [#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) (P2、bug_report.yml 同意チェック付き) が OPEN のまま — 更新後 plan で Lane IV-b' から scope-out (実装完了済、release gate 後 handoff)
 
 更新後の roadmap は 23 件 / 11 group / 3 wave / 最大 6 lane 並行の構造を採る。
 
@@ -59,7 +59,7 @@
 | **D** | **ErrorModal / Export UX (拡張)** | **4** | OPEN | [#678](https://github.com/Idios/kobutachan-allaganeye/issues/678) (P2) → [#669](https://github.com/Idios/kobutachan-allaganeye/issues/669) → [#680](https://github.com/Idios/kobutachan-allaganeye/issues/680) → **[#696](https://github.com/Idios/kobutachan-allaganeye/issues/696) (新規 fold)** |
 | **E** | **横断 UI bugs** | **1** | OPEN | [#676](https://github.com/Idios/kobutachan-allaganeye/issues/676) ([#680](https://github.com/Idios/kobutachan-allaganeye/issues/680) は D に fold 済) |
 | F | l2b 配布 | 4 | ✅ DONE | [#617](https://github.com/Idios/kobutachan-allaganeye/issues/617) [#616](https://github.com/Idios/kobutachan-allaganeye/issues/616) [#668](https://github.com/Idios/kobutachan-allaganeye/issues/668) [#681](https://github.com/Idios/kobutachan-allaganeye/issues/681) |
-| **G** | **l2-workflow 残** | **1** | OPEN | [#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) (P2) |
+| **G** | **l2-workflow 残** | **1** | OPEN | [#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) (P2) — Lane IV-b' から scope-out (release gate 後 handoff) |
 | H | lint / CLI polish | 2 | ✅ DONE | [#643](https://github.com/Idios/kobutachan-allaganeye/issues/643) [#365](https://github.com/Idios/kobutachan-allaganeye/issues/365) |
 | **★ I** | **post-#663 GUI cleanup** | **7** | OPEN (新規) | Phase 1: [#691](https://github.com/Idios/kobutachan-allaganeye/issues/691) // [#693](https://github.com/Idios/kobutachan-allaganeye/issues/693) // [#695](https://github.com/Idios/kobutachan-allaganeye/issues/695) // [#697](https://github.com/Idios/kobutachan-allaganeye/issues/697) // [#698](https://github.com/Idios/kobutachan-allaganeye/issues/698) → Phase 2: [#694](https://github.com/Idios/kobutachan-allaganeye/issues/694) → Phase 3: [#699](https://github.com/Idios/kobutachan-allaganeye/issues/699) |
 | **★ J** | **post-#663 workflow polish** | **2** | OPEN (新規) | [#692](https://github.com/Idios/kobutachan-allaganeye/issues/692) // [#700](https://github.com/Idios/kobutachan-allaganeye/issues/700) |
@@ -106,10 +106,12 @@ WAVE 1  (CURRENT — 最大 6 lane 並行可)
                 #699 docstring 更新 (refactor 結果反映)
               1 spec / 7 章 (3 phase 構成)
 
-  Lane IV-b'  Group G remainder + Group J 統合 (workflow / CI / docs polish)
-              #458 (P2、bug_report.yml) // #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
+  Lane IV-b'  Group J 単独 (workflow / CI / docs polish)
+              #692 (error.rs hint drift CI) // #700 (markdownlint nested ignore)
               file 完全独立、PR 並行可
-              1 spec / 3 章
+              1 spec / 2 章
+
+              ※ Group G #458 は本 lane から scope-out (実装完了済、release gate 後 /close-issue handoff)
 
   Lane IV-e   Group K (l2b cleanup)
               #704 (Pester PS5.1 BOM) // #705 (BtbN URL 陳腐化対策、旧 plan 「5 章目」)
@@ -142,7 +144,7 @@ WAVE 3  (release gate)
 | V Phase 1 (5 件) | | ✓ #691 | | | | | ✓ #695 | ✓ #697 | ✓ #698 | | | | | | | |
 | V Phase 2 (#694) | | ✓ refactor | (consumer) | (consumer) | | (consumer) | (consumer) | (consumer) | (consumer) | ✓ refactor | | | | | | |
 | V Phase 3 (#699) | | | | | | | | | | | | | | | | (docstring) |
-| IV-b' (#458 #692 #700) | | | | | | | | | | | ✓ #692 | ✓ #692 | ✓ #458 | ✓ #700 | | |
+| IV-b' (#692 #700) | | | | | | | | | | | ✓ #692 | ✓ #692 | | ✓ #700 | | |
 | IV-e (#704 #705) | | | | | | | | | | | | | | | ✓ #704 | ✓ #705 |
 
 **衝突注意点**:
@@ -180,7 +182,7 @@ WAVE 3  (release gate)
 /superpowers:brainstorming Lane V Phase 3: Group I #699 docstring 更新 (#694 merge 後)
 
 # Wave 1 polish - Lane IV (workflow / CI / installer)
-/superpowers:brainstorming Lane IV-b': Group G #458 + Group J #692 #700 (workflow / CI / docs polish)
+/superpowers:brainstorming Lane IV-b': Group J #692 #700 (workflow / CI / docs polish、#458 は scope-out)
 /superpowers:brainstorming Lane IV-e: Group K の問題を解決したい (#704 #705 l2b cleanup)
 
 # Wave 2 (Wave 1 完走後)

--- a/docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md
+++ b/docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md
@@ -1,0 +1,569 @@
+# L2 Lane IV-b' (Group J + Group G remainder 調整) 設計
+
+> **Status**: L2 (v0.2.0) Wave 1 polish lane の workflow / CI / docs polish スコープ
+> **Scope**: [#692](https://github.com/Idios/kobutachan-allaganeye/issues/692) + [#700](https://github.com/Idios/kobutachan-allaganeye/issues/700) 統合 (1 spec / 2 章 / 2 並行 PR) + [#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) は scope-out (release gate 後 handoff)
+> **session**: `tender-moore-2a5d2f` (2026-05-11 brainstorming)
+> **roadmap**: [`docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md`](../plans/2026-05-11-l2-v020-roadmap-update.md) §Lane IV-b'
+>
+> **precedent**: [`docs/superpowers/specs/2026-05-08-lane-iv-b-group-g-design.md`](2026-05-08-lane-iv-b-group-g-design.md) (Wave 0 Lane IV-b、#624 / #458 / #682)
+
+## §1 Overview
+
+Lane IV-b' は L2 (v0.2.0) Wave 1 polish lane の 1 つで、post-#663 cleanup の workflow / CI / docs polish を担う。当初 roadmap (`2026-05-11-l2-v020-roadmap-update.md`) では Group G #458 + Group J #692 #700 の 3 件 / 3 章を想定したが、本 brainstorming session (Q1) で **#458 を scope-out** に確定した:
+
+- **#458 (bug_report.yml)**: 本体は PR [#497](https://github.com/Idios/kobutachan-allaganeye/pull/497) (2026-04-21 develop-0.2.0 マージ済) + PR [#688](https://github.com/Idios/kobutachan-allaganeye/pull/688) (2026-05-08 Wave 0 で field id 凍結 + #669 連動 note 先取り済) で実装完了。受け入れ条件 5 項目中 4 項目検証済、残る 1 項目「New issue UI でテンプレ選択可能」は L2 release (`develop-0.2.0 → main` マージ) 後でないと検証不能。**Lane IV-b' では実装作業を行わず、release gate 後の L3 初期に `/close-issue` skill で UI 実測 → close する handoff として扱う**
+
+実装対象は **2 件 / 2 章 / 2 並行 PR** (Q2):
+
+| issue | priority | 概要 | 本 spec での扱い |
+| --- | --- | --- | --- |
+| [#692](https://github.com/Idios/kobutachan-allaganeye/issues/692) | P3 (task) | error.rs hint table drift check CI job 追加 | §3 (中核章、mid-weight PR-1) |
+| [#700](https://github.com/Idios/kobutachan-allaganeye/issues/700) | P3 (bug) | markdownlint ignore で nested `gui/node_modules` を除外 | §4 (1 行修正、light PR-2) |
+
+加えて、3 件 → 2 件への縮小に伴う roadmap doc 表現の事実訂正を §5 で扱う。
+
+### Lane / wave 設計上の位置づけ
+
+- **Lane IV-b'** = Wave 1 polish lane (Group I Lane V / Group J Lane IV-b' / Group K Lane IV-e) の 1 つ
+- file 完全独立 (`.github/scripts/*.sh,*.awk` / `.github/workflows/ci.yml` / `docs/tauri-commands.md` / `gui/src-tauri/src/error.rs` / `.markdownlint-cli2.yaml` / `docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md` / `docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md`) → Wave 1 全 lane と並行可
+- Wave 1 main lane (I-B / II-a / II-b) と file 衝突なし、後段 wave への依存なし
+
+## §2 Goals
+
+1. **#692**: `gui/src-tauri/src/error.rs::default_hint_for_code` (22 hint entries + 2 None entries `subprocess.cancelled` / `internal.error`、or-pattern `io.would_block | io.timed_out` を 2 code に展開して計 24 codes) と `docs/tauri-commands.md` §「AppError default hint mapping」 table の (code, hint) ペア文言完全一致を CI で保証する drift check job (bash + awk、`doc-tauri-commands-drift` precedent 踏襲) を `.github/workflows/ci.yml` に追加。TDD red→green 検証 (故意 drift → red 確認 → revert → green) で挙動を担保
+2. **#700**: `.markdownlint-cli2.yaml` の `ignores: node_modules/**` に `**/node_modules/**` を併記し、`gui/node_modules/` 配下 7712 誤検出を 0 にする。CI は `npm install` しないため CI 挙動に影響なし、dev 体験 (`bash scripts/check-markdownlint.sh`) のみ改善
+3. **roadmap doc adjustment**: `docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md` および同 design `docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md` の Lane IV-b' 関連記述 4 ヶ所を 2 件 / 2 章 (#692 / #700) に縮小、#458 は「release gate 後 `/close-issue` handoff」として deferred 表に明記
+
+## §3 #692 hint drift CI 設計
+
+### §3.1 現状
+
+`gui/src-tauri/src/error.rs::default_hint_for_code` (現行、抜粋):
+
+```rust
+fn default_hint_for_code(code: &str) -> Option<&'static str> {
+    match code {
+        "state.mtime_conflict" => Some("metadata.json が他の..."),
+        // ... 中略 ...
+        "io.would_block" | "io.timed_out" => Some("I/O 処理が..."),  // or-pattern (2 codes)
+        // ... 中略 ...
+        "subprocess.cancelled" => None,  // None entry
+        "internal.error" => None,         // None entry
+        _ => None,
+    }
+}
+```
+
+合計 **24 codes** (22 hint entries + 2 None entries、or-pattern を展開済)。Source of truth は error.rs (docstring に「本 fn が source of truth、docs は mirror」と明記)。
+
+`docs/tauri-commands.md` §「AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)」 table (現行、抜粋):
+
+```markdown
+| code | hint |
+| ... | ... |
+| `state.mtime_conflict` | metadata.json が他の... |
+| `io.would_block` | I/O 処理が... |
+| `io.timed_out` | I/O 処理が... |
+| `subprocess.cancelled` | (hint なし: ユーザー操作によるキャンセルは UI 側で十分な情報を出す) |
+| `internal.error` | (hint なし: 内部エラーで具体的アクションがない、message 側で logs 参照を案内) |
+```
+
+実装時の前提確認 (writing-plans 段階): docs table で or-pattern が **2 行に展開** されているか **1 行併記** か (`grep` で実物確認)。awk parser はどちらでも対応する設計 (§3.3)。
+
+### §3.2 改修方針 (Q3 (a) Bash + awk + Q4 (a) 文言完全一致 + None 含む)
+
+`.github/scripts/check-error-hint-drift.sh` を新規作成し、`.github/workflows/ci.yml` に `doc-error-hint-drift` job を追加。`doc-tauri-commands-drift` (既存 ci.yml:157、参照: [PR #689](https://github.com/Idios/kobutachan-allaganeye/pull/689) Round 1 で確立) と同じ **awk + sort -u + diff -u pattern** を踏襲。
+
+**抽出 pair 形式**: `<code>\t<hint_normalized>`
+
+- code: ``` `<code>` ``` の backtick を剥がした文字列
+- hint: 下記 normalize 適用後の文字列
+- None entries: hint = sentinel `<<NONE>>`
+
+**normalize ルール** (両 side 同じ規則):
+
+- whitespace 縮約 (連続 space → 1 space)
+- 改行 → space (multi-line hint 対応)
+- 前後 trim
+- quote (`"`) / カッコ / 「」はそのまま保持 (両 side で同形式前提)
+- None sentinel:
+  - error.rs `=> None,` の arm → `<<NONE>>`
+  - docs `(hint なし: ...)` で始まる cell → `<<NONE>>`
+
+**比較**: 両 pair set を sort して diff -u、差分行があれば exit 1。
+
+### §3.3 実装構造
+
+awk parser を 2 file に外出しする (script-内 inline awk は or-pattern + None で複雑化するため可読性優先、本 spec §9 トレードオフ参照):
+
+```text
+.github/scripts/
+├── check-error-hint-drift.sh         (新規、メイン)
+├── extract-rust-hints.awk            (新規、error.rs parser)
+└── extract-doc-hints.awk             (新規、tauri-commands.md parser)
+```
+
+#### §3.3.1 `check-error-hint-drift.sh` (擬似コード)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUST_FILE="gui/src-tauri/src/error.rs"
+DOC_FILE="docs/tauri-commands.md"
+
+extract_rust_pairs() {
+  awk -f "$SCRIPT_DIR/extract-rust-hints.awk" "$RUST_FILE"
+}
+
+extract_doc_pairs() {
+  awk -f "$SCRIPT_DIR/extract-doc-hints.awk" "$DOC_FILE"
+}
+
+if ! diff -u \
+    <(extract_rust_pairs | sort) \
+    <(extract_doc_pairs | sort); then
+  cat >&2 <<'EOF'
+
+ERROR: error.rs ↔ docs/tauri-commands.md hint drift detected.
+
+Source of truth: gui/src-tauri/src/error.rs::default_hint_for_code
+Mirror:          docs/tauri-commands.md §「AppError default hint mapping」 table
+
+Both must be updated in the same PR. See docs/tauri-commands.md docstring +
+gui/src-tauri/src/error.rs::default_hint_for_code docstring for the contract.
+EOF
+  exit 1
+fi
+```
+
+#### §3.3.2 `extract-rust-hints.awk` (擬似コード)
+
+```awk
+# fn default_hint_for_code の match arm を (code, hint) pair に展開
+# or-pattern: "a" | "b" => Some("...") → 2 行に展開
+# None entry: "c" => None, → c<TAB><<NONE>>
+
+BEGIN { in_fn = 0 }
+/^fn default_hint_for_code/ { in_fn = 1; next }
+in_fn && /^\}/ { in_fn = 0; exit }
+
+in_fn && /=>/ {
+  # 左辺: "code1" | "code2" | ... (or-pattern)
+  # 右辺: Some("hint") | None
+  # multi-line hint も catch (continuation line で =>) — 実装時に対応
+  split_or_pattern_into_codes(...)
+  if (right_side ~ /None/) hint = "<<NONE>>"
+  else                     hint = normalize(extract_some_arg(...))
+  for (c in codes) print c "\t" hint
+}
+```
+
+#### §3.3.3 `extract-doc-hints.awk` (擬似コード)
+
+```awk
+# ## AppError default hint mapping section 内の table row を (code, hint) pair に展開
+# `| `code` | hint |` → code<TAB>hint
+# `| `code` | (hint なし: ...) |` → code<TAB><<NONE>>
+
+BEGIN { in_section = 0 }
+/^## AppError default hint mapping/ { in_section = 1; next }
+in_section && /^## / && !/^## AppError default hint mapping/ { in_section = 0; exit }
+
+in_section && /^\| `[^`]+` \|/ {
+  # parse table row
+  # extract code from `...` and hint from cell after second |
+  code = extract_code_backticked(...)
+  raw_hint = extract_second_cell(...)
+  if (raw_hint ~ /^\(hint なし:/) hint = "<<NONE>>"
+  else                            hint = normalize(raw_hint)
+  print code "\t" hint
+}
+```
+
+#### §3.3.4 `.github/workflows/ci.yml` job 追加
+
+`doc-tauri-commands-drift` と相似形:
+
+```yaml
+  doc-error-hint-drift:
+    name: docs ↔ error.rs hint drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check error.rs ↔ docs/tauri-commands.md hint drift
+        run: bash .github/scripts/check-error-hint-drift.sh
+```
+
+### §3.4 TDD red→green 検証
+
+1. **(red 1: 文言変更)** docs の 1 hint cell を故意に文言変更 (例: `io.file_not_found` の「パスを確認」→「パスを再確認」)
+2. local: `bash .github/scripts/check-error-hint-drift.sh` → exit 1 + diff 出力確認
+3. **(green)** 上記変更を revert
+4. local 再実行 → exit 0
+5. **(red 2: or-pattern code 削除)** docs から `io.timed_out` 行を削除 → exit 1 (`io.timed_out` が error.rs 側にあるが docs 側にない)
+6. revert → exit 0
+7. **(red 3: None sentinel 変更)** docs の `subprocess.cancelled` cell を `(hint なし: ...)` から実際の文言 (例: "キャンセルされました") に変更 → exit 1 (sentinel mismatch)
+8. revert → exit 0
+9. **(CI 確認)** PR-1 で `doc-error-hint-drift` job が green であることを確認 (drift なし状態)
+
+検証エビデンスは PR-1 の commit log + Self-Test Report (§7.5) に記述。
+
+### §3.5 受け入れ条件 → §3 対応
+
+| # | issue [#692](https://github.com/Idios/kobutachan-allaganeye/issues/692) 受け入れ条件 | 対応 |
+| --- | --- | --- |
+| 1 | error.rs から (code, hint) 抽出 script | §3.3.2 `extract-rust-hints.awk` |
+| 2 | docs/tauri-commands.md から (code, hint) 抽出 script | §3.3.3 `extract-doc-hints.awk` |
+| 3 | sort + diff -u で drift → CI fail | §3.3.1 `check-error-hint-drift.sh` + §3.3.4 ci.yml job |
+| 4 | or-pattern / None entries の handling | §3.2 normalize + §3.4 red 2/3 で検証 |
+| 5 | 故意 drift → red → fix → green の TDD 検証 | §3.4 手順 |
+
+## §4 #700 markdownlint nested ignore
+
+### §4.1 現状
+
+`.markdownlint-cli2.yaml:43-52`:
+
+```yaml
+globs:
+  - "**/*.md"
+
+ignores:
+  - "node_modules/**"
+  - ".venv/**"
+  - ".git/**"
+  - ".pytest_cache/**"
+  - ".ruff_cache/**"
+  - "**/kobutachan_allaganeye.egg-info/**"
+```
+
+`markdownlint-cli2` の glob 仕様: `node_modules/**` は cwd 直下の `node_modules/` のみ match、nested `gui/node_modules/**` には未到達。`cd gui && npm install` 後の `bash scripts/check-markdownlint.sh` で 7712 errors が誤報告される (issue [#700](https://github.com/Idios/kobutachan-allaganeye/issues/700) 本文)。
+
+CI は `npm install` を実行しないため `gui/node_modules/` 不在、CI 挙動には影響なし。dev 体験のみ阻害。
+
+### §4.2 修正方針
+
+`.markdownlint-cli2.yaml` の `ignores` に `**/node_modules/**` を追加 (issue 本文の推奨案、併記で安全):
+
+```yaml
+ignores:
+  - "node_modules/**"
+  - "**/node_modules/**"  # nested (gui/node_modules 等) も除外 (#700)
+  - ".venv/**"
+  - ".git/**"
+  - ".pytest_cache/**"
+  - ".ruff_cache/**"
+  - "**/kobutachan_allaganeye.egg-info/**"
+```
+
+### §4.3 検証手順
+
+1. **(pre)** `cd gui && npm install` で `gui/node_modules/` を生成
+2. **(red)** `bash scripts/check-markdownlint.sh` → 7712 errors (issue 報告通り)
+3. **(green)** `.markdownlint-cli2.yaml` を §4.2 修正
+4. **(verify)** `bash scripts/check-markdownlint.sh` → 0 errors
+5. **(CI 無影響確認)** CI の `markdownlint` job が引き続き pass (CI は `npm install` を実行しないため `gui/node_modules/` 不在、挙動変化なし)
+
+### §4.4 受け入れ条件 → §4 対応
+
+| # | issue [#700](https://github.com/Idios/kobutachan-allaganeye/issues/700) 受け入れ条件 | 対応 |
+| --- | --- | --- |
+| 1 | `.markdownlint-cli2.yaml` の ignores glob 修正 | §4.2 (1 行追加) |
+| 2 | `gui/node_modules/**/*.md` の誤検出 7712 → 0 | §4.3 step 4 |
+| 3 | CI markdownlint job pass 維持 | §4.3 step 5 |
+
+## §5 roadmap doc adjustment
+
+### §5.1 修正対象 4 ヶ所 + 関連 design doc 2 ヶ所
+
+[`docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md`](../plans/2026-05-11-l2-v020-roadmap-update.md) の Lane IV-b' 関連記述を 2 件 / 2 章 (#692 / #700) に縮小、#458 は handoff として明記:
+
+| 行 (現在) | 現状 | 修正後 |
+| --- | --- | --- |
+| 81 | `**並行安全度**: high (...) / **brainstorming 単位**: Lane IV-b' で Group J と統合 (1 spec / 3 章)` | `...1 spec / 2 章 (#458 は scope-out、release gate 後 /close-issue で handoff)` |
+| 110 | `#458 (P2、bug_report.yml) // #692 ... // #700 ...` | `#692 ... // #700 ...` + Lane 説明文に「#458 は scope-out、release gate 後 handoff」を脚注追加 |
+| 162 | `#458 // #692 // #700` (Wave 1 ASCII 図内) | `#692 // #700` + `(#458 deferred、release gate 後 handoff)` を 1 行追加 |
+| 200 | `/superpowers:brainstorming Lane IV-b': Group G #458 + Group J #692 #700 ...` | `/superpowers:brainstorming Lane IV-b': Group J #692 #700 (workflow / CI / docs polish、#458 は release gate 後 handoff)` |
+| §4 deferred 表 (255-) | (記述なし) | 「#458 は Lane IV-b' から scope-out、release gate 後 L3 初期に UI 実測 → close 予定 (handoff path)」を 1 行追記 |
+
+更に同 spec の base [`docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md`](2026-05-11-l2-v020-roadmap-update-design.md) の同等 4 ヶ所 (§4.1 Group G 行 / §4.2 Lane IV-b' 行 / §4.3 file matrix 行 / §4.6 brainstorming 入り口) も整合修正。
+
+実装時は writing-plans フェーズで `grep -n "Lane IV-b'\|Lane IV-b prime\|#458"` で全 hit を確認し、本 §5.1 表の修正方針に従って一括修正する。
+
+### §5.2 同梱 PR (#692 PR-1)
+
+roadmap doc 修正は **PR-1 (#692、mid-weight) に同梱** する (Q1-Q2 + brainstorming session で確定)。PR-2 (#700) は config 1 行修正で trivial、roadmap doc を別 PR にする利益が薄い。
+
+### §5.3 scope creep 警戒の透明化
+
+Iron Law 3 (1 PR = 1 scope) に従えば、roadmap doc 修正は厳密には `#692` issue scope の外にあるが、本 brainstorming session で確定した「Lane IV-b' scope 縮小」という **事実訂正** の性格を持つ:
+
+- 新規 issue 起票するほどの規模ではない (4 行修正 × 2 file)
+- Lane IV-b' に紐づく実装 PR で扱うのが trace 上自然
+- 別 PR にすると "roadmap doc 修正だけの PR" が発生し PR 数増
+
+このため本 spec doc § で「Lane IV-b' 事実訂正 = Lane IV-b' scope 内」と判断する。PR-1 本文 `## スコープ` 節に明示し透明化する (§6.1)。
+
+## §6 PR 統合方針 + 受け入れ条件統合
+
+### §6.1 PR 構成 (Q2 (a) 2 並行 PR)
+
+#### PR-1 (#692 hint drift CI、mid-weight)
+
+```text
+title: feat(ci): error.rs hint table drift check job 追加 (Refs #692)
+
+body 内 scope 宣言:
+  ## スコープ
+
+  Lane IV-b' (Group J #692 hint drift CI) を実装:
+
+  - .github/scripts/check-error-hint-drift.sh + 2 awk file (extract-rust-hints.awk
+    / extract-doc-hints.awk) 新規作成
+  - .github/workflows/ci.yml に doc-error-hint-drift job 追加 (doc-tauri-commands-drift
+    precedent 踏襲)
+  - ci.yml に shellcheck job 新規追加 (repo 全体 .sh 対象、§7.4)
+
+  加えて、本 brainstorming session で確定した Lane IV-b' scope 縮小 (#458 scope-out、
+  release gate 後 handoff) を docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md
+  + docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md に反映する
+  fact 訂正修正を同梱 (§5)。
+
+  本 Lane IV-b' spec doc も新規追加: docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md
+
+  Refs #692
+```
+
+#### PR-2 (#700 markdownlint nested ignore、light)
+
+```text
+title: fix(markdownlint): nested gui/node_modules を ignore に追加 (Refs #700)
+
+body 内 scope 宣言:
+  ## スコープ
+
+  Lane IV-b' (Group J #700 markdownlint nested ignore) を実装:
+
+  - .markdownlint-cli2.yaml の ignores に **/node_modules/** を追加 (1 行)
+  - 検証: bash scripts/check-markdownlint.sh で 7712 → 0
+
+  spec doc は PR-1 に同梱: docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md §4
+
+  Refs #700
+```
+
+**merge 順序**: 依存なし、どちらが先でも OK。並行レビュー / merge 可。
+
+### §6.2 受け入れ条件統合 (各 PR 本文)
+
+PR-1 本文 `## 受け入れ条件`:
+
+```markdown
+## 受け入れ条件 (#692)
+
+- [x] error.rs から (code, hint) 抽出 script (.github/scripts/extract-rust-hints.awk)
+- [x] docs/tauri-commands.md から (code, hint) 抽出 script (.github/scripts/extract-doc-hints.awk)
+- [x] sort + diff -u で drift → CI fail (ci.yml に doc-error-hint-drift job 追加)
+- [x] or-pattern (io.would_block | io.timed_out) / None entries (subprocess.cancelled / internal.error) の handling
+- [x] 故意 drift → red → fix → green の TDD 検証 (commit log + Self-Test Report で記録)
+```
+
+PR-2 本文 `## 受け入れ条件`:
+
+```markdown
+## 受け入れ条件 (#700)
+
+- [x] .markdownlint-cli2.yaml の ignores glob 修正
+- [x] gui/node_modules/**/*.md の誤検出 7712 → 0 (local 検証済)
+- [x] CI markdownlint job pass 維持 (npm install 不要のため挙動変化なし)
+```
+
+### §6.3 chicken-and-egg 回避
+
+本 lane の各 PR 本文に `- [ ]` を含めない (旧 `pr-checklist.yml` 全文 grep 仕様は PR [#688](https://github.com/Idios/kobutachan-allaganeye/pull/688) で section-aware 化済だが、安全マージンとして受け入れ条件は全件 `[x]` で書く)。
+
+### §6.4 Iron Law 整合
+
+| Iron Law | 担保 |
+| --- | --- |
+| Law 1 (受け入れ条件全件チェック) | PR 各々の §6.2 で逐条 |
+| Law 2 (bulk 操作 AskUserQuestion) | 2 PR merge 後の close は `/close-issue` skill で個別実施 (各 PR ↔ 1 issue 1:1、Iron Law 2 bulk 該当せず) |
+| Law 3 (1 PR = 1 scope) | PR-1 = 「Lane IV-b' #692 hint drift CI + Lane IV-b' scope 確定 (fact 訂正)」で 1 scope / PR-2 = 「Lane IV-b' #700 markdownlint nested ignore」で 1 scope。scope creep 透明化は §5.3 |
+| Law 4 (Closes 禁止) | 両 PR とも `Refs #N` のみ |
+| Law 5 (曖昧点 AskUserQuestion) | brainstorming session で Q1-Q6 の 6 質問を実施 (本 spec session メタ参照) |
+| Law 6 (PR 作成 Pre-flight) | `git fetch origin develop-0.2.0` + 取り込み未済 commit 確認 + 並行 worktree PR 重複確認を各 PR 作成直前に実施 (§8.1 step 5) |
+
+## §7 Test
+
+### §7.1 #692 検証
+
+- **awk parser TDD**: §3.4 の red→green 手順 (故意 drift × 3 ケース: 文言変更 / or-pattern 1 code 削除 / None sentinel 変更) を local で実施、commit log + Self-Test Report に検証エビデンスを残す
+- **CI 統合確認**: PR-1 の CI で `doc-error-hint-drift` job が pass することを確認 (drift なし状態)
+- **shellcheck**: 本 lane で追加する `.github/scripts/check-error-hint-drift.sh` + 既存 `scripts/check-markdownlint.sh` / `scripts/cleanup-worktrees.sh` の shellcheck pass を確認 (§7.4 で詳細)
+- **awk script の portability**: bash + awk (GNU awk 前提) は ci.yml `runs-on: ubuntu-latest` で動作確認、Windows / macOS local 実行は範囲外 (CI で完結する設計)
+
+### §7.2 #700 検証
+
+§4.3 手順 (pre-install → red → green → CI 無影響確認) を local で実施。本 lane の changed file が `.md` を含むため、PR-1 / PR-2 とも `bash scripts/check-markdownlint.sh` で 0 errors を確認。
+
+### §7.3 自動チェック (path 別)
+
+本 lane の変更 path:
+
+- PR-1:
+  - `.github/scripts/check-error-hint-drift.sh` (新規)
+  - `.github/scripts/extract-rust-hints.awk` (新規)
+  - `.github/scripts/extract-doc-hints.awk` (新規)
+  - `.github/workflows/ci.yml` (更新: drift job + shellcheck job 追加)
+  - `docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md` (新規、本 spec)
+  - `docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md` (更新: §5)
+  - `docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md` (更新: §5)
+- PR-2:
+  - `.markdownlint-cli2.yaml` (更新: 1 行追加)
+
+必要チェック:
+
+- ✓ markdownlint (`bash scripts/check-markdownlint.sh`、PR-1 / PR-2 とも)
+- ✓ shellcheck (PR-1 のみ、`.github/scripts/*.sh` + `scripts/*.sh`、§7.4)
+- ✓ ci.yml の syntax (GitHub Actions が自動)
+- ✗ Python (`ruff` / `pyright` / `pytest`) — touch なし
+- ✗ GUI (`npm run lint` / `typecheck` / `test` / `build` / `cargo check`) — touch なし
+
+### §7.4 shellcheck job (新規、PR-1)
+
+Q5 確定: ci.yml に `shellcheck` job を新規追加、対象は **repo 全体の .sh** (`.github/scripts/*.sh` + `scripts/*.sh`)。
+
+#### §7.4.1 想定 ci.yml step
+
+```yaml
+  shellcheck:
+    name: shellcheck (.github/scripts + scripts)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          severity: warning
+          scandir: '.'
+          additional_files: |
+            .github/scripts/check-error-hint-drift.sh
+            scripts/check-markdownlint.sh
+            scripts/cleanup-worktrees.sh
+```
+
+または equivalent な `apt-get install shellcheck && shellcheck **/*.sh` step。実装時に既存 CI の style (ludeeus/action-shellcheck vs `apt-get` 直接) を確認し統一する (writing-plans 段階で精査)。
+
+#### §7.4.2 既存 script の shellcheck pass 状況確認
+
+実装時に local で `shellcheck scripts/check-markdownlint.sh scripts/cleanup-worktrees.sh` を実行し pass 状況を確認:
+
+- **pass する場合**: shellcheck job をそのまま追加して PR-1 commit
+- **pass しない場合 (warning 1-3 件程度)**: 本 PR 内で軽微修正 (shellcheck pragma 追加 or quote 修正等)。scope creep 透明化は PR-1 本文に追記
+- **pass しない場合 (多数 / structural 修正必要)**: 本 PR から shellcheck job を一旦外し、別 issue 起票で対応。`AskUserQuestion` で Idios に判断を仰ぐ (Iron Law 5)
+
+### §7.5 Self-Test Report 規約 (`docs/l2-workflow.md`)
+
+- **machine-verified** (`[x]`):
+  - markdownlint pass (両 PR)
+  - shellcheck pass (PR-1)
+  - drift check CI job green (PR-1)
+  - red→green TDD (PR-1、commit log + report)
+  - `gui/node_modules/` の `cd gui && npm install` 後の 7712 → 0 (PR-2)
+- **machine-unverifiable** (plain bullet `-`):
+  - 該当なし (CI workflow / lint config / docs のみの変更、GPU / audio / video detector / GUI Tauri touch なし)
+
+Self-Test Report の `### 実機検証 (machine-unverifiable)` 節は plain bullet `-` で「該当なし」と記述する。
+
+## §8 Rollout
+
+### §8.1 実装順序
+
+```text
+1. 本 spec を docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md に commit
+   (本 brainstorming session の終端、writing-plans 起動前)
+
+2. /superpowers:writing-plans 起動
+   → docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md 作成
+
+3. PR-1 (#692) 実装:
+   a. 本 spec doc 新規追加
+   b. roadmap doc + 同 design doc の §5.1 表通り 4 ヶ所修正
+      (plan.md + design.md の両 file、grep -n "Lane IV-b'\|#458" で hit 確認)
+   c. awk script 2 file 作成 (extract-rust-hints.awk / extract-doc-hints.awk)
+   d. メイン bash script (.github/scripts/check-error-hint-drift.sh)
+   e. ci.yml に doc-error-hint-drift job 追加
+   f. ci.yml に shellcheck job 追加 (§7.4.1)
+   g. local 検証: shellcheck repo 全体 .sh pass (§7.4.2 で多数失敗時は別判断)
+   h. TDD red→green 検証 (§3.4)
+
+4. PR-2 (#700) 実装:
+   a. .markdownlint-cli2.yaml 1 行追加
+   b. local 検証 (§4.3)
+
+5. Iron Law 6 PR Pre-flight (各 PR 作成直前):
+   - git fetch origin develop-0.2.0 && git log HEAD..origin/develop-0.2.0 --oneline
+   - 取り込み未済 commit ある場合 → git merge origin/develop-0.2.0 + 自動チェック再実行
+   - gh pr list --search "#692|#700|Lane IV-b" --state all で並行 worktree PR 重複確認
+
+6. PR-1 / PR-2 並行作成 (依存なし)
+   - 本文は printf | gh pr create --body-file - で渡す (memory feedback_gh_command_ja_heredoc.md)
+
+7. /iterate-review で各 PR review-fix ループ (subagent dispatch + collapse)
+
+8. CI 確認 (各 PR で markdownlint / shellcheck / drift job / 既存 job 全 green)
+
+9. merge (並行 OK、依存なし)
+
+10. /close-issue skill で各 issue 個別 close:
+    - #692: 全項目検証 → close
+    - #700: 全項目検証 → close
+    - #458: 本 lane 対象外 (release gate 後 L3 初期 handoff、本 lane では touch なし)
+```
+
+### §8.2 着手順序の根拠
+
+- **PR-1 を先**: spec doc を PR-1 に同梱するため、spec が確定する PR-1 を先行。PR-2 は spec の §4 を Refs して作成
+- **PR-2 を後**: config 1 行修正で trivial、PR-1 完了後に立てる方が PR-1 のレビュー集中度高い (同 session で順次着手)
+- **merge 順序は任意**: 依存なし、レビュー先着優先
+
+## §9 トレードオフ整理
+
+| 設計ポイント | 選択 | リスク | 緩和 |
+| --- | --- | --- | --- |
+| #458 を本 lane に含めるか | scope-out (Q1) | roadmap doc の Lane IV-b' エントリと事実乖離 | §5 で roadmap doc 4 ヶ所修正、handoff path を spec + doc に明記 |
+| PR 統合 vs 並行 | 2 並行 PR (Q2) | 並行 worktree PR 重複リスク | Iron Law 6 Pre-flight で `gh pr list` 確認、依存なし設計 |
+| awk script 言語 | bash + awk (Q3) | bash 経験差で可読性低下 | precedent `doc-tauri-commands-drift` と style 統一、awk 外出しで複雑性緩和 |
+| drift 照合範囲 | (code, hint) 文言完全一致 + None (Q4) | 文言の whitespace / 改行 normalize miss で false positive | §3.2 normalize ルール明示、§3.4 red 3 ケースで検証 |
+| awk script の外出し | `.github/scripts/extract-*.awk` 2 file | precedent は inline awk | 本 task は or-pattern + None で複雑、可読性優先、`doc-tauri-commands-drift` と style 多少不一致は許容 |
+| None sentinel `<<NONE>>` | sentinel 方式 | docs `(hint なし: ...)` 説明文との bridging | drift check 前処理で sentinel 変換、docs 本体は人間向け情報量を保持 |
+| spec doc の場所 | PR-1 (mid-weight) に同梱 | PR-2 だけ見た人は spec 文脈不明 | PR-2 本文に spec doc への link を明記 (§6.1) |
+| roadmap doc 修正の PR | PR-1 に同梱 | Iron Law 3 scope creep 警戒 | §5.3 で「Lane IV-b' 事実訂正 = scope 内」を明示、PR-1 本文に透明化 |
+| shellcheck job 対象 | repo 全体 .sh (Q5) | 既存 script が pass しない場合 scope 拡大 | §7.4.2 で local 事前確認、多数失敗時は AskUserQuestion で判断 |
+| spec doc file 名日付 | 2026-05-11 (session 実施日、Q6) | commit 日と乖離する場合あり | precedent (`2026-05-08-lane-iv-b-group-g-design.md`) と整合、trace しやすい |
+
+## §10 Memory feedback / 関連 doc / Iron Law 整合
+
+> Iron Law 整合は §6.4 を参照 (本節では重複させない)。
+
+### §10.1 Memory feedback 適用
+
+- `feedback_gh_command_ja_heredoc.md`: 各 PR 本文 (日本語) は `printf | gh pr create --body-file -` または HEREDOC で渡す
+- `feedback_msys_path_conv_git_show.md`: bash tool 経由 `git show <rev>:<path>` は `MSYS_NO_PATHCONV=1` prefix (実装中 spec 確認で参照する場合)
+- `feedback_powershell_native_redirect.md`: 本 lane の CI は `runs-on: ubuntu-latest` + bash のため適用外。Windows local 検証時の参考としてのみ保持
+- `feedback_skill_revision_empirical.md`: 本 lane は skill 改訂なしのため適用外
+- `feedback_taskstop_child_process_leak.md`: 本 lane では `run_in_background` 利用なし、念のため writing-plans 時に subagent dispatch があれば再確認
+
+### §10.2 関連 doc
+
+- [`docs/l2-workflow.md`](../../l2-workflow.md) — PR Pre-flight / Self-Test Report / (A) PR 内修正優先 / 実機検証 trigger
+- [`docs/tauri-commands.md`](../../tauri-commands.md) §「AppError default hint mapping」 — #692 drift check 対象 (mirror 側)
+- [`gui/src-tauri/src/error.rs`](../../../gui/src-tauri/src/error.rs) — #692 drift check 対象 (source of truth 側)
+- [`.markdownlint-cli2.yaml`](../../../.markdownlint-cli2.yaml) — #700 修正対象
+- [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml) §`doc-tauri-commands-drift` — #692 precedent
+- [`docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md`](../plans/2026-05-11-l2-v020-roadmap-update.md) — Lane IV-b' エントリ (本 lane で §5 修正)
+- [`docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md`](2026-05-11-l2-v020-roadmap-update-design.md) — 同上 (§5 修正)
+- [`docs/superpowers/specs/2026-05-08-lane-iv-b-group-g-design.md`](2026-05-08-lane-iv-b-group-g-design.md) — Wave 0 Lane IV-b spec (#624 / #458 / #682)、本 lane (Lane IV-b') の precedent
+- [`.claude/hooks/session-start.sh`](../../../.claude/hooks/session-start.sh) — Iron Law の正

--- a/docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md
+++ b/docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md
@@ -38,8 +38,12 @@ Spec: docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md §3.4
 
 検証を再実行したい場合は本 log の各 red ケースに記載した sed pattern をそのまま適用すれば再現できる。手順:
 
-1. `git diff --quiet docs/tauri-commands.md` で事前 clean 確認
-2. 該当 red ケースの sed コマンドを `-i.bak` 付きで実行
-3. `bash .github/scripts/check-error-hint-drift.sh` で exit 1 を確認
+1. `git diff --quiet docs/tauri-commands.md` で事前 clean 確認 (exit 0)
+2. backup を退避してから sed で書き換え:
+   - 安全な統一方法: `cp docs/tauri-commands.md docs/tauri-commands.md.bak` で先に backup を作成し、続けて該当 red ケースの sed pattern を `sed -i 's/.../.../' docs/tauri-commands.md` で適用 (GNU sed 前提、Linux / Git Bash / WSL)
+   - 等価で 1 コマンドに圧縮する場合: `sed -i.bak 's/.../.../' docs/tauri-commands.md` でも同じ結果になる (GNU sed が in-place edit 前に `.bak` を残す)。BSD sed (macOS 既定) では挙動が異なるので `sed -i '' -e '...'` が必要 — 本 project は Windows + Git Bash (GNU sed) 想定で、CI も `ubuntu-latest` (GNU sed) のため通常は気にしなくて良い
+3. `bash .github/scripts/check-error-hint-drift.sh` で exit 1 を確認 (`UNEXPECTED PASS` が出ないこと)
 4. `mv docs/tauri-commands.md.bak docs/tauri-commands.md` で revert
-5. `bash .github/scripts/check-error-hint-drift.sh` で exit 0 を確認
+5. `bash .github/scripts/check-error-hint-drift.sh` で exit 0 を確認、加えて `git diff --quiet docs/tauri-commands.md` で差分なしを確認
+
+以上 3 ケースで spec §3.4 が要求する drift detection 仕様 (文言変更 / or-pattern code 削除 / None sentinel 変更) を完全に検証した。

--- a/docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md
+++ b/docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md
@@ -1,0 +1,23 @@
+# TDD red×3 verification log (Lane IV-b' #692)
+
+Spec: docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md §3.4
+
+## red 1: 文言変更
+
+- 変更: `io.file_not_found` hint cell を「パスを確認」→「パスを再確認」
+- 結果: exit 1、diff 出力で文言 mismatch を明示
+
+## red 2: or-pattern code 削除
+
+- 変更: docs から `io.timed_out` を削除 (or-pattern を `io.would_block` のみに)
+- 結果: exit 1、`+ io.timed_out\t...` 行が docs side に欠落
+
+## red 3: None sentinel 変更
+
+- 変更: `subprocess.cancelled` の cell を `(hint なし: ...)` → 「キャンセルされました」
+- 結果: exit 1、Rust side `<<NONE>>` vs docs side 実文言 mismatch
+
+## green (revert 後)
+
+- すべての revert 後で `OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync (24 entries)`
+- `git diff --quiet docs/tauri-commands.md` exit 0

--- a/docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md
+++ b/docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md
@@ -2,22 +2,44 @@
 
 Spec: docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md §3.4
 
+各 red ケースで `docs/tauri-commands.md` を一時的に sed で書き換え、`bash .github/scripts/check-error-hint-drift.sh` が exit 1 (drift detected) を返すことを実証する。検証後すべて revert し、最終的に `git diff --quiet docs/tauri-commands.md` exit 0 (差分なし) を確認した。
+
 ## red 1: 文言変更
 
-- 変更: `io.file_not_found` hint cell を「パスを確認」→「パスを再確認」
-- 結果: exit 1、diff 出力で文言 mismatch を明示
+- 対象: `io.file_not_found` の hint cell
+- sed pattern: `s/パスを確認するか/パスを再確認するか/`
+- 想定: `io.file_not_found` の hint 文字列の中の「パスを確認するか」を「パスを再確認するか」に書き換える
+- 結果: `check-error-hint-drift.sh` exit 1。diff 出力で `io.file_not_found` の hint が docs 側のみ変化していることが明示された
+- revert: `mv docs/tauri-commands.md.bak docs/tauri-commands.md` で復元、`check-error-hint-drift.sh` が `OK: ... 24 entries in sync` で exit 0 に戻ったことを確認
 
 ## red 2: or-pattern code 削除
 
-- 変更: docs から `io.timed_out` を削除 (or-pattern を `io.would_block` のみに)
-- 結果: exit 1、`+ io.timed_out\t...` 行が docs side に欠落
+- 対象: or-pattern 行 `` | `io.would_block` / `io.timed_out` | ... | ``
+- sed pattern: ``s/`io.would_block` \/ `io.timed_out`/`io.would_block`/``
+- 想定: docs 側から `io.timed_out` を削除 (or-pattern の片方が消える)
+- 結果: `check-error-hint-drift.sh` exit 1。diff 出力で `io.timed_out\tI/O 処理が...` 行が Rust side にのみ存在し docs side に欠落していることが明示された (TAB は実 TAB 文字)
+- revert: 復元後 `OK: ... 24 entries in sync` exit 0 で green を確認
 
 ## red 3: None sentinel 変更
 
-- 変更: `subprocess.cancelled` の cell を `(hint なし: ...)` → 「キャンセルされました」
-- 結果: exit 1、Rust side `<<NONE>>` vs docs side 実文言 mismatch
+- 対象: `subprocess.cancelled` の hint cell (現状 `(hint なし: ユーザー操作によるキャンセルは UI 側で十分な情報を出す)`)
+- sed pattern: `s/(hint なし: ユーザー操作.*)/キャンセルされました/` (regex `.*` が cell の閉じカッコまで一致して全体を `キャンセルされました` で置換)
+- 想定: docs 側で sentinel `(hint なし: ...)` が消え、実文言が入る
+- 結果: `check-error-hint-drift.sh` exit 1。diff 出力で `subprocess.cancelled` の hint が `<<NONE>>` (Rust side、`=> None,` arm 由来) vs `キャンセルされました` (docs side) で mismatch であることが明示された
+- revert: 復元後 `OK: ... 24 entries in sync` exit 0 で green を確認
 
-## green (revert 後)
+## green (3 ケース完了後の最終 verify)
 
-- すべての revert 後で `OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync (24 entries)`
-- `git diff --quiet docs/tauri-commands.md` exit 0
+- 3 red ケースの revert 後、`bash .github/scripts/check-error-hint-drift.sh` が `OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync (24 entries)` を出力し exit 0
+- `git diff --quiet docs/tauri-commands.md` が exit 0 (差分なし、完全 revert)
+- `docs/tauri-commands.md.bak` が残存していないことを確認
+
+## 再現手順 (将来の作業者向け)
+
+検証を再実行したい場合は本 log の各 red ケースに記載した sed pattern をそのまま適用すれば再現できる。手順:
+
+1. `git diff --quiet docs/tauri-commands.md` で事前 clean 確認
+2. 該当 red ケースの sed コマンドを `-i.bak` 付きで実行
+3. `bash .github/scripts/check-error-hint-drift.sh` で exit 1 を確認
+4. `mv docs/tauri-commands.md.bak docs/tauri-commands.md` で revert
+5. `bash .github/scripts/check-error-hint-drift.sh` で exit 0 を確認

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -79,7 +79,8 @@ try {
 ## AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)
 
 > 本 table の文言は `gui/src-tauri/src/error.rs` の `default_hint_for_code()` と
-> 完全一致させる (CI integrity check は今回入れないが、文言変更時は両方を
+> 完全一致させる (CI integrity check は `.github/scripts/check-error-hint-drift.sh`
+> および `doc-error-hint-drift` job で自動保証されている (#692)。文言変更時は両方を
 > 同 PR で更新する規約)。
 
 | code | hint |

--- a/gui/src-tauri/src/error.rs
+++ b/gui/src-tauri/src/error.rs
@@ -110,10 +110,12 @@ impl From<String> for AppError {
 }
 
 /// AppError code に対する日本語 default hint を返す。未登録 code は None。
-/// 22 entries (現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
-/// validation.* / path.* / platform.* / internal.*)。
+/// 24 codes (or-pattern `io.would_block | io.timed_out` を 2 codes に展開後、22 hint
+/// + 2 None = 24)。現在の lib.rs inventory: io.* / parse.* / state.* / subprocess.* /
+/// validation.* / path.* / platform.* / internal.*。
 /// 文言は `docs/tauri-commands.md` の AppError default hint mapping table と一致させる
-/// (本 fn が source of truth、docs は mirror)。
+/// (本 fn が source of truth、docs は mirror、`.github/scripts/check-error-hint-drift.sh`
+/// + ci.yml `doc-error-hint-drift` job で drift を CI で防ぐ #692)。
 fn default_hint_for_code(code: &str) -> Option<&'static str> {
     match code {
         // state

--- a/scripts/cleanup-worktrees.sh
+++ b/scripts/cleanup-worktrees.sh
@@ -91,6 +91,7 @@ for d in "$WT_DIR"/*/; do
       echo "  kept $name (directory not empty; inspect manually)"
     fi
   else
+    # shellcheck disable=SC2012  # ls -A is intentional: simpler than find for empty-dir check
     if [[ -z "$(ls -A "$d" 2>/dev/null)" ]]; then
       echo "  would remove $name (empty)"
     else

--- a/tests/fixtures/error-hints/expected-doc.tsv
+++ b/tests/fixtures/error-hints/expected-doc.tsv
@@ -1,0 +1,6 @@
+internal.error	<<NONE>>
+io.file_not_found	ファイルが見つかりません。パスを確認してください
+io.timed_out	I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください
+io.would_block	I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください
+state.mtime_conflict	metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください
+subprocess.cancelled	<<NONE>>

--- a/tests/fixtures/error-hints/expected-rust.tsv
+++ b/tests/fixtures/error-hints/expected-rust.tsv
@@ -1,0 +1,6 @@
+internal.error	<<NONE>>
+io.file_not_found	ファイルが見つかりません。パスを確認してください
+io.timed_out	I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください
+io.would_block	I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください
+state.mtime_conflict	metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください
+subprocess.cancelled	<<NONE>>

--- a/tests/fixtures/error-hints/sample-error.rs
+++ b/tests/fixtures/error-hints/sample-error.rs
@@ -1,0 +1,19 @@
+// Minimal fixture for extract-rust-hints.awk TDD.
+// Includes: single-line hint, multi-line hint, or-pattern, None entry, catch-all.
+
+fn default_hint_for_code(code: &str) -> Option<&'static str> {
+    match code {
+        "state.mtime_conflict" => Some(
+            "metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください"
+        ),
+        "io.file_not_found" => Some(
+            "ファイルが見つかりません。パスを確認してください"
+        ),
+        "io.would_block" | "io.timed_out" => Some(
+            "I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください"
+        ),
+        "subprocess.cancelled" => None,
+        "internal.error" => None,
+        _ => None,
+    }
+}

--- a/tests/fixtures/error-hints/sample-tauri-commands.md
+++ b/tests/fixtures/error-hints/sample-tauri-commands.md
@@ -1,0 +1,23 @@
+# Sample tauri-commands.md (fixture for extract-doc-hints.awk TDD)
+
+## 他の section (本 awk は処理しない)
+
+| col | val |
+| --- | --- |
+| `not.a.code` | should be ignored |
+
+## AppError default hint mapping (`gui/src-tauri/src/error.rs::default_hint_for_code`)
+
+> 本 table の文言は ... と完全一致させる (規約)。
+
+| code | hint |
+| --- | --- |
+| `state.mtime_conflict` | metadata.json が他のプロセスで書き換えられました。「リロード」で最新を読み直すか、「上書き」で現在の編集を強制適用してください |
+| `io.file_not_found` | ファイルが見つかりません。パスを確認してください |
+| `io.would_block` / `io.timed_out` | I/O 処理がタイムアウト / ブロックされました。少し時間をおいて再試行してください |
+| `subprocess.cancelled` | (hint なし: ユーザー操作によるキャンセルは UI 側で十分な情報を出す) |
+| `internal.error` | (hint なし: 内部エラーで具体的アクションがない、message 側で logs 参照を案内) |
+
+## 関連 (本 awk は処理しない)
+
+- See spec ...

--- a/tests/scripts/test_check_error_hint_drift.sh
+++ b/tests/scripts/test_check_error_hint_drift.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Integration test: check-error-hint-drift.sh against fixture files.
+# Fixtures are designed to match (expected pairs identical), so the
+# script should exit 0.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+export RUST_FILE="$SCRIPT_DIR/tests/fixtures/error-hints/sample-error.rs"
+export DOC_FILE="$SCRIPT_DIR/tests/fixtures/error-hints/sample-tauri-commands.md"
+
+if bash "$SCRIPT_DIR/.github/scripts/check-error-hint-drift.sh"; then
+    echo "PASS: fixtures match"
+    exit 0
+else
+    echo "FAIL: fixtures should match but drift detected" >&2
+    exit 1
+fi

--- a/tests/scripts/test_extract_doc_hints.sh
+++ b/tests/scripts/test_extract_doc_hints.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AWK_FILE="$SCRIPT_DIR/.github/scripts/extract-doc-hints.awk"
+FIXTURE="$SCRIPT_DIR/tests/fixtures/error-hints/sample-tauri-commands.md"
+EXPECTED="$SCRIPT_DIR/tests/fixtures/error-hints/expected-doc.tsv"
+
+if [[ ! -f "$AWK_FILE" ]]; then
+  echo "FAIL: awk script not found: $AWK_FILE" >&2
+  exit 1
+fi
+
+actual=$(awk -f "$AWK_FILE" "$FIXTURE" | sort)
+expected=$(sort "$EXPECTED")
+
+if [[ "$actual" == "$expected" ]]; then
+  echo "PASS: extract-doc-hints.awk matches expected"
+  exit 0
+else
+  echo "FAIL: drift detected"
+  diff -u <(echo "$expected") <(echo "$actual")
+  exit 1
+fi

--- a/tests/scripts/test_extract_rust_hints.sh
+++ b/tests/scripts/test_extract_rust_hints.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# TDD harness for .github/scripts/extract-rust-hints.awk
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AWK_FILE="$SCRIPT_DIR/.github/scripts/extract-rust-hints.awk"
+FIXTURE="$SCRIPT_DIR/tests/fixtures/error-hints/sample-error.rs"
+EXPECTED="$SCRIPT_DIR/tests/fixtures/error-hints/expected-rust.tsv"
+
+if [[ ! -f "$AWK_FILE" ]]; then
+  echo "FAIL: awk script not found: $AWK_FILE" >&2
+  exit 1
+fi
+
+actual=$(awk -f "$AWK_FILE" "$FIXTURE" | sort)
+expected=$(sort "$EXPECTED")
+
+if [[ "$actual" == "$expected" ]]; then
+  echo "PASS: extract-rust-hints.awk matches expected"
+  exit 0
+else
+  echo "FAIL: drift detected"
+  diff -u <(echo "$expected") <(echo "$actual")
+  exit 1
+fi


### PR DESCRIPTION
## スコープ

Lane IV-b' (Group J #692 hint drift CI) を実装。post-#663 cleanup の workflow / CI / docs polish lane で、当初 roadmap で想定された 3 件 / 3 章 (#458 + #692 + #700) のうち #458 を本 brainstorming session で scope-out 確定 (release gate 後 `/close-issue` handoff)、本 PR は #692 単独 + Lane IV-b' scope 縮小の roadmap doc fact 訂正 + spec doc 新規追加を扱う (#700 は別 PR で並行作成)。

### 追加・変更内容

- `.github/scripts/check-error-hint-drift.sh` + 2 awk parser (extract-rust-hints.awk / extract-doc-hints.awk) 新規作成 — error.rs ↔ docs/tauri-commands.md の AppError default hint mapping を sort + diff -u で比較、24 entries (or-pattern 1 件展開後) を文言完全一致 + None sentinel 対応で照合
- `.github/workflows/ci.yml` に doc-error-hint-drift job 追加 (`doc-tauri-commands-drift` precedent 踏襲、ubuntu-latest + bash + awk)
- `.github/workflows/ci.yml` に shellcheck job 追加 (`ludeeus/action-shellcheck@2.0.0` pin、severity: warning、`.github/scripts/*.sh + tests/scripts/*.sh + scripts/*.sh` 対象)
- `scripts/cleanup-worktrees.sh`: SC2012 (Use find instead of ls) を Option A pragma (`# shellcheck disable=SC2012` + 意図記述) で対応
- `.shellcheckignore` 新規: `.claude/hooks/` を除外 (Claude Code agent infrastructure、本 PR scope 外)
- `tests/fixtures/error-hints/` + `tests/scripts/test_*.sh` でフィクスチャ + harness 整備
- TDD red×3 verification log を `docs/superpowers/specs/lane-iv-b-prime-evidence/` に保存

### 関連 doc 反映

- 本 Lane IV-b' spec 新規: `docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md`
- 本 Lane IV-b' implementation plan 新規: `docs/superpowers/plans/2026-05-11-lane-iv-b-prime-implementation.md`
- `docs/superpowers/plans/2026-05-11-l2-v020-roadmap-update.md` (Lane IV-b' = Group J 単独、#458 scope-out、§4 deferred 表に handoff path 追記)
- `docs/superpowers/specs/2026-05-11-l2-v020-roadmap-update-design.md` (sibling 整合修正)

Refs #692

## 受け入れ条件 (#692)

- [x] error.rs から (code, hint) 抽出 script (`.github/scripts/extract-rust-hints.awk`、or-pattern + None entry handling)
- [x] docs/tauri-commands.md から (code, hint) 抽出 script (`.github/scripts/extract-doc-hints.awk`、`/` 区切り or-pattern + `(hint なし: ...)` sentinel)
- [x] sort + diff -u で drift → CI fail (`.github/workflows/ci.yml` に `doc-error-hint-drift` job 追加)
- [x] or-pattern (`io.would_block | io.timed_out`) / None entries (`subprocess.cancelled` / `internal.error`) の handling
- [x] 故意 drift → red → fix → green の TDD 検証 (`docs/superpowers/specs/lane-iv-b-prime-evidence/tdd-red-green-log.md`、3 red ケース + revert で green)

## Test plan (本 PR 提出前にローカルで実行済)

- [x] `bash tests/scripts/test_extract_rust_hints.sh` → PASS
- [x] `bash tests/scripts/test_extract_doc_hints.sh` → PASS
- [x] `bash tests/scripts/test_check_error_hint_drift.sh` → PASS (fixtures match)
- [x] `bash .github/scripts/check-error-hint-drift.sh` → OK: error.rs ↔ docs/tauri-commands.md hint mapping in sync (24 entries) (Task 4 実機 verify、commit 55d8e41)
- [x] §3.4 red×3 (文言変更 / or-pattern code 削除 / None sentinel 変更) → 3 ケース exit 1、revert で exit 0
- [x] `bash scripts/check-markdownlint.sh` → 0 error
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML OK
- shellcheck local 実行: sandbox 制限で skip (Task 0 で確認、手動 static analysis で SC2012 1 warning 想定 → pragma で対応済)。CI 上の実証は本 PR push 時に確認

## scope creep 透明化

本 PR は (a) #692 実装 / (b) shellcheck job + cleanup-worktrees.sh pragma + `.shellcheckignore` / (c) Lane IV-b' scope 縮小の roadmap doc fact 訂正 / (d) Lane IV-b' spec doc + implementation plan の新規追加 を含む。Iron Law 3 (1 PR = 1 scope) との整合は spec §5.3 で「Lane IV-b' 事実訂正 = scope 内」と判断、(d) は spec doc 同梱の慣習に従う。各 commit は責務単位で分割 (18 commits)。

## 実機検証 (machine-unverifiable)

- 該当なし (CI workflow / lint config / docs / awk scripts のみの変更、GPU / audio / video detector / GUI Tauri / Python ロジック touch なし)

session-id: tender-moore-2a5d2f
