### PR TITLE
refactor(state): #691 metadataStore *ErrorHint lifecycle pinning (案 X、Lane V Phase 1)

### DIFF
--- a/docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md
+++ b/docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md
@@ -375,6 +375,11 @@ if (appErrorCodeIs(e, 'state.mtime_conflict')) {
 
 `add_recent` / `clear_recent` / `read_recent` の catch path で同パターンを適用 (state field 名は実コード参照、追加方針は metadataStore と同じ「error + errorHint pair」)。
 
+- Lane V Phase 1 #691 (PR #TBD) で 5 catch path × 5 `*ErrorHint` の clear matrix
+  を test で pin、規約を明文化。本 spec で残された non-symmetric pattern
+  (load() catch の partial clear) は採用案 **X** (symmetric 化) で削除し、各
+  catch path を self-only に揃えた。
+
 ## §8 Layer 4 設計: Frontend UI (inline error 2-line render)
 
 ### §8.1 影響 component と変更内容

--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -118,6 +118,17 @@ Tauri command の `Result<T, AppError>` で frontend に届く構造化 error �
   message のみ取得、hint は null になる (PR #663 で legacy raw を返す
   command は存在しないが、helper の互換性として温存)
 
+### §4.7 metadataStore \*ErrorHint lifecycle 規約 (#691)
+
+各 catch path (`load()` / `runApply()` / `restore()` / `saveDraft()` / `loadDraft()`)
+は自身の `*Error` / `*ErrorHint` のみを `set` し、他経路の error state は touch
+しない (案 X、PR #691 で symmetric 化)。lifecycle 終端 (`clear()` / `loadSample()`)
+でのみ全 5 `*Error` + 5 `*ErrorHint` を null reset する。
+
+この規約は `metadataStore.test.ts` の `#691: catch path lifecycle pinning`
+describe block で test で pin されている。将来 catch path 追加時は同 describe
+block に test を追加し、self-only 規約を継承する。
+
 ## 5. 各画面の phase state
 
 ### drop (動画ファイル選択)

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -1195,3 +1195,280 @@ describe('AppError hint pair (#663)', () => {
     expect(s.loadErrorHint).toBeNull();
   });
 });
+
+describe('#691: catch path lifecycle pinning', () => {
+  beforeEach(() => {
+    // Reset to clean state
+    useMetadataStore.setState({
+      metadata: null,
+      filePath: null,
+      dirty: false,
+      loadError: null,
+      loadErrorHint: null,
+      applying: false,
+      applyError: null,
+      applyErrorHint: null,
+      hasBackup: false,
+      restoring: false,
+      restoreError: null,
+      restoreErrorHint: null,
+      loadedMtimeMs: null,
+      conflictError: null,
+      pendingDraft: null,
+      draftLoadError: null,
+      draftLoadErrorHint: null,
+      draftSaving: false,
+      draftSaveError: null,
+      draftSaveErrorHint: null,
+    });
+  });
+
+  it('案 X: load() catch sets load*Error/Hint only, leaves apply/restore/draft *Error/Hint untouched', async () => {
+    // pre-condition: 全 path の *ErrorHint が non-null
+    useMetadataStore.setState({
+      applyError: 'old apply error',
+      applyErrorHint: 'old apply hint',
+      restoreError: 'old restore error',
+      restoreErrorHint: 'old restore hint',
+      draftLoadError: 'old draft load error',
+      draftLoadErrorHint: 'old draft load hint',
+      draftSaveError: 'old draft save error',
+      draftSaveErrorHint: 'old draft save hint',
+    });
+
+    invokeMock.mockImplementation(async () => {
+      throw {
+        code: 'io.file_not_found',
+        message: 'file not found',
+        hint: 'check path',
+      };
+    });
+
+    await useMetadataStore.getState().load('/non-existent');
+
+    const state = useMetadataStore.getState();
+    // self set
+    expect(state.loadError).toBe('file not found');
+    expect(state.loadErrorHint).toBe('check path');
+    // 案 X: other paths' *Error / *ErrorHint untouched
+    expect(state.applyError).toBe('old apply error');
+    expect(state.applyErrorHint).toBe('old apply hint');
+    expect(state.restoreError).toBe('old restore error');
+    expect(state.restoreErrorHint).toBe('old restore hint');
+    expect(state.draftLoadError).toBe('old draft load error');
+    expect(state.draftLoadErrorHint).toBe('old draft load hint');
+    expect(state.draftSaveError).toBe('old draft save error');
+    expect(state.draftSaveErrorHint).toBe('old draft save hint');
+  });
+
+  it('runApply() non-conflict catch sets applyError/Hint only', async () => {
+    useMetadataStore.setState({
+      metadata: { source: '/test.mp4', matches: [] } as never,
+      filePath: '/test.mp4',
+      loadedMtimeMs: 1000,
+      loadError: 'old load error',
+      loadErrorHint: 'old load hint',
+      restoreError: 'old restore error',
+      restoreErrorHint: 'old restore hint',
+    });
+
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'apply_changes') {
+        throw {
+          code: 'io.permission_denied',
+          message: 'denied',
+          hint: 'check write permission',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+
+    await useMetadataStore.getState().apply();
+
+    const state = useMetadataStore.getState();
+    expect(state.applyError).toBe('denied');
+    expect(state.applyErrorHint).toBe('check write permission');
+    expect(state.loadError).toBe('old load error');
+    expect(state.loadErrorHint).toBe('old load hint');
+    expect(state.restoreError).toBe('old restore error');
+    expect(state.restoreErrorHint).toBe('old restore hint');
+  });
+
+  it('runApply() conflict catch sets conflictError only, leaves *Error/Hint untouched', async () => {
+    useMetadataStore.setState({
+      metadata: { source: '/test.mp4', matches: [] } as never,
+      filePath: '/test.mp4',
+      loadedMtimeMs: 1000,
+      applyError: 'old apply error',
+      applyErrorHint: 'old apply hint',
+      loadError: 'old load error',
+      loadErrorHint: 'old load hint',
+    });
+
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'apply_changes') {
+        throw {
+          code: 'state.mtime_conflict',
+          message: 'mtime conflict',
+          hint: 'reload or overwrite',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+
+    await useMetadataStore.getState().apply();
+
+    const state = useMetadataStore.getState();
+    expect(state.conflictError).toBe('mtime conflict');
+    // runApply initial set clears applyError/applyErrorHint/conflictError before invoke
+    // conflict catch then only sets { applying: false, conflictError: msg }
+    // so applyError/applyErrorHint are null from the initial set (not 'old' anymore)
+    expect(state.loadError).toBe('old load error');
+    expect(state.loadErrorHint).toBe('old load hint');
+  });
+
+  it('restore() catch sets restoreError/Hint only', async () => {
+    useMetadataStore.setState({
+      filePath: '/test.mp4',
+      loadError: 'old load error',
+      loadErrorHint: 'old load hint',
+      applyError: 'old apply error',
+      applyErrorHint: 'old apply hint',
+    });
+
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'restore_from_original') {
+        throw {
+          code: 'io.backup_failed',
+          message: 'backup failed',
+          hint: 'check disk',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+
+    await useMetadataStore.getState().restore();
+
+    const state = useMetadataStore.getState();
+    expect(state.restoreError).toBe('backup failed');
+    expect(state.restoreErrorHint).toBe('check disk');
+    expect(state.loadError).toBe('old load error');
+    expect(state.loadErrorHint).toBe('old load hint');
+    expect(state.applyError).toBe('old apply error');
+    expect(state.applyErrorHint).toBe('old apply hint');
+  });
+
+  it('saveDraft() catch sets draftSaveError/Hint only', async () => {
+    useMetadataStore.setState({
+      metadata: { source: '/test.mp4', matches: [] } as never,
+      filePath: '/test.mp4',
+      loadError: 'old load error',
+      loadErrorHint: 'old load hint',
+    });
+
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'save_draft') {
+        throw {
+          code: 'io.write_failed',
+          message: 'write failed',
+          hint: 'check space',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+
+    await useMetadataStore.getState().saveDraft();
+
+    const state = useMetadataStore.getState();
+    expect(state.draftSaveError).toBe('write failed');
+    expect(state.draftSaveErrorHint).toBe('check space');
+    expect(state.loadError).toBe('old load error');
+    expect(state.loadErrorHint).toBe('old load hint');
+  });
+
+  it('loadDraft() catch sets draftLoadError/Hint only', async () => {
+    useMetadataStore.setState({
+      metadata: { source: '/test.mp4', matches: [] } as never,
+      filePath: '/test.mp4',
+      applyError: 'old apply error',
+      applyErrorHint: 'old apply hint',
+    });
+
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'load_draft') {
+        throw {
+          code: 'parse.json_invalid',
+          message: 'json invalid',
+          hint: 'restore from backup',
+        };
+      }
+      throw new Error(`unexpected invoke: ${cmd}`);
+    });
+
+    await useMetadataStore.getState().loadDraft();
+
+    const state = useMetadataStore.getState();
+    expect(state.draftLoadError).toBe('json invalid');
+    expect(state.draftLoadErrorHint).toBe('restore from backup');
+    expect(state.applyError).toBe('old apply error');
+    expect(state.applyErrorHint).toBe('old apply hint');
+  });
+
+  it('clear() resets all *Error and *ErrorHint to null', () => {
+    useMetadataStore.setState({
+      loadError: 'a',
+      loadErrorHint: 'A',
+      applyError: 'b',
+      applyErrorHint: 'B',
+      restoreError: 'c',
+      restoreErrorHint: 'C',
+      draftLoadError: 'd',
+      draftLoadErrorHint: 'D',
+      draftSaveError: 'e',
+      draftSaveErrorHint: 'E',
+    });
+
+    useMetadataStore.getState().clear();
+
+    const state = useMetadataStore.getState();
+    expect(state.loadError).toBeNull();
+    expect(state.loadErrorHint).toBeNull();
+    expect(state.applyError).toBeNull();
+    expect(state.applyErrorHint).toBeNull();
+    expect(state.restoreError).toBeNull();
+    expect(state.restoreErrorHint).toBeNull();
+    expect(state.draftLoadError).toBeNull();
+    expect(state.draftLoadErrorHint).toBeNull();
+    expect(state.draftSaveError).toBeNull();
+    expect(state.draftSaveErrorHint).toBeNull();
+  });
+
+  it('loadSample() resets all *Error and *ErrorHint to null', () => {
+    useMetadataStore.setState({
+      loadError: 'a',
+      loadErrorHint: 'A',
+      applyError: 'b',
+      applyErrorHint: 'B',
+      restoreError: 'c',
+      restoreErrorHint: 'C',
+      draftLoadError: 'd',
+      draftLoadErrorHint: 'D',
+      draftSaveError: 'e',
+      draftSaveErrorHint: 'E',
+    });
+
+    useMetadataStore.getState().loadSample();
+
+    const state = useMetadataStore.getState();
+    expect(state.loadError).toBeNull();
+    expect(state.loadErrorHint).toBeNull();
+    expect(state.applyError).toBeNull();
+    expect(state.applyErrorHint).toBeNull();
+    expect(state.restoreError).toBeNull();
+    expect(state.restoreErrorHint).toBeNull();
+    expect(state.draftLoadError).toBeNull();
+    expect(state.draftLoadErrorHint).toBeNull();
+    expect(state.draftSaveError).toBeNull();
+    expect(state.draftSaveErrorHint).toBeNull();
+  });
+});

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -282,6 +282,10 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       // modal via `pendingDraft`.
       await get().loadDraft();
     } catch (e) {
+      // #691 案 X: catch path は self-only (loadError/loadErrorHint のみ set)。
+      // apply / restore / draft 系の旧 error は別経路の文脈なので保持する
+      // (load 失敗時に user に見せる context を消さない設計、lifecycle 終端
+      // clear() / loadSample() でのみ全 *ErrorHint を null reset する規約)。
       set({
         metadata: null,
         filePath: null,
@@ -292,10 +296,6 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         loadedMtimeMs: null,
         conflictError: null,
         pendingDraft: null,
-        draftLoadError: null,
-        draftLoadErrorHint: null,
-        draftSaveError: null,
-        draftSaveErrorHint: null,
       });
     }
   },


### PR DESCRIPTION
## Summary

#691 (Refs #663) の対応。`metadataStore.ts` の 5 catch path × 5 `*ErrorHint` state の clear 範囲を test で pin、規約を docstring + docs に明文化。Wave 1.1 で PR 1 #693 と完全並行 (UI 非依存)。

**採用案: X (symmetric 化)** — Idios brainstorming で確定 (#712 spec §10 Open question 解決)。

session-id: `lane-v-pr2-691`
spec: `docs/superpowers/specs/2026-05-11-lane-v-phase-1-group-i-design.md` §5.2 (現在 #712 で docs PR 化中)

## 確定 matrix (案 X 適用後)

| catch path | `loadError(Hint)` | `applyError(Hint)` | `restoreError(Hint)` | `draftSaveError(Hint)` | `draftLoadError(Hint)` |
| --- | --- | --- | --- | --- | --- |
| `load()` catch | **set (自)** | - 保持 | - 保持 | - **保持 (本 PR で symmetric 化)** | - **保持 (本 PR で symmetric 化)** |
| `runApply()` non-conflict catch | - | set (自) | - | - | - |
| `runApply()` conflict catch | - | (initial set で reset 済) | - | - | - |
| `restore()` catch | - | - | set (自) | - | - |
| `saveDraft()` catch | - | - | - | set (自) | - |
| `loadDraft()` catch | - | - | - | - | set (自) |
| `clear()` lifecycle 終端 | null | null | null | null | null |
| `loadSample()` lifecycle 終端 | null | null | null | null | null |

**変更点**: `load()` catch path から `draftLoadError(Hint)` / `draftSaveError(Hint)` の clear (`= null`) を削除。各 catch path は自身の `*Error` / `*ErrorHint` のみを set し、他経路の error state は touch しない self-only 規約に揃えた。lifecycle 終端 (`clear()` / `loadSample()`) でのみ全 5 `*Error` + 5 `*ErrorHint` を null reset。

## 変更内容 (2 commits)

- `ad811b4` test+refactor(state): metadataStore catch path lifecycle pinning
  - 8 件の TDD test 追加 (5 catch path 各々 + clear() + loadSample() + conflict path edge case)
  - `gui/src/state/metadataStore.ts:284-300` (load() catch) から 4 lines 削除 (draft*Error / draft*ErrorHint clear)
  - 案 X の意図を catch block 内コメントで明記
- `ce696ec` docs(state): metadataStore *ErrorHint lifecycle 規約を明文化
  - `docs/ui-architecture.md` §4.7 に lifecycle 規約節追加
  - `docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md` §7 に本 PR の Refs bullet 追加

## 受け入れ条件 (元 issue #691 を逐条引用)

- [x] 5 catch path × `*Error` / `*ErrorHint` の clear 範囲を表に整理 (PR body の matrix table で明文化) → 完了
- [x] 非対称な clear 範囲を symmetric に整える → **案 X 採用**、`load()` catch の partial clear を削除
- [x] `metadataStore.test.ts` に各 catch / success path の clear lifecycle を pin する test を追加 → 8 件追加
- [x] 関連 doc (`docs/ui-architecture.md` § 4 / `docs/superpowers/specs/2026-05-08-l2-appError-migration-completion-design.md` §7) 整合更新 → §4.7 / §7 追記

## Self-Test Report

### Machine-verified

- [x] `git fetch origin develop-0.2.0` + 取り込み未済 commit なし
- [x] `gh pr list --search "#691"` で並行 PR 重複なし (#712 は本 lane の docs PR、sibling)
- [x] `cd gui && npm run lint` exit 0
- [x] `cd gui && npm run typecheck` exit 0
- [x] `cd gui && npm test -- --run` 619/619 pass (新規 8 件 + 既存 611 件)
- [x] `cd gui/src-tauri && cargo check` clean (frontend のみ変更、Rust 影響なし)
- [x] `bash scripts/check-markdownlint.sh` 0 errors

### Machine-unverifiable

- 機能変更は load() catch の partial clear 削除のみ (load 失敗時に draft 系 error が残るようになる)。UX 影響は軽微 (draft error は modal で個別 dismiss されるので残存しても次回 modal 表示で上書き)。frontend mock test (619 件) で regression なし確認済のため、実機検証は不要と判定 (spec §6.4 trigger 表通り)。

## 関連

Refs #691 #663 #689

Wave 1.1 で PR 1 #693 と完全並行 (UI 非依存)。本 PR は #693 merge 順序を問わない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
