### PR TITLE
fix(markdownlint): nested gui/node_modules を ignore に追加 (Refs #700)

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -45,6 +45,7 @@ globs:
 
 ignores:
   - "node_modules/**"
+  - "**/node_modules/**"  # nested (gui/node_modules 等) も除外 (#700)
   - ".venv/**"
   - ".git/**"
   - ".pytest_cache/**"


### PR DESCRIPTION
## スコープ

Lane IV-b' (Group J #700 markdownlint nested ignore) を実装。

- `.markdownlint-cli2.yaml` の `ignores` に `**/node_modules/**` を 1 行追加
- `markdownlint-cli2` の glob 仕様で `node_modules/**` は cwd 直下のみ match し nested (`gui/node_modules/`) に届かない問題を解消
- CI は `npm install` 未実行のため `gui/node_modules/` 不在、CI 挙動変化なし

spec doc は PR-1 (#715) に同梱: [docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md §4](docs/superpowers/specs/2026-05-11-lane-iv-b-prime-design.md)

Refs #700

## 受け入れ条件 (#700)

- [x] `.markdownlint-cli2.yaml` の ignores glob 修正
- [x] `gui/node_modules/**/*.md` の誤検出が解消 (local 検証済、修正前 多数 errors → 修正後 0 errors)
- [x] CI markdownlint job pass 維持 (`npm install` 不要のため挙動変化なし)

## Test plan (本 PR 提出前にローカルで実行済)

- [x] `cd gui && npm install` で `gui/node_modules/` を用意
- [x] 修正前 `bash scripts/check-markdownlint.sh` → `gui/node_modules/**/*.md` 由来の errors を確認 (red、issue 本文では 7712 errors と報告、実測も同等)
- [x] `.markdownlint-cli2.yaml` に `**/node_modules/**` を追加
- [x] 修正後 `bash scripts/check-markdownlint.sh` → 0 errors (green、`Linting: 119 file(s) Summary: 0 error(s)`)
- [x] `.markdownlint-cli2.yaml` の syntax (yaml load) は markdownlint-cli2 が起動した時点で確認済

## 実機検証 (machine-unverifiable)

- 該当なし (lint config 1 行修正のみ、GPU / audio / video detector / GUI Tauri / Python ロジック touch なし)

session-id: lane-iv-b-prime-pr2 (derived from tender-moore-2a5d2f)
