### PR TITLE
fix(markdownlint): build/** を ignores に追加 (Refs #723)

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -52,3 +52,4 @@ ignores:
   - ".ruff_cache/**"
   - "**/kobutachan_allaganeye.egg-info/**"
   - "build/**"  # Portable ZIP build dry-run 出力 (third-party LICENSE/SKILL 誤検出回避、#723)
+  - "build-cache/**"  # Portable ZIP build キャッシュ ($env:ALLAGANEYE_BUILD_CACHE_DIR、third-party LICENSE 誤検出回避、#723 sweep)

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -51,3 +51,4 @@ ignores:
   - ".pytest_cache/**"
   - ".ruff_cache/**"
   - "**/kobutachan_allaganeye.egg-info/**"
+  - "build/**"  # Portable ZIP build dry-run 出力 (third-party LICENSE/SKILL 誤検出回避、#723)


### PR DESCRIPTION
## 概要

`.markdownlint-cli2.yaml` の `ignores` リスト末尾に `"build/**"` を追加し、`scripts/build-portable-zip.ps1` の build dry-run で生成される third-party LICENSE / SKILL ファイル (numpy / typer 等) を markdownlint の対象から除外する。

Refs #723

## 変更内容

- `.markdownlint-cli2.yaml` 末尾 (`**/kobutachan_allaganeye.egg-info/**` の後) に `"build/**"` を 1 行追加
- インラインコメントで意図と issue 番号 (#723) を記載

```diff
   - "**/kobutachan_allaganeye.egg-info/**"
+  - "build/**"  # Portable ZIP build dry-run 出力 (third-party LICENSE/SKILL 誤検出回避、#723)
```

## 背景

`pwsh -File scripts/build-portable-zip.ps1 -Version <ver> -SkipArchive` 実行後に `bash scripts/check-markdownlint.sh` を回すと、`build/portable/` 配下に展開された numpy / typer 等の bundled wheel 内の `LICENSE.md` / `SKILL.md` が markdownlint ルールに準拠しない第三者コンテンツとして 29 errors を生む。

`build/` は `.gitignore` 済みで CI には影響しないが、ローカル開発者がリント結果をノイズとして無視する習慣を防ぐため、ignores に追加する。

#700 で nested `gui/node_modules` を同様の理由で除外済み。本 PR は同方針の延長線上の対応。

## Self-Test Report

### Machine-verified

- [x] **ベースライン (build/ なし)**: `bash scripts/check-markdownlint.sh` が pass (132 files / 0 errors / SCRIPT_EXIT=0)
- [x] **TDD Red (reproducer 反映)**: `build/portable/dummy_pkg/licenses/LICENSE.md` を MD022/MD040/MD028 違反含む reproducer として作成 → markdownlint が 3 errors で fail (133 files / SCRIPT_EXIT=1) を確認
- [x] **TDD Green (修正適用後)**: 同 reproducer 残置のまま `build/**` を ignores に追加 → glob に `!build/**` 反映、132 files / 0 errors / SCRIPT_EXIT=0
- [x] **最終検証 (cleanup + post-merge)**: reproducer 削除 + `git pull --ff-only origin develop-0.2.0` で `9e0a537` (PR #716) を取り込み後、`bash scripts/check-markdownlint.sh` 再実行 → 132 files / 0 errors / SCRIPT_EXIT=0
- [x] **YAML 構文**: markdownlint-cli2 が config を正常 parse して上記 4 回 pass している (構文 implicit verification)

### Machine-unverifiable

- 実 build dry-run (`pwsh -File scripts/build-portable-zip.ps1 -Version 0.2.0-test -SkipArchive`) での numpy / typer LICENSE.md 29 errors 解消は **本 PR では未実施**。理由:
  - (a) glob `build/**` は build/ 配下を全て除外する単純パターンで、minimal reproducer により glob mechanism が証明済み
  - (b) 実 build は ~250MB ダウンロード + 5-10 min を要し、依存物 (Python embed / FFmpeg LGPL / pip install) の不安定性も含むため自動チェックには不向き
  - (c) `build/` 不在の clean checkout なら CI には影響しないため CI regression リスクなし
  - 本 PR スコープでは glob mechanism 証明で十分と判断。実 build による numpy / typer specific file 検証が必要なら別途対応する

## Iron Law 6 Pre-flight

- [x] `git fetch origin develop-0.2.0` 実施 → 当初 `up-to-date`、作業中に PR #716 (`9e0a537`) が landed → `git pull --ff-only` で取り込み + 自動チェック再実行
- [x] PR #716 touched files (`gui/src/state/metadataStore.{ts,test.ts}`, `docs/superpowers/specs/*.md`, `docs/ui-architecture.md`) は当 PR の touched file (`.markdownlint-cli2.yaml`) と非交差で機能 regression リスクなし
- [x] `gh pr list --search "markdownlint build"` / `--search "ignores config markdownlint"` で並行 worktree PR 重複なし (関連する OPEN PR #720 / #719 / #716 は markdownlint config 非関与)
- [x] 当該 path (`.markdownlint-cli2.yaml`) の自動チェック = `bash scripts/check-markdownlint.sh` を 4 回 pass (baseline → TDD Red → TDD Green → post-merge final)
- [x] 実機検証 trigger 表外: GUI / GPU / audio / 長時間動画 / Tauri logic 非関与のため Idios 実機検証依頼不要 (config / docs カテゴリ)

## Out of scope

- `dist/**` 等の派生先 ignore (今回未観測、必要時に別 issue 起票)
- `ignores` リストの順序整理・既存エントリの整備
- markdownlint ルール有効化フェーズの進行 (#474 系)

session-id: elegant-faraday-97779a
