### PR TITLE
feat(gui): #695 ConflictModal で state.mtime_conflict AppError hint 表示 (C 案、Lane V Phase 1)

### DIFF
--- a/docs/ui-interaction-spec.md
+++ b/docs/ui-interaction-spec.md
@@ -113,6 +113,21 @@ Tauri command 失敗時の error 表示は以下を厳守する:
 4. globalErrorListener が拾うのは uncaught (window.error / unhandledrejection /
    panic) のみ。catch 済 Tauri command error は ErrorModal に出さない (規約)
 
+#### §1.5.1 ConflictModal の hint slot 規約 (#695、C 案)
+
+`state.mtime_conflict` の ConflictModal では、AppError hint を主表示し、modal
+局所文言 (キャンセル ボタン挙動説明) は補足 1 行として別 paragraph に表示する規約:
+
+- 1 行目 (`<p>{conflictError}</p>`): AppError.message を danger 色で表示
+- 2 行目 (`<InlineErrorHint hint={conflictErrorHint} />`): AppError.hint を `💡`
+  prefix + `var(--ae-text-dim)` で表示 (hint null 時は非表示)
+- 3 行目 (`<p>{cancel 補足}</p>`): 「「キャンセル」で何もせずこのモーダルを閉じます。」
+  を常時表示 (modal 局所文言、上書き / リロード の挙動は AppError hint がカバー)
+
+旧 compose hint (3 button 全説明) は削除済 (PR #695)。AppError hint と modal
+文言の重複を避けるため、modal 局所文言は modal-only な action (キャンセル 等) に
+限定する規約。
+
 ## 2. 画面別 UI 部品状態機械
 
 §2 は 5 画面それぞれを **1 画面 = 1 PR** で順次追加する (#590 着手フローに従う)。

--- a/gui/src/components/ConflictModal.module.css
+++ b/gui/src/components/ConflictModal.module.css
@@ -36,7 +36,7 @@
   line-height: 1.5;
 }
 
-.hint {
+.cancelHint {
   font-family: var(--ae-font-body);
   font-size: 12px;
   color: var(--ae-text-dim);

--- a/gui/src/components/ConflictModal.test.tsx
+++ b/gui/src/components/ConflictModal.test.tsx
@@ -155,3 +155,65 @@ describe('ConflictModal', () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 });
+
+describe('#695: AppError hint display (C 案)', () => {
+  it('renders InlineErrorHint when conflictErrorHint is set', () => {
+    useMetadataStore.setState({
+      conflictError: 'metadata.json was modified',
+      conflictErrorHint: 'リロード or 上書き',
+    });
+
+    render(<ConflictModal />);
+
+    expect(screen.getByText('💡 リロード or 上書き')).toBeInTheDocument();
+  });
+
+  it('does not render InlineErrorHint when conflictErrorHint is null', () => {
+    useMetadataStore.setState({
+      conflictError: 'metadata.json was modified',
+      conflictErrorHint: null,
+    });
+
+    render(<ConflictModal />);
+
+    expect(screen.queryByText(/💡/)).not.toBeInTheDocument();
+  });
+
+  it('always renders the cancel hint regardless of conflictErrorHint', () => {
+    useMetadataStore.setState({
+      conflictError: 'msg',
+      conflictErrorHint: 'hint',
+    });
+
+    render(<ConflictModal />);
+
+    expect(
+      screen.getByText('「キャンセル」で何もせずこのモーダルを閉じます。')
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT render the legacy compose hint (旧 3 button 全説明)', () => {
+    useMetadataStore.setState({
+      conflictError: 'msg',
+      conflictErrorHint: 'hint',
+    });
+
+    render(<ConflictModal />);
+
+    expect(
+      screen.queryByText(/「上書き」で外部変更を破棄し GUI の編集を適用/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('hint inside role="dialog" passes jest-axe', async () => {
+    useMetadataStore.setState({
+      conflictError: 'msg',
+      conflictErrorHint: 'hint',
+    });
+
+    const { container } = render(<ConflictModal />);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/gui/src/components/ConflictModal.tsx
+++ b/gui/src/components/ConflictModal.tsx
@@ -4,6 +4,7 @@ import { useEscapeKey } from '../hooks/useEscapeKey';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { useMetadataStore } from '../state/metadataStore';
 import styles from './ConflictModal.module.css';
+import { InlineErrorHint } from './InlineErrorHint';
 
 /**
  * #514: modal surfaced when `apply_changes` returns a conflict error because
@@ -18,6 +19,7 @@ import styles from './ConflictModal.module.css';
  */
 export function ConflictModal() {
   const conflictError = useMetadataStore((s) => s.conflictError);
+  const conflictErrorHint = useMetadataStore((s) => s.conflictErrorHint);
   const applying = useMetadataStore((s) => s.applying);
   const applyOverwrite = useMetadataStore((s) => s.applyOverwrite);
   const reloadAfterConflict = useMetadataStore((s) => s.reloadAfterConflict);
@@ -45,8 +47,9 @@ export function ConflictModal() {
           metadata.json が外部で変更されました
         </h2>
         <p className={styles.message}>{conflictError}</p>
-        <p className={styles.hint}>
-          「上書き」で外部変更を破棄し GUI の編集を適用、「リロード」で最新の metadata.json を読み直し (編集は破棄)、「キャンセル」で何もせずこのモーダルを閉じます。
+        <InlineErrorHint hint={conflictErrorHint} />
+        <p className={styles.cancelHint}>
+          「キャンセル」で何もせずこのモーダルを閉じます。
         </p>
         <div className={styles.actions}>
           <button

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -523,9 +523,16 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
   });
 
   it('reloadAfterConflict is a no-op when filePath is null (sample mode)', async () => {
-    useMetadataStore.setState({ conflictError: 'stale' });
+    // #695: conflictError と conflictErrorHint の pair atomicity (Round 1 fix c929aae)。
+    // sample mode (filePath === null) では load() を呼べず、両 state を直接 null reset する。
+    useMetadataStore.setState({
+      conflictError: 'stale',
+      conflictErrorHint: 'stale hint',
+    });
     await useMetadataStore.getState().reloadAfterConflict();
-    expect(useMetadataStore.getState().conflictError).toBeNull();
+    const state = useMetadataStore.getState();
+    expect(state.conflictError).toBeNull();
+    expect(state.conflictErrorHint).toBeNull();
   });
 
   it('dismissConflict clears the modal state without reloading or reapplying', () => {
@@ -538,12 +545,19 @@ describe('useMetadataStore (#514 mtime + conflict)', () => {
 
   it('load that fails clears loadedMtimeMs and conflictError', async () => {
     // Seed with prior state
-    useMetadataStore.setState({ loadedMtimeMs: 999, conflictError: 'stale' });
+    // #695: conflictError と conflictErrorHint の pair atomicity (Round 1 fix c929aae)。
+    // load() 失敗時は file-state リセットの一部として両 state を null reset。
+    useMetadataStore.setState({
+      loadedMtimeMs: 999,
+      conflictError: 'stale',
+      conflictErrorHint: 'stale hint',
+    });
     configureInvoke({ load_metadata_error: new Error('io error') });
     await useMetadataStore.getState().load('p');
     const state = useMetadataStore.getState();
     expect(state.loadedMtimeMs).toBeNull();
     expect(state.conflictError).toBeNull();
+    expect(state.conflictErrorHint).toBeNull();
     expect(state.loadError).toContain('io error');
   });
 

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -1502,7 +1502,7 @@ describe('#695: conflictErrorHint lifecycle', () => {
 
   it('runApply() catch (conflict) sets conflictErrorHint', async () => {
     useMetadataStore.setState({
-      metadata: { source: '/test.mp4', matches: [] } as any,
+      metadata: { source: '/test.mp4', matches: [] } as never,
       filePath: '/test.mp4',
     });
 
@@ -1565,7 +1565,7 @@ describe('#695: conflictErrorHint lifecycle', () => {
     // applyOverwrite calls runApply(true) which clears conflictError/conflictErrorHint
     // in the initial set({ applying: true, ... }) before invoking apply_changes.
     useMetadataStore.setState({
-      metadata: { source: '/test.mp4', matches: [] } as any,
+      metadata: { source: '/test.mp4', matches: [] } as never,
       filePath: '/test.mp4',
       conflictError: 'prev conflict',
       conflictErrorHint: 'prev hint',

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -1472,3 +1472,116 @@ describe('#691: catch path lifecycle pinning', () => {
     expect(state.draftSaveErrorHint).toBeNull();
   });
 });
+
+describe('#695: conflictErrorHint lifecycle', () => {
+  beforeEach(() => {
+    useMetadataStore.setState({
+      metadata: null,
+      filePath: null,
+      dirty: false,
+      loadError: null,
+      loadErrorHint: null,
+      applying: false,
+      applyError: null,
+      applyErrorHint: null,
+      hasBackup: false,
+      restoring: false,
+      restoreError: null,
+      restoreErrorHint: null,
+      loadedMtimeMs: null,
+      conflictError: null,
+      conflictErrorHint: null,
+      pendingDraft: null,
+      draftLoadError: null,
+      draftLoadErrorHint: null,
+      draftSaving: false,
+      draftSaveError: null,
+      draftSaveErrorHint: null,
+    });
+  });
+
+  it('runApply() catch (conflict) sets conflictErrorHint', async () => {
+    useMetadataStore.setState({
+      metadata: { source: '/test.mp4', matches: [] } as any,
+      filePath: '/test.mp4',
+    });
+
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'apply_changes') {
+        throw {
+          code: 'state.mtime_conflict',
+          message: 'metadata.json was modified',
+          hint: 'リロード or 上書き',
+        };
+      }
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    await useMetadataStore.getState().apply();
+
+    const state = useMetadataStore.getState();
+    expect(state.conflictError).toBeTruthy();
+    expect(state.conflictErrorHint).toBe('リロード or 上書き');
+  });
+
+  it('dismissConflict() clears both conflictError and conflictErrorHint', () => {
+    useMetadataStore.setState({
+      conflictError: 'msg',
+      conflictErrorHint: 'hint',
+    });
+
+    useMetadataStore.getState().dismissConflict();
+
+    const state = useMetadataStore.getState();
+    expect(state.conflictError).toBeNull();
+    expect(state.conflictErrorHint).toBeNull();
+  });
+
+  it('clear() resets conflictErrorHint', () => {
+    useMetadataStore.setState({
+      conflictError: 'msg',
+      conflictErrorHint: 'hint',
+    });
+
+    useMetadataStore.getState().clear();
+
+    const state = useMetadataStore.getState();
+    expect(state.conflictErrorHint).toBeNull();
+  });
+
+  it('loadSample() resets conflictErrorHint', () => {
+    useMetadataStore.setState({
+      conflictError: 'msg',
+      conflictErrorHint: 'hint',
+    });
+
+    useMetadataStore.getState().loadSample();
+
+    const state = useMetadataStore.getState();
+    expect(state.conflictErrorHint).toBeNull();
+  });
+
+  it('applyOverwrite() success path resets conflictErrorHint', async () => {
+    // applyOverwrite calls runApply(true) which clears conflictError/conflictErrorHint
+    // in the initial set({ applying: true, ... }) before invoking apply_changes.
+    useMetadataStore.setState({
+      metadata: { source: '/test.mp4', matches: [] } as any,
+      filePath: '/test.mp4',
+      conflictError: 'prev conflict',
+      conflictErrorHint: 'prev hint',
+    });
+
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'apply_changes') return 12345; // new mtime ms
+      if (cmd === 'check_backup_exists') return true;
+      if (cmd === 'clear_draft') return undefined;
+      throw new Error(`unexpected: ${cmd}`);
+    });
+
+    await useMetadataStore.getState().applyOverwrite();
+
+    const state = useMetadataStore.getState();
+    expect(state.conflictError).toBeNull();
+    expect(state.conflictErrorHint).toBeNull();
+  });
+});

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -57,6 +57,8 @@ export interface MetadataState {
    * `applyOverwrite` / `reloadAfterConflict` / `dismissConflict`.
    */
   conflictError: string | null;
+  /** #695: hint for conflictError (state.mtime_conflict AppError), if carried one. */
+  conflictErrorHint: string | null;
   /**
    * #517: a draft snapshot loaded from metadata.draft.json that differs from
    * the live metadata on disk. Non-null means the UI should ask the user
@@ -190,7 +192,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
   async function runApply(overwrite: boolean): Promise<void> {
     const { metadata, filePath, loadedMtimeMs } = get();
     if (!metadata || !filePath) return;
-    set({ applying: true, applyError: null, applyErrorHint: null, conflictError: null });
+    set({ applying: true, applyError: null, applyErrorHint: null, conflictError: null, conflictErrorHint: null });
     try {
       const normalized = normalizeForPersistence(metadata);
       const newMtime = await invoke<number>('apply_changes', {
@@ -206,6 +208,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         applyErrorHint: null,
         loadedMtimeMs: newMtime,
         conflictError: null,
+        conflictErrorHint: null,
       });
       await get().refreshBackupStatus();
       // #517: successful apply means the on-disk state caught up with our
@@ -219,7 +222,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       // fallback (msg.startsWith('conflict:')) は廃止する。code === 'state.mtime_conflict'
       // のみで分岐する。
       if (appErrorCodeIs(e, 'state.mtime_conflict')) {
-        set({ applying: false, conflictError: msg });
+        set({ applying: false, conflictError: msg, conflictErrorHint: hint });
       } else {
         set({ applying: false, applyError: msg, applyErrorHint: hint });
       }
@@ -243,6 +246,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
 
   loadedMtimeMs: null,
   conflictError: null,
+  conflictErrorHint: null,
   pendingDraft: null,
   draftLoadError: null,
   draftLoadErrorHint: null,
@@ -270,6 +274,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         restoreErrorHint: null,
         loadedMtimeMs: mtime ?? null,
         conflictError: null,
+        conflictErrorHint: null,
         pendingDraft: null,
         draftLoadError: null,
         draftLoadErrorHint: null,
@@ -344,6 +349,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       restoreErrorHint: null,
       loadedMtimeMs: null,
       conflictError: null,
+      conflictErrorHint: null,
       pendingDraft: null,
       draftLoadError: null,
       draftLoadErrorHint: null,
@@ -402,7 +408,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
   },
 
   dismissConflict: () => {
-    set({ conflictError: null });
+    set({ conflictError: null, conflictErrorHint: null });
   },
 
   saveDraft: async () => {
@@ -520,6 +526,7 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
       restoreErrorHint: null,
       loadedMtimeMs: null,
       conflictError: null,
+      conflictErrorHint: null,
       pendingDraft: null,
       draftLoadError: null,
       draftLoadErrorHint: null,

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -299,7 +299,11 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         loadErrorHint: appErrorHint(e),
         hasBackup: false,
         loadedMtimeMs: null,
+        // #695: conflictError/conflictErrorHint pair atomicity (load() 失敗時の
+        // file-state リセットの一部、#691 案 X self-only 規約とは別軸 = file-state
+        // 関連の state は touch する慣習を継承)。conflictErrorHint も pair で reset。
         conflictError: null,
+        conflictErrorHint: null,
         pendingDraft: null,
       });
     }
@@ -401,7 +405,10 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
   reloadAfterConflict: async () => {
     const { filePath } = get();
     if (!filePath) {
-      set({ conflictError: null });
+      // #695: conflictError/conflictErrorHint pair atomicity。filePath が無い場合
+      // (sample mode 等) は load() を呼べないので、ここで両方を null reset する
+      // (plan §5.3 reloadAfterConflict() lifecycle 規約)。
+      set({ conflictError: null, conflictErrorHint: null });
       return;
     }
     await get().load(filePath);


### PR DESCRIPTION
## Summary

#695 (Refs #663) の対応。ConflictModal の compose hint を全削除し、AppError hint を `<InlineErrorHint>` で表示、その下に「キャンセル」補足 1 行を配置 (**採用案: C**)。`metadataStore` に `conflictErrorHint: string | null` state を追加し、5 lifecycle 経路 (`runApply` 初期 set / conflict catch / `dismissConflict` / `clear()` / `loadSample()` / `load()` success) で同期。

session-id: `lane-v-pr3-695`
spec: `docs/superpowers/specs/2026-05-11-lane-v-phase-1-group-i-design.md` §5.3
依存元 PR: #714 (InlineErrorHint component、merge 済) / #716 (#691 lifecycle 規約、merge 済)

## 変更内容 (3 commits)

- `e2aad5c` feat(state): add conflictErrorHint state for ConflictModal
  - `MetadataState` に `conflictErrorHint: string | null` 追加 + 初期値 null
  - `runApply` 初期 set + conflict catch で `conflictErrorHint` も touch
  - `dismissConflict` / `clear()` / `loadSample()` / `load()` success で null reset
  - **load() catch は self-only 維持** (#691 案 X 規約整合、`conflictErrorHint` を touch しない)
  - 5 件 TDD test 追加 (`#695: conflictErrorHint lifecycle` describe block)
- `68e4c2e` feat(gui): ConflictModal displays AppError hint via InlineErrorHint (C 案)
  - `ConflictModal.tsx` の compose hint 削除 + `<InlineErrorHint hint={conflictErrorHint} />` + 「キャンセル」補足 1 行
  - `ConflictModal.module.css` `.hint` → `.cancelHint` rename (style 維持)
  - 5 件 TDD test 追加 (hint set/null / 補足常時 / 旧 compose hint 削除 / jest-axe a11y)
- `277696c` docs(ui): ConflictModal hint slot 規約を追記
  - `docs/ui-interaction-spec.md §1.5.1 ConflictModal の hint slot 規約 (#695、C 案)` 追加

## 受け入れ条件 (元 issue #695 を逐条引用)

- [x] AppError hint と compose hint の表示位置を設計 → C 案 (Idios brainstorming で確定): 3-line 構造 (message / AppError hint / キャンセル補足)
- [x] AppError hint の `metadata.json が他のプロセスで...` と modal 既存 hint `「上書き」で外部変更を破棄し...` の重複文言を整理 → compose hint を**完全削除**、AppError hint を主、modal 局所文言は「キャンセル」補足 1 行のみ
- [x] ConflictModal.tsx で `appErrorHint(e)` を read する経路を整える → `useMetadataStore((s) => s.conflictErrorHint)` で read
- [x] store に `conflictErrorHint: string|null` を追加 → `metadataStore.ts` で追加、5 経路で lifecycle 同期
- [x] a11y: hint 追加で `role="dialog"` 内部の screen-reader 読み上げ順序が崩れないことを test で pin → `ConflictModal.test.tsx` jest-axe test 追加

## Self-Test Report

### Machine-verified

- [x] `git fetch origin develop-0.2.0` + 取り込み未済 commit ゼロ
- [x] `gh pr list --search "#695"` で並行 PR 重複なし (#712 / #714 / #716 は merged、#719 は別 issue #633)
- [x] `cd gui && npm run lint` exit 0
- [x] `cd gui && npm run typecheck` exit 0
- [x] `cd gui && npm test -- --run` **647/647 pass** (45 test files、新規 +10 件 = metadataStore 5 + ConflictModal 5)
- [x] `cd gui && npm run build` success (367.51 kB JS)
- [x] `cd gui/src-tauri && cargo check` clean (pre-existing OS-level incremental dir warning は本 PR 無関係)
- [x] `cd gui/src-tauri && cargo test --lib` 171/171 pass
- [x] `bash scripts/check-markdownlint.sh` 本 PR 修正 docs に対しては 0 errors (`gui/node_modules/zustand/README.md` は pre-existing baseline、本 PR 無関係)
- [x] Iron Law 3: 6 files only (`metadataStore.ts` + `.test.ts` + `ConflictModal.tsx` + `.module.css` + `.test.tsx` + `ui-interaction-spec.md`)

### Machine-unverifiable (Iron Law 6 実機検証 — `AskUserQuestion` で依頼)

- 実 conflict (2 プロセス同時 edit → apply) で ConflictModal の AppError hint + 「キャンセル」補足 1 行の 3-line 表示確認
- 旧 compose hint (「『上書き』で外部変更を破棄し GUI の編集を適用...」全文) が表示されないことの目視確認

## Refs

Refs #695 #663 #689 #714 #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)
