### PR TITLE
feat(gui): #697 DraftRestoreModal で draftLoadErrorHint 表示 (Lane V Phase 1)

### DIFF
--- a/gui/src/components/DraftRestoreModal.test.tsx
+++ b/gui/src/components/DraftRestoreModal.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
@@ -134,5 +135,52 @@ describe('DraftRestoreModal', () => {
     });
     const { container } = render(<DraftRestoreModal />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('#697: draftLoadErrorHint display', () => {
+  beforeEach(() => {
+    useMetadataStore.setState({
+      pendingDraft: null,
+      draftLoadError: null,
+      draftLoadErrorHint: null,
+      conflictError: null,
+    });
+  });
+
+  it('renders InlineErrorHint when draftLoadErrorHint is set', () => {
+    useMetadataStore.setState({
+      draftLoadError: 'metadata.draft.json corrupt',
+      draftLoadErrorHint: 'バックアップから復元してください',
+    });
+
+    render(<DraftRestoreModal />);
+
+    expect(
+      screen.getByText('💡 バックアップから復元してください')
+    ).toBeInTheDocument();
+  });
+
+  it('does not render InlineErrorHint when draftLoadErrorHint is null', () => {
+    useMetadataStore.setState({
+      draftLoadError: 'corrupt',
+      draftLoadErrorHint: null,
+    });
+
+    render(<DraftRestoreModal />);
+
+    expect(screen.queryByText(/💡/)).not.toBeInTheDocument();
+  });
+
+  it('hint inside role="dialog" passes jest-axe', async () => {
+    useMetadataStore.setState({
+      draftLoadError: 'corrupt',
+      draftLoadErrorHint: 'some hint',
+    });
+
+    const { container } = render(<DraftRestoreModal />);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/gui/src/components/DraftRestoreModal.tsx
+++ b/gui/src/components/DraftRestoreModal.tsx
@@ -1,5 +1,6 @@
 import { useMetadataStore } from '../state/metadataStore';
 import styles from './DraftRestoreModal.module.css';
+import { InlineErrorHint } from './InlineErrorHint';
 
 /**
  * #517: modal offered on mount / after load when a `metadata.draft.json`
@@ -11,6 +12,7 @@ import styles from './DraftRestoreModal.module.css';
 export function DraftRestoreModal() {
   const pendingDraft = useMetadataStore((s) => s.pendingDraft);
   const draftLoadError = useMetadataStore((s) => s.draftLoadError);
+  const draftLoadErrorHint = useMetadataStore((s) => s.draftLoadErrorHint);
   const conflictError = useMetadataStore((s) => s.conflictError);
   const restoreDraft = useMetadataStore((s) => s.restoreDraft);
   const discardDraft = useMetadataStore((s) => s.discardDraft);
@@ -34,6 +36,7 @@ export function DraftRestoreModal() {
             draft を読み取れませんでした
           </h2>
           <p className={styles.message}>{draftLoadError}</p>
+          <InlineErrorHint hint={draftLoadErrorHint} />
           <p className={styles.hint}>
             metadata.draft.json が破損しているか schema が一致しません。破棄して続行します。
           </p>


### PR DESCRIPTION
## Summary

#697 (Refs #663) の対応。`DraftRestoreModal.tsx` の `draftLoadError` 経路に `<InlineErrorHint>` を追加し、PR #689 Phase 3 で導入済の `draftLoadErrorHint` state (現状 dead state) を活用。3-line 構造 (message / AppError hint / 既存 modal-local hint) で配置。

session-id: `lane-v-pr4-697`
spec: `docs/superpowers/specs/2026-05-11-lane-v-phase-1-group-i-design.md` §5.4
依存元 PR: #714 (InlineErrorHint、merge 済) / #716 (#691 lifecycle 規約、merge 済)

## 変更内容 (1 commit)

- `12f8d51` feat(gui): DraftRestoreModal displays draftLoadErrorHint via InlineErrorHint
  - `import { InlineErrorHint }` 追加
  - `const draftLoadErrorHint = useMetadataStore((s) => s.draftLoadErrorHint)` で read
  - draftLoadError 経路 (line 38) の `<p className={styles.message}>` 直下に `<InlineErrorHint hint={draftLoadErrorHint} />` を挿入
  - 既存 modal-local hint (「metadata.draft.json が破損しているか schema が一致しません。破棄して続行します。」) は **削除しない**: modal 固有のシナリオ説明 + 唯一 button「破棄」の意味説明であり、ConflictModal (PR #725 C 案) と異なり情報損失になるため保持
  - 3 件 TDD test 追加 (`#697: draftLoadErrorHint display` describe: hint set/null / jest-axe a11y)

## 受け入れ条件 (元 issue #697 を逐条引用)

- [x] DraftRestoreModal.tsx で `draftLoadErrorHint` を read (`useMetadataStore((s) => s.draftLoadErrorHint)`) → line 15
- [x] `draftLoadError` の inline 表示直下に `{draftLoadErrorHint && <div className={styles.errorHint}>💡 {draftLoadErrorHint}</div>}` 同等を追加 → `<InlineErrorHint hint={draftLoadErrorHint} />` (component 経由、`💡` prefix 集約は PR #714 で確立)
- [x] DraftRestoreModal.module.css に `.errorHint` class 追加 — **不要** (`InlineErrorHint` 内部 styling で 完結、wrapper class 不要、CSS 変更ゼロ)
- [x] DraftRestoreModal.test.tsx に hint render の test 追加 (hint set 時 / null 時) → 2 件追加
- [x] a11y: hint が `role="dialog"` 内側に nest され、screen-reader 読み上げ順序が維持されることを test で pin → jest-axe 1 件追加

## Self-Test Report

### Machine-verified

- [x] `git fetch origin develop-0.2.0` + 取り込み未済 commit (#719 / #724) は本 PR touched files (DraftRestoreModal) と非交差、base sync 不要
- [x] `gh pr list --search "#697"` で並行 PR 重複なし (#712 / #714 / #716 / #719 は merged / #725 は別 issue #695 で別 file)
- [x] `cd gui && npm run lint` exit 0
- [x] `cd gui && npm run typecheck` exit 0
- [x] `cd gui && npm test -- --run` **640/640 pass** (45 test files、新規 +3 件)
- [x] `cd gui && npm run build` success
- [x] `cd gui/src-tauri && cargo check` clean
- [x] `cd gui/src-tauri && cargo test --lib` 171/171 pass
- [x] Iron Law 3: 2 files only (`DraftRestoreModal.tsx` + `.test.tsx`)

### Machine-unverifiable (Iron Law 6 実機検証 — `AskUserQuestion` で依頼)

- 破損 draft (`metadata.draft.json` を意図的に壊す) 経路で DraftRestoreModal を発火させ、AppError hint (`💡` prefix) が message と既存 modal hint の間 (3-line 構造) に表示されることを目視確認

## Refs

Refs #697 #663 #689 #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
