### PR TITLE
fix(gui): parse_detect_progress_line silent skip を warn 出力に (#648)

### DIFF
--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -72,6 +72,29 @@ try {
 }
 ```
 
+## `start_detect` stdout schema と parse 失敗時の挙動 (#648)
+
+`start_detect` が spawn する `allaganeye detect --progress-format json` の stdout は **1 行 1 JSON object の stream** (UTF-8、LF separator)。GUI 側は `parse_detect_progress_line` で 1 行ずつ deserialize する。
+
+**許容パターン (silent skip)**:
+
+- 空行 (改行のみの LF flush 等)
+- 空白のみ行
+
+**想定外パターン (warn 出力)**:
+
+- malformed JSON (debug print 混入、schema 不整合)
+- 上記の場合、`parse_detect_progress_line` は `eprintln!` で
+  `[parse_detect_progress_line] malformed JSON (len=N): "<escaped truncated line>"`
+  形式の warn を stderr に出力する。先頭 64 文字で truncate、制御文字 (TAB/LF/CR 以外) は `\xNN` escape
+
+**観察可能範囲**:
+
+- **dev build** (`cargo tauri dev`): `windows_subsystem` が default = `console` のため、`eprintln!` は terminal stderr に届く
+- **release build** (`cargo tauri build`): `windows_subsystem = "windows"` で console を切り離しているため、`eprintln!` は **失われる** (Windows OS が stderr を dev null 相当に向ける)。release で観察可能にしたい場合は `tauri-plugin-log` 導入 (post-Lane I-B 別 issue) で file output 化する
+
+**設計選択 (#648 spec)**: `phase=error` event 発火による DetectingScreen の error UI 接続は採用していない (UX 過剰、roadmap で却下)。silent skip → warn 化のみで UX に影響なし。
+
 ## CI による doc 整合性検査
 
 `.github/workflows/ci.yml` の `doc-tauri-commands-drift` job が `gui/src-tauri/src/lib.rs` 内の `#[tauri::command]` 数と本 doc の table 行数を比較し、不一致時に CI を fail させる (本 doc 漏れ防止、issue [#619](https://github.com/Idios/kobutachan-allaganeye/issues/619) 受け入れ条件 2)。command を追加・削除した場合は本 doc の table 行も同時に更新すること。

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2279,15 +2279,56 @@ pub struct DetectResult {
     pub matches: u64,
 }
 
+/// #648 -- truncate `line` to at most `max_chars` Unicode chars and escape
+/// non-printable control characters (except `\t` / `\n` / `\r`) as `\xNN`
+/// so they don't inject terminal escape sequences into stderr.
+fn truncate_and_escape(line: &str, max_chars: usize) -> String {
+    line.chars()
+        .take(max_chars)
+        .map(|c| match c {
+            '\t' | '\n' | '\r' => c.to_string(),
+            c if (c as u32) < 0x20 => format!("\\x{:02X}", c as u32),
+            c => c.to_string(),
+        })
+        .collect()
+}
+
 /// #569 -- pure parser for one JSON-lines progress event.  Returns
 /// `None` for blank lines or lines that fail to deserialize so a stray
 /// stdout write from the CLI doesn't break the overall stream.
+///
+/// #648 -- malformed JSON (non-empty / non-whitespace lines that fail to
+/// deserialize) は silent skip ではなく `eprintln!` で warn 出力するよう
+/// 拡張済。空行 / 空白のみ行 (LF flush 等で発生) は引き続き silent skip。
+/// public signature は変えていない (戻り値も呼び出し側も既存通り)。
 fn parse_detect_progress_line(line: &str) -> Option<DetectProgress> {
-    let line = line.trim();
-    if line.is_empty() {
+    parse_detect_progress_line_with_warn(line, |msg| eprintln!("{}", msg))
+}
+
+/// #648 -- testable variant: takes a `on_warn` closure to capture warn
+/// output, so cargo test can assert on the warning content without
+/// touching the real stderr stream. Production wrapper above passes
+/// `eprintln!`.
+fn parse_detect_progress_line_with_warn(
+    line: &str,
+    mut on_warn: impl FnMut(&str),
+) -> Option<DetectProgress> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
         return None;
     }
-    serde_json::from_str(line).ok()
+    match serde_json::from_str(trimmed) {
+        Ok(p) => Some(p),
+        Err(_) => {
+            let escaped = truncate_and_escape(trimmed, 64);
+            on_warn(&format!(
+                "[parse_detect_progress_line] malformed JSON (len={}): \"{}\"",
+                trimmed.len(),
+                escaped,
+            ));
+            None
+        }
+    }
 }
 
 /// #646 -- how to invoke the `allaganeye` CLI from Rust.
@@ -4556,6 +4597,112 @@ mod tests {
         assert_eq!(parsed.width, Some(1920));
         assert_eq!(parsed.fps, Some(60.0));
         assert_eq!(parsed.codec.as_deref(), Some("h264"));
+    }
+
+    // -- #648 truncate_and_escape (parse_detect_progress_line warn 出力前処理)
+
+    #[test]
+    fn truncate_and_escape_empty_returns_empty() {
+        assert_eq!(truncate_and_escape("", 64), "");
+    }
+
+    #[test]
+    fn truncate_and_escape_zero_max_returns_empty() {
+        assert_eq!(truncate_and_escape("hello", 0), "");
+    }
+
+    #[test]
+    fn truncate_and_escape_short_ascii_returned_verbatim() {
+        assert_eq!(truncate_and_escape("hello", 64), "hello");
+    }
+
+    #[test]
+    fn truncate_and_escape_truncates_long_input_at_char_boundary() {
+        let long = "a".repeat(128);
+        assert_eq!(truncate_and_escape(&long, 64).chars().count(), 64);
+    }
+
+    #[test]
+    fn truncate_and_escape_preserves_tab_newline_cr() {
+        assert_eq!(truncate_and_escape("a\tb\nc\rd", 64), "a\tb\nc\rd");
+    }
+
+    #[test]
+    fn truncate_and_escape_escapes_other_control_chars() {
+        assert_eq!(truncate_and_escape("a\x01b", 64), "a\\x01b");
+        assert_eq!(truncate_and_escape("a\x1Fb", 64), "a\\x1Fb");
+    }
+
+    #[test]
+    fn truncate_and_escape_handles_multibyte_char_boundary() {
+        // "まったく" は 4 chars (各 3 bytes UTF-8 = 12 bytes)。
+        // max_chars=3 で 3 chars 取得・byte boundary で panic しないことを確認。
+        assert_eq!(truncate_and_escape("まったく", 3).chars().count(), 3);
+    }
+
+    // -- #648 parse_detect_progress_line_with_warn (DI variant)
+
+    #[test]
+    fn parse_with_warn_empty_line_no_warn() {
+        let mut warns: Vec<String> = Vec::new();
+        let result = parse_detect_progress_line_with_warn("", |m| warns.push(m.to_string()));
+        assert!(result.is_none());
+        assert!(warns.is_empty());
+    }
+
+    #[test]
+    fn parse_with_warn_whitespace_only_no_warn() {
+        let mut warns: Vec<String> = Vec::new();
+        let result =
+            parse_detect_progress_line_with_warn("   \n", |m| warns.push(m.to_string()));
+        assert!(result.is_none());
+        assert!(warns.is_empty());
+    }
+
+    #[test]
+    fn parse_with_warn_valid_json_no_warn() {
+        let mut warns: Vec<String> = Vec::new();
+        let line = r#"{"phase":"scan","completed":12,"total":100,"elapsed_s":1.25}"#;
+        let result =
+            parse_detect_progress_line_with_warn(line, |m| warns.push(m.to_string()));
+        assert!(result.is_some());
+        assert!(warns.is_empty());
+    }
+
+    #[test]
+    fn parse_with_warn_malformed_json_emits_warn() {
+        let mut warns: Vec<String> = Vec::new();
+        let result =
+            parse_detect_progress_line_with_warn("not json", |m| warns.push(m.to_string()));
+        assert!(result.is_none());
+        assert_eq!(warns.len(), 1);
+        assert!(warns[0].contains("malformed JSON"));
+        assert!(warns[0].contains("\"not json\""));
+        assert!(warns[0].contains("len=8"));
+    }
+
+    #[test]
+    fn parse_with_warn_long_malformed_json_truncated_and_escaped() {
+        let mut warns: Vec<String> = Vec::new();
+        // 70 chars + 制御文字 \x01
+        let line = format!("{}{}", "x".repeat(63), "\x01yyy");
+        let result =
+            parse_detect_progress_line_with_warn(&line, |m| warns.push(m.to_string()));
+        assert!(result.is_none());
+        assert_eq!(warns.len(), 1);
+        // 64 char truncate (\x01 escape の 4 char を含む、x 63 + control の 1 char = 64 char、escape は format 後に 4 char に膨れる)
+        // よって warn message 内には `\\x01` が現れる
+        assert!(
+            warns[0].contains("\\x01"),
+            "expected escaped control char in warn message: {}",
+            warns[0]
+        );
+        // 元 len は 67 (63 + 4)
+        assert!(
+            warns[0].contains(&format!("len={}", line.len())),
+            "expected original length in warn message: {}",
+            warns[0]
+        );
     }
 
     #[test]

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -4684,7 +4684,8 @@ mod tests {
     #[test]
     fn parse_with_warn_long_malformed_json_truncated_and_escaped() {
         let mut warns: Vec<String> = Vec::new();
-        // 70 chars + 制御文字 \x01
+        // 67 chars (63 x + 制御文字 \x01 + 3 y) を作り、64 char truncate と
+        // \x01 → \\x01 escape の両方が warn message に現れることを確認する
         let line = format!("{}{}", "x".repeat(63), "\x01yyy");
         let result =
             parse_detect_progress_line_with_warn(&line, |m| warns.push(m.to_string()));


### PR DESCRIPTION
## Summary

[#648](https://github.com/Idios/kobutachan-allaganeye/issues/648) の実装。Lane I-B Group B の章 2 (P3-low)。

Spec: [docs/superpowers/specs/2026-05-11-l2-lane-ib-group-b-design.md](docs/superpowers/specs/2026-05-11-l2-lane-ib-group-b-design.md) §6
Plan: [docs/superpowers/plans/2026-05-11-l2-lane-ib-group-b.md](docs/superpowers/plans/2026-05-11-l2-lane-ib-group-b.md) Chapter 2

## 変更内容

- `truncate_and_escape` helper 新設 (64 char truncate + 制御文字 `\xNN` escape、TAB/LF/CR は保持)
- `parse_detect_progress_line` を DI 化 (`parse_detect_progress_line_with_warn` を内部に分離)、公開 signature 不変、呼び出し側無変更
- malformed JSON を `eprintln!` で stderr warn 出力、空行 / 空白のみ行は silent skip 維持
- `docs/tauri-commands.md` に `start_detect` stdout schema + 挙動 + 観察範囲 (dev / release の差) + 設計選択を追記

## 受け入れ条件 ([issue #648](https://github.com/Idios/kobutachan-allaganeye/issues/648))

- [x] `parse_detect_progress_line` の公開 signature 不変、呼び出し側無変更
- [x] 空行 / 空白のみ行は silent skip 維持
- [x] malformed JSON は warn 出力 (truncate + control char escape 込み)
- [x] dev console で warn 観察可能、release では stderr が失われる旨を doc 化
- [x] `phase=error` 化しない (UX 変更なし)
- [x] unit test 7 + 5 = 12 件追加 (既存 6 件は維持)

## Self-Test Report

### Machine-verified

- [x] `git fetch origin develop-0.2.0` + `git log HEAD..origin/develop-0.2.0` (取り込み未済 commit なし)
- [x] `gh pr list --search "#648"` 並行 worktree PR 重複なし
- [x] `cd gui/src-tauri && cargo check` (warnings 0 errors)
- [x] `cd gui/src-tauri && cargo test --lib` (186 件 pass、174 件 + 新 12 件)
- [x] `cd gui && npm run lint` (eslint clean)
- [x] `cd gui && npm run typecheck` (tsc --noEmit clean)
- [x] `cd gui && npm test -- --run` (46 test files / 659 件 pass)
- [x] `cd gui && npm run build` (dist 生成成功、369.07 kB)
- [x] `bash scripts/check-markdownlint.sh` (0 errors、134 files lint pass)

### Machine-unverifiable (Iron Law 6 実機検証 — Idios)

- [ ] dev build (`cargo tauri dev`) を terminal 起動 + DevTools / terminal stderr を開く
- [ ] CLI 側に意図的な debug print 混入を再現 (例: `allaganeye/commands/detect.py` 冒頭に一時的に `print('debug')` 追加 + GUI から detect 実行)
- [ ] terminal stderr に `[parse_detect_progress_line] malformed JSON (len=...): "debug"` warn が出力されることを確認
- [ ] DetectingScreen が `phase=error` UI に切り替わらないこと (silent skip の UX 維持) を確認
- [ ] 一時的な `print('debug')` を revert

Refs #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)
