### PR TITLE
fix(cli): run_split / --from-metadata で brightness_samples を書く (#644)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 
 import typer
 from click._termui_impl import ProgressBar as _ClickProgressBar  # subclass 用 (#365)
@@ -181,6 +181,16 @@ def run_split(
 
     detect_stats: DetectionStats | None = {} if verbose else None
 
+    # #644 -- Pass 1 で計測された輝度マップを捕捉して metadata.json に書く
+    # ため、`_run_detection` に brightness_callback を渡す。detect.py の
+    # run_detect (line 230-260) と同じパターン。callback が呼ばれない経路
+    # (cache hit や Pass 1 skip) では captured_brightness が空のまま残り、
+    # `_split_and_write_metadata` 呼び出し時に None を渡す。
+    captured_brightness: dict[float, float] = {}
+
+    def _on_brightness(samples: dict[float, float]) -> None:
+        captured_brightness.update(samples)
+
     boundaries = _run_detection(
         video_path,
         metadata,
@@ -191,6 +201,7 @@ def run_split(
         stats=detect_stats,
         use_gpu=use_gpu,
         gpu_vendor=gpu_vendor,
+        brightness_callback=_on_brightness,
     )
 
     if not boundaries:
@@ -239,6 +250,13 @@ def run_split(
         available_vendors=available_vendors,
         vendor_used=gpu_vendor if use_gpu else None,
     )
+    # #644 -- captured_brightness が空なら build_brightness_samples が None を
+    # 返す (split_matches.py:1373-1374 `if not raw_brightness: return None`)。
+    # detect.py:239 (run_detect) と同パターン: guard なしで build_brightness_samples
+    # を呼び、None を _split_and_write_metadata に渡す。_build_metadata_payload が
+    # None で brightness_samples キーを skip するため、cache hit / Pass 1 skip 経路
+    # では metadata.json に書かれない (既存仕様「Pass 1 が走った場合のみ」と整合)。
+    brightness_samples = build_brightness_samples(captured_brightness)
     split_start = time.monotonic()
     _split_and_write_metadata(
         video_path,
@@ -249,6 +267,7 @@ def run_split(
         effective_interval=effective_interval,
         detected_at=detected_at,
         system_info=detected_system_info,
+        brightness_samples=brightness_samples,
         quiet=quiet,
     )
     _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -354,6 +373,21 @@ def run_split_from_metadata(
         old_completed_at if isinstance(old_completed_at, str) else None
     )
 
+    # #644 -- preserve brightness_samples across `--from-metadata`.
+    # 元 metadata に brightness_samples があれば新 metadata にもそのまま
+    # コピーする。PR #626 の detection_started_at / detection_completed_at
+    # と同じ preserve パターン。元に無ければ None を渡して新 metadata でも
+    # 欠落させる (cache hit / pre-#569 metadata 経路と同じ挙動)。
+    # JSON payload は Any 型なので isinstance チェック後に cast で
+    # BrightnessSamples (TypedDict) に narrow する。schema 検証は
+    # _build_metadata_payload 側の TypedDict 構造に委譲。
+    old_brightness_samples = payload.get("brightness_samples")
+    preserve_brightness_samples: BrightnessSamples | None = (
+        cast("BrightnessSamples", old_brightness_samples)
+        if isinstance(old_brightness_samples, dict)
+        else None
+    )
+
     detection_params = payload.get("detection_params")
     if isinstance(detection_params, dict):
         effective_interval = float(
@@ -390,6 +424,7 @@ def run_split_from_metadata(
         detection_started_at=preserve_started_at,
         detection_completed_at=preserve_completed_at,
         system_info=split_only_system_info,
+        brightness_samples=preserve_brightness_samples,
         quiet=quiet,
     )
     _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -1162,6 +1197,7 @@ def _split_and_write_metadata(
     detection_started_at: str | None = None,
     detection_completed_at: str | None = None,
     system_info: SystemInfo,
+    brightness_samples: BrightnessSamples | None = None,
     quiet: bool = False,
 ) -> None:
     """Split video and write metadata.json (#591: system_info required).
@@ -1222,6 +1258,7 @@ def _split_and_write_metadata(
         output_files=output_files,
         gaps=gaps,
         system_info=system_info,
+        brightness_samples=brightness_samples,
     )
     metadata_path = config.output_dir / "metadata.json"
     write_metadata_atomic(metadata_path, result)

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -123,11 +123,16 @@ GUI complete 画面の輝度タイムライン (`BrightnessTimeline` SVG) 用の
 | `interval_s` | number | ✓ | 配列の各要素が表す秒間隔 (例: `25.0` なら `values[i]` は `i * 25` 秒の輝度) |
 | `values` | array of number | ✓ | 平均輝度 (0-255 の float) を時系列順に並べたもの。最大 512 要素 |
 
-書き込みパス:
+**書き込みパス別の挙動 (#569 + #644)**:
 
-- `allaganeye detect`: cache miss path で Pass 1 が走った場合に書き込む。cache hit / 空 (Pass 1 未実行) の場合はフィールド自体を省略 (`null` ではなく key 不在)
-- `allaganeye split <video>` (legacy): 同上。`run_split` 経由でも `brightness_callback` を渡せば書ける (#569 では detect コマンドのみ書き込み)
-- `allaganeye split --from-metadata`: 入力 metadata.json の値をそのまま転記 (再計算しない)
+| 経路 | 書き込み |
+| --- | --- |
+| `allaganeye detect` (Pass 1 走行) | ✓ 書く (#569) |
+| `allaganeye split` (新規検知、Pass 1 走行) | ✓ 書く (#644 で `brightness_callback` 配線) |
+| `allaganeye split` (cache hit、Pass 1 skip) | ✗ 欠落 (cache に brightness を含めない設計) |
+| `allaganeye split --from-metadata` | 元 metadata から **preserve** (元が欠落なら欠落、PR #626 detection_started_at と同パターン) |
+
+cache hit / Pass 1 未実行の場合は key 自体を省略する (`null` ではなく key 不在)。GUI 側は欠落許容済 (#569) のため、欠落時は `sampleBrightness()` 固定波形 fallback で描画する。`allaganeye split --no-cache` を使えば常に Pass 1 を走らせて書ける。
 
 GUI complete 画面は `metadata.brightness_samples?.values` を読み、欠落時はサンプルデータ (`buildSampleBrightness`) にフォールバックする。
 

--- a/tests/test_split_from_metadata.py
+++ b/tests/test_split_from_metadata.py
@@ -388,3 +388,76 @@ def test_run_split_from_metadata_rejects_future_schema_version(tmp_path):
     config = SplitConfig(output_dir=tmp_path / "out", min_match_duration=60.0)
     with pytest.raises(InputFileError, match="unsupported schema_version"):
         run_split_from_metadata(meta_path, config, quiet=True)
+
+
+# -- #644 brightness_samples preserve through --from-metadata --
+
+
+def test_run_split_from_metadata_preserves_brightness_samples(tmp_path):
+    """#644 -- --from-metadata 経路で元 metadata.json の brightness_samples
+    が新 metadata.json に preserve されること (PR #626 の detection_started_at
+    preserve と同パターン)。
+    """
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    original_samples = {
+        "interval_s": 0.5,
+        "values": [10.0, 12.5, 15.0, 17.5],
+    }
+    payload = {
+        **_sample_metadata(str(source)),
+        "brightness_samples": original_samples,
+    }
+    meta_path = _write_metadata(tmp_path, payload)
+    config = SplitConfig(output_dir=tmp_path / "out", min_match_duration=60.0)
+
+    with (
+        patch(f"{MODULE}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE}.split_video",
+            return_value=[
+                tmp_path / "out" / "match_001.mp4",
+                tmp_path / "out" / "match_002.mp4",
+            ],
+        ),
+    ):
+        run_split_from_metadata(meta_path, config, quiet=True)
+
+    out_meta = tmp_path / "out" / "metadata.json"
+    fresh = json.loads(out_meta.read_text("utf-8"))
+    assert "brightness_samples" in fresh, (
+        "--from-metadata は元 metadata の brightness_samples を新 metadata に "
+        "preserve するはず (#644 / PR #626 同パターン)"
+    )
+    assert fresh["brightness_samples"] == original_samples
+
+
+def test_run_split_from_metadata_omits_brightness_samples_when_source_lacks(tmp_path):
+    """#644 -- --from-metadata 経路で元 metadata に brightness_samples が
+    無い場合、新 metadata.json にも無いまま (legacy / cache hit 互換)。
+    """
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    # _sample_metadata はデフォルトで brightness_samples を含めない
+    payload = _sample_metadata(str(source))
+    assert "brightness_samples" not in payload
+    meta_path = _write_metadata(tmp_path, payload)
+    config = SplitConfig(output_dir=tmp_path / "out", min_match_duration=60.0)
+
+    with (
+        patch(f"{MODULE}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE}.split_video",
+            return_value=[
+                tmp_path / "out" / "match_001.mp4",
+                tmp_path / "out" / "match_002.mp4",
+            ],
+        ),
+    ):
+        run_split_from_metadata(meta_path, config, quiet=True)
+
+    out_meta = tmp_path / "out" / "metadata.json"
+    fresh = json.loads(out_meta.read_text("utf-8"))
+    assert "brightness_samples" not in fresh, (
+        "元 metadata に brightness_samples が無いなら新 metadata にも書かない"
+    )

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -4083,3 +4083,97 @@ def test_eta_progressbar_finished_no_eta_tail() -> None:
 
     assert "ETA:" not in line, f"100% で ETA tail が残存: {line!r}"
     assert "100%" in line
+
+
+# -- #644 brightness_samples wiring through run_split (一気通貫) --
+
+# `MODULE` / `PROBE_RESULT` / `BOUNDARIES` / `_mock_audio_scan` (autouse)
+# は file 冒頭で既定義。`mock_pipeline` fixture は `detect_match_boundaries`
+# を mock するが、本ケースは `_run_detection` を直接 patch して
+# `brightness_callback` の wiring を assert したいため、`mock_pipeline` は
+# 使わず個別に patch する。
+
+
+@patch(f"{MODULE}._run_detection")
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_run_split_writes_brightness_samples_when_callback_fires(
+    mock_probe, mock_split, mock_run_detection, tmp_path
+):
+    """#644 -- run_split (一気通貫) で Pass 1 が走ったら brightness_samples
+    が metadata.json に書かれること。`_run_detection` に渡される
+    `brightness_callback` を fake_run_detection から call して輝度 sample
+    を注入し、最終 metadata.json に payload が現れることを assert する。
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def fake_run_detection(*args, **kwargs):
+        cb = kwargs.get("brightness_callback")
+        assert cb is not None, (
+            "run_split must pass brightness_callback to _run_detection (#644)"
+        )
+        cb({0.0: 10.5, 0.5: 12.3, 1.0: 14.1})
+        return BOUNDARIES
+
+    mock_run_detection.side_effect = fake_run_detection
+
+    output_dir = tmp_path / "out"
+    mock_split.return_value = [
+        output_dir / "match_001.mp4",
+        output_dir / "match_002.mp4",
+    ]
+
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"")
+    config = SplitConfig(output_dir=output_dir, min_match_duration=60.0)
+
+    run_split(video, config, verbose=False, quiet=True)
+
+    metadata_path = output_dir / "metadata.json"
+    assert metadata_path.exists()
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert "brightness_samples" in payload, (
+        "run_split で Pass 1 が走った時 brightness_samples が metadata.json に "
+        "書かれているはず (#644)"
+    )
+    samples = payload["brightness_samples"]
+    assert isinstance(samples, dict)
+    assert "values" in samples and isinstance(samples["values"], list)
+    assert len(samples["values"]) > 0
+
+
+@patch(f"{MODULE}._run_detection")
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_run_split_omits_brightness_samples_when_callback_silent(
+    mock_probe, mock_split, mock_run_detection, tmp_path
+):
+    """#644 -- `_run_detection` が callback を呼ばない (例: cache hit 経路と
+    同じ意味の no-op detection) 場合は brightness_samples キーを書かない。
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def fake_run_detection(*args, **kwargs):
+        # callback を呼ばない (Pass 1 走っていない想定)
+        return BOUNDARIES
+
+    mock_run_detection.side_effect = fake_run_detection
+
+    output_dir = tmp_path / "out2"
+    mock_split.return_value = [
+        output_dir / "match_001.mp4",
+        output_dir / "match_002.mp4",
+    ]
+
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"")
+    config = SplitConfig(output_dir=output_dir, min_match_duration=60.0)
+
+    run_split(video, config, verbose=False, quiet=True)
+
+    metadata_path = output_dir / "metadata.json"
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert "brightness_samples" not in payload, (
+        "callback が silent (Pass 1 skip / cache hit 相当) なら "
+        "brightness_samples キーは書かないはず"
+    )

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -4177,3 +4177,52 @@ def test_run_split_omits_brightness_samples_when_callback_silent(
         "callback が silent (Pass 1 skip / cache hit 相当) なら "
         "brightness_samples キーは書かないはず"
     )
+
+
+@patch("allaganeye.system_info.probe_gpu_vendors", return_value=[])
+@patch(f"{MODULE}._run_detection")
+@patch(f"{MODULE}._load_cache")
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_run_split_cache_hit_omits_brightness_samples(
+    mock_probe,
+    mock_split,
+    mock_load_cache,
+    mock_run_detection,
+    mock_probe_gpu,
+    tmp_path,
+):
+    """#644 -- cache hit 経路では Pass 1 が走らず brightness_samples キー
+    が metadata.json から欠落する (cache に brightness を含めない設計と整合)。
+
+    run_split: cache hit early-return branch (line 100-146) を直接 exercise し、
+    `_run_detection` が呼ばれないこと + metadata.json に key 不在を assert。
+    Round 1 F1 (subagent finding): callback_silent test では `_run_detection`
+    レベルで mock するため cache hit branch そのものを exercise せず、ここで
+    補完する。
+    """
+    mock_probe.return_value = PROBE_RESULT
+    mock_load_cache.return_value = BOUNDARIES  # cache hit -> Pass 1 skip
+
+    output_dir = tmp_path / "out_cache_hit"
+    mock_split.return_value = [
+        output_dir / "match_001.mp4",
+        output_dir / "match_002.mp4",
+    ]
+
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"")
+    config = SplitConfig(output_dir=output_dir, min_match_duration=60.0)
+
+    run_split(video, config, verbose=False, quiet=True)
+
+    # cache hit branch は _run_detection を skip するはず
+    mock_run_detection.assert_not_called()
+
+    metadata_path = output_dir / "metadata.json"
+    assert metadata_path.exists()
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert "brightness_samples" not in payload, (
+        "cache hit 経路では Pass 1 を skip するため brightness_samples キー"
+        "は欠落するはず (#644、metadata-spec.md 書き込みパス表と整合)"
+    )


### PR DESCRIPTION
## Summary

[#644](https://github.com/Idios/kobutachan-allaganeye/issues/644) の実装。Lane I-B Group B の章 3 (P3-low、Lane 最終 PR)。

Spec: [docs/superpowers/specs/2026-05-11-l2-lane-ib-group-b-design.md](docs/superpowers/specs/2026-05-11-l2-lane-ib-group-b-design.md) §7
Plan: [docs/superpowers/plans/2026-05-11-l2-lane-ib-group-b.md](docs/superpowers/plans/2026-05-11-l2-lane-ib-group-b.md) Chapter 3

## 変更内容

- `run_split` で `_run_detection` に `brightness_callback` を配線し Pass 1 輝度を捕捉、`build_brightness_samples` で downsample (`detect.py:239` と同パターン、guard なし)
- `_split_and_write_metadata` に `brightness_samples` 引数 (keyword-only) を追加、`_build_metadata_payload` へ pass-through
- `run_split_from_metadata` で元 metadata の `brightness_samples` を読み取り `preserve_brightness_samples` として渡す (PR #626 `detection_started_at` preserve と同パターン、`cast("BrightnessSamples", ...)` で TypedDict narrow)
- `docs/metadata-spec.md` の `brightness_samples` 節を書き込みパス別の挙動表 (4 経路) に更新

| 経路 | 書き込み |
| --- | --- |
| `allaganeye detect` (Pass 1 走行) | ✓ (#569) |
| `allaganeye split` (新規検知、Pass 1 走行) | ✓ ← #644 で対応 |
| `allaganeye split` (cache hit) | ✗ 欠落 (cache に brightness 含めない設計) |
| `allaganeye split --from-metadata` | preserve (元欠落なら欠落) |

## 受け入れ条件 ([issue #644](https://github.com/Idios/kobutachan-allaganeye/issues/644))

- [x] `allaganeye split <video> -o <dir>` 経路の metadata.json に `brightness_samples` が書かれる (Pass 1 走行時)
- [x] cache hit 時の挙動を `docs/metadata-spec.md` に明記 (欠落許容)
- [x] `--from-metadata` 経路の挙動を決定し doc 化 (preserve)
- [x] pytest で `run_split` 経路 + `--from-metadata` 経路の各分岐を網羅 (4 件)
- [ ] **実機検証 (Idios)**: `allaganeye split <video>` で metadata.json に `brightness_samples` あり、GUI で実 brightness 描画

## Self-Test Report

### Machine-verified

- [x] `git fetch origin develop-0.2.0` + `git log HEAD..origin/develop-0.2.0` (取り込み未済 commit なし)
- [x] `gh pr list --search "#644"` 並行 worktree PR 重複なし
- [x] `ruff check .` (All checks passed)
- [x] `ruff format --check .` (79 files already formatted)
- [x] `pyright` (0 errors, 0 warnings, 0 informations)
- [x] `pytest` (931 passed, 1 skipped, 37 deselected、新 4 件含む)
- [x] `bash scripts/check-markdownlint.sh` (0 errors、134 files lint pass)

### Machine-unverifiable (Iron Law 6 実機検証 — Idios)

- [ ] `allaganeye split <video> -o <dir> --no-cache` (新規) → metadata.json に `brightness_samples` キー存在 (`jq .brightness_samples.values | head` 等で確認)
- [ ] 同 metadata を GUI で load → CompleteScreen の BrightnessTimeline が **実 brightness 描画** (サンプル波形と異なる、dev tools で `metadata.brightness_samples.values` を inspect)
- [ ] 同動画で `allaganeye split <video> -o <dir2>` (cache hit) → metadata.json に `brightness_samples` 無し
- [ ] `allaganeye split --from-metadata <metadata.json> -o <dir3>` (元 metadata に brightness_samples あり) → 新 metadata.json に preserve

Refs #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
