### PR TITLE
docs: v0.2.1 patch release design + initial plans (Track 0/A/C) [crazy-swirles-bed20b]

### DIFF
--- a/docs/superpowers/plans/2026-05-16-v0.2.1-track-0-branch-cut.md
+++ b/docs/superpowers/plans/2026-05-16-v0.2.1-track-0-branch-cut.md
@@ -1,0 +1,276 @@
+# v0.2.1 Track 0: develop-0.2.1 Branch Cut + Spec/Plan 取り込み Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** main から `develop-0.2.1` 統合ブランチを cut し、現 worktree branch (`claude/crazy-swirles-bed20b`、HEAD = 873a990) の spec / plans 3 commit を PR 経由で develop-0.2.1 にマージする。これで後続 Track A / B-x / C / D が `develop-0.2.1` ベースで進められる。
+
+**Architecture:** git branch / push 操作 + 1 PR の流れのみ。コード変更なし。
+
+**Tech Stack:** git, gh CLI
+
+**Spec reference:** [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md](../specs/2026-05-16-security-alerts-response-design.md) §5 Branch Strategy / §8 Release Flow Step 1
+
+---
+
+## File Structure
+
+- 作成: `develop-0.2.1` branch (origin)
+- 変更なし (本 plan ではコード変更なし、PR mergeで既存 spec / plan ファイルを develop-0.2.1 に取り込むだけ)
+
+## Task 1: main 最新化確認
+
+**Files:** なし (git 操作のみ)
+
+- [ ] **Step 1: origin/main の最新を fetch**
+
+Run:
+
+```bash
+git fetch origin main
+```
+
+Expected: `From github.com:Idios/kobutachan-allaganeye` で main 更新の有無を確認 (0.2.0 リリース直後で更新なし想定)
+
+- [ ] **Step 2: main HEAD が `22031f6` であることを確認**
+
+Run:
+
+```bash
+git log origin/main -1 --format="%H %s"
+```
+
+Expected: `22031f6671e616d25cbb59709fdac58f69c113ec Release v0.2.0: develop-0.2.0 → main (#757)`
+
+main HEAD が予期と違う場合は本 plan を停止し、main の最新を確認してから本 Task 1 を再実行する。
+
+## Task 2: develop-0.2.1 branch を main から cut
+
+**Files:** なし (git 操作のみ)
+
+- [ ] **Step 1: ローカル branch を作成 (main HEAD 起点)**
+
+Run:
+
+```bash
+git branch develop-0.2.1 origin/main
+```
+
+Expected: 出力なし (success)。`git branch --list develop-0.2.1` で確認可能。
+
+- [ ] **Step 2: 作成された branch HEAD が main と同一であることを確認**
+
+Run:
+
+```bash
+git log develop-0.2.1 -1 --format="%H %s"
+```
+
+Expected: `22031f6671e616d25cbb59709fdac58f69c113ec Release v0.2.0: develop-0.2.0 → main (#757)`
+
+- [ ] **Step 3: develop-0.2.1 を origin に push (upstream 設定付き)**
+
+Run:
+
+```bash
+git push -u origin develop-0.2.1
+```
+
+Expected: `* [new branch]      develop-0.2.1 -> develop-0.2.1` + `Branch 'develop-0.2.1' set up to track remote branch 'develop-0.2.1' from 'origin'.`
+
+push fail (権限等) は plan を停止して原因調査。
+
+## Task 3: GitHub default branch / branch protection 設定確認
+
+**Files:** なし (gh 操作のみ)
+
+- [ ] **Step 1: default branch が main であることを確認**
+
+Run:
+
+```bash
+gh repo view Idios/kobutachan-allaganeye --json defaultBranchRef --jq '.defaultBranchRef.name'
+```
+
+Expected: `main`
+
+L2 リリース時のリリース PR は main がターゲット。本 plan では default 変更しない (release-process.md §ブランチ戦略 ルール 1 維持)。
+
+- [ ] **Step 2: develop-0.2.1 が origin に存在することを確認**
+
+Run:
+
+```bash
+gh api repos/Idios/kobutachan-allaganeye/branches/develop-0.2.1 --jq '.name'
+```
+
+Expected: `develop-0.2.1`
+
+## Task 4: worktree branch の spec/plan 3 commit を develop-0.2.1 にマージする PR を作成
+
+**Files:** worktree branch (`claude/crazy-swirles-bed20b`) を develop-0.2.1 にマージ
+
+worktree branch は spec / plan 3 commit を保持している:
+
+- `873a990 docs(spec): add Track B-4 for #458 bug_report.yml link + UI verification`
+- `865bf12 docs(spec): expand v0.2.1 scope to security + UX + CI audit`
+- `d61b8fd docs(spec): v0.2.1 security hotfix response design`
+
+加えて本 plan 自体の Plan 0 / A / C も commit 済みであることを期待 (本 plan を書き終えた writing-plans skill 完了時点で commit される)。
+
+- [ ] **Step 1: 現 worktree branch の commit を確認**
+
+Run:
+
+```bash
+git log claude/crazy-swirles-bed20b --oneline -10
+```
+
+Expected: 873a990 / 865bf12 / d61b8fd の spec commits + Plan 0 / A / C を含む docs commit が存在 (writing-plans skill の terminal でユーザーが選んだ実行 mode により異なる)
+
+- [ ] **Step 2: PR Pre-flight (Iron Law 6)**
+
+Run (Step 0: 既存 open PR check):
+
+```bash
+gh pr list --search "v0.2.1 OR develop-0.2.1" --state open
+```
+
+Expected: 出力空 (並行作業がないことを確認)。出力があれば本 PR と関係するか判定し、必要に応じて plan を停止して相談。
+
+Run (Step 1: base 同期確認):
+
+```bash
+git fetch origin develop-0.2.1 && git log claude/crazy-swirles-bed20b..origin/develop-0.2.1 --oneline
+```
+
+Expected: 出力空 (develop-0.2.1 が worktree branch の祖先と一致)。出力があれば base 取り込み必要。
+
+Run (Step 2: 取り込み未済 commit):
+
+```bash
+git log HEAD..origin/develop-0.2.1 --oneline
+```
+
+Expected: 出力空。
+
+Run (Step 3: touched files):
+
+```bash
+git diff --name-only origin/develop-0.2.1...HEAD
+```
+
+Expected: spec / plan 関連の .md ファイルのみ。
+
+- [ ] **Step 3: PR を develop-0.2.1 ベースで作成**
+
+Run:
+
+```bash
+gh pr create --base develop-0.2.1 --head claude/crazy-swirles-bed20b --title "docs: v0.2.1 patch release design + initial plans (Track 0/A/C) [crazy-swirles-bed20b]" --body-file - <<'EOF'
+## 概要
+
+v0.2.1 patch リリースの設計文書 (spec) と初回作業 plan (Track 0 / A / C) を develop-0.2.1 に取り込む。
+
+## 含まれる commits
+
+- d61b8fd docs(spec): v0.2.1 security hotfix response design
+- 865bf12 docs(spec): expand v0.2.1 scope to security + UX + CI audit
+- 873a990 docs(spec): add Track B-4 for #458 bug_report.yml link + UI verification
+- (writing-plans 完了 commit) Plan 0 (本 plan) + Plan A + Plan C を新規追加
+
+## Refs
+
+- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md`
+- Plans: `docs/superpowers/plans/2026-05-16-v0.2.1-track-0-branch-cut.md` 他
+
+## Self-Test Report
+
+machine-verified:
+- [x] markdownlint pass (`bash scripts/check-markdownlint.sh` で 0 errors)
+
+machine-unverifiable:
+- N/A (docs-only PR)
+
+## Notes
+
+本 PR には実装変更は含まない (spec / plans のみ)。後続の Track A / B / C / D 作業 PR で実装を進める。
+EOF
+```
+
+Expected: PR URL が出力される。
+
+PR 番号を Plan 内のメモ用 ENV var として記録 (例: `export V021_DESIGN_PR=<num>`)、後続 Tasks で参照する。
+
+- [ ] **Step 4: PR を develop-0.2.1 にマージ (squash or merge commit、Idios 判断)**
+
+User confirmation を求める (本 PR は docs-only だが、develop-0.2.1 の最初の merge commit になるため merge 方式を明示する):
+
+`AskUserQuestion` で:
+
+- (a) squash merge (1 commit に集約、Recommended for docs PR)
+- (b) merge commit (3+ commit の history を保持、後で grep しやすい)
+
+Idios の選択に従い:
+
+```bash
+gh pr merge <PR#> --squash --delete-branch=false   # (a) を選んだ場合
+# または
+gh pr merge <PR#> --merge --delete-branch=false    # (b) を選んだ場合
+```
+
+`--delete-branch=false` 理由: worktree branch (`claude/crazy-swirles-bed20b`) はまだ後続 Track 作業に転用可能性があるため、現時点で削除しない。
+
+Expected: PR がマージされる。
+
+## Task 5: develop-0.2.1 の最新化 + 次の Track 作業準備
+
+**Files:** なし
+
+- [ ] **Step 1: develop-0.2.1 を pull**
+
+Run:
+
+```bash
+git checkout develop-0.2.1 && git pull origin develop-0.2.1
+```
+
+Expected: Task 4 の merge commit (squash 1 個 or merge 3 個 + merge commit) が反映される。
+
+- [ ] **Step 2: develop-0.2.1 に spec / plans が含まれていることを確認**
+
+Run:
+
+```bash
+ls docs/superpowers/specs/2026-05-16-security-alerts-response-design.md docs/superpowers/plans/2026-05-16-v0.2.1-*.md
+```
+
+Expected: spec 1 ファイル + plan 3 ファイル (Plan 0 / A / C) が存在。
+
+## Task 6: 完了確認
+
+- [ ] **Step 1: develop-0.2.1 が origin に存在し、spec / plans が含まれている**
+
+Run:
+
+```bash
+gh api repos/Idios/kobutachan-allaganeye/contents/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md?ref=develop-0.2.1 --jq '.name'
+```
+
+Expected: `2026-05-16-security-alerts-response-design.md`
+
+- [ ] **Step 2: 後続 Track の plan 内で `git fetch origin develop-0.2.1 && git checkout -b claude/<scope> origin/develop-0.2.1` で作業 branch を cut 可能になっている**
+
+Expected: Plan A / C 等が前提とする「develop-0.2.1 から作業 branch cut」のフローが利用可能。
+
+## 受け入れ条件 (本 Track 0 完了判定)
+
+- [ ] `develop-0.2.1` branch が origin に存在 (HEAD = main HEAD or merge commit)
+- [ ] `develop-0.2.1` に v0.2.1 patch の spec ファイル + Plan 0 / A / C が含まれる
+- [ ] 後続 Track の作業 branch を develop-0.2.1 から cut 可能 (Plan A Task 1 / Plan C Task 1 の前提)
+- [ ] worktree branch (`claude/crazy-swirles-bed20b`) は削除されず保持 (後続 Track 作業転用可能性のため)
+
+## Out of scope (本 plan で扱わない)
+
+- Track A / B-x / C / D の作業 branch cut (各 Plan の Task 1 で扱う)
+- Plan B-1 / B-2 / B-3 / B-4 / D の生成 (Track A マージ完了後に追加 writing-plans skill invoke で生成)
+- 別 worktree の作成 (本 plan は単一 worktree 内で完結)

--- a/docs/superpowers/plans/2026-05-16-v0.2.1-track-a-security-alerts.md
+++ b/docs/superpowers/plans/2026-05-16-v0.2.1-track-a-security-alerts.md
@@ -1,0 +1,698 @@
+# v0.2.1 Track A: Security Alerts 解消 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dependabot security alerts 5 件 (`#2 fast-uri high` / `#3 fast-uri high` / `#4 glib medium` / `#5 rand low` / `#6 tauri medium`) と PR [#758](https://github.com/Idios/kobutachan-allaganeye/pull/758) を、1 PR (5 commits) で develop-0.2.1 に取り込む。配布物 (Portable ZIP の `allaganeye-gui.exe`) の runtime に影響する medium 脆弱性 (tauri) を消し、dev-only の high 脆弱性 (fast-uri) も併せて解消する。
+
+**Architecture:**
+
+- Cargo.toml の direct dep (`tauri = "=2.11.1"`, `tauri-build = "=2.6.1"`) を変更し、`cargo update --precise` で transitive を含めて確実な version pin に置き換える
+- npm 側は `npm install fast-uri@3.1.2 --package-lock-only` で transitive (devDeps ajv 経由) を package-lock 単独更新
+- 5 commits 分割で各 alert との対応をトレース可能にする
+- PR base = `develop-0.2.1` (Track 0 完了後の統合 branch)
+
+**Tech Stack:** Rust (cargo), npm (Node.js), Tauri 2.x, GitHub Actions CI
+
+**Spec reference:** [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md](../specs/2026-05-16-security-alerts-response-design.md) §4 Track A / §6 Track A 詳細 / §7 Verification
+
+**前提:** Plan 0 (Track 0) 完了済 (`develop-0.2.1` が origin に存在、spec / plans が含まれる)。
+
+---
+
+## File Structure
+
+- 変更: `gui/package-lock.json` (Commit A-1)
+- 変更: `gui/src-tauri/Cargo.toml` (Commit A-2 / A-3)
+- 変更: `gui/src-tauri/Cargo.lock` (Commit A-2 / A-3 / A-4)
+- 作成: `docs/audit-logs/2026-05-16-v0.2.1-audit.log` (Commit A-5、cargo audit + npm audit の出力を残す)
+
+## Task 1: Track A 作業 branch を develop-0.2.1 から cut
+
+**Files:** なし (git 操作のみ)
+
+- [ ] **Step 1: develop-0.2.1 を最新化**
+
+Run:
+
+```bash
+git fetch origin develop-0.2.1 && git checkout develop-0.2.1 && git pull origin develop-0.2.1
+```
+
+Expected: `Already up to date.` または最新化される。
+
+- [ ] **Step 2: 作業 branch を cut**
+
+Run:
+
+```bash
+git checkout -b claude/security-v0.2.1 origin/develop-0.2.1
+```
+
+Expected: `Switched to a new branch 'claude/security-v0.2.1'`
+
+## Task 2: Commit A-1 — fast-uri 3.1.0 → 3.1.2 (alert #2, #3)
+
+**Files:**
+
+- Modify: `gui/package-lock.json` (transitive: ajv → fast-uri)
+
+- [ ] **Step 1: baseline test pass を確認**
+
+Run:
+
+```bash
+cd gui && npm run lint && npm run typecheck && npm run test && npm run build
+```
+
+Expected: すべて pass (現状 gui 側は test 緑のはず)。fail があれば本 plan 開始前に解消。
+
+- [ ] **Step 2: fast-uri を 3.1.2 に bump (lock-only)**
+
+Run:
+
+```bash
+cd gui && npm install fast-uri@3.1.2 --package-lock-only
+```
+
+Expected: `gui/package-lock.json` のみ更新される。`gui/package.json` の direct deps には fast-uri は含まれないので変更なし。
+
+- [ ] **Step 3: 変更ファイル確認**
+
+Run:
+
+```bash
+git status --short gui/
+```
+
+Expected: `M gui/package-lock.json` のみ (gui/package.json に変更なし)。
+
+- [ ] **Step 4: fast-uri version が 3.1.2 になっていることを確認**
+
+Run (Linux/macOS):
+
+```bash
+grep -A2 '"node_modules/fast-uri"' gui/package-lock.json | head -5
+```
+
+Run (Windows PowerShell):
+
+```powershell
+Select-String -Path gui/package-lock.json -Pattern '"node_modules/fast-uri"' -Context 0,2 | Select-Object -First 1
+```
+
+Expected: `"version": "3.1.2"` が表示される。
+
+- [ ] **Step 5: regression test pass を再確認**
+
+Run:
+
+```bash
+cd gui && npm run lint && npm run typecheck && npm run test && npm run build
+```
+
+Expected: すべて pass。1 件でも fail なら本 task を停止し、原因調査 (fast-uri 3.1.2 が ajv との compat を壊した可能性)。
+
+- [ ] **Step 6: commit**
+
+Run:
+
+```bash
+git add gui/package-lock.json && git commit -m "$(cat <<'EOF'
+chore(deps): bump fast-uri 3.1.0 to 3.1.2 (alerts #2 #3) [crazy-swirles-bed20b]
+
+ajv (devDependencies) 経由の transitive を package-lock 単独 update。
+GHSA-q3j6-qgpj-74h6 (path traversal) と GHSA-v39h-62p7-jpjc (host
+confusion) を両方解消。direct deps に変更なし、dev-only の影響範囲。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 3: Commit A-2 — tauri 2.10.3 → 2.11.1 + tauri-build 2.5.6 → 2.6.1 (alert #6)
+
+**Files:**
+
+- Modify: `gui/src-tauri/Cargo.toml` (tauri / tauri-build pin)
+- Modify: `gui/src-tauri/Cargo.lock` (tauri / tauri-build + 関連 transitive)
+
+- [ ] **Step 1: baseline cargo check / test を確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo check && cargo test
+```
+
+Expected: すべて pass。fail があれば本 plan 開始前に解消。
+
+- [ ] **Step 2: Cargo.toml の tauri 行を編集**
+
+Edit `gui/src-tauri/Cargo.toml` の line 11:
+
+Before:
+
+```toml
+tauri = { version = "=2.10.3", features = ["protocol-asset"] }
+```
+
+After:
+
+```toml
+tauri = { version = "=2.11.1", features = ["protocol-asset"] }
+```
+
+(security advisory GHSA-7gmj-67g7-phm9 の first_patched = 2.11.1、2.11.0 ではまだ脆弱)
+
+- [ ] **Step 3: Cargo.toml の tauri-build 行を編集**
+
+Edit `gui/src-tauri/Cargo.toml` の line 8:
+
+Before:
+
+```toml
+tauri-build = { version = "=2.5.6", features = [] }
+```
+
+After:
+
+```toml
+tauri-build = { version = "=2.6.1", features = [] }
+```
+
+(tauri 2.11.0 release notes で tauri-build@2.6.0 への bump 記載、現在 latest は 2.6.1。cargo search 確認済 2026-05-16)
+
+- [ ] **Step 4: cargo update --precise で lock 更新**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo update -p tauri --precise 2.11.1 && cargo update -p tauri-build --precise 2.6.1
+```
+
+Expected: `Updating tauri v2.10.3 -> v2.11.1` + `Updating tauri-build v2.5.6 -> v2.6.1` + 関連 transitive (tauri-codegen / tauri-macros / tauri-runtime 等) も同時 update される。
+
+- [ ] **Step 5: Cargo.lock 内の tauri version 確認**
+
+Run:
+
+```bash
+grep -B1 -A3 '^name = "tauri"$' gui/src-tauri/Cargo.lock | head -10
+```
+
+Expected: `version = "2.11.1"` が表示される。
+
+- [ ] **Step 6: cargo check で compile pass を確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo check
+```
+
+Expected: compile pass (warnings は許容、errors なし)。errors があれば本 task を停止し、tauri 2.11 への migration 要件を確認 (Tauri 2.11 release notes は breaking changes なしを確認済だが、特定 feature が deprecated されている可能性)。
+
+- [ ] **Step 7: cargo test で test pass を確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo test
+```
+
+Expected: すべて pass。
+
+- [ ] **Step 8: commit**
+
+Run:
+
+```bash
+git add gui/src-tauri/Cargo.toml gui/src-tauri/Cargo.lock && git commit -m "$(cat <<'EOF'
+chore(deps): bump tauri 2.10.3 to 2.11.1 + tauri-build 2.5.6 to 2.6.1 (alert #6) [crazy-swirles-bed20b]
+
+tauri Origin Confusion 脆弱性 (GHSA-7gmj-67g7-phm9) を解消。
+first_patched = 2.11.1 (2.11.0 ではまだ脆弱)。
+tauri-build は tauri 2.11.0 release notes の bump 仕様に従い 2.6.1。
+runtime (allaganeye-gui.exe) に直接効く medium severity 脆弱性消化。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 4: Commit A-3 — tauri-plugin-dialog 2.7.0 → 2.7.1 + tauri-plugin-fs 2.5.0 → 2.5.1 (alert なし、互換性整合)
+
+**Files:**
+
+- Modify: `gui/src-tauri/Cargo.toml` (tauri-plugin-dialog / tauri-plugin-fs pin)
+- Modify: `gui/src-tauri/Cargo.lock`
+
+注: tauri-plugin-shell は 2.3.5 で latest と同じため変更なし (cargo search 確認済 2026-05-16)。
+
+- [ ] **Step 1: Cargo.toml の tauri-plugin-dialog 行を編集**
+
+Edit `gui/src-tauri/Cargo.toml` の line 12:
+
+Before:
+
+```toml
+tauri-plugin-dialog = "=2.7.0"
+```
+
+After:
+
+```toml
+tauri-plugin-dialog = "=2.7.1"
+```
+
+- [ ] **Step 2: Cargo.toml の tauri-plugin-fs 行を編集**
+
+Edit `gui/src-tauri/Cargo.toml` の line 13:
+
+Before:
+
+```toml
+tauri-plugin-fs = "=2.5.0"
+```
+
+After:
+
+```toml
+tauri-plugin-fs = "=2.5.1"
+```
+
+- [ ] **Step 3: cargo update で lock 更新**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo update -p tauri-plugin-dialog --precise 2.7.1 && cargo update -p tauri-plugin-fs --precise 2.5.1
+```
+
+Expected: `Updating tauri-plugin-dialog v2.7.0 -> v2.7.1` + `Updating tauri-plugin-fs v2.5.0 -> v2.5.1`
+
+- [ ] **Step 4: cargo check / test 確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo check && cargo test
+```
+
+Expected: すべて pass。
+
+- [ ] **Step 5: commit**
+
+Run:
+
+```bash
+git add gui/src-tauri/Cargo.toml gui/src-tauri/Cargo.lock && git commit -m "$(cat <<'EOF'
+chore(deps): align tauri-plugin-dialog and tauri-plugin-fs with tauri 2.11 [crazy-swirles-bed20b]
+
+tauri-plugin-dialog 2.7.0 -> 2.7.1
+tauri-plugin-fs     2.5.0 -> 2.5.1
+tauri-plugin-shell  2.3.5 (latest と一致のため変更なし)
+
+tauri-plugins-workspace の独自 release cadence に追従。
+本 commit 自体は alert を解消しないが、tauri 2.11 系の compat 整合性を担保。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 5: Commit A-4 — transitive rand 0.8.6 / glib 0.20.0 検証 (alert #4, #5)
+
+**Files:**
+
+- Modify: `gui/src-tauri/Cargo.lock` (該当時のみ)
+
+注: rand 0.7.3 は phf_generator 0.8.0 経由の build-dep。glib 0.18.5 は Windows ビルドでは未使用 (Linux/macOS GTK 系)。tauri 2.11 系の更新で transitive 解決される見込みだが、本 Task で実測確認する。
+
+- [ ] **Step 1: rand 0.7.3 がまだ存在するか確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo tree -i rand@0.7.3 2>&1 | head -5
+```
+
+Expected (もし解決済の場合): `error: package ID specification 'rand@0.7.3' did not match any packages` または `warning: nothing to print.`
+
+Expected (もし残存の場合): `rand v0.7.3` と依存元 trace が表示される。
+
+- [ ] **Step 2: glib version 確認**
+
+Run:
+
+```bash
+grep -B1 -A2 '^name = "glib"$' gui/src-tauri/Cargo.lock | head -10
+```
+
+Expected (もし更新済の場合): `version = "0.20.0"` 以上が表示される。
+Expected (もし未更新の場合): `version = "0.18.5"` が表示される。
+
+- [ ] **Step 3a: rand 0.7.3 が残存している場合のみ実行**
+
+Run (該当時のみ):
+
+```bash
+cd gui/src-tauri && cargo update -p rand@0.7.3 --precise 0.8.6
+```
+
+注: 一部 crate が rand 0.7 系を strict に要求する場合、cargo update が fail する可能性。その場合は依存元 (phf_generator) の新版へ間接的に push する必要 (新 phf_generator が rand 0.8 系を使用)。実行 fail なら本 Task を停止して Idios に escalate。
+
+Expected: `Updating rand v0.7.3 -> v0.8.6`
+
+- [ ] **Step 3b: glib 0.18.5 のままなら実行**
+
+Run (該当時のみ):
+
+```bash
+cd gui/src-tauri && cargo update -p glib --precise 0.20.0
+```
+
+Expected: `Updating glib v0.18.5 -> v0.20.0` または mid version (例 0.19.x 経由)。
+
+- [ ] **Step 4: cargo check / test 確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo check && cargo test
+```
+
+Expected: すべて pass。
+
+- [ ] **Step 5: commit (transitive 解決済の場合は CHANGELOG memo として、未解決の場合は実際の lock 変更を含めて)**
+
+Run:
+
+```bash
+git add gui/src-tauri/Cargo.lock 2>/dev/null || true
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(deps): verify transitive rand 0.8.6 and glib 0.20.0 (alerts #4 #5) [crazy-swirles-bed20b]
+
+tauri 2.11 系への bump で transitive に rand と glib が新 version へ
+解決されたことを cargo tree / Cargo.lock で確認 (or 未解決分は個別
+cargo update --precise で patch)。
+- alert #4: glib VariantStrIter unsoundness (GHSA-wrw7-89jp-8q8g)
+- alert #5: rand custom logger unsoundness (GHSA-cq8v-f236-94qc)
+
+rand 0.7.3 は build-dep (phf_generator 経由) のため runtime 不含。
+glib は Windows ビルドでは未使用 (Linux/macOS GTK 系の依存)。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される (空 commit でも `--allow-empty` で OK)。
+
+## Task 6: Commit A-5 — cargo audit + npm audit local 実行 + log 保存
+
+**Files:**
+
+- Create: `docs/audit-logs/2026-05-16-v0.2.1-audit.log`
+
+- [ ] **Step 1: cargo-audit がインストールされているか確認**
+
+Run:
+
+```bash
+cargo audit --version 2>&1 | head -1
+```
+
+Expected: `cargo-audit X.Y.Z` (version が表示される)。未インストールなら次 Step で install。
+
+- [ ] **Step 2: cargo-audit インストール (未インストール時のみ)**
+
+Run (必要時のみ):
+
+```bash
+cargo install cargo-audit --locked
+```
+
+Expected: install success (時間がかかる、数分)。
+
+- [ ] **Step 3: docs/audit-logs/ ディレクトリ作成**
+
+Run:
+
+```bash
+mkdir -p docs/audit-logs
+```
+
+Expected: ディレクトリ作成 or 既存。
+
+- [ ] **Step 4: cargo audit 実行 + log 保存**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo audit > ../../docs/audit-logs/2026-05-16-v0.2.1-cargo-audit.log 2>&1
+echo "--- exit code: $? ---" >> ../../docs/audit-logs/2026-05-16-v0.2.1-cargo-audit.log
+```
+
+Expected: exit code = 0 (脆弱性 0 件) を期待。1 件でも残るなら本 Task を停止し、Idios に escalate (Track A の transitive 解決を見直す)。
+
+- [ ] **Step 5: npm audit 実行 + log 保存**
+
+Run:
+
+```bash
+cd gui && npm audit > ../docs/audit-logs/2026-05-16-v0.2.1-npm-audit.log 2>&1
+echo "--- exit code: $? ---" >> ../docs/audit-logs/2026-05-16-v0.2.1-npm-audit.log
+```
+
+Expected: exit code = 0 (脆弱性 0 件) を期待。
+
+- [ ] **Step 6: 統合ログとして 1 ファイルにまとめる**
+
+Run:
+
+```bash
+cat docs/audit-logs/2026-05-16-v0.2.1-cargo-audit.log docs/audit-logs/2026-05-16-v0.2.1-npm-audit.log > docs/audit-logs/2026-05-16-v0.2.1-audit.log
+rm docs/audit-logs/2026-05-16-v0.2.1-cargo-audit.log docs/audit-logs/2026-05-16-v0.2.1-npm-audit.log
+```
+
+Expected: 1 つの統合ログファイルが作成される。
+
+- [ ] **Step 7: commit**
+
+Run:
+
+```bash
+git add docs/audit-logs/2026-05-16-v0.2.1-audit.log && git commit -m "$(cat <<'EOF'
+chore(self-test): record cargo audit + npm audit logs for v0.2.1 [crazy-swirles-bed20b]
+
+Track A 完了後の local audit 結果。Track C で追加する CI workflow
+(.github/workflows/security-audit.yml) との突合せ用 baseline。
+脆弱性 0 件であることを記録 (期待)。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 7: 実機検証依頼 (Idios)
+
+**Files:** なし
+
+- [ ] **Step 1: AskUserQuestion で Idios に実機検証を依頼**
+
+Iron Law 6 に従い、`gui/src-tauri/**` の Cargo.toml + Cargo.lock 変更により tauri runtime 動作影響あり。AskUserQuestion で以下の検証を依頼:
+
+検証項目:
+
+```text
+1. cd gui && npm run tauri dev で Tauri GUI が起動する
+2. drop screen に動画ファイルを drop → detecting → complete → preview → export まで通る
+3. export 時の H.264 エンコーダ自動選択が動く (NVENC / QSV / AMF / libx264 fallback、metadata.system_info の gpu_vendors_available 反映)
+4. 既存 <install dir>/recent.json が読み込まれ、recent 履歴が GUI に表示される
+5. 検証中・終了後に GUI が clean に exit (#756 残バグの再現は本 Track A の範囲外、後 Track B-2 で fix)
+```
+
+- [ ] **Step 2: 実機検証結果を AskUserQuestion 回答として受け取り、本 Task を完了 (or 問題発見で Track A を停止)**
+
+検証 fail の場合は本 plan を停止し、原因 (tauri 2.11.1 への bump で何かが破壊された等) を調査する。
+
+## Task 8: PR Pre-flight + PR 作成
+
+**Files:** なし (gh CLI 操作のみ)
+
+- [ ] **Step 1: PR Pre-flight Step 0 (既存 open PR check)**
+
+Run:
+
+```bash
+gh pr list --search "security-v0.2.1 OR develop-0.2.1 security" --state open
+```
+
+Expected: 出力空 (Plan 0 の PR は既マージ、本 Track A の PR は未作成)。
+
+- [ ] **Step 2: PR Pre-flight Step 1 (base 同期)**
+
+Run:
+
+```bash
+git fetch origin develop-0.2.1
+git log claude/security-v0.2.1..origin/develop-0.2.1 --oneline
+```
+
+Expected: 出力空 (Plan 0 直後で develop-0.2.1 は変化なし想定)。出力があれば base 取り込みを実施 (`git rebase origin/develop-0.2.1`)。
+
+- [ ] **Step 3: PR Pre-flight Step 2 (touched files)**
+
+Run:
+
+```bash
+git diff --name-only origin/develop-0.2.1...HEAD
+```
+
+Expected: 4 ファイル (`gui/package-lock.json`, `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`, `docs/audit-logs/2026-05-16-v0.2.1-audit.log`)
+
+- [ ] **Step 4: PR Pre-flight Step 4 (並行 PR 重複確認)**
+
+Run:
+
+```bash
+gh pr list --search "Cargo.lock OR package-lock.json" --state all --limit 5
+```
+
+Expected: 直近 5 件で同 manifest を扱う open PR がないことを確認。
+
+- [ ] **Step 5: branch push**
+
+Run:
+
+```bash
+git push -u origin claude/security-v0.2.1
+```
+
+Expected: `* [new branch]      claude/security-v0.2.1 -> claude/security-v0.2.1` + upstream 設定。
+
+- [ ] **Step 6: PR 作成**
+
+Run:
+
+```bash
+gh pr create --base develop-0.2.1 --head claude/security-v0.2.1 --title "chore(deps): v0.2.1 Track A — security alerts 5 件解消 [crazy-swirles-bed20b]" --body-file - <<'EOF'
+## 概要
+
+v0.2.1 patch Track A。Dependabot security alerts 5 件 + PR #758 を解消。
+
+## 解決 alert
+
+- #2 fast-uri high (GHSA-q3j6-qgpj-74h6, path traversal)
+- #3 fast-uri high (GHSA-v39h-62p7-jpjc, host confusion)
+- #4 glib medium (GHSA-wrw7-89jp-8q8g, VariantStrIter unsoundness)
+- #5 rand low (GHSA-cq8v-f236-94qc, custom logger unsoundness)
+- #6 tauri medium (GHSA-7gmj-67g7-phm9, Origin Confusion → Remote→Local IPC)
+
+## 含まれる commits
+
+- A-1: fast-uri 3.1.0 → 3.1.2 (dev-only)
+- A-2: tauri 2.10.3 → 2.11.1 + tauri-build 2.5.6 → 2.6.1
+- A-3: tauri-plugin-dialog 2.7.0 → 2.7.1, tauri-plugin-fs 2.5.0 → 2.5.1
+- A-4: transitive rand 0.8.6 / glib 0.20.0 検証
+- A-5: cargo audit + npm audit local log
+
+## Refs
+
+- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §4 Track A
+- Plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-a-security-alerts.md`
+- 元 Dependabot PR: #758 (本 PR マージ後 auto-close 期待)
+
+## Self-Test Report
+
+machine-verified:
+- [x] cd gui && npm run lint / typecheck / test / build (全 pass)
+- [x] cd gui/src-tauri && cargo check / cargo test (全 pass)
+- [x] cargo audit / npm audit local 実行で脆弱性 0 件 (docs/audit-logs/2026-05-16-v0.2.1-audit.log)
+
+machine-unverifiable:
+- Idios 実機検証: Tauri GUI 起動 + golden path (drop → detecting → complete → preview → export) + H.264 encoder selection + recent.json load
+- 実機検証ログを本 PR コメントに記載予定
+
+## Notes
+
+- 配布物 (Portable ZIP の allaganeye-gui.exe) に直接効く脆弱性は #6 tauri (medium)
+- #2 #3 fast-uri は dev-only (ajv via devDeps)、配布物には未含
+- #4 glib は Windows ビルドで未使用 (Linux/macOS GTK 系)
+- #5 rand は build-dep のみ (phf_generator 経由)、runtime 不含
+EOF
+```
+
+Expected: PR URL が出力される。PR 番号を後続 Tasks 用に記録。
+
+- [ ] **Step 7: CI green を待つ**
+
+GitHub Actions が走り、ci.yml の全 job が green になるのを待つ。
+
+Run (polling 推奨):
+
+```bash
+gh pr checks <PR#> --watch
+```
+
+Expected: 全 check が pass。fail がある場合は本 Task を停止し、原因調査。
+
+- [ ] **Step 8: Idios レビュー + マージ**
+
+User confirmation で `/review-pr <PR#>` を Idios が実行 (or 別セッション)。LGTM 後にマージ:
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+Expected: PR マージ + claude/security-v0.2.1 branch 削除。
+
+## Task 9: PR マージ後の確認 (Dependabot auto-close 監視)
+
+**Files:** なし
+
+- [ ] **Step 1: Dependabot alerts の auto-close 状態確認 (PR マージ後 24h 以内)**
+
+Run:
+
+```bash
+gh api repos/Idios/kobutachan-allaganeye/dependabot/alerts --jq '.[] | select(.state == "open") | {number, dependency_name: .dependency.package.name}'
+```
+
+Expected: 出力空 (alerts #2 #3 #4 #5 #6 がすべて closed)。残るものがあれば手動 close (reason: "Fixed via v0.2.1 Track A PR")。
+
+- [ ] **Step 2: PR #758 の auto-close 確認**
+
+Run:
+
+```bash
+gh pr view 758 --json state,closedAt
+```
+
+Expected: `state: CLOSED`、`closedAt: <timestamp>`。auto-close されていない場合は手動 close (`gh pr close 758 --comment "Superseded by v0.2.1 Track A PR (alerts #2 #3 解消済)"`)。
+
+## 受け入れ条件 (本 Track A 完了判定)
+
+- [ ] PR `claude/security-v0.2.1 → develop-0.2.1` がマージされる
+- [ ] CI (ci.yml) が全 job green
+- [ ] Idios 実機検証で Tauri GUI golden path が pass
+- [ ] PR マージ後 24h 以内に Dependabot alerts #2, #3, #4, #5, #6 がすべて closed
+- [ ] PR #758 が closed (auto-close or 手動 close)
+- [ ] `docs/audit-logs/2026-05-16-v0.2.1-audit.log` に cargo audit + npm audit の 脆弱性 0 件 log が記録される
+
+## Out of scope (本 plan で扱わない)
+
+- Track C (CI security-audit.yml) — Plan C で扱う
+- Track B-1〜B-4 (UX issue) — 後続 Plan で扱う
+- Track D (version bump + CHANGELOG) — 最後の Plan で扱う
+- `develop-0.2.1 → main` のリリース PR — Track D 完了後に別途
+- Dependabot grouped update 設定見直し — Spec の Out of scope

--- a/docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md
+++ b/docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md
@@ -1,0 +1,382 @@
+# v0.2.1 Track C: Pre-merge Security Audit CI Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR 作成 / push 時に cargo audit + npm audit を自動実行する GitHub Actions workflow (`.github/workflows/security-audit.yml`) を追加し、今後 GitHub から指摘される security advisory を PR マージ前に自前で検出する仕組みを確立する。
+
+**Architecture:**
+
+- 既存 `ci.yml` には触らず、独立 `security-audit.yml` を新規追加 (関心分離)
+- pull_request trigger で manifest 変更 (`Cargo.lock` / `Cargo.toml` / `package-lock.json` / `package.json`) ある PR にのみ実行 (CI 時間節約)
+- 2 ジョブ: `cargo-audit` (Rust) と `npm-audit` (npm)、並列実行
+- fail 条件:
+  - `cargo audit --deny warnings`: warning level 以上で fail (medium severity 以上を捕捉)
+  - `npm audit --audit-level=high`: high 以上で fail (dev-only medium/low は warning 通過)
+- workflow_dispatch も追加し、手動で全 PR baseline 実行可能に
+
+**Tech Stack:** GitHub Actions, `rustsec/audit-check` (alternatively `cargo-audit`), npm audit (built-in)
+
+**Spec reference:** [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md](../specs/2026-05-16-security-alerts-response-design.md) §4 Track C / §6 Track C 詳細
+
+**前提:**
+
+- Plan 0 (Track 0) 完了済 (`develop-0.2.1` が origin に存在)
+- **Plan A (Track A) との関係**: 本 Track C の workflow を `develop-0.2.1` baseline で走らせると、Track A 未マージ時点では脆弱性 5 件で fail する。そのため **Track A のマージを先に行い**、本 Track C はその後に Ready PR にする運用とする (spec §6 「推奨マージ順 C → A」を本 plan では実情に合わせて A → C に補正)
+
+---
+
+## File Structure
+
+- 作成: `.github/workflows/security-audit.yml`
+- 作成: `docs/ci-security-audit.md` (workflow 説明 + 運用 note、optional だが本 plan では追加)
+
+## Task 1: Track C 作業 branch を develop-0.2.1 から cut
+
+**Files:** なし (git 操作のみ)
+
+- [ ] **Step 1: develop-0.2.1 を最新化**
+
+Run:
+
+```bash
+git fetch origin develop-0.2.1 && git checkout develop-0.2.1 && git pull origin develop-0.2.1
+```
+
+Expected: 最新化。Track A マージ後に本 plan を実行するため、Track A の commits が含まれた状態を想定。
+
+- [ ] **Step 2: 作業 branch を cut**
+
+Run:
+
+```bash
+git checkout -b claude/ci-security-audit origin/develop-0.2.1
+```
+
+Expected: `Switched to a new branch 'claude/ci-security-audit'`
+
+## Task 2: `security-audit.yml` の最小 workflow を作成
+
+**Files:**
+
+- Create: `.github/workflows/security-audit.yml`
+
+- [ ] **Step 1: workflow ファイルを作成**
+
+Create `.github/workflows/security-audit.yml`:
+
+```yaml
+name: Security Audit
+
+on:
+  pull_request:
+    paths:
+      - 'gui/src-tauri/Cargo.lock'
+      - 'gui/src-tauri/Cargo.toml'
+      - 'gui/package-lock.json'
+      - 'gui/package.json'
+      - '.github/workflows/security-audit.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit (Rust)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version "^0.20"
+
+      - name: Run cargo audit
+        working-directory: gui/src-tauri
+        run: cargo audit --deny warnings
+
+  npm-audit:
+    name: npm audit (JavaScript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: gui
+        run: npm ci
+
+      - name: Run npm audit
+        working-directory: gui
+        run: npm audit --audit-level=high
+```
+
+- [ ] **Step 2: yaml syntax check (local)**
+
+Run (Linux/macOS):
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/security-audit.yml'))"
+```
+
+Run (Windows PowerShell, if Python 3 available):
+
+```powershell
+python -c "import yaml; yaml.safe_load(open('.github/workflows/security-audit.yml'))"
+```
+
+Expected: 出力なし (success)。エラーが出る場合は YAML syntax 修正。
+
+- [ ] **Step 3: actionlint で workflow syntax を確認 (optional だが推奨)**
+
+Run (actionlint がインストール済の場合):
+
+```bash
+actionlint .github/workflows/security-audit.yml
+```
+
+Expected: 出力なし (no findings)。findings があれば修正。actionlint 未インストールなら skip。
+
+## Task 3: workflow 説明 doc を追加
+
+**Files:**
+
+- Create: `docs/ci-security-audit.md`
+
+- [ ] **Step 1: doc を作成**
+
+Create `docs/ci-security-audit.md`:
+
+```markdown
+# CI: Security Audit Workflow
+
+`.github/workflows/security-audit.yml` の運用 note。
+
+## 目的
+
+PR を `develop-x.x.x` や `main` にマージする前に、cargo audit + npm audit を自動実行し、Dependabot より早く脆弱性を検出する。
+
+## 発火条件
+
+- `pull_request` trigger
+- paths: `gui/src-tauri/Cargo.lock`, `gui/src-tauri/Cargo.toml`, `gui/package-lock.json`, `gui/package.json`, `.github/workflows/security-audit.yml`
+- `workflow_dispatch` で手動実行も可能
+
+paths filter により、Python のみ変更の PR では本 workflow は走らない (CI 時間節約)。
+
+## ジョブ
+
+| ジョブ | コマンド | fail 条件 |
+| --- | --- | --- |
+| cargo-audit | `cargo audit --deny warnings` | warning level 以上の advisory 検出 (= medium severity 相当以上) |
+| npm-audit | `npm audit --audit-level=high` | high 以上の advisory 検出 (dev-only の medium/low は warning 通過) |
+
+## 失敗時の対応
+
+1. PR 作者は失敗 log を確認し、影響のある依存を特定
+2. 該当依存の patched version を確認 (cargo upgrade / npm install)
+3. 本 PR 内で修正 commit を追加、または別 PR で先に hotfix
+4. medium/low で warning のみの場合は警告として report し、本 PR では (1) 修正、(2) deferred 起票、(3) ignore 理由を本 PR 本文に明記、のいずれか
+
+## Dependabot との関係
+
+- Dependabot: 既存依存の脆弱性を post-merge で検出 (auto PR で patch を提案)
+- 本 workflow: PR 提案 (Dependabot or 手動) を merge する**前**に検証
+
+両者は補完関係。本 workflow が green でも Dependabot alert は別途出る可能性 (advisory DB の更新タイミング差)。
+
+## 参照
+
+- spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §2.5 / §4 Track C
+- plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md`
+```
+
+- [ ] **Step 2: markdownlint check (Track C 単独)**
+
+Run:
+
+```bash
+bash scripts/check-markdownlint.sh
+```
+
+Expected: `Summary: 0 error(s)`。errors があれば修正 (MD060 separator style 等は前回事例参照)。
+
+## Task 4: 作業 commit
+
+- [ ] **Step 1: 全変更を 1 commit にまとめる**
+
+Run:
+
+```bash
+git add .github/workflows/security-audit.yml docs/ci-security-audit.md
+git commit -m "$(cat <<'EOF'
+ci: add security-audit.yml for cargo audit + npm audit pre-merge gate [crazy-swirles-bed20b]
+
+PR マージ前に Rust と npm の脆弱性を自動検出する workflow を新規追加。
+- cargo audit --deny warnings (medium 相当以上で fail)
+- npm audit --audit-level=high (high 以上で fail、dev-only medium/low は通過)
+paths filter で manifest 変更時のみ実行し CI 時間を節約。
+docs/ci-security-audit.md に運用 note を併設。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 5: PR Pre-flight + Ready PR 作成
+
+**Files:** なし (gh CLI 操作のみ)
+
+- [ ] **Step 1: PR Pre-flight Step 0 (既存 open PR check)**
+
+Run:
+
+```bash
+gh pr list --search "security-audit OR ci-security" --state open
+```
+
+Expected: 出力空。
+
+- [ ] **Step 2: PR Pre-flight Step 1 (base 同期)**
+
+Run:
+
+```bash
+git fetch origin develop-0.2.1
+git log claude/ci-security-audit..origin/develop-0.2.1 --oneline
+```
+
+Expected: 出力空 (Track A マージ済の develop-0.2.1 と作業 branch が同期)。出力があれば `git rebase origin/develop-0.2.1`。
+
+- [ ] **Step 3: PR Pre-flight Step 2 (touched files)**
+
+Run:
+
+```bash
+git diff --name-only origin/develop-0.2.1...HEAD
+```
+
+Expected: 2 ファイル (`.github/workflows/security-audit.yml`, `docs/ci-security-audit.md`)
+
+- [ ] **Step 4: branch push**
+
+Run:
+
+```bash
+git push -u origin claude/ci-security-audit
+```
+
+Expected: branch push 成功。
+
+- [ ] **Step 5: PR 作成 (Ready)**
+
+Track A 既マージ前提で、Track C の workflow が現 develop-0.2.1 baseline で green になることを期待:
+
+```bash
+gh pr create --base develop-0.2.1 --head claude/ci-security-audit --title "ci: v0.2.1 Track C — add pre-merge security audit workflow [crazy-swirles-bed20b]" --body-file - <<'EOF'
+## 概要
+
+v0.2.1 patch Track C。PR マージ前に cargo audit + npm audit を自動実行する GitHub Actions workflow を追加。
+
+## 含まれる変更
+
+- `.github/workflows/security-audit.yml` を新規追加
+  - cargo audit (Rust): `cargo audit --deny warnings`
+  - npm audit (JS): `npm audit --audit-level=high`
+  - paths filter で manifest 変更時のみ実行
+  - workflow_dispatch で手動実行も可
+- `docs/ci-security-audit.md` 新規追加 (運用 note)
+
+## Refs
+
+- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §4 Track C / §6 Track C
+- Plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md`
+
+## マージ前提
+
+本 Track C は **Track A マージ後** に実施する運用 (spec §6 「推奨マージ順 C → A」を本 plan で A → C に補正)。理由: Track A 未マージで本 workflow を走らせると既存 5 件の脆弱性で fail するため。
+
+## Self-Test Report
+
+machine-verified:
+- [x] yaml syntax check (python -c "import yaml; yaml.safe_load(...)" pass)
+- [x] markdownlint pass (`bash scripts/check-markdownlint.sh`)
+- [x] 本 PR の CI で security-audit.yml の cargo-audit + npm-audit が green になる (Track A マージ済 develop-0.2.1 baseline 前提)
+
+machine-unverifiable:
+- N/A (CI 自動化のみ、実機検証不要)
+
+## Notes
+
+- 本 workflow は今後の PR (Track B-1 〜 B-4 / Track D 含む) で manifest 変更があれば自動発火
+- failure 時は PR 作者が対応 (詳細は docs/ci-security-audit.md 参照)
+EOF
+```
+
+Expected: PR URL が出力される。
+
+- [ ] **Step 6: CI green を待つ**
+
+Run:
+
+```bash
+gh pr checks <PR#> --watch
+```
+
+Expected: ci.yml + 新規 security-audit.yml の cargo-audit + npm-audit が全 green。fail があれば原因調査。
+
+- [ ] **Step 7: Idios レビュー + マージ**
+
+`/review-pr <PR#>` で Idios レビュー後にマージ:
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+Expected: PR マージ + claude/ci-security-audit branch 削除。
+
+## Task 6: 後続 PR への影響確認
+
+**Files:** なし
+
+- [ ] **Step 1: security-audit.yml が develop-0.2.1 上で active になっていることを確認**
+
+Run:
+
+```bash
+gh api repos/Idios/kobutachan-allaganeye/contents/.github/workflows/security-audit.yml?ref=develop-0.2.1 --jq '.name'
+```
+
+Expected: `security-audit.yml`
+
+- [ ] **Step 2: 後続 Track B-x / D PR で manifest 変更がある場合、本 workflow が自動発火することを確認 (発火確認は実際の B-x / D PR 作成時に観察)**
+
+メモ: paths filter に該当する変更がない PR (例: Track B-3 の `scripts/build-portable-zip.ps1` のみ変更) では本 workflow は走らない (意図通り)。
+
+## 受け入れ条件 (本 Track C 完了判定)
+
+- [ ] PR `claude/ci-security-audit → develop-0.2.1` がマージされる
+- [ ] CI (ci.yml) が全 job green
+- [ ] **本 PR 自体の CI で security-audit.yml の cargo-audit + npm-audit が green** (Track A マージ済前提で 0 件 expected)
+- [ ] `.github/workflows/security-audit.yml` が develop-0.2.1 上に存在
+- [ ] `docs/ci-security-audit.md` が develop-0.2.1 上に存在
+- [ ] Track B-1 〜 B-4 / D PR (manifest 変更を含む場合) で本 workflow が自動発火
+
+## Out of scope (本 plan で扱わない)
+
+- GitHub CodeQL workflow 新規追加 (spec の Out of scope)
+- Dependabot grouped update 設定見直し (spec の Out of scope、follow-up issue 候補)
+- 既存 ci.yml の改修 (本 plan では touch しない、関心分離)
+- third-party scanner (trivy / grype 等) の導入 (spec の Out of scope)
+- pre-commit hook 化 (spec の Out of scope)

--- a/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
+++ b/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
@@ -1,0 +1,215 @@
+# v0.2.1 Security Hotfix Response Design
+
+- 日付: 2026-05-16
+- 作成者: Claude (brainstorming skill, with Idios)
+- 対象リリース: v0.2.1 (L2 ホットフィックス)
+- ベース: `main` (タグ `v0.2.0`)
+
+## 1. Overview / Goal
+
+v0.2.0 リリース後に GitHub 上で open 状態の Dependabot security alert 5 件と Dependabot PR 1 件 ([#758](https://github.com/Idios/kobutachan-allaganeye/pull/758)) を、単一の v0.2.1 ホットフィックスリリースで解消する。配布バイナリ (Portable ZIP) を rebuild して medium severity 以下の脆弱性を消し、`main` + 新規 cut の `develop-0.3.0` 両方に反映する。
+
+## 2. Context
+
+### Open Dependabot alerts (5 件)
+
+| # | Package | Severity | Manifest | Vulnerable | Patched | 配布物影響 | GHSA |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 6 | tauri | medium | gui/src-tauri/Cargo.lock | `=2.10.3` (現状), `<= 2.11.0` | 2.11.1 | あり (runtime) | GHSA-7gmj-67g7-phm9 (Origin Confusion → Remote→Local IPC invocation) |
+| 4 | glib | medium | gui/src-tauri/Cargo.lock | `0.18.5` (現状), `< 0.20.0` | 0.20.0 | なし (Windows ビルド未使用、GTK 系 Linux/macOS deps) | GHSA-wrw7-89jp-8q8g (`VariantStrIter` unsoundness) |
+| 5 | rand | low | gui/src-tauri/Cargo.lock | `0.7.3` (現状), `< 0.8.6` | 0.8.6 | build-dep のみ (runtime 不含) | GHSA-cq8v-f236-94qc (custom logger + `rand::rng()` unsoundness) |
+| 3 | fast-uri | high | gui/package-lock.json | `<= 3.1.1` | 3.1.2 | なし (dev-only: ajv via devDeps) | GHSA-v39h-62p7-jpjc (host confusion via percent-encoded authority delimiters) |
+| 2 | fast-uri | high | gui/package-lock.json | `<= 3.1.0` | 3.1.1 | 同上 | GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments) |
+
+### Dependabot PR
+
+- [#758](https://github.com/Idios/kobutachan-allaganeye/pull/758) `chore(deps): bump fast-uri from 3.1.0 to 3.1.2 in /gui in the npm_and_yarn group`
+  - alert #2 + #3 両方を解決
+  - base = `main` (default branch)
+  - 当 repo の `develop-x.x.x` 統合先規約と齟齬
+
+### 配布物影響の評価
+
+- **runtime (`.exe` に同梱)**: tauri (medium)
+- **runtime (transitive build only, .exe 不含)**: rand (low)
+- **Windows 配布物に未含 (Linux/macOS GTK 系)**: glib (medium)
+- **dev environment のみ**: fast-uri (high x 2、`ajv` via `devDependencies`)
+
+high severity (fast-uri) は dev-only のため配布ユーザーへの影響なし。runtime ユーザー観点で最重要は tauri (Origin Confusion)。
+
+## 3. Decisions
+
+| 判断点 | 選択 | 理由 |
+| --- | --- | --- |
+| Q1: 対応単位とリリース戦略 | **(A) v0.2.1 ホットフィックスで全 5 件対応** | 配布物の medium 脆弱性を一気に消す。Iron Law 1 / 4 の手動レビュー・close フローと整合 |
+| Q2: PR 構造 | **(C) 1 PR 統合・細粒度 commit 分割** | 単一 PR で `main` への security hotfix を完結。各 alert と commit の対応をトレース可能にする。`cargo update` を 1 段で実行しつつ commit を 5 本に分けて意図を明示 |
+
+## 4. Scope
+
+### In scope
+
+1. Cargo.lock / package-lock.json の脆弱な依存を patched 版に置き換え
+2. `Cargo.toml` direct dep の tauri を `=2.11.1` へ pin 更新
+3. tauri 2.11 系と互換性のある tauri-build / tauri-plugin-* への bump
+4. version bump (0.2.0 → 0.2.1) を 4 ファイル (`pyproject.toml`, `gui/package.json`, `gui/src-tauri/Cargo.toml`, `gui/src-tauri/tauri.conf.json`) に適用
+5. `CHANGELOG.md` に v0.2.1 セクション追加 (5 alert + GHSA リンク + 配布物影響説明)
+6. PR `claude/security-v0.2.1 → main` 作成、レビュー、マージ
+7. v0.2.1 タグ → [release.yml](.github/workflows/release.yml) による Portable ZIP 自動 build + GitHub Release 作成
+8. `main` から `develop-0.3.0` 新規 cut + version 0.3.0 bump (release-process.md §ブランチ戦略 ルール 4)
+
+### Out of scope (別議論 / 別 issue 起票検討)
+
+- `cargo audit` を CI workflow に統合する仕組み (継続的検出体制、follow-up issue 起票候補)
+- Dependabot grouped update 設定の見直し (Rust 側も group 化するか)
+- v0.2.0 配布バイナリの差し戻し or 公開警告 (v0.2.0 リリースから日が浅いため、v0.2.1 ZIP 公開で対応十分と判断)
+- L3 (v0.3.0) スコープへの security 関連機能追加 (本リリースは hotfix に専念)
+
+## 5. Branch Strategy
+
+`docs/release-process.md` §ブランチ戦略 ルール 5 (ホットフィックス) に従う。
+
+```text
+main (タグ v0.2.0)
+ └── claude/security-v0.2.1 (本作業ブランチ、main から派生)
+       └── PR → main
+              ├── マージ + git tag v0.2.1 + git push origin v0.2.1
+              │       └── release.yml 発火 → allaganeye-v0.2.1-windows.zip 自動生成 + GitHub Release
+              └── main から develop-0.3.0 を新規 cut + version 0.3.0 bump
+```
+
+### 作業ブランチ名
+
+- 候補 (a): 現 worktree branch `claude/crazy-swirles-bed20b` を流用 (低コスト、命名規約からは外れる)
+- 候補 (b): 新規に `claude/security-v0.2.1` を main から切り直し、worktree 内の git branch を切り替え (規約準拠だが手間)
+
+→ writing-plans 段階で確定。(a) で進めると軽量、(b) で進めるとレビュー視認性が高い。
+
+## 6. Update Plan (5 commit 構造)
+
+### Commit 1: `chore(deps): bump fast-uri 3.1.0 → 3.1.2 (#2, #3)`
+
+- `cd gui && npm install fast-uri@3.1.2 --package-lock-only`
+- 影響ファイル: `gui/package-lock.json` のみ
+- 検証: `gui/package.json` の direct deps は不変、`ajv` (devDeps) の transitive のみ更新されることを確認
+- 解決 alert: #2, #3
+
+### Commit 2: `chore(deps): bump tauri 2.10.3 → 2.11.1 + tauri-build (#6)`
+
+- `gui/src-tauri/Cargo.toml`:
+  - `tauri = "=2.11.1"` (現 `=2.10.3`、`first_patched: 2.11.1`、2.11.0 ではまだ脆弱なので 2.11.1 まで上げる必要あり)
+  - `tauri-build = "=2.6.0"` (現 `=2.5.6`、tauri 2.11.0 release notes で `tauri-build@2.6.0` への bump が記載)
+- `cd gui/src-tauri && cargo update -p tauri --precise 2.11.1`
+- 影響ファイル: `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`
+- 検証: `cargo check` で compile pass、tauri 系 entries が 2.11 系に揃う
+- 解決 alert: #6
+
+### Commit 3: `chore(deps): align tauri-plugin-* with tauri 2.11`
+
+- `tauri-plugin-dialog` / `-fs` / `-shell` の tauri 2.11 互換 latest 版を plan 段階で確認後 bump
+  - 現状: 2.7.0 / 2.5.0 / 2.3.5
+  - これらは tauri-plugins-workspace の独自 release cadence のため、tauri version とは別系列
+- 影響ファイル: `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`
+- 検証: `cargo check`, `cargo test`
+- 解決 alert: なし (互換性整合のための支援 commit)
+
+### Commit 4: `chore(deps): verify transitive rand 0.8.6 / glib 0.20.0 (#4, #5)`
+
+- Commit 2-3 後の `Cargo.lock` を確認、transitive で解決されていれば commit 内容は意図表明 (CHANGELOG メモ) のみ
+- 未解決の場合のみ個別 `cargo update -p rand@0.7.3 --precise 0.8.6` / `cargo update -p glib --precise 0.20.0` を実行
+- 影響ファイル: `gui/src-tauri/Cargo.lock` (該当時のみ)
+- 検証: GitHub 上で Dependabot alert #4 / #5 が auto-resolve されることを PR マージ後に確認
+- 解決 alert: #4, #5
+
+### Commit 5: `chore: bump version 0.2.0 → 0.2.1 + CHANGELOG`
+
+- version bump (4 ファイル):
+  - `pyproject.toml`
+  - `gui/package.json`
+  - `gui/src-tauri/Cargo.toml`
+  - `gui/src-tauri/tauri.conf.json`
+- `CHANGELOG.md` に新規セクション追加:
+
+  ```markdown
+  ## v0.2.1 - 2026-05-?? - Security hotfix
+
+  ### Security
+
+  - tauri 2.10.3 → 2.11.1 (medium: Origin Confusion, GHSA-7gmj-67g7-phm9)
+  - glib transitive → 0.20.0 (medium: VariantStrIter unsoundness, GHSA-wrw7-89jp-8q8g, Windows build 未使用)
+  - rand transitive 0.7.3 → 0.8.6 (low: rng() unsoundness, GHSA-cq8v-f236-94qc, build-dep のみ)
+  - fast-uri 3.1.0 → 3.1.2 (high: GHSA-v39h-62p7-jpjc / GHSA-q3j6-qgpj-74h6, dev-only deps)
+
+  ### Notes
+
+  - Portable ZIP (`allaganeye-v0.2.1-windows.zip`) は GUI runtime (tauri) のみ実効的に更新される。Python CLI 側に変更なし
+  ```
+
+- 影響ファイル: 4 + 1 = 5 ファイル
+
+## 7. Verification (Iron Law 6 準拠)
+
+### 自動チェック (PR 作成前に local + CI 両方で pass)
+
+| 範囲 | コマンド |
+| --- | --- |
+| Python | `ruff check . / ruff format --check . / pyright / pytest` |
+| GUI frontend | `cd gui && npm run lint / typecheck / test / build` |
+| GUI Rust | `cd gui/src-tauri && cargo check / cargo test` |
+| docs | `bash scripts/check-markdownlint.sh` (CHANGELOG 更新分) |
+
+### 実機検証 (Idios 依頼、Iron Law 6 で必須)
+
+`gui/src-tauri/**` (Cargo.toml + Cargo.lock) の変更により tauri runtime の動作に影響あり。以下を Idios の Windows 実機で確認:
+
+- Tauri GUI 起動 (`cd gui && npm run tauri dev` または build 済 `.exe`)
+- Golden path: drop → detecting → complete → preview → export
+- Export 時の H.264 エンコーダ自動選択 (NVENC / QSV / AMF / libx264 fallback) — `select_h264_encoder_for_export` の動作確認
+- 既存 `recent.json` の load (`<install dir>/recent.json` 配置、#571)
+
+### ローカル Portable ZIP smoke (任意)
+
+`pwsh ./scripts/build-portable-zip.ps1 -Version 0.2.1` を local で実行し、ZIP 生成成功と `docs/l2-e2e-checklist.md §3 T1` smoke を実施。
+
+### 受け入れ条件 (Iron Law 1 準拠)
+
+- [ ] Dependabot alert #2, #3, #4, #5, #6 が PR マージ後 24h 以内に auto-resolve される (or 手動 close)
+- [ ] [release.yml](.github/workflows/release.yml) が `allaganeye-v0.2.1-windows.zip` を artifact + Release に添付
+- [ ] Portable ZIP の `allaganeye-gui.exe` が起動し、export まで通る (Idios 実機検証)
+- [ ] `main` から `develop-0.3.0` が cut され、version が 0.3.0 に bump
+- [ ] PR #758 が PR `claude/security-v0.2.1 → main` マージ後 24h 以内に Dependabot により auto-close される。auto-close されない場合は手動 close (reason: "superseded by v0.2.1 hotfix")
+
+## 8. Release Flow
+
+1. PR `claude/security-v0.2.1 → main` をマージ
+2. `main` HEAD にタグ: `git tag -a v0.2.1 -m "Release v0.2.1: Security hotfix"` + `git push origin v0.2.1`
+3. [release.yml](.github/workflows/release.yml) が以下を自動実行:
+   - Portable ZIP build (`scripts/build-portable-zip.ps1 -Version 0.2.1`)
+   - SHA256 verify (Python embed / get-pip / FFmpeg)
+   - GitHub Release 作成 (`extract_release_notes.py 0.2.1` で CHANGELOG から抽出)
+4. PR 作者 (Claude or Idios) が以下を手動確認:
+   - Dependabot alerts 5 件の auto-close 状態
+   - PR #758 の close 状態
+   - GitHub Release ページに ZIP + release notes が掲載
+5. `main` から `develop-0.3.0` 新規 cut + version 0.3.0 bump コミット
+
+## 9. References
+
+### Project docs
+
+- [docs/release-process.md](../../release-process.md) §ブランチ戦略 / §タグ運用 / §レイヤーリリース受け入れゲート
+- [docs/l2-workflow.md](../../l2-workflow.md) §「PR 作成 Pre-flight」 / §「Self-Test Report 規約」
+- [docs/l2-e2e-checklist.md](../../l2-e2e-checklist.md) §3 T1 (Portable ZIP smoke)
+- [CLAUDE.md](../../../CLAUDE.md) §Iron Law / §PR 作成ルール
+
+### Security advisories
+
+- [GHSA-7gmj-67g7-phm9](https://github.com/advisories/GHSA-7gmj-67g7-phm9) — tauri Origin Confusion
+- [GHSA-wrw7-89jp-8q8g](https://github.com/advisories/GHSA-wrw7-89jp-8q8g) — glib VariantStrIter unsoundness
+- [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) — rand custom logger unsoundness
+- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — fast-uri host confusion
+- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — fast-uri path traversal
+
+### GitHub artifacts
+
+- [PR #758](https://github.com/Idios/kobutachan-allaganeye/pull/758) — Dependabot fast-uri 3.1.2 PR
+- [Release v0.2.0](https://github.com/Idios/kobutachan-allaganeye/releases/tag/v0.2.0)

--- a/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
+++ b/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
@@ -1,17 +1,24 @@
-# v0.2.1 Security Hotfix Response Design
+# v0.2.1 Patch Release Design (Security + UX + CI 強化)
 
 - 日付: 2026-05-16
 - 作成者: Claude (brainstorming skill, with Idios)
-- 対象リリース: v0.2.1 (L2 ホットフィックス)
+- 対象リリース: v0.2.1 (L2 patch)
 - ベース: `main` (タグ `v0.2.0`)
+- 統合ブランチ: `develop-0.2.1` (本 spec で main から新規 cut)
 
 ## 1. Overview / Goal
 
-v0.2.0 リリース後に GitHub 上で open 状態の Dependabot security alert 5 件と Dependabot PR 1 件 ([#758](https://github.com/Idios/kobutachan-allaganeye/pull/758)) を、単一の v0.2.1 ホットフィックスリリースで解消する。配布バイナリ (Portable ZIP) を rebuild して medium severity 以下の脆弱性を消し、`main` + 新規 cut の `develop-0.3.0` 両方に反映する。
+v0.2.0 リリース後に発生した課題を v0.2.1 patch リリースで一括解消する:
+
+1. **Security alerts (Dependabot) 5 件** + Dependabot PR 1 件 ([#758](https://github.com/Idios/kobutachan-allaganeye/pull/758))
+2. **UX 影響のある deferred bug 4 件** ([#374](https://github.com/Idios/kobutachan-allaganeye/issues/374) / [#743](https://github.com/Idios/kobutachan-allaganeye/issues/743) / [#749](https://github.com/Idios/kobutachan-allaganeye/issues/749) / [#756](https://github.com/Idios/kobutachan-allaganeye/issues/756))
+3. **今後の GitHub security 指摘を PR マージ前に自前で検出する仕組み**: cargo audit + npm audit を CI workflow に組み込む
+
+`main` から `develop-0.2.1` 統合ブランチを新規 cut し、Track 別作業ブランチからの PR を統合した後、`develop-0.2.1 → main` で v0.2.1 リリースする。
 
 ## 2. Context
 
-### Open Dependabot alerts (5 件)
+### 2.1 Open Dependabot alerts (5 件)
 
 | # | Package | Severity | Manifest | Vulnerable | Patched | 配布物影響 | GHSA |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -21,14 +28,13 @@ v0.2.0 リリース後に GitHub 上で open 状態の Dependabot security alert
 | 3 | fast-uri | high | gui/package-lock.json | `<= 3.1.1` | 3.1.2 | なし (dev-only: ajv via devDeps) | GHSA-v39h-62p7-jpjc (host confusion via percent-encoded authority delimiters) |
 | 2 | fast-uri | high | gui/package-lock.json | `<= 3.1.0` | 3.1.1 | 同上 | GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments) |
 
-### Dependabot PR
+### 2.2 Dependabot PR
 
 - [#758](https://github.com/Idios/kobutachan-allaganeye/pull/758) `chore(deps): bump fast-uri from 3.1.0 to 3.1.2 in /gui in the npm_and_yarn group`
   - alert #2 + #3 両方を解決
-  - base = `main` (default branch)
-  - 当 repo の `develop-x.x.x` 統合先規約と齟齬
+  - base = `main` (default branch、当 repo の `develop-x.x.x` 統合先規約と齟齬)
 
-### 配布物影響の評価
+### 2.3 配布物影響の評価 (Dependabot alerts)
 
 - **runtime (`.exe` に同梱)**: tauri (medium)
 - **runtime (transitive build only, .exe 不含)**: rand (low)
@@ -37,100 +43,261 @@ v0.2.0 リリース後に GitHub 上で open 状態の Dependabot security alert
 
 high severity (fast-uri) は dev-only のため配布ユーザーへの影響なし。runtime ユーザー観点で最重要は tauri (Origin Confusion)。
 
+### 2.4 取り込み対象 UX issue (4 件、すべて deferred)
+
+| # | Severity | Scope | 概要 |
+| --- | --- | --- | --- |
+| 756 | P2-medium, bug | l2a-gui | detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留 (Windows process tree orphan)。Python CLI 経由で spawn された ffmpeg が孫プロセスとして orphan 化し、CPU/disk リソースを消費し続ける |
+| 743 | P3-low, task | role:lead-engineer | Windows process group orphan 挙動 audit (#727 派生 (3))。6 spawn site の振る舞いを実機検証 + audit document 作成 |
+| 374 | P3-low, bug | (none) | metadata.json の `note` フィールドが H.264 想定 (2s) で固定。AV1 等の codec で誤情報 |
+| 749 | P3-low, doc | l2b-installer | Portable ZIP 内 `README.txt` が英語のまま。ターゲットユーザー (日本語話者) 向けに日本語化が必要 |
+
+**#743 と #756 の関係**: #756 は #743 の audit 対象 (process orphan) の具体的 bug。#756 の fix で #743 の audit が完了する形にできる (1 Track 内で両方クローズ)。
+
+### 2.5 Pre-merge security check の現状
+
+| 仕組み | 状態 | 検出範囲 |
+| --- | --- | --- |
+| Dependabot alerts | enabled | npm + Cargo の脆弱性 DB 照会、PR マージ後の post-hoc |
+| Dependabot PRs | enabled (npm grouped, Cargo 個別) | 自動 PR 生成、main base |
+| GitHub CodeQL | **未設定** (`no analysis found`) | - |
+| GitHub Secret scanning | **disabled** | - |
+| CI security audit job | **未実装** | - |
+| cargo audit / npm audit (local) | 手動のみ | - |
+
+→ **gap**: PR マージ前の自動検出がない。Dependabot は post-merge での発見が標準で、マージ前 review でも手動 audit が不要に放置されている。
+
+### 2.6 既存 CI workflows (`.github/workflows/`)
+
+- `ci.yml` (Python + GUI test)
+- `markdownlint.yml`
+- `pr-checklist.yml` / `check-pr-checklist-test.yml`
+- `release.yml`
+
+新規追加 (本 spec): `security-audit.yml` (cargo audit + npm audit を PR ごとに走らせる)
+
 ## 3. Decisions
 
 | 判断点 | 選択 | 理由 |
 | --- | --- | --- |
-| Q1: 対応単位とリリース戦略 | **(A) v0.2.1 ホットフィックスで全 5 件対応** | 配布物の medium 脆弱性を一気に消す。Iron Law 1 / 4 の手動レビュー・close フローと整合 |
-| Q2: PR 構造 | **(C) 1 PR 統合・細粒度 commit 分割** | 単一 PR で `main` への security hotfix を完結。各 alert と commit の対応をトレース可能にする。`cargo update` を 1 段で実行しつつ commit を 5 本に分けて意図を明示 |
+| Q1: 対応単位とリリース戦略 | **(A) v0.2.1 patch リリースで全部対応** | 配布物の medium 脆弱性 + UX deferred bug を同一 patch リリースで解消。Iron Law 1 / 4 の手動レビュー・close フローと整合 |
+| Q2: Security 部分の PR 構造 | **(C) 細粒度 commit 分割** | 単一 PR (security Track) 内で commit を 5 本に分けて各 alert との対応をトレース可能にする。`cargo update` を 1 段で実行しつつ commit を分離 |
+| Q3: UX 取り込み範囲 | **4 件 (#374 / #743 / #756 / #749)** | Idios が v0.2.1 に取り込むと判断した deferred bug。`docs/release-process.md` §共通項目 deferred ラベル全件レビューと整合 |
+| Q4: Pre-merge check の仕組み | **cargo audit + npm audit を CI ジョブに追加** | 軽量、既存 Actions 拡張のみ、Dependabot と補完関係。CodeQL や Dependabot 設定見直しは後続検討に deferred |
+| Q5: 統合ブランチ | **`develop-0.2.1` を main から新規 cut** | release-process.md §ブランチ戦略の `develop-x.x.x` 命名規約と整合。複数 Track の PR を統合する標準フロー |
 
 ## 4. Scope
 
-### In scope
+### In scope (5 Track)
 
-1. Cargo.lock / package-lock.json の脆弱な依存を patched 版に置き換え
-2. `Cargo.toml` direct dep の tauri を `=2.11.1` へ pin 更新
-3. tauri 2.11 系と互換性のある tauri-build / tauri-plugin-* への bump
-4. version bump (0.2.0 → 0.2.1) を 4 ファイル (`pyproject.toml`, `gui/package.json`, `gui/src-tauri/Cargo.toml`, `gui/src-tauri/tauri.conf.json`) に適用
-5. `CHANGELOG.md` に v0.2.1 セクション追加 (5 alert + GHSA リンク + 配布物影響説明)
-6. PR `claude/security-v0.2.1 → main` 作成、レビュー、マージ
-7. v0.2.1 タグ → [release.yml](.github/workflows/release.yml) による Portable ZIP 自動 build + GitHub Release 作成
-8. `main` から `develop-0.3.0` 新規 cut + version 0.3.0 bump (release-process.md §ブランチ戦略 ルール 4)
+#### Track A: Security alerts 解消 (元 hotfix 設計)
+
+- Cargo.lock / package-lock.json の脆弱な依存を patched 版に置き換え
+- `Cargo.toml` direct dep の tauri を `=2.11.1` へ pin 更新
+- tauri 2.11 系互換の tauri-build / tauri-plugin-* への bump
+- 解決対象: Dependabot alerts #2, #3, #4, #5, #6 + PR #758
+
+#### Track B-1: #374 metadata note codec 不正確 修正
+
+- `allaganeye/commands/split_matches.py` (`_split_and_write_metadata`) の `note` 文字列定義を案 2 (codec 依存定数の削除) で更新
+- 影響範囲: Python CLI のみ
+
+#### Track B-2: #743 + #756 Windows process tree orphan 一括対応
+
+- **#756 fix**: gui/src-tauri/src/lib.rs の Windows process tree kill 実装 (Option A: Job Object 推奨、または Option B: taskkill /T /F)
+- **#743 audit**: 6 spawn site の振る舞いを実機検証 + `docs/` 配下に audit document 作成 (#756 fix を audit 成果として位置付け)
+- 影響範囲: Tauri Rust + 検証 docs
+
+#### Track B-3: #749 Portable ZIP 内 README.txt 日本語化
+
+- `scripts/build-portable-zip.ps1` の `Format-ReadmeContent` 関数の text template を日本語化
+- `scripts/tests/build-portable-zip.Tests.ps1` の Pester assertion を日本語見出しに更新
+- 影響範囲: PS script + Pester test
+
+#### Track C: Pre-merge security audit CI 追加
+
+- `.github/workflows/security-audit.yml` を新規追加 (cargo audit + npm audit を PR ごとに実行)
+- failure 条件: high severity 以上の脆弱性検出で job fail (medium 以下は warning として report)
+- 取り込み trigger: pull_request (paths: `gui/src-tauri/Cargo.lock`, `gui/package-lock.json`)
+- Track A の Cargo.lock / package-lock.json 更新後に発火し、green を確認できることが事前テスト
+
+#### Track D: Version bump + CHANGELOG (リリース直前)
+
+- version bump (4 ファイル): `pyproject.toml`, `gui/package.json`, `gui/src-tauri/Cargo.toml`, `gui/src-tauri/tauri.conf.json`
+- `CHANGELOG.md` に v0.2.1 セクション追加 (Security / Fixed / Changed / CI)
 
 ### Out of scope (別議論 / 別 issue 起票検討)
 
-- `cargo audit` を CI workflow に統合する仕組み (継続的検出体制、follow-up issue 起票候補)
-- Dependabot grouped update 設定の見直し (Rust 側も group 化するか)
+- GitHub CodeQL workflow 新規有効化 (継続的 static analysis、本 patch では cargo/npm audit のみで開始)
+- Dependabot grouped update 設定の見直し (Rust 側も group 化、schedule daily 化) — Q4 で deferred 判断、follow-up issue 候補
+- Secret scanning 有効化
 - v0.2.0 配布バイナリの差し戻し or 公開警告 (v0.2.0 リリースから日が浅いため、v0.2.1 ZIP 公開で対応十分と判断)
-- L3 (v0.3.0) スコープへの security 関連機能追加 (本リリースは hotfix に専念)
+- L3 (v0.3.0) スコープへの security / UX 機能追加 (本リリースは patch に専念)
+- third-party scanner (trivy / grype 等)、pre-commit hook の導入
 
 ## 5. Branch Strategy
 
-`docs/release-process.md` §ブランチ戦略 ルール 5 (ホットフィックス) に従う。
+`docs/release-process.md` §ブランチ戦略 に従い、`develop-x.x.x` 統合ブランチ + 作業ブランチの標準フローで運用する。
 
 ```text
 main (タグ v0.2.0)
- └── claude/security-v0.2.1 (本作業ブランチ、main から派生)
-       └── PR → main
-              ├── マージ + git tag v0.2.1 + git push origin v0.2.1
-              │       └── release.yml 発火 → allaganeye-v0.2.1-windows.zip 自動生成 + GitHub Release
-              └── main から develop-0.3.0 を新規 cut + version 0.3.0 bump
+ └── develop-0.2.1 (本 spec で main から新規 cut、v0.2.1 統合ブランチ)
+       ├── claude/<scope>-deps (Track A)        → PR → develop-0.2.1
+       ├── claude/issue-374-codec-note          → PR → develop-0.2.1
+       ├── claude/issue-743-756-process-orphan  → PR → develop-0.2.1
+       ├── claude/issue-749-readme-ja           → PR → develop-0.2.1
+       ├── claude/ci-security-audit             → PR → develop-0.2.1
+       └── claude/release-v0.2.1 (Track D)      → PR → develop-0.2.1
+              └── 全 Track 統合後 develop-0.2.1 → main PR
+                     └── マージ + git tag v0.2.1
+                            └── release.yml 発火 → Portable ZIP + GitHub Release
+                                   └── main から develop-0.3.0 を新規 cut + version 0.3.0 bump
 ```
 
-### 作業ブランチ名
+### 作業ブランチ名候補
 
-- 候補 (a): 現 worktree branch `claude/crazy-swirles-bed20b` を流用 (低コスト、命名規約からは外れる)
-- 候補 (b): 新規に `claude/security-v0.2.1` を main から切り直し、worktree 内の git branch を切り替え (規約準拠だが手間)
+- 現 worktree branch (`claude/crazy-swirles-bed20b`、HEAD = `d61b8fd` で main から 1 commit (spec) 先行) を **Track A の作業ブランチに転用**するか、それとも spec commit のみを保持して別 branch で Track A を進めるかは writing-plans 段階で確定
+- 他 Track の作業ブランチは plan 段階で worktree 戦略 (単一 worktree で skill ベース dispatch / per-Track worktree) と合わせて確定
 
-→ writing-plans 段階で確定。(a) で進めると軽量、(b) で進めるとレビュー視認性が高い。
+### #743 と #756 の Track 統合理由
 
-## 6. Update Plan (5 commit 構造)
+両 issue は同じ原因 (Windows process tree orphan) を扱う。#756 が具体的 bug、#743 が audit task。両者を 1 PR で扱うことで:
 
-### Commit 1: `chore(deps): bump fast-uri 3.1.0 → 3.1.2 (#2, #3)`
+- fix と audit document を同一 PR でレビュー可能 (前提・対策・検証の整合性確認が容易)
+- `enforce-acceptance-criteria` skill が #743 受け入れ条件 (audit document 作成、kill_tracked_processes 実機検証、orphan risk fix 起票) と #756 受け入れ条件 (Windows tree kill 実装) を同時に検証可能
+
+## 6. Update Plan
+
+### Track A: Security alerts (1 PR、5 commit 構造)
+
+#### Commit A-1: `chore(deps): bump fast-uri 3.1.0 → 3.1.2 (#2, #3)`
 
 - `cd gui && npm install fast-uri@3.1.2 --package-lock-only`
-- 影響ファイル: `gui/package-lock.json` のみ
-- 検証: `gui/package.json` の direct deps は不変、`ajv` (devDeps) の transitive のみ更新されることを確認
+- 影響: `gui/package-lock.json` のみ
 - 解決 alert: #2, #3
 
-### Commit 2: `chore(deps): bump tauri 2.10.3 → 2.11.1 + tauri-build (#6)`
+#### Commit A-2: `chore(deps): bump tauri 2.10.3 → 2.11.1 + tauri-build (#6)`
 
 - `gui/src-tauri/Cargo.toml`:
-  - `tauri = "=2.11.1"` (現 `=2.10.3`、`first_patched: 2.11.1`、2.11.0 ではまだ脆弱なので 2.11.1 まで上げる必要あり)
-  - `tauri-build = "=2.6.0"` (現 `=2.5.6`、tauri 2.11.0 release notes で `tauri-build@2.6.0` への bump が記載)
+  - `tauri = "=2.11.1"` (現 `=2.10.3`、`first_patched: 2.11.1`、2.11.0 では未 fix)
+  - `tauri-build = "=2.6.0"` (現 `=2.5.6`、tauri 2.11.0 release notes で bump 記載)
 - `cd gui/src-tauri && cargo update -p tauri --precise 2.11.1`
-- 影響ファイル: `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`
-- 検証: `cargo check` で compile pass、tauri 系 entries が 2.11 系に揃う
+- 影響: `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`
 - 解決 alert: #6
 
-### Commit 3: `chore(deps): align tauri-plugin-* with tauri 2.11`
+#### Commit A-3: `chore(deps): align tauri-plugin-* with tauri 2.11`
 
-- `tauri-plugin-dialog` / `-fs` / `-shell` の tauri 2.11 互換 latest 版を plan 段階で確認後 bump
-  - 現状: 2.7.0 / 2.5.0 / 2.3.5
-  - これらは tauri-plugins-workspace の独自 release cadence のため、tauri version とは別系列
-- 影響ファイル: `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`
-- 検証: `cargo check`, `cargo test`
-- 解決 alert: なし (互換性整合のための支援 commit)
+- `tauri-plugin-dialog` / `-fs` / `-shell` の tauri 2.11 互換 latest 版を plan 段階で確認後 bump (現状 2.7.0 / 2.5.0 / 2.3.5)
+- 影響: `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`
+- 解決 alert: なし (互換性整合)
 
-### Commit 4: `chore(deps): verify transitive rand 0.8.6 / glib 0.20.0 (#4, #5)`
+#### Commit A-4: `chore(deps): verify transitive rand 0.8.6 / glib 0.20.0 (#4, #5)`
 
-- Commit 2-3 後の `Cargo.lock` を確認、transitive で解決されていれば commit 内容は意図表明 (CHANGELOG メモ) のみ
-- 未解決の場合のみ個別 `cargo update -p rand@0.7.3 --precise 0.8.6` / `cargo update -p glib --precise 0.20.0` を実行
-- 影響ファイル: `gui/src-tauri/Cargo.lock` (該当時のみ)
-- 検証: GitHub 上で Dependabot alert #4 / #5 が auto-resolve されることを PR マージ後に確認
+- Commit A-2 / A-3 後の `Cargo.lock` を確認、transitive で解決されていれば commit 内容は CHANGELOG メモのみ
+- 未解決の場合のみ個別 `cargo update -p rand@0.7.3 --precise 0.8.6` / `cargo update -p glib --precise 0.20.0`
+- 影響: `gui/src-tauri/Cargo.lock` (該当時のみ)
 - 解決 alert: #4, #5
 
-### Commit 5: `chore: bump version 0.2.0 → 0.2.1 + CHANGELOG`
+#### Commit A-5: `chore(self-test): security audit local verification`
 
-- version bump (4 ファイル):
-  - `pyproject.toml`
-  - `gui/package.json`
-  - `gui/src-tauri/Cargo.toml`
-  - `gui/src-tauri/tauri.conf.json`
+- `cd gui/src-tauri && cargo audit` で local audit 実行、output を PR 本文に貼付
+- `cd gui && npm audit --omit=dev` (runtime のみ) / `npm audit` (full) の output を PR 本文に貼付
+- Track C で追加する CI workflow との突合せ確認
+
+### Track B-1: #374 metadata note codec 不正確
+
+#### 修正内容
+
+- `allaganeye/commands/split_matches.py` (`_split_and_write_metadata` の note 定義) を case 2 (codec 依存定数の削除) で更新
+- 旧: `"Split times are approximate due to keyframe-aligned copy mode. Actual start/end may differ by up to the source keyframe interval (typically 2s for OBS recordings)."`
+- 新: `"Split times are approximate due to keyframe-aligned copy mode. Actual start/end may differ by up to the source keyframe interval."`
+- pytest unit test (該当 metadata 生成テスト) を更新
+
+### Track B-2: #743 + #756 Windows process tree orphan
+
+#### 修正内容 (#756)
+
+- `gui/src-tauri/src/lib.rs` で Windows Job Object を用いた process tree kill を実装 (Option A 推奨):
+  - `windows-rs` (または `winapi`) crate を deps に追加
+  - `start_detect` 等の spawn site で `CreateJobObject` + `SetInformationJobObject` (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) + `AssignProcessToJobObject` を実装
+  - `kill_tracked_processes` で Job handle を drop することで子孫プロセスを一括 kill
+- Option B (`taskkill /T /F /PID`) は fallback として保持 (Job Object 設定 fail 時用)
+
+#### Audit document (#743)
+
+- `docs/` 配下に `process-tree-orphan-audit.md` を新規追加:
+  - 6 spawn site (`probe_video_with` / `ensure_thumbnail_exists` / `extract_brightness_window_impl` / `run_ffmpeg_export_attempt` / `start_detect` / `open_folder_in_explorer`) の振る舞いを記録
+  - Job Object 適用前 (= 現状) と適用後の挙動差を実機検証で示す
+  - `explorer.exe` 等の意図的 detach プロセスは Job 対象外として明記
+- `enforce-acceptance-criteria` skill で #743 受け入れ条件全件を逐条検証 (1 PR 内に audit doc + fix が揃う)
+
+### Track B-3: #749 Portable ZIP README.txt 日本語化
+
+#### 修正内容
+
+- `scripts/build-portable-zip.ps1` の `Format-ReadmeContent` 関数の text template を日本語化:
+  - 見出し: `## 使い方` / `## ライセンス` / `## トラブルシューティング` 等
+  - 法的引用 (MIT / LGPLv3 / PSF License 文言) は原文保持
+- `scripts/tests/build-portable-zip.Tests.ps1` の Pester assertion を日本語見出しに更新
+
+### Track C: cargo audit + npm audit CI workflow
+
+#### 新規ファイル: `.github/workflows/security-audit.yml`
+
+```yaml
+name: Security Audit
+
+on:
+  pull_request:
+    paths:
+      - 'gui/src-tauri/Cargo.lock'
+      - 'gui/src-tauri/Cargo.toml'
+      - 'gui/package-lock.json'
+      - 'gui/package.json'
+      - '.github/workflows/security-audit.yml'
+  workflow_dispatch:
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo install cargo-audit --locked
+      - run: cd gui/src-tauri && cargo audit --deny warnings
+
+  npm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+      - run: cd gui && npm ci
+      - run: cd gui && npm audit --audit-level=high
+```
+
+- **fail 条件**:
+  - `cargo audit --deny warnings`: medium 以上の advisory 検出で fail (Cargo の audit level)
+  - `npm audit --audit-level=high`: high 以上で fail (dev-only の medium/low は warning として通過)
+- 既存 `ci.yml` には touch せず、独立 workflow として追加 (ci.yml の規模を肥大化させない)
+- pull_request trigger で manifest 変更のある PR にのみ実行 (CI 時間節約)
+
+#### Track A との結合テスト
+
+- Track C を Track A より先にマージすると、Track A の PR で security-audit.yml が走り、Cargo.lock / package-lock.json の更新が green になることを CI で確認できる
+- 推奨マージ順: **Track C → Track A** (Track C で baseline 確立、Track A で確実に脆弱性消化を検証)
+
+### Track D: Version bump + CHANGELOG (リリース直前)
+
+#### Commit D-1: `chore(release): bump version 0.2.0 → 0.2.1`
+
+- 4 ファイル: `pyproject.toml`, `gui/package.json`, `gui/src-tauri/Cargo.toml`, `gui/src-tauri/tauri.conf.json`
+
+#### Commit D-2: `docs(changelog): add v0.2.1 section`
+
 - `CHANGELOG.md` に新規セクション追加:
 
   ```markdown
-  ## v0.2.1 - 2026-05-?? - Security hotfix
+  ## v0.2.1 - 2026-05-?? - Patch release
 
   ### Security
 
@@ -139,67 +306,96 @@ main (タグ v0.2.0)
   - rand transitive 0.7.3 → 0.8.6 (low: rng() unsoundness, GHSA-cq8v-f236-94qc, build-dep のみ)
   - fast-uri 3.1.0 → 3.1.2 (high: GHSA-v39h-62p7-jpjc / GHSA-q3j6-qgpj-74h6, dev-only deps)
 
-  ### Notes
+  ### Fixed
 
-  - Portable ZIP (`allaganeye-v0.2.1-windows.zip`) は GUI runtime (tauri) のみ実効的に更新される。Python CLI 側に変更なし
+  - #756: detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留する問題を Windows Job Object で解消
+  - #374: metadata.json の `note` 文言から codec 依存定数を削除し誤情報を解消
+
+  ### Changed
+
+  - #749: Portable ZIP 内 `README.txt` を日本語化
+
+  ### CI / Infrastructure
+
+  - cargo audit + npm audit を `.github/workflows/security-audit.yml` で PR ごとに実行
+  - #743: Windows process tree orphan audit を `docs/process-tree-orphan-audit.md` として整理
   ```
-
-- 影響ファイル: 4 + 1 = 5 ファイル
 
 ## 7. Verification (Iron Law 6 準拠)
 
-### 自動チェック (PR 作成前に local + CI 両方で pass)
+### 7.1 自動チェック (PR 作成前に local + CI 両方で pass)
 
-| 範囲 | コマンド |
+| 範囲 | コマンド | 該当 Track |
+| --- | --- | --- |
+| Python | `ruff check . / ruff format --check . / pyright / pytest` | A (依存変更時のみ regression check) / B-1 / D |
+| GUI frontend | `cd gui && npm run lint / typecheck / test / build` | A / D |
+| GUI Rust | `cd gui/src-tauri && cargo check / cargo test` | A / B-2 / D |
+| docs | `bash scripts/check-markdownlint.sh` | B-2 (audit doc) / B-3 (README 日本語) / D (CHANGELOG) |
+| Pester | `pwsh scripts/tests/build-portable-zip.Tests.ps1` | B-3 |
+| Security audit | `cargo audit` / `npm audit` (Track C の CI workflow も同等) | A / C |
+
+### 7.2 実機検証 (Idios 依頼、Iron Law 6 で必須)
+
+| Track | 検証項目 |
 | --- | --- |
-| Python | `ruff check . / ruff format --check . / pyright / pytest` |
-| GUI frontend | `cd gui && npm run lint / typecheck / test / build` |
-| GUI Rust | `cd gui/src-tauri && cargo check / cargo test` |
-| docs | `bash scripts/check-markdownlint.sh` (CHANGELOG 更新分) |
+| A | Tauri GUI 起動 + golden path (drop → detecting → complete → preview → export) + H.264 エンコーダ自動選択動作 (`select_h264_encoder_for_export`) + 既存 `recent.json` の load |
+| B-1 | 短い MKV (AV1 サンプルあれば) で split → metadata.json の note 文言確認 |
+| B-2 | detecting 中に GUI を × で閉じて ffmpeg 子孫プロセスが Task Manager で 5 秒以内に全消去されることを実機確認。`open_folder_in_explorer` 経由で開いた Explorer は kill されないことも併せて確認 |
+| B-3 | Portable ZIP build → 展開後 README.txt が日本語表示されることを Notepad で確認 |
+| D | local Portable ZIP build (`pwsh ./scripts/build-portable-zip.ps1 -Version 0.2.1`) で ZIP 生成 + `docs/l2-e2e-checklist.md §3 T1` smoke |
 
-### 実機検証 (Idios 依頼、Iron Law 6 で必須)
+### 7.3 受け入れ条件 (Iron Law 1 準拠)
 
-`gui/src-tauri/**` (Cargo.toml + Cargo.lock) の変更により tauri runtime の動作に影響あり。以下を Idios の Windows 実機で確認:
+#### Security alerts (Track A)
 
-- Tauri GUI 起動 (`cd gui && npm run tauri dev` または build 済 `.exe`)
-- Golden path: drop → detecting → complete → preview → export
-- Export 時の H.264 エンコーダ自動選択 (NVENC / QSV / AMF / libx264 fallback) — `select_h264_encoder_for_export` の動作確認
-- 既存 `recent.json` の load (`<install dir>/recent.json` 配置、#571)
+- [ ] Dependabot alert #2, #3, #4, #5, #6 が PR マージ後 24h 以内に auto-resolve
+- [ ] PR #758 が auto-close (or 手動 close、reason: "superseded by v0.2.1 Track A PR")
 
-### ローカル Portable ZIP smoke (任意)
+#### UX issues (Track B)
 
-`pwsh ./scripts/build-portable-zip.ps1 -Version 0.2.1` を local で実行し、ZIP 生成成功と `docs/l2-e2e-checklist.md §3 T1` smoke を実施。
+- [ ] #374 受け入れ条件: metadata.json の note から codec 依存定数 (`typically 2s for OBS recordings`) が削除され、AV1 サンプルで誤情報なし確認
+- [ ] #743 受け入れ条件 (5 件): audit document 作成、kill_tracked_processes 実機検証、親 app crash 時の挙動確認、orphan risk fix を本 PR に統合 (= #756)、audit 結果を `docs/` 配下に記録
+- [ ] #749 受け入れ条件: Portable ZIP README.txt が日本語、Pester assertion で日本語見出し検証
+- [ ] #756 受け入れ条件: ffmpeg 子孫プロセスが GUI 終了時に Windows Task Manager で 5 秒以内に全消去
 
-### 受け入れ条件 (Iron Law 1 準拠)
+#### CI 強化 (Track C)
 
-- [ ] Dependabot alert #2, #3, #4, #5, #6 が PR マージ後 24h 以内に auto-resolve される (or 手動 close)
+- [ ] `.github/workflows/security-audit.yml` が PR ごとに cargo audit + npm audit を実行
+- [ ] Track A の PR でこの workflow が green に通る (脆弱性消化の自己テスト)
+- [ ] Track C の PR 自体でも workflow が green (現状の Cargo.lock / package-lock.json が green になっていること、または Track A マージ後に green になることを期待)
+
+#### Release (Track D)
+
 - [ ] [release.yml](.github/workflows/release.yml) が `allaganeye-v0.2.1-windows.zip` を artifact + Release に添付
 - [ ] Portable ZIP の `allaganeye-gui.exe` が起動し、export まで通る (Idios 実機検証)
 - [ ] `main` から `develop-0.3.0` が cut され、version が 0.3.0 に bump
-- [ ] PR #758 が PR `claude/security-v0.2.1 → main` マージ後 24h 以内に Dependabot により auto-close される。auto-close されない場合は手動 close (reason: "superseded by v0.2.1 hotfix")
 
 ## 8. Release Flow
 
-1. PR `claude/security-v0.2.1 → main` をマージ
-2. `main` HEAD にタグ: `git tag -a v0.2.1 -m "Release v0.2.1: Security hotfix"` + `git push origin v0.2.1`
-3. [release.yml](.github/workflows/release.yml) が以下を自動実行:
+1. main から `develop-0.2.1` を cut + push (`git checkout main && git pull && git checkout -b develop-0.2.1 && git push -u origin develop-0.2.1`)
+2. 各 Track の作業ブランチ → PR → `develop-0.2.1` マージ (Track 並列実施可能。推奨順: **C → A → B-1 / B-2 / B-3 (並列) → D**)
+3. 全 Track 統合後、PR `develop-0.2.1 → main` を作成
+4. PR `develop-0.2.1 → main` をマージ
+5. `main` HEAD にタグ: `git tag -a v0.2.1 -m "Release v0.2.1: Patch release"` + `git push origin v0.2.1`
+6. [release.yml](.github/workflows/release.yml) が以下を自動実行:
    - Portable ZIP build (`scripts/build-portable-zip.ps1 -Version 0.2.1`)
    - SHA256 verify (Python embed / get-pip / FFmpeg)
    - GitHub Release 作成 (`extract_release_notes.py 0.2.1` で CHANGELOG から抽出)
-4. PR 作者 (Claude or Idios) が以下を手動確認:
+7. PR 作者 (Claude or Idios) が以下を手動確認:
    - Dependabot alerts 5 件の auto-close 状態
    - PR #758 の close 状態
+   - UX issue 4 件 (#374 / #743 / #749 / #756) の close (`/close-issue` skill で受け入れ条件再検証 + 手動クローズ、Iron Law 4)
    - GitHub Release ページに ZIP + release notes が掲載
-5. `main` から `develop-0.3.0` 新規 cut + version 0.3.0 bump コミット
+8. `main` から `develop-0.3.0` 新規 cut + version 0.3.0 bump コミット (release-process.md §レイヤー間移行手順)
 
 ## 9. References
 
 ### Project docs
 
-- [docs/release-process.md](../../release-process.md) §ブランチ戦略 / §タグ運用 / §レイヤーリリース受け入れゲート
-- [docs/l2-workflow.md](../../l2-workflow.md) §「PR 作成 Pre-flight」 / §「Self-Test Report 規約」
+- [docs/release-process.md](../../release-process.md) §ブランチ戦略 / §タグ運用 / §レイヤーリリース受け入れゲート (共通項目)
+- [docs/l2-workflow.md](../../l2-workflow.md) §「PR 作成 Pre-flight」 / §「Self-Test Report 規約」 / §「(A) PR 内修正優先 規約」
 - [docs/l2-e2e-checklist.md](../../l2-e2e-checklist.md) §3 T1 (Portable ZIP smoke)
-- [CLAUDE.md](../../../CLAUDE.md) §Iron Law / §PR 作成ルール
+- [CLAUDE.md](../../../CLAUDE.md) §Iron Law / §PR 作成ルール / §バグ修正時の方針
 
 ### Security advisories
 
@@ -213,3 +409,7 @@ main (タグ v0.2.0)
 
 - [PR #758](https://github.com/Idios/kobutachan-allaganeye/pull/758) — Dependabot fast-uri 3.1.2 PR
 - [Release v0.2.0](https://github.com/Idios/kobutachan-allaganeye/releases/tag/v0.2.0)
+- [Issue #374](https://github.com/Idios/kobutachan-allaganeye/issues/374) — metadata.json note codec
+- [Issue #743](https://github.com/Idios/kobutachan-allaganeye/issues/743) — Windows process group orphan audit
+- [Issue #749](https://github.com/Idios/kobutachan-allaganeye/issues/749) — Portable ZIP README.txt 日本語化
+- [Issue #756](https://github.com/Idios/kobutachan-allaganeye/issues/756) — ffmpeg 子孫プロセス残留

--- a/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
+++ b/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
@@ -11,7 +11,7 @@
 v0.2.0 リリース後に発生した課題を v0.2.1 patch リリースで一括解消する:
 
 1. **Security alerts (Dependabot) 5 件** + Dependabot PR 1 件 ([#758](https://github.com/Idios/kobutachan-allaganeye/pull/758))
-2. **UX 影響のある deferred bug 4 件** ([#374](https://github.com/Idios/kobutachan-allaganeye/issues/374) / [#743](https://github.com/Idios/kobutachan-allaganeye/issues/743) / [#749](https://github.com/Idios/kobutachan-allaganeye/issues/749) / [#756](https://github.com/Idios/kobutachan-allaganeye/issues/756))
+2. **UX 影響のある deferred bug / task 5 件** ([#374](https://github.com/Idios/kobutachan-allaganeye/issues/374) / [#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) / [#743](https://github.com/Idios/kobutachan-allaganeye/issues/743) / [#749](https://github.com/Idios/kobutachan-allaganeye/issues/749) / [#756](https://github.com/Idios/kobutachan-allaganeye/issues/756))
 3. **今後の GitHub security 指摘を PR マージ前に自前で検出する仕組み**: cargo audit + npm audit を CI workflow に組み込む
 
 `main` から `develop-0.2.1` 統合ブランチを新規 cut し、Track 別作業ブランチからの PR を統合した後、`develop-0.2.1 → main` で v0.2.1 リリースする。
@@ -43,16 +43,19 @@ v0.2.0 リリース後に発生した課題を v0.2.1 patch リリースで一�
 
 high severity (fast-uri) は dev-only のため配布ユーザーへの影響なし。runtime ユーザー観点で最重要は tauri (Origin Confusion)。
 
-### 2.4 取り込み対象 UX issue (4 件、すべて deferred)
+### 2.4 取り込み対象 UX issue (5 件、すべて deferred)
 
 | # | Severity | Scope | 概要 |
 | --- | --- | --- | --- |
 | 756 | P2-medium, bug | l2a-gui | detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留 (Windows process tree orphan)。Python CLI 経由で spawn された ffmpeg が孫プロセスとして orphan 化し、CPU/disk リソースを消費し続ける |
+| 458 | P2-medium, task | l2-workflow | bug_report.yml UI 動作確認 (L3 初期残作業) + `.github/ISSUE_TEMPLATE/bug_report.yml:18` の link を `../../blob/develop-0.2.0/...` から `../../blob/main/...` に修正 + 「(公開までしばらくお待ちください)」placeholder 削除 (v0.2.0 main マージで bug-report-guide.md は公開済) |
 | 743 | P3-low, task | role:lead-engineer | Windows process group orphan 挙動 audit (#727 派生 (3))。6 spawn site の振る舞いを実機検証 + audit document 作成 |
 | 374 | P3-low, bug | (none) | metadata.json の `note` フィールドが H.264 想定 (2s) で固定。AV1 等の codec で誤情報 |
 | 749 | P3-low, doc | l2b-installer | Portable ZIP 内 `README.txt` が英語のまま。ターゲットユーザー (日本語話者) 向けに日本語化が必要 |
 
 **#743 と #756 の関係**: #756 は #743 の audit 対象 (process orphan) の具体的 bug。#756 の fix で #743 の audit が完了する形にできる (1 Track 内で両方クローズ)。
+
+**#458 の特殊性**: 既に PR #497 / #498 で実装本体は完了し develop-0.2.0 → main マージ済 (v0.2.0)。残作業は (a) bug_report.yml 内 link の `develop-0.2.0` → `main` 更新 + placeholder 削除、(b) GitHub UI での実測検証 (issue template 選択 / 必須項目 block / 自動付与 label / blank 経路併存) の 2 点。前者はコード修正、後者は Idios の実機検証で完了。
 
 ### 2.5 Pre-merge security check の現状
 
@@ -82,7 +85,7 @@ high severity (fast-uri) は dev-only のため配布ユーザーへの影響な
 | --- | --- | --- |
 | Q1: 対応単位とリリース戦略 | **(A) v0.2.1 patch リリースで全部対応** | 配布物の medium 脆弱性 + UX deferred bug を同一 patch リリースで解消。Iron Law 1 / 4 の手動レビュー・close フローと整合 |
 | Q2: Security 部分の PR 構造 | **(C) 細粒度 commit 分割** | 単一 PR (security Track) 内で commit を 5 本に分けて各 alert との対応をトレース可能にする。`cargo update` を 1 段で実行しつつ commit を分離 |
-| Q3: UX 取り込み範囲 | **4 件 (#374 / #743 / #756 / #749)** | Idios が v0.2.1 に取り込むと判断した deferred bug。`docs/release-process.md` §共通項目 deferred ラベル全件レビューと整合 |
+| Q3: UX 取り込み範囲 | **5 件 (#374 / #458 / #743 / #756 / #749)** | Idios が v0.2.1 に取り込むと判断した deferred bug / task。`docs/release-process.md` §共通項目 deferred ラベル全件レビューと整合。#458 は v0.2.0 main マージ後に link 更新と UI 検証残作業を実施 |
 | Q4: Pre-merge check の仕組み | **cargo audit + npm audit を CI ジョブに追加** | 軽量、既存 Actions 拡張のみ、Dependabot と補完関係。CodeQL や Dependabot 設定見直しは後続検討に deferred |
 | Q5: 統合ブランチ | **`develop-0.2.1` を main から新規 cut** | release-process.md §ブランチ戦略の `develop-x.x.x` 命名規約と整合。複数 Track の PR を統合する標準フロー |
 
@@ -114,6 +117,13 @@ high severity (fast-uri) は dev-only のため配布ユーザーへの影響な
 - `scripts/tests/build-portable-zip.Tests.ps1` の Pester assertion を日本語見出しに更新
 - 影響範囲: PS script + Pester test
 
+#### Track B-4: #458 bug_report.yml link 修正 + UI 検証
+
+- `.github/ISSUE_TEMPLATE/bug_report.yml:18` の link を `../../blob/develop-0.2.0/...` から `../../blob/main/...` に変更
+- 「(公開までしばらくお待ちください)」placeholder を削除 (v0.2.0 main マージで bug-report-guide.md は公開済)
+- L3 初期残作業の UI 動作確認チェックリスト (#458 §「L3 初期残作業」) を Idios 実機で実施し、結果を PR 本文に Self-Test Report として記載
+- 影響範囲: GitHub Issue Template + 実機 UI 検証
+
 #### Track C: Pre-merge security audit CI 追加
 
 - `.github/workflows/security-audit.yml` を新規追加 (cargo audit + npm audit を PR ごとに実行)
@@ -142,12 +152,13 @@ high severity (fast-uri) は dev-only のため配布ユーザーへの影響な
 ```text
 main (タグ v0.2.0)
  └── develop-0.2.1 (本 spec で main から新規 cut、v0.2.1 統合ブランチ)
-       ├── claude/<scope>-deps (Track A)        → PR → develop-0.2.1
-       ├── claude/issue-374-codec-note          → PR → develop-0.2.1
-       ├── claude/issue-743-756-process-orphan  → PR → develop-0.2.1
-       ├── claude/issue-749-readme-ja           → PR → develop-0.2.1
-       ├── claude/ci-security-audit             → PR → develop-0.2.1
-       └── claude/release-v0.2.1 (Track D)      → PR → develop-0.2.1
+       ├── claude/<scope>-deps (Track A)            → PR → develop-0.2.1
+       ├── claude/issue-374-codec-note (Track B-1)  → PR → develop-0.2.1
+       ├── claude/issue-743-756-orphan (Track B-2)  → PR → develop-0.2.1
+       ├── claude/issue-749-readme-ja (Track B-3)   → PR → develop-0.2.1
+       ├── claude/issue-458-bug-template (Track B-4) → PR → develop-0.2.1
+       ├── claude/ci-security-audit (Track C)       → PR → develop-0.2.1
+       └── claude/release-v0.2.1 (Track D)          → PR → develop-0.2.1
               └── 全 Track 統合後 develop-0.2.1 → main PR
                      └── マージ + git tag v0.2.1
                             └── release.yml 発火 → Portable ZIP + GitHub Release
@@ -314,11 +325,13 @@ jobs:
   ### Changed
 
   - #749: Portable ZIP 内 `README.txt` を日本語化
+  - #458: `.github/ISSUE_TEMPLATE/bug_report.yml` の `docs/bug-report-guide.md` link を `develop-0.2.0` から `main` に更新、未公開 placeholder を削除
 
   ### CI / Infrastructure
 
   - cargo audit + npm audit を `.github/workflows/security-audit.yml` で PR ごとに実行
   - #743: Windows process tree orphan audit を `docs/process-tree-orphan-audit.md` として整理
+  - #458: GitHub Issue Template の UI 動作 (template 選択 / 必須項目 block / 自動付与 / blank 経路併存) を実機検証完了
   ```
 
 ## 7. Verification (Iron Law 6 準拠)
@@ -342,6 +355,7 @@ jobs:
 | B-1 | 短い MKV (AV1 サンプルあれば) で split → metadata.json の note 文言確認 |
 | B-2 | detecting 中に GUI を × で閉じて ffmpeg 子孫プロセスが Task Manager で 5 秒以内に全消去されることを実機確認。`open_folder_in_explorer` 経由で開いた Explorer は kill されないことも併せて確認 |
 | B-3 | Portable ZIP build → 展開後 README.txt が日本語表示されることを Notepad で確認 |
+| B-4 | `https://github.com/Idios/kobutachan-allaganeye/issues/new/choose` を開いて bug 報告テンプレ表示確認、必須 textarea / checkbox 未入力時の submit block、自動付与 (title prefix / labels / assignees)、blank 経路併存、`docs/bug-report-guide.md` link が 200 で開けることを実測 |
 | D | local Portable ZIP build (`pwsh ./scripts/build-portable-zip.ps1 -Version 0.2.1`) で ZIP 生成 + `docs/l2-e2e-checklist.md §3 T1` smoke |
 
 ### 7.3 受け入れ条件 (Iron Law 1 準拠)
@@ -357,6 +371,7 @@ jobs:
 - [ ] #743 受け入れ条件 (5 件): audit document 作成、kill_tracked_processes 実機検証、親 app crash 時の挙動確認、orphan risk fix を本 PR に統合 (= #756)、audit 結果を `docs/` 配下に記録
 - [ ] #749 受け入れ条件: Portable ZIP README.txt が日本語、Pester assertion で日本語見出し検証
 - [ ] #756 受け入れ条件: ffmpeg 子孫プロセスが GUI 終了時に Windows Task Manager で 5 秒以内に全消去
+- [ ] #458 受け入れ条件: bug_report.yml の link が `main` を指し placeholder 削除済、L3 初期残作業チェックリスト (UI 動作確認 7 項目) すべて pass
 
 #### CI 強化 (Track C)
 
@@ -373,7 +388,7 @@ jobs:
 ## 8. Release Flow
 
 1. main から `develop-0.2.1` を cut + push (`git checkout main && git pull && git checkout -b develop-0.2.1 && git push -u origin develop-0.2.1`)
-2. 各 Track の作業ブランチ → PR → `develop-0.2.1` マージ (Track 並列実施可能。推奨順: **C → A → B-1 / B-2 / B-3 (並列) → D**)
+2. 各 Track の作業ブランチ → PR → `develop-0.2.1` マージ (Track 並列実施可能。推奨順: **C → A → B-1 / B-2 / B-3 / B-4 (並列) → D**)
 3. 全 Track 統合後、PR `develop-0.2.1 → main` を作成
 4. PR `develop-0.2.1 → main` をマージ
 5. `main` HEAD にタグ: `git tag -a v0.2.1 -m "Release v0.2.1: Patch release"` + `git push origin v0.2.1`
@@ -384,7 +399,7 @@ jobs:
 7. PR 作者 (Claude or Idios) が以下を手動確認:
    - Dependabot alerts 5 件の auto-close 状態
    - PR #758 の close 状態
-   - UX issue 4 件 (#374 / #743 / #749 / #756) の close (`/close-issue` skill で受け入れ条件再検証 + 手動クローズ、Iron Law 4)
+   - UX issue 5 件 (#374 / #458 / #743 / #749 / #756) の close (`/close-issue` skill で受け入れ条件再検証 + 手動クローズ、Iron Law 4)
    - GitHub Release ページに ZIP + release notes が掲載
 8. `main` から `develop-0.3.0` 新規 cut + version 0.3.0 bump コミット (release-process.md §レイヤー間移行手順)
 
@@ -410,6 +425,8 @@ jobs:
 - [PR #758](https://github.com/Idios/kobutachan-allaganeye/pull/758) — Dependabot fast-uri 3.1.2 PR
 - [Release v0.2.0](https://github.com/Idios/kobutachan-allaganeye/releases/tag/v0.2.0)
 - [Issue #374](https://github.com/Idios/kobutachan-allaganeye/issues/374) — metadata.json note codec
+- [Issue #458](https://github.com/Idios/kobutachan-allaganeye/issues/458) — bug_report.yml 同意 checkbox 付き UI 検証残作業
 - [Issue #743](https://github.com/Idios/kobutachan-allaganeye/issues/743) — Windows process group orphan audit
 - [Issue #749](https://github.com/Idios/kobutachan-allaganeye/issues/749) — Portable ZIP README.txt 日本語化
 - [Issue #756](https://github.com/Idios/kobutachan-allaganeye/issues/756) — ffmpeg 子孫プロセス残留
+- [docs/bug-report-guide.md](../../bug-report-guide.md) — Track B-4 link 先 (Idios 提供)


### PR DESCRIPTION
## 概要

v0.2.1 patch リリースの設計文書 (spec) と初回作業 plan (Track 0 / A / C) を develop-0.2.1 に取り込む。

## 含まれる commits

- d61b8fd `docs(spec): v0.2.1 security hotfix response design`
- 865bf12 `docs(spec): expand v0.2.1 scope to security + UX + CI audit`
- 873a990 `docs(spec): add Track B-4 for #458 bug_report.yml link + UI verification`
- 4d2618c `docs(plan): add v0.2.1 Track 0 / A / C implementation plans`

## Refs

- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md`
- Plan 0: `docs/superpowers/plans/2026-05-16-v0.2.1-track-0-branch-cut.md`
- Plan A: `docs/superpowers/plans/2026-05-16-v0.2.1-track-a-security-alerts.md`
- Plan C: `docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md`

## v0.2.1 スコープ概要

| Track | 内容 | Refs |
| --- | --- | --- |
| 0 | develop-0.2.1 cut + spec/plan 取り込み | 本 PR |
| A | Security alerts 5 件解消 (tauri / glib / rand / fast-uri x2) | Plan A |
| B-1 | #374 metadata note codec 修正 | Plan B-1 (後追い writing-plans) |
| B-2 | #743 + #756 Windows process tree orphan | Plan B-2 (後追い) |
| B-3 | #749 Portable ZIP README.txt 日本語化 | Plan B-3 (後追い) |
| B-4 | #458 bug_report.yml link 修正 + UI 検証 | Plan B-4 (後追い) |
| C | cargo audit + npm audit CI workflow | Plan C |
| D | version bump + CHANGELOG | Plan D (後追い) |

## Self-Test Report

machine-verified:
- [x] markdownlint pass (`bash scripts/check-markdownlint.sh` で 0 errors)
- [x] PR Pre-flight Step 0-3 (既存 open PR なし、base 同期済、touched files 4 ファイル)

machine-unverifiable:
- N/A (docs-only PR)

## Notes

本 PR には実装変更は含まない (spec / plans のみ)。後続の Track A / B / C / D 作業 PR で実装を進める。Plan B-1〜B-4 と Plan D は Track A マージ後に追加 writing-plans skill invoke で生成予定。
