### PR TITLE
chore(deps): v0.2.1 Track A — security alerts 3 件解消 + 2 件 deferred [crazy-swirles-bed20b]

### DIFF
--- a/docs/audit-logs/2026-05-16-v0.2.1-audit.log
+++ b/docs/audit-logs/2026-05-16-v0.2.1-audit.log
@@ -1,0 +1,840 @@
+    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
+      Loaded 1090 security advisories (from C:\Users\idios\.cargo\advisory-db)
+    Updating crates.io index
+    Scanning Cargo.lock for vulnerabilities (530 crate dependencies)
+Crate:     atk
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0413
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0413
+Dependency tree:
+atk 0.18.2
+└── gtk 0.18.2
+    ├── wry 0.55.1
+    │   └── tauri-runtime-wry 2.11.1
+    │       └── tauri 2.11.1
+    │           ├── tauri-plugin-shell 2.3.5
+    │           │   └── allaganeye-gui 0.2.0
+    │           ├── tauri-plugin-fs 2.5.1
+    │           │   ├── tauri-plugin-dialog 2.7.1
+    │           │   │   └── allaganeye-gui 0.2.0
+    │           │   └── allaganeye-gui 0.2.0
+    │           ├── tauri-plugin-dialog 2.7.1
+    │           └── allaganeye-gui 0.2.0
+    ├── webkit2gtk 2.0.2
+    │   ├── wry 0.55.1
+    │   ├── tauri-runtime-wry 2.11.1
+    │   ├── tauri-runtime 2.11.1
+    │   │   ├── tauri-runtime-wry 2.11.1
+    │   │   └── tauri 2.11.1
+    │   └── tauri 2.11.1
+    ├── tauri-runtime-wry 2.11.1
+    ├── tauri-runtime 2.11.1
+    ├── tauri 2.11.1
+    ├── tao 0.35.2
+    │   └── tauri-runtime-wry 2.11.1
+    ├── muda 0.19.1
+    │   ├── tray-icon 0.23.1
+    │   │   └── tauri 2.11.1
+    │   └── tauri 2.11.1
+    └── libappindicator 0.9.0
+        └── tray-icon 0.23.1
+
+Crate:     atk-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0416
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0416
+Dependency tree:
+atk-sys 0.18.2
+├── gtk-sys 0.18.2
+│   ├── webkit2gtk-sys 2.0.2
+│   │   ├── wry 0.55.1
+│   │   │   └── tauri-runtime-wry 2.11.1
+│   │   │       └── tauri 2.11.1
+│   │   │           ├── tauri-plugin-shell 2.3.5
+│   │   │           │   └── allaganeye-gui 0.2.0
+│   │   │           ├── tauri-plugin-fs 2.5.1
+│   │   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │   │           │   │   └── allaganeye-gui 0.2.0
+│   │   │           │   └── allaganeye-gui 0.2.0
+│   │   │           ├── tauri-plugin-dialog 2.7.1
+│   │   │           └── allaganeye-gui 0.2.0
+│   │   └── webkit2gtk 2.0.2
+│   │       ├── wry 0.55.1
+│   │       ├── tauri-runtime-wry 2.11.1
+│   │       ├── tauri-runtime 2.11.1
+│   │       │   ├── tauri-runtime-wry 2.11.1
+│   │       │   └── tauri 2.11.1
+│   │       └── tauri 2.11.1
+│   ├── webkit2gtk 2.0.2
+│   ├── rfd 0.16.0
+│   │   └── tauri-plugin-dialog 2.7.1
+│   ├── libappindicator-sys 0.9.0
+│   │   └── libappindicator 0.9.0
+│   │       └── tray-icon 0.23.1
+│   │           └── tauri 2.11.1
+│   ├── libappindicator 0.9.0
+│   └── gtk 0.18.2
+│       ├── wry 0.55.1
+│       ├── webkit2gtk 2.0.2
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       ├── tauri 2.11.1
+│       ├── tao 0.35.2
+│       │   └── tauri-runtime-wry 2.11.1
+│       ├── muda 0.19.1
+│       │   ├── tray-icon 0.23.1
+│       │   └── tauri 2.11.1
+│       └── libappindicator 0.9.0
+└── atk 0.18.2
+    └── gtk 0.18.2
+
+Crate:     fxhash
+Version:   0.2.1
+Warning:   unmaintained
+Title:     fxhash - no longer maintained
+Date:      2025-09-05
+ID:        RUSTSEC-2025-0057
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0057
+Dependency tree:
+fxhash 0.2.1
+└── selectors 0.24.0
+    └── kuchikiki 0.8.8-speedreader
+        └── tauri-utils 2.9.1
+            ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            │       ├── tauri-plugin-shell 2.3.5
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-fs 2.5.1
+            │       │   ├── tauri-plugin-dialog 2.7.1
+            │       │   │   └── allaganeye-gui 0.2.0
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-dialog 2.7.1
+            │       └── allaganeye-gui 0.2.0
+            ├── tauri-runtime 2.11.1
+            │   ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            ├── tauri-plugin-fs 2.5.1
+            ├── tauri-plugin 2.5.4
+            │   ├── tauri-plugin-shell 2.3.5
+            │   ├── tauri-plugin-fs 2.5.1
+            │   └── tauri-plugin-dialog 2.7.1
+            ├── tauri-macros 2.6.1
+            │   └── tauri 2.11.1
+            ├── tauri-codegen 2.6.1
+            │   └── tauri-macros 2.6.1
+            ├── tauri-build 2.6.1
+            │   ├── tauri 2.11.1
+            │   └── allaganeye-gui 0.2.0
+            └── tauri 2.11.1
+
+Crate:     gdk
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0412
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0412
+Dependency tree:
+gdk 0.18.2
+├── webkit2gtk 2.0.2
+│   ├── wry 0.55.1
+│   │   └── tauri-runtime-wry 2.11.1
+│   │       └── tauri 2.11.1
+│   │           ├── tauri-plugin-shell 2.3.5
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-fs 2.5.1
+│   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │           │   │   └── allaganeye-gui 0.2.0
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-dialog 2.7.1
+│   │           └── allaganeye-gui 0.2.0
+│   ├── tauri-runtime-wry 2.11.1
+│   ├── tauri-runtime 2.11.1
+│   │   ├── tauri-runtime-wry 2.11.1
+│   │   └── tauri 2.11.1
+│   └── tauri 2.11.1
+├── gtk 0.18.2
+│   ├── wry 0.55.1
+│   ├── webkit2gtk 2.0.2
+│   ├── tauri-runtime-wry 2.11.1
+│   ├── tauri-runtime 2.11.1
+│   ├── tauri 2.11.1
+│   ├── tao 0.35.2
+│   │   └── tauri-runtime-wry 2.11.1
+│   ├── muda 0.19.1
+│   │   ├── tray-icon 0.23.1
+│   │   │   └── tauri 2.11.1
+│   │   └── tauri 2.11.1
+│   └── libappindicator 0.9.0
+│       └── tray-icon 0.23.1
+└── gdkx11 0.18.2
+    └── wry 0.55.1
+
+Crate:     gdk-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0418
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0418
+Dependency tree:
+gdk-sys 0.18.2
+├── webkit2gtk-sys 2.0.2
+│   ├── wry 0.55.1
+│   │   └── tauri-runtime-wry 2.11.1
+│   │       └── tauri 2.11.1
+│   │           ├── tauri-plugin-shell 2.3.5
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-fs 2.5.1
+│   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │           │   │   └── allaganeye-gui 0.2.0
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-dialog 2.7.1
+│   │           └── allaganeye-gui 0.2.0
+│   └── webkit2gtk 2.0.2
+│       ├── wry 0.55.1
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       │   ├── tauri-runtime-wry 2.11.1
+│       │   └── tauri 2.11.1
+│       └── tauri 2.11.1
+├── webkit2gtk 2.0.2
+├── gtk-sys 0.18.2
+│   ├── webkit2gtk-sys 2.0.2
+│   ├── webkit2gtk 2.0.2
+│   ├── rfd 0.16.0
+│   │   └── tauri-plugin-dialog 2.7.1
+│   ├── libappindicator-sys 0.9.0
+│   │   └── libappindicator 0.9.0
+│   │       └── tray-icon 0.23.1
+│   │           └── tauri 2.11.1
+│   ├── libappindicator 0.9.0
+│   └── gtk 0.18.2
+│       ├── wry 0.55.1
+│       ├── webkit2gtk 2.0.2
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       ├── tauri 2.11.1
+│       ├── tao 0.35.2
+│       │   └── tauri-runtime-wry 2.11.1
+│       ├── muda 0.19.1
+│       │   ├── tray-icon 0.23.1
+│       │   └── tauri 2.11.1
+│       └── libappindicator 0.9.0
+├── gdkx11-sys 0.18.2
+│   ├── tao 0.35.2
+│   └── gdkx11 0.18.2
+│       └── wry 0.55.1
+├── gdkwayland-sys 0.18.2
+│   └── tao 0.35.2
+└── gdk 0.18.2
+    ├── webkit2gtk 2.0.2
+    ├── gtk 0.18.2
+    └── gdkx11 0.18.2
+
+Crate:     gdkwayland-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0411
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0411
+Dependency tree:
+gdkwayland-sys 0.18.2
+└── tao 0.35.2
+    └── tauri-runtime-wry 2.11.1
+        └── tauri 2.11.1
+            ├── tauri-plugin-shell 2.3.5
+            │   └── allaganeye-gui 0.2.0
+            ├── tauri-plugin-fs 2.5.1
+            │   ├── tauri-plugin-dialog 2.7.1
+            │   │   └── allaganeye-gui 0.2.0
+            │   └── allaganeye-gui 0.2.0
+            ├── tauri-plugin-dialog 2.7.1
+            └── allaganeye-gui 0.2.0
+
+Crate:     gdkx11
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0417
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0417
+Dependency tree:
+gdkx11 0.18.2
+└── wry 0.55.1
+    └── tauri-runtime-wry 2.11.1
+        └── tauri 2.11.1
+            ├── tauri-plugin-shell 2.3.5
+            │   └── allaganeye-gui 0.2.0
+            ├── tauri-plugin-fs 2.5.1
+            │   ├── tauri-plugin-dialog 2.7.1
+            │   │   └── allaganeye-gui 0.2.0
+            │   └── allaganeye-gui 0.2.0
+            ├── tauri-plugin-dialog 2.7.1
+            └── allaganeye-gui 0.2.0
+
+Crate:     gdkx11-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0414
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0414
+Dependency tree:
+gdkx11-sys 0.18.2
+├── tao 0.35.2
+│   └── tauri-runtime-wry 2.11.1
+│       └── tauri 2.11.1
+│           ├── tauri-plugin-shell 2.3.5
+│           │   └── allaganeye-gui 0.2.0
+│           ├── tauri-plugin-fs 2.5.1
+│           │   ├── tauri-plugin-dialog 2.7.1
+│           │   │   └── allaganeye-gui 0.2.0
+│           │   └── allaganeye-gui 0.2.0
+│           ├── tauri-plugin-dialog 2.7.1
+│           └── allaganeye-gui 0.2.0
+└── gdkx11 0.18.2
+    └── wry 0.55.1
+        └── tauri-runtime-wry 2.11.1
+
+Crate:     gtk
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0415
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0415
+Dependency tree:
+gtk 0.18.2
+├── wry 0.55.1
+│   └── tauri-runtime-wry 2.11.1
+│       └── tauri 2.11.1
+│           ├── tauri-plugin-shell 2.3.5
+│           │   └── allaganeye-gui 0.2.0
+│           ├── tauri-plugin-fs 2.5.1
+│           │   ├── tauri-plugin-dialog 2.7.1
+│           │   │   └── allaganeye-gui 0.2.0
+│           │   └── allaganeye-gui 0.2.0
+│           ├── tauri-plugin-dialog 2.7.1
+│           └── allaganeye-gui 0.2.0
+├── webkit2gtk 2.0.2
+│   ├── wry 0.55.1
+│   ├── tauri-runtime-wry 2.11.1
+│   ├── tauri-runtime 2.11.1
+│   │   ├── tauri-runtime-wry 2.11.1
+│   │   └── tauri 2.11.1
+│   └── tauri 2.11.1
+├── tauri-runtime-wry 2.11.1
+├── tauri-runtime 2.11.1
+├── tauri 2.11.1
+├── tao 0.35.2
+│   └── tauri-runtime-wry 2.11.1
+├── muda 0.19.1
+│   ├── tray-icon 0.23.1
+│   │   └── tauri 2.11.1
+│   └── tauri 2.11.1
+└── libappindicator 0.9.0
+    └── tray-icon 0.23.1
+
+Crate:     gtk-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0420
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0420
+Dependency tree:
+gtk-sys 0.18.2
+├── webkit2gtk-sys 2.0.2
+│   ├── wry 0.55.1
+│   │   └── tauri-runtime-wry 2.11.1
+│   │       └── tauri 2.11.1
+│   │           ├── tauri-plugin-shell 2.3.5
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-fs 2.5.1
+│   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │           │   │   └── allaganeye-gui 0.2.0
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-dialog 2.7.1
+│   │           └── allaganeye-gui 0.2.0
+│   └── webkit2gtk 2.0.2
+│       ├── wry 0.55.1
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       │   ├── tauri-runtime-wry 2.11.1
+│       │   └── tauri 2.11.1
+│       └── tauri 2.11.1
+├── webkit2gtk 2.0.2
+├── rfd 0.16.0
+│   └── tauri-plugin-dialog 2.7.1
+├── libappindicator-sys 0.9.0
+│   └── libappindicator 0.9.0
+│       └── tray-icon 0.23.1
+│           └── tauri 2.11.1
+├── libappindicator 0.9.0
+└── gtk 0.18.2
+    ├── wry 0.55.1
+    ├── webkit2gtk 2.0.2
+    ├── tauri-runtime-wry 2.11.1
+    ├── tauri-runtime 2.11.1
+    ├── tauri 2.11.1
+    ├── tao 0.35.2
+    │   └── tauri-runtime-wry 2.11.1
+    ├── muda 0.19.1
+    │   ├── tray-icon 0.23.1
+    │   └── tauri 2.11.1
+    └── libappindicator 0.9.0
+
+Crate:     gtk3-macros
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0419
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0419
+Dependency tree:
+gtk3-macros 0.18.2
+└── gtk 0.18.2
+    ├── wry 0.55.1
+    │   └── tauri-runtime-wry 2.11.1
+    │       └── tauri 2.11.1
+    │           ├── tauri-plugin-shell 2.3.5
+    │           │   └── allaganeye-gui 0.2.0
+    │           ├── tauri-plugin-fs 2.5.1
+    │           │   ├── tauri-plugin-dialog 2.7.1
+    │           │   │   └── allaganeye-gui 0.2.0
+    │           │   └── allaganeye-gui 0.2.0
+    │           ├── tauri-plugin-dialog 2.7.1
+    │           └── allaganeye-gui 0.2.0
+    ├── webkit2gtk 2.0.2
+    │   ├── wry 0.55.1
+    │   ├── tauri-runtime-wry 2.11.1
+    │   ├── tauri-runtime 2.11.1
+    │   │   ├── tauri-runtime-wry 2.11.1
+    │   │   └── tauri 2.11.1
+    │   └── tauri 2.11.1
+    ├── tauri-runtime-wry 2.11.1
+    ├── tauri-runtime 2.11.1
+    ├── tauri 2.11.1
+    ├── tao 0.35.2
+    │   └── tauri-runtime-wry 2.11.1
+    ├── muda 0.19.1
+    │   ├── tray-icon 0.23.1
+    │   │   └── tauri 2.11.1
+    │   └── tauri 2.11.1
+    └── libappindicator 0.9.0
+        └── tray-icon 0.23.1
+
+Crate:     proc-macro-error
+Version:   1.0.4
+Warning:   unmaintained
+Title:     proc-macro-error is unmaintained
+Date:      2024-09-01
+ID:        RUSTSEC-2024-0370
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0370
+Dependency tree:
+proc-macro-error 1.0.4
+├── gtk3-macros 0.18.2
+│   └── gtk 0.18.2
+│       ├── wry 0.55.1
+│       │   └── tauri-runtime-wry 2.11.1
+│       │       └── tauri 2.11.1
+│       │           ├── tauri-plugin-shell 2.3.5
+│       │           │   └── allaganeye-gui 0.2.0
+│       │           ├── tauri-plugin-fs 2.5.1
+│       │           │   ├── tauri-plugin-dialog 2.7.1
+│       │           │   │   └── allaganeye-gui 0.2.0
+│       │           │   └── allaganeye-gui 0.2.0
+│       │           ├── tauri-plugin-dialog 2.7.1
+│       │           └── allaganeye-gui 0.2.0
+│       ├── webkit2gtk 2.0.2
+│       │   ├── wry 0.55.1
+│       │   ├── tauri-runtime-wry 2.11.1
+│       │   ├── tauri-runtime 2.11.1
+│       │   │   ├── tauri-runtime-wry 2.11.1
+│       │   │   └── tauri 2.11.1
+│       │   └── tauri 2.11.1
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       ├── tauri 2.11.1
+│       ├── tao 0.35.2
+│       │   └── tauri-runtime-wry 2.11.1
+│       ├── muda 0.19.1
+│       │   ├── tray-icon 0.23.1
+│       │   │   └── tauri 2.11.1
+│       │   └── tauri 2.11.1
+│       └── libappindicator 0.9.0
+│           └── tray-icon 0.23.1
+└── glib-macros 0.18.5
+    └── glib 0.18.5
+        ├── webkit2gtk 2.0.2
+        ├── soup3 0.5.0
+        │   ├── wry 0.55.1
+        │   └── webkit2gtk 2.0.2
+        ├── pango 0.18.3
+        │   ├── gtk 0.18.2
+        │   └── gdk 0.18.2
+        │       ├── webkit2gtk 2.0.2
+        │       ├── gtk 0.18.2
+        │       └── gdkx11 0.18.2
+        │           └── wry 0.55.1
+        ├── libappindicator 0.9.0
+        ├── javascriptcore-rs 1.1.2
+        │   ├── wry 0.55.1
+        │   └── webkit2gtk 2.0.2
+        ├── gtk 0.18.2
+        ├── gio 0.18.4
+        │   ├── webkit2gtk 2.0.2
+        │   ├── soup3 0.5.0
+        │   ├── pango 0.18.3
+        │   ├── gtk 0.18.2
+        │   ├── gdkx11 0.18.2
+        │   ├── gdk-pixbuf 0.18.5
+        │   │   ├── gtk 0.18.2
+        │   │   └── gdk 0.18.2
+        │   └── gdk 0.18.2
+        ├── gdkx11 0.18.2
+        ├── gdk-pixbuf 0.18.5
+        ├── gdk 0.18.2
+        ├── cairo-rs 0.18.5
+        │   ├── webkit2gtk 2.0.2
+        │   ├── gtk 0.18.2
+        │   └── gdk 0.18.2
+        └── atk 0.18.2
+            └── gtk 0.18.2
+
+Crate:     unic-char-property
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-char-property` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0081
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0081
+Dependency tree:
+unic-char-property 0.9.0
+└── unic-ucd-ident 0.9.0
+    └── urlpattern 0.3.0
+        └── tauri-utils 2.9.1
+            ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            │       ├── tauri-plugin-shell 2.3.5
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-fs 2.5.1
+            │       │   ├── tauri-plugin-dialog 2.7.1
+            │       │   │   └── allaganeye-gui 0.2.0
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-dialog 2.7.1
+            │       └── allaganeye-gui 0.2.0
+            ├── tauri-runtime 2.11.1
+            │   ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            ├── tauri-plugin-fs 2.5.1
+            ├── tauri-plugin 2.5.4
+            │   ├── tauri-plugin-shell 2.3.5
+            │   ├── tauri-plugin-fs 2.5.1
+            │   └── tauri-plugin-dialog 2.7.1
+            ├── tauri-macros 2.6.1
+            │   └── tauri 2.11.1
+            ├── tauri-codegen 2.6.1
+            │   └── tauri-macros 2.6.1
+            ├── tauri-build 2.6.1
+            │   ├── tauri 2.11.1
+            │   └── allaganeye-gui 0.2.0
+            └── tauri 2.11.1
+
+Crate:     unic-char-range
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-char-range` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0075
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0075
+Dependency tree:
+unic-char-range 0.9.0
+├── unic-ucd-ident 0.9.0
+│   └── urlpattern 0.3.0
+│       └── tauri-utils 2.9.1
+│           ├── tauri-runtime-wry 2.11.1
+│           │   └── tauri 2.11.1
+│           │       ├── tauri-plugin-shell 2.3.5
+│           │       │   └── allaganeye-gui 0.2.0
+│           │       ├── tauri-plugin-fs 2.5.1
+│           │       │   ├── tauri-plugin-dialog 2.7.1
+│           │       │   │   └── allaganeye-gui 0.2.0
+│           │       │   └── allaganeye-gui 0.2.0
+│           │       ├── tauri-plugin-dialog 2.7.1
+│           │       └── allaganeye-gui 0.2.0
+│           ├── tauri-runtime 2.11.1
+│           │   ├── tauri-runtime-wry 2.11.1
+│           │   └── tauri 2.11.1
+│           ├── tauri-plugin-fs 2.5.1
+│           ├── tauri-plugin 2.5.4
+│           │   ├── tauri-plugin-shell 2.3.5
+│           │   ├── tauri-plugin-fs 2.5.1
+│           │   └── tauri-plugin-dialog 2.7.1
+│           ├── tauri-macros 2.6.1
+│           │   └── tauri 2.11.1
+│           ├── tauri-codegen 2.6.1
+│           │   └── tauri-macros 2.6.1
+│           ├── tauri-build 2.6.1
+│           │   ├── tauri 2.11.1
+│           │   └── allaganeye-gui 0.2.0
+│           └── tauri 2.11.1
+└── unic-char-property 0.9.0
+    └── unic-ucd-ident 0.9.0
+
+Crate:     unic-common
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-common` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0080
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0080
+Dependency tree:
+unic-common 0.9.0
+└── unic-ucd-version 0.9.0
+    └── unic-ucd-ident 0.9.0
+        └── urlpattern 0.3.0
+            └── tauri-utils 2.9.1
+                ├── tauri-runtime-wry 2.11.1
+                │   └── tauri 2.11.1
+                │       ├── tauri-plugin-shell 2.3.5
+                │       │   └── allaganeye-gui 0.2.0
+                │       ├── tauri-plugin-fs 2.5.1
+                │       │   ├── tauri-plugin-dialog 2.7.1
+                │       │   │   └── allaganeye-gui 0.2.0
+                │       │   └── allaganeye-gui 0.2.0
+                │       ├── tauri-plugin-dialog 2.7.1
+                │       └── allaganeye-gui 0.2.0
+                ├── tauri-runtime 2.11.1
+                │   ├── tauri-runtime-wry 2.11.1
+                │   └── tauri 2.11.1
+                ├── tauri-plugin-fs 2.5.1
+                ├── tauri-plugin 2.5.4
+                │   ├── tauri-plugin-shell 2.3.5
+                │   ├── tauri-plugin-fs 2.5.1
+                │   └── tauri-plugin-dialog 2.7.1
+                ├── tauri-macros 2.6.1
+                │   └── tauri 2.11.1
+                ├── tauri-codegen 2.6.1
+                │   └── tauri-macros 2.6.1
+                ├── tauri-build 2.6.1
+                │   ├── tauri 2.11.1
+                │   └── allaganeye-gui 0.2.0
+                └── tauri 2.11.1
+
+Crate:     unic-ucd-ident
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-ucd-ident` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0100
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0100
+Dependency tree:
+unic-ucd-ident 0.9.0
+└── urlpattern 0.3.0
+    └── tauri-utils 2.9.1
+        ├── tauri-runtime-wry 2.11.1
+        │   └── tauri 2.11.1
+        │       ├── tauri-plugin-shell 2.3.5
+        │       │   └── allaganeye-gui 0.2.0
+        │       ├── tauri-plugin-fs 2.5.1
+        │       │   ├── tauri-plugin-dialog 2.7.1
+        │       │   │   └── allaganeye-gui 0.2.0
+        │       │   └── allaganeye-gui 0.2.0
+        │       ├── tauri-plugin-dialog 2.7.1
+        │       └── allaganeye-gui 0.2.0
+        ├── tauri-runtime 2.11.1
+        │   ├── tauri-runtime-wry 2.11.1
+        │   └── tauri 2.11.1
+        ├── tauri-plugin-fs 2.5.1
+        ├── tauri-plugin 2.5.4
+        │   ├── tauri-plugin-shell 2.3.5
+        │   ├── tauri-plugin-fs 2.5.1
+        │   └── tauri-plugin-dialog 2.7.1
+        ├── tauri-macros 2.6.1
+        │   └── tauri 2.11.1
+        ├── tauri-codegen 2.6.1
+        │   └── tauri-macros 2.6.1
+        ├── tauri-build 2.6.1
+        │   ├── tauri 2.11.1
+        │   └── allaganeye-gui 0.2.0
+        └── tauri 2.11.1
+
+Crate:     unic-ucd-version
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-ucd-version` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0098
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0098
+Dependency tree:
+unic-ucd-version 0.9.0
+└── unic-ucd-ident 0.9.0
+    └── urlpattern 0.3.0
+        └── tauri-utils 2.9.1
+            ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            │       ├── tauri-plugin-shell 2.3.5
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-fs 2.5.1
+            │       │   ├── tauri-plugin-dialog 2.7.1
+            │       │   │   └── allaganeye-gui 0.2.0
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-dialog 2.7.1
+            │       └── allaganeye-gui 0.2.0
+            ├── tauri-runtime 2.11.1
+            │   ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            ├── tauri-plugin-fs 2.5.1
+            ├── tauri-plugin 2.5.4
+            │   ├── tauri-plugin-shell 2.3.5
+            │   ├── tauri-plugin-fs 2.5.1
+            │   └── tauri-plugin-dialog 2.7.1
+            ├── tauri-macros 2.6.1
+            │   └── tauri 2.11.1
+            ├── tauri-codegen 2.6.1
+            │   └── tauri-macros 2.6.1
+            ├── tauri-build 2.6.1
+            │   ├── tauri 2.11.1
+            │   └── allaganeye-gui 0.2.0
+            └── tauri 2.11.1
+
+Crate:     glib
+Version:   0.18.5
+Warning:   unsound
+Title:     Unsoundness in `Iterator` and `DoubleEndedIterator` impls for `glib::VariantStrIter`
+Date:      2024-03-30
+ID:        RUSTSEC-2024-0429
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0429
+Dependency tree:
+glib 0.18.5
+├── webkit2gtk 2.0.2
+│   ├── wry 0.55.1
+│   │   └── tauri-runtime-wry 2.11.1
+│   │       └── tauri 2.11.1
+│   │           ├── tauri-plugin-shell 2.3.5
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-fs 2.5.1
+│   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │           │   │   └── allaganeye-gui 0.2.0
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-dialog 2.7.1
+│   │           └── allaganeye-gui 0.2.0
+│   ├── tauri-runtime-wry 2.11.1
+│   ├── tauri-runtime 2.11.1
+│   │   ├── tauri-runtime-wry 2.11.1
+│   │   └── tauri 2.11.1
+│   └── tauri 2.11.1
+├── soup3 0.5.0
+│   ├── wry 0.55.1
+│   └── webkit2gtk 2.0.2
+├── pango 0.18.3
+│   ├── gtk 0.18.2
+│   │   ├── wry 0.55.1
+│   │   ├── webkit2gtk 2.0.2
+│   │   ├── tauri-runtime-wry 2.11.1
+│   │   ├── tauri-runtime 2.11.1
+│   │   ├── tauri 2.11.1
+│   │   ├── tao 0.35.2
+│   │   │   └── tauri-runtime-wry 2.11.1
+│   │   ├── muda 0.19.1
+│   │   │   ├── tray-icon 0.23.1
+│   │   │   │   └── tauri 2.11.1
+│   │   │   └── tauri 2.11.1
+│   │   └── libappindicator 0.9.0
+│   │       └── tray-icon 0.23.1
+│   └── gdk 0.18.2
+│       ├── webkit2gtk 2.0.2
+│       ├── gtk 0.18.2
+│       └── gdkx11 0.18.2
+│           └── wry 0.55.1
+├── libappindicator 0.9.0
+├── javascriptcore-rs 1.1.2
+│   ├── wry 0.55.1
+│   └── webkit2gtk 2.0.2
+├── gtk 0.18.2
+├── gio 0.18.4
+│   ├── webkit2gtk 2.0.2
+│   ├── soup3 0.5.0
+│   ├── pango 0.18.3
+│   ├── gtk 0.18.2
+│   ├── gdkx11 0.18.2
+│   ├── gdk-pixbuf 0.18.5
+│   │   ├── gtk 0.18.2
+│   │   └── gdk 0.18.2
+│   └── gdk 0.18.2
+├── gdkx11 0.18.2
+├── gdk-pixbuf 0.18.5
+├── gdk 0.18.2
+├── cairo-rs 0.18.5
+│   ├── webkit2gtk 2.0.2
+│   ├── gtk 0.18.2
+│   └── gdk 0.18.2
+└── atk 0.18.2
+    └── gtk 0.18.2
+
+Crate:     rand
+Version:   0.7.3
+Warning:   unsound
+Title:     Rand is unsound with a custom logger using `rand::rng()`
+Date:      2026-04-09
+ID:        RUSTSEC-2026-0097
+URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097
+Dependency tree:
+rand 0.7.3
+└── phf_generator 0.8.0
+    └── phf_codegen 0.8.0
+        └── selectors 0.24.0
+            └── kuchikiki 0.8.8-speedreader
+                └── tauri-utils 2.9.1
+                    ├── tauri-runtime-wry 2.11.1
+                    │   └── tauri 2.11.1
+                    │       ├── tauri-plugin-shell 2.3.5
+                    │       │   └── allaganeye-gui 0.2.0
+                    │       ├── tauri-plugin-fs 2.5.1
+                    │       │   ├── tauri-plugin-dialog 2.7.1
+                    │       │   │   └── allaganeye-gui 0.2.0
+                    │       │   └── allaganeye-gui 0.2.0
+                    │       ├── tauri-plugin-dialog 2.7.1
+                    │       └── allaganeye-gui 0.2.0
+                    ├── tauri-runtime 2.11.1
+                    │   ├── tauri-runtime-wry 2.11.1
+                    │   └── tauri 2.11.1
+                    ├── tauri-plugin-fs 2.5.1
+                    ├── tauri-plugin 2.5.4
+                    │   ├── tauri-plugin-shell 2.3.5
+                    │   ├── tauri-plugin-fs 2.5.1
+                    │   └── tauri-plugin-dialog 2.7.1
+                    ├── tauri-macros 2.6.1
+                    │   └── tauri 2.11.1
+                    ├── tauri-codegen 2.6.1
+                    │   └── tauri-macros 2.6.1
+                    ├── tauri-build 2.6.1
+                    │   ├── tauri 2.11.1
+                    │   └── allaganeye-gui 0.2.0
+                    └── tauri 2.11.1
+
+warning: 19 allowed warnings found
+exit=0
+# npm audit report
+
+ajv  7.0.0-alpha.0 - 8.17.1
+Severity: moderate
+ajv has ReDoS when using `$data` option - https://github.com/advisories/GHSA-2g4f-4pwh-qvx6
+fix available via `npm audit fix --force`
+Will install ajv@8.20.0, which is outside the stated dependency range
+node_modules/ajv
+
+1 moderate severity vulnerability
+
+To address all issues, run:
+  npm audit fix --force
+npm exit=1

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -30,6 +30,7 @@
         "ajv-formats": "3.0.1",
         "eslint": "10.2.1",
         "eslint-plugin-react-hooks": "7.1.1",
+        "fast-uri": "^3.1.2",
         "globals": "17.5.0",
         "jest-axe": "10.0.0",
         "jsdom": "29.0.2",
@@ -2593,7 +2594,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "allaganeye-gui",
       "version": "0.2.0",
       "dependencies": {
-        "@tauri-apps/plugin-dialog": "2.7.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "zod": "4.3.6",
@@ -16,8 +16,8 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@tauri-apps/api": "2.10.1",
-        "@tauri-apps/cli": "2.10.1",
+        "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/cli": "^2.11.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
@@ -1119,7 +1119,9 @@
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1127,7 +1129,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.10.1",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.1.tgz",
+      "integrity": "sha512-rpEbaJ/HzNb6fwsquwoAbq29/Vt4gADhS423A8fdkwL4edJ0wZmoB8ar7O6JPDL834MUKOCm/rrJ7c9oAaEaYQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -1141,23 +1145,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.10.1",
-        "@tauri-apps/cli-darwin-x64": "2.10.1",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
+        "@tauri-apps/cli-darwin-arm64": "2.11.1",
+        "@tauri-apps/cli-darwin-x64": "2.11.1",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.1",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.1",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.1",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.1",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.1",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.1"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.1.tgz",
+      "integrity": "sha512-6eEKMBXsQPCuM1EmvrjT2+aBuxWQuFdKdW8pzNuNQtpq45nEEpBlD5gr8pUeAyOU1DQKlkFaEc/MPBxb/Pfjtg==",
       "cpu": [
         "arm64"
       ],
@@ -1172,9 +1176,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.1.tgz",
+      "integrity": "sha512-LQUO7exfRWjWALNhetph5guWpMeHphRpokOLk0OIbTTExaNwJNFu3I4vb+CCM/4G/QGoZe/5XikZOJdNEFP1ig==",
       "cpu": [
         "x64"
       ],
@@ -1189,9 +1193,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.1.tgz",
+      "integrity": "sha512-5i/awiBCRRhOUG8yjn0fMHXIWD5Ez8eEk5LtvOxyQrKuJkRaZDvnbIjZbE183blAwkoA4xN3aO/prJiqscl02Q==",
       "cpu": [
         "arm"
       ],
@@ -1206,9 +1210,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.1.tgz",
+      "integrity": "sha512-9LrwDw3S9Fygtw/Q6WDhOP+3svJRGAsejeE+GKrc0eO1ThMVhwi2LL6hw4dlKw93IfS7VY1G19sWGxJ/NcU4nA==",
       "cpu": [
         "arm64"
       ],
@@ -1226,9 +1230,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.1.tgz",
+      "integrity": "sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==",
       "cpu": [
         "arm64"
       ],
@@ -1246,9 +1250,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.1.tgz",
+      "integrity": "sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1266,9 +1270,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.1.tgz",
+      "integrity": "sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==",
       "cpu": [
         "x64"
       ],
@@ -1286,9 +1290,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.1.tgz",
+      "integrity": "sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==",
       "cpu": [
         "x64"
       ],
@@ -1306,9 +1310,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.1.tgz",
+      "integrity": "sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==",
       "cpu": [
         "arm64"
       ],
@@ -1323,9 +1327,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.1.tgz",
+      "integrity": "sha512-VBGkuH0eB9K9LLSMv361Gzr5Ou72sCS4+ztpmkWEQ+wd/amhcYOsf3X6qn1RJZDzIhiOYHJEOysZUC3baD01rA==",
       "cpu": [
         "ia32"
       ],
@@ -1340,7 +1344,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.10.1",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.1.tgz",
+      "integrity": "sha512-b3ORhIAKgp9ZYY+zBt7b7r0kLU2kjvyGF0+MS2SBym3emsweGPybEqocJcmtMuxyBhkOKHP4CiuEJEDuAlTx6A==",
       "cpu": [
         "x64"
       ],
@@ -1355,10 +1361,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.7.0",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -15,7 +15,7 @@
     "generate-types": "node scripts/generate-ts.mjs"
   },
   "dependencies": {
-    "@tauri-apps/plugin-dialog": "2.7.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "zod": "4.3.6",
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@tauri-apps/api": "2.10.1",
-    "@tauri-apps/cli": "2.10.1",
+    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/cli": "^2.11.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",

--- a/gui/package.json
+++ b/gui/package.json
@@ -37,6 +37,7 @@
     "ajv-formats": "3.0.1",
     "eslint": "10.2.1",
     "eslint-plugin-react-hooks": "7.1.1",
+    "fast-uri": "^3.1.2",
     "globals": "17.5.0",
     "jest-axe": "10.0.0",
     "jsdom": "29.0.2",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2417,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3878,9 +3878,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -3896,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
@@ -3914,7 +3914,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
 ]
 
@@ -4023,7 +4023,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4048,7 +4048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -4222,6 +4222,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -553,13 +553,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -593,6 +599,17 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -667,7 +684,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -756,6 +773,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,7 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1503,7 +1535,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1522,7 +1554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1874,6 +1906,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2040,7 +2081,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2060,12 +2101,6 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2158,6 +2193,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2235,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2260,8 +2348,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2310,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2399,7 +2506,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -2500,19 +2606,6 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
@@ -2592,6 +2685,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2975,7 +3081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3389,7 +3495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3584,15 +3690,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.8"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -3603,13 +3710,14 @@ dependencies = [
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -3639,9 +3747,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3691,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3707,22 +3815,21 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -3740,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3834,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -3859,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
@@ -3885,14 +3992,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
  "html5ever 0.29.1",
@@ -3902,7 +4010,8 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -3939,10 +4048,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4271,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -4285,7 +4394,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -4736,7 +4845,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5326,9 +5435,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.54.4"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -5,10 +5,10 @@ description = "Allagan Eye GUI shell (Tauri 2 + React)"
 edition = "2021"
 
 [build-dependencies]
-tauri-build = { version = "=2.5.6", features = [] }
+tauri-build = { version = "=2.6.1", features = [] }
 
 [dependencies]
-tauri = { version = "=2.10.3", features = ["protocol-asset"] }
+tauri = { version = "=2.11.1", features = ["protocol-asset"] }
 tauri-plugin-dialog = "=2.7.0"
 tauri-plugin-fs = "=2.5.0"
 tauri-plugin-shell = "=2.3.5"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -9,8 +9,8 @@ tauri-build = { version = "=2.6.1", features = [] }
 
 [dependencies]
 tauri = { version = "=2.11.1", features = ["protocol-asset"] }
-tauri-plugin-dialog = "=2.7.0"
-tauri-plugin-fs = "=2.5.0"
+tauri-plugin-dialog = "=2.7.1"
+tauri-plugin-fs = "=2.5.1"
 tauri-plugin-shell = "=2.3.5"
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"


### PR DESCRIPTION
## 概要

v0.2.1 patch Track A。Dependabot security alerts のうち 3 件 (#2 #3 #6) を解消、2 件 (#4 #5) は transitive 解決不可で deferred (配布物影響なし)。

## 解決 alert (3 件)

- #2 fast-uri high (GHSA-q3j6-qgpj-74h6, path traversal)
- #3 fast-uri high (GHSA-v39h-62p7-jpjc, host confusion)
- #6 tauri medium (GHSA-7gmj-67g7-phm9, Origin Confusion → Remote→Local IPC)

## Deferred alert (2 件、配布物影響なし)

- #4 glib medium (GHSA-wrw7-89jp-8q8g) — Linux/macOS GTK 依存、Windows ビルド未使用
- #5 rand low (GHSA-cq8v-f236-94qc) — phf_generator 0.8.0 build-dep 経由、runtime 不含

両者とも tauri 2.11.1 + kuchikiki 0.8.8-speedreader chain で strict pin (rand "^0.7" / glib 0.18.5) されており、cargo update --precise fail。tauri 上流が phf_generator / kuchikiki を新版へ移行するのを待つ (Idios 2026-05-16 判断)。

## 含まれる commits

- c687605 A-1: fast-uri 3.1.0 → 3.1.2 (devDeps direct pin)
- 90bbb76 A-2: tauri 2.10.3 → 2.11.1 + tauri-build 2.5.6 → 2.6.1
- a93555a A-3: tauri-plugin-dialog 2.7.0 → 2.7.1, tauri-plugin-fs 2.5.0 → 2.5.1
- 46a5d56 A-4: rand 0.7.3 / glib 0.18.5 deferred memo (empty commit)
- 3f0d8fe A-5: cargo audit + npm audit local log (docs/audit-logs/2026-05-16-v0.2.1-audit.log)

## Refs

- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §4 Track A
- Plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-a-security-alerts.md`
- 元 Dependabot PR: #758 (本 PR マージ後 auto-close 期待、ただし fast-uri 3.1.2 が direct pin として package.json に追加されたため Dependabot による rebase 状況次第)

## Self-Test Report

machine-verified:
- [x] cd gui && npm run lint / typecheck / test / build (test 728 件全 pass)
- [x] cd gui/src-tauri && cargo check (39.41s pass) / cargo test (2 passed, 1 ignored)
- [x] cargo audit: exit=0 (0 vulnerabilities, 19 allowed warnings = deferred)
- [x] npm audit: exit=1 (1 moderate: ajv ReDoS GHSA-2g4f-4pwh-qvx6、dev-only、Dependabot 未 alert、Track A scope 外)

machine-unverifiable:
- Idios 実機検証 (Iron Law 6): Tauri GUI 起動 + golden path (drop → detecting → complete → preview → export) + H.264 encoder selection + recent.json load。全項目 Pass を Idios 確認済 (2026-05-16)。

## Notes

- 配布物 (Portable ZIP の `allaganeye-gui.exe`) に直接効く脆弱性 #6 (tauri Origin Confusion) を解消
- fast-uri は元 spec/plan の「ajv 経由 transitive のみ」想定だったが、npm install --package-lock-only の behavior 制約により package.json devDependencies に "fast-uri": "^3.1.2" を direct pin で追加した (Idios 承認、回帰防止目的)
- alert #4 #5 は配布物影響なし (Windows .exe 不含 or build-dep のみ)、tauri 上流 patch まで deferred
- ajv moderate (npm audit で発見) は Track A scope 外として deferred (follow-up issue 起票候補)
- Track C (CI security-audit.yml) で `cargo audit --deny warnings` を予定したが、19 件の deferred warnings (unmaintained / unsound) があるため、Plan C 実行時に設定見直し要 (default の `cargo audit` = warnings allowed, vulnerabilities only fail)
