### PR TITLE
fix(template): v0.2.1 Track B-4 — bug_report.yml link を main に更新 (Refs #458) [crazy-swirles-bed20b]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
         <!-- ErrorModal 連動 note (Group D #669 マージで rendered 化、それまで外部 reporter には非表示):
         ErrorModal の `[GitHub Issue を作成]` ボタンを使うと一部項目 (実際の動作 / 環境情報 / ログファイル) が自動入力されます。 -->
 
-        詳細は [`docs/bug-report-guide.md`](../../blob/develop-0.2.0/docs/bug-report-guide.md) を参照してください (公開までしばらくお待ちください)。
+        詳細は [`docs/bug-report-guide.md`](../../blob/main/docs/bug-report-guide.md) を参照してください。
 
   - type: textarea
     id: reproduction


### PR DESCRIPTION
## 概要

v0.2.1 patch Track B-4。`.github/ISSUE_TEMPLATE/bug_report.yml` の `docs/bug-report-guide.md` リンクを `develop-0.2.0` から `main` に更新し、「(公開までしばらくお待ちください)」placeholder を削除。

## 背景

v0.2.0 リリース (PR #757 merged、2026-05-16) で `docs/bug-report-guide.md` が main で公開済になったが、bug_report.yml の link は `develop-0.2.0` を指したままだった。外部ユーザーが Issue Forms 経由でバグ報告する際、リンク先が古い branch を参照する状態。

## 修正内容

`.github/ISSUE_TEMPLATE/bug_report.yml:18`:

```diff
-        詳細は [`docs/bug-report-guide.md`](../../blob/develop-0.2.0/docs/bug-report-guide.md) を参照してください (公開までしばらくお待ちください)。
+        詳細は [`docs/bug-report-guide.md`](../../blob/main/docs/bug-report-guide.md) を参照してください。
```

## Refs

- Issue: #458 (L3 初期残作業の一部)
- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §4 Track B-4

## #458 受け入れ条件 (本 PR 完了分)

- [x] `.github/ISSUE_TEMPLATE/bug_report.yml` の link が `main` を指す
- [x] 「(公開までしばらくお待ちください)」placeholder 削除

### 別途 Idios 実機検証 (UI 動作確認、本 PR マージ後)

- [ ] `https://github.com/Idios/kobutachan-allaganeye/issues/new/choose` で「[bug] バグ報告」テンプレ表示
- [ ] Markdown 冒頭案内 + textarea 4 件 + checkbox 2 件 が正しくレンダリング
- [ ] `docs/bug-report-guide.md` link が main を 200 で開く
- [ ] 必須 textarea (3 件) + checkbox 未入力時に submit block
- [ ] submit 成功時に title prefix `[bug] ` + labels `bug` + assignees `Idios` が自動付与
- [ ] blank issue 経路が引き続き機能

## Self-Test Report

machine-verified:
- [x] yaml syntax check (`python -c "import yaml; yaml.safe_load(..., encoding='utf-8')"` exit=0)
- [x] git diff = 1 行のみの最小変更 (link path + placeholder 削除)

machine-unverifiable:
- GitHub Issue UI での実際の表示確認 (上記「別途 Idios 実機検証」)
- 本 PR は light scope のため Iron Law 6 の実機検証は GitHub Web UI レベルのみ (Tauri / Python 影響なし)
