### PR TITLE
docs: v0.2.1 Track B-1 — design-overview metadata example の stale note 削除 (Refs #374) [crazy-swirles-bed20b]

### DIFF
--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -108,7 +108,6 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
   "source": "2026-01-20 22-33-17.mkv",
   "source_duration": 7303.0,
   "source_duration_display": "2:01:43",
-  "note": "Split times are approximate due to keyframe-aligned copy mode. ...",
   "detected_at": "2026-04-19T12:34:56Z",
   "detection_params": {
     "sample_interval": 2.0,


### PR DESCRIPTION
## 概要

v0.2.1 Track B-1 として、`docs/design-overview.md:111` の metadata.json example で残っていた stale な note 行を削除する。

## 背景 (scope 縮小判断)

元 spec ([2026-05-16-security-alerts-response-design.md §6 Track B-1](../blob/develop-0.2.1/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md#track-b-1-374-metadata-note-codec-不正確)) では `allaganeye/commands/split_matches.py` の `_split_and_write_metadata` 内 note 文字列定義を「案 2 (codec 依存定数の削除)」で更新する想定だったが、実装確認の結果:

- 実コードの `note` field は **#463 (PR で note retired)** で既に削除済 ([split_matches.py:1241](../blob/develop-0.2.1/allaganeye/commands/split_matches.py#L1241) コメント `#463: ``note`` field retired; caveats documented in docs/cli-spec.md and docs/metadata-spec.md instead of being embedded in the payload` 参照)
- pytest test も既に `"note" not in payload` 検証で retired 状態を確認 ([test_split_from_metadata.py:213](../blob/develop-0.2.1/tests/test_split_from_metadata.py#L213), [:282](../blob/develop-0.2.1/tests/test_split_from_metadata.py#L282), [test_detect.py:59](../blob/develop-0.2.1/tests/test_detect.py#L59))
- 残っていたのは `docs/design-overview.md:111` の example JSON 内 stale 文言のみ

→ #374 で報告された codec 依存定数 (`typically 2s for OBS recordings`) の不正確問題は #463 で実質解決済、本 PR は docs example の整合化のみで完全解消する。

## 変更内容

- [docs/design-overview.md:111](../blob/claude/issue-374-codec-note/docs/design-overview.md#L111) から `\"note\": \"Split times are approximate due to keyframe-aligned copy mode. ...\",` 行を削除

## Self-Test Report

### machine-verified

- [x] markdownlint (`bash scripts/check-markdownlint.sh`): 220 file(s), 0 error(s)
- [x] git diff stat: 1 file changed, 1 deletion(-)
- [x] PR Pre-flight Step 0 (open): `gh pr list --search \"374\" --state open` → 0 件
- [x] PR Pre-flight Step 2 (base 同期): `git log HEAD..origin/develop-0.2.1` → 空 (同期完了)
- [x] PR Pre-flight Step 4 (all): `gh pr list --search \"374\" --state all` → 直接 #374 を扱う過去 PR なし
- [x] Python: docs 変更のみのため Python lint/test は対象外 (Iron Law 6 path 判定で skip)
- [x] GUI: 該当 path 変更なしのため skip
- [x] Rust: 該当 path 変更なしのため skip
- [x] 実機検証: docs 変更のみのため不要 (Iron Law 6 実機検証 trigger に該当せず)

### 受け入れ条件 (#374、Iron Law 1)

- [x] metadata.json の note から codec 依存定数 (`typically 2s for OBS recordings`) が削除され、AV1 サンプルで誤情報なし確認
  - 実コード note は #463 で完全削除済、本 PR で docs example の stale 文言も削除し整合完了
  - AV1 サンプルで note field が出力されないこと: [test_split_from_metadata.py:213/282](../blob/develop-0.2.1/tests/test_split_from_metadata.py) で codec 不問の `"note" not in payload` assertion により検証済

## 関連

- 元 issue: [#374](https://github.com/Idios/kobutachan-allaganeye/issues/374) ([bug] metadata.json の note 文言が AV1 等の codec で不正確)
- 実コード note 削除 PR: #463 (#586 で metadata schema 整理)
- spec: [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md §6 Track B-1](../blob/develop-0.2.1/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md)

Refs #374