### PR TITLE
docs: v0.2.1 Track B-3 — Portable ZIP README.txt を日本語化 (Refs #749) [crazy-swirles-bed20b]

### DIFF
--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -205,20 +205,20 @@ function Format-ReadmeContent {
   $guiSection = if ($IncludeGui) {
 @'
 
-### Easiest: double-click `allaganeye.bat`
+### 最も簡単: `allaganeye.bat` をダブルクリック
 
-Double-click `allaganeye.bat` in this folder to launch the GUI
-(`allaganeye-gui.exe`). The GUI lets you drop a video file, review detected
-matches, fine-tune match boundaries, and export each match as MP4.
+このフォルダの `allaganeye.bat` をダブルクリックすると GUI
+(`allaganeye-gui.exe`) が起動します。GUI に動画ファイルをドロップして、
+検出された試合を確認・微調整し、各試合を MP4 でエクスポートできます。
 
-NOTE: The GUI requires Microsoft Edge WebView2 Runtime, which is preinstalled
-on Windows 11 and recent Windows 10 builds. If the GUI fails to start with a
-missing-runtime dialog, install it from:
+NOTE: GUI は Microsoft Edge WebView2 Runtime を必要とします (Windows 11 と
+最近の Windows 10 にはプリインストール済み)。GUI が起動せず runtime missing
+のダイアログが出た場合は以下からインストールしてください:
 
     https://developer.microsoft.com/en-us/microsoft-edge/webview2/
 
-(`Evergreen Standalone Installer` is sufficient and does not require admin
-rights for per-user install.)
+(`Evergreen Standalone Installer` で十分。管理者権限なしで per-user
+インストール可能です。)
 
 '@
   }
@@ -234,45 +234,45 @@ rights for per-user install.)
   else { '' }
 
   return @"
-# allaganeye v$Version (Portable ZIP for Windows)
+# allaganeye v$Version (Windows 向け Portable ZIP)
 
-Python 3.11 and FFmpeg LGPL binaries are bundled alongside allaganeye.
+allaganeye と一緒に Python 3.11 と FFmpeg LGPL バイナリが同梱されています。
 
-## Usage
+## 使い方
 $guiSection
-### Drag-and-drop a video file
+### 動画ファイルをドラッグ＆ドロップ
 
-Drop a video file (.mkv / .mp4 / .avi / .mov) onto ``allaganeye.bat`` and it
-will split the video automatically. The command window stays open at the end so
-you can read the result -- press any key to close it.
+動画ファイル (.mkv / .mp4 / .avi / .mov) を ``allaganeye.bat`` にドロップすると、
+自動で試合分割が始まります。処理結果を確認できるようにコマンドウィンドウは
+終了後も開いたままになります -- 何かキーを押すと閉じます。
 
-Output MP4 files and metadata.json land under ``output\`` inside this folder.
+出力された MP4 と metadata.json はこのフォルダ内の ``output\`` に保存されます。
 
-### From a Command Prompt
+### コマンドプロンプトから実行
 
-If you want to pass options such as --dry-run or -o, open a Command Prompt in
-this folder and run:
+--dry-run や -o などのオプションを指定したい場合は、このフォルダで
+コマンドプロンプトを開き、以下のように実行してください:
 
     allaganeye.bat split "C:\path\to\video.mkv"
     allaganeye.bat split "C:\path\to\video.mkv" --dry-run
     allaganeye.bat --version
 
-See https://github.com/Idios/kobutachan-allaganeye for full documentation.
+詳細なドキュメントは https://github.com/Idios/kobutachan-allaganeye を参照してください。
 
-## Licenses
+## ライセンス
 
-- allaganeye: MIT (see the repository LICENSE file)
+- allaganeye: MIT (リポジトリの LICENSE ファイル参照)
 $guiLicenseLine- Python: PSF License (python\LICENSE.txt)
-- FFmpeg: LGPLv3 (full text in ffmpeg\LICENSE.txt)
+- FFmpeg: LGPLv3 (全文は ffmpeg\LICENSE.txt)
     Build:         ffmpeg n$FFmpegVersion win64-lgpl-shared build (BtbN/FFmpeg-Builds)
     Build tag:     $FFmpegBuildTag
     Source:        https://git.ffmpeg.org/ffmpeg.git (ref $FFmpegSourceRef)
     Build scripts: https://github.com/BtbN/FFmpeg-Builds
 
-allaganeye (MIT) invokes the FFmpeg binary as a separate subprocess only.
-The shared-build DLLs are loaded dynamically by the FFmpeg executables and are
-redistributed under LGPLv3 alongside the license text; LGPLv3 therefore does
-not apply to allaganeye itself.
+allaganeye (MIT) は FFmpeg バイナリを独立したサブプロセスとして呼び出すのみです。
+shared-build DLLs は FFmpeg 実行ファイルが動的にロードし、LGPLv3 のライセンス本文と
+ともに LGPLv3 のもとで再配布しています。したがって LGPLv3 は allaganeye 本体には
+適用されません。
 "@
 }
 

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -193,7 +193,7 @@ function Format-ReadmeContent {
   usage entry, followed by drag-drop and Command Prompt sections (#617). The
   WebView2 Runtime dependency note moves into this section. -IncludeGui:$false
   (default, CLI-only ZIP) keeps drag-drop as the first usage entry without any
-  GUI references. README body is Japanese since #749 (see PR #767).
+  GUI references. README body is Japanese since #749 (see PR #768).
   #>
   param(
     [Parameter(Mandatory = $true)][string]$Version,
@@ -291,7 +291,7 @@ function Get-LauncherTemplate {
   non-existent exe. Symmetric with Format-ReadmeContent -IncludeGui (#570).
 
   Launcher help text intentionally stays English (cmd.exe + CP932 console can
-  garble multi-byte glyphs); README.txt body is Japanese as of #749 (PR #767).
+  garble multi-byte glyphs); README.txt body is Japanese as of #749 (PR #768).
 
   Branch order in the template (top-down, first match wins, #617):
     1. --help / -h / /?               -> :show_help (explicit help flags always reach help)

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -189,11 +189,11 @@ function Format-ReadmeContent {
   present without running a full build.
 
   -IncludeGui:$true (when the Tauri-built `allaganeye-gui.exe` is bundled, #570)
-  emits a "Easiest: double-click `allaganeye.bat`" section as the FIRST usage
-  entry, followed by drag-drop and Command Prompt sections (#617). The WebView2
-  Runtime dependency note moves into this section. -IncludeGui:$false (default,
-  CLI-only ZIP) keeps drag-drop as the first usage entry without any GUI
-  references.
+  emits a "最も簡単: `allaganeye.bat` をダブルクリック" section as the FIRST
+  usage entry, followed by drag-drop and Command Prompt sections (#617). The
+  WebView2 Runtime dependency note moves into this section. -IncludeGui:$false
+  (default, CLI-only ZIP) keeps drag-drop as the first usage entry without any
+  GUI references. README body is Japanese since #749 (see PR #767).
   #>
   param(
     [Parameter(Mandatory = $true)][string]$Version,
@@ -289,6 +289,9 @@ function Get-LauncherTemplate {
   text that mentions ".bat double-click -> GUI" as the primary entry. -IncludeGui:$false
   (default, CLI-only ZIP) omits the GUI mention so users are not directed to a
   non-existent exe. Symmetric with Format-ReadmeContent -IncludeGui (#570).
+
+  Launcher help text intentionally stays English (cmd.exe + CP932 console can
+  garble multi-byte glyphs); README.txt body is Japanese as of #749 (PR #767).
 
   Branch order in the template (top-down, first match wins, #617):
     1. --help / -h / /?               -> :show_help (explicit help flags always reach help)

--- a/scripts/tests/build-portable-zip.Tests.ps1
+++ b/scripts/tests/build-portable-zip.Tests.ps1
@@ -160,7 +160,7 @@ Describe 'Format-ReadmeContent' {
       -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
       -FFmpegSourceRef '7f5c90f77e' `
       -IncludeGui:$true
-    $readme | Should -Match 'double-click'
+    $readme | Should -Match 'ダブルクリック'
     $readme | Should -Match 'WebView2 Runtime'
     $readme | Should -Match 'developer\.microsoft\.com'
   }
@@ -210,31 +210,32 @@ Describe 'Format-ReadmeContent' {
 
   It '-IncludeGui:$true README documents .bat double-click as the primary GUI entry (#617)' {
     # README must explain that `.bat` double-click launches the GUI when
-    # GUI exe is bundled. The phrase "Double-click" + "allaganeye.bat" must
+    # GUI exe is bundled. The phrase "ダブルクリック" + "allaganeye.bat" must
     # appear together so the new UX (issue #617) is documented for users
-    # who read README.txt before running anything.
+    # who read README.txt before running anything. README は #749 で日本語化済み。
     $readme = Format-ReadmeContent `
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
       -FFmpegBuildTag 'autobuild-2026-05-06-13-32' `
       -FFmpegSourceRef 'n8.1.1' `
       -IncludeGui:$true
-    $readme | Should -Match 'Double-click `?allaganeye\.bat`?'
+    $readme | Should -Match '`allaganeye\.bat`.*ダブルクリック'
   }
 
   It '-IncludeGui:$true README orders GUI section before drag-drop and Command Prompt sections (#617)' {
     # Per spec §3 + issue #617 doc requirement: ".bat double-click → GUI"
     # comes first, drag-drop and Command Prompt are 2-3.
     # We assert relative ordering by comparing IndexOf positions.
+    # README は #749 で日本語化済みのため IndexOf 検索キーも日本語化。
     $readme = Format-ReadmeContent `
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
       -FFmpegBuildTag 'autobuild-2026-05-06-13-32' `
       -FFmpegSourceRef 'n8.1.1' `
       -IncludeGui:$true
-    $idxBatDoubleClick = $readme.IndexOf('Double-click')
-    $idxDragDrop = $readme.IndexOf('Drop a video file')
-    $idxCommandPrompt = $readme.IndexOf('Command Prompt')
+    $idxBatDoubleClick = $readme.IndexOf('最も簡単')
+    $idxDragDrop = $readme.IndexOf('ドラッグ＆ドロップ')
+    $idxCommandPrompt = $readme.IndexOf('コマンドプロンプトから実行')
 
     $idxBatDoubleClick | Should -BeGreaterThan -1
     $idxDragDrop | Should -BeGreaterThan -1


### PR DESCRIPTION
## 概要

v0.2.1 Track B-3 として、Portable ZIP に同梱される `README.txt` を**日本語化**する。

ターゲットユーザー (日本語話者中心の FF14 FL プレイヤー) が Portable ZIP 展開後最初に目にする README が英語のままだったため、`docs/quickstart.md` と同じスタイルで日本語化する (#106 残タスク、#749 で改めて起票)。

## 変更内容

### `scripts/build-portable-zip.ps1` Format-ReadmeContent (line 185-277)

- Title: `Portable ZIP for Windows` → `Windows 向け Portable ZIP`
- セクション見出し:
  - `## Usage` → `## 使い方`
  - `### Easiest: double-click \`allaganeye.bat\`` → `### 最も簡単: \`allaganeye.bat\` をダブルクリック`
  - `### Drag-and-drop a video file` → `### 動画ファイルをドラッグ＆ドロップ`
  - `### From a Command Prompt` → `### コマンドプロンプトから実行`
  - `## Licenses` → `## ライセンス`
- 本文 (intro / GUI launch / WebView2 install / drag-drop / command prompt / LGPLv3 shared-build explanation) を日本語化
- **法的固有名詞は原文保持**: `LGPLv3`, `MIT`, `PSF License`, `BtbN/FFmpeg-Builds`, `WebView2 Runtime`, `Microsoft Edge WebView2 Runtime`, `Evergreen Standalone Installer`, `Allagan Eye GUI`, `Tauri 2.x + React 19`, build tag / commit hash / 全 URL / `$FFmpegVersion`等 interpolation
- スタイル参考: [docs/quickstart.md](../blob/develop-0.2.1/docs/quickstart.md) の「ダブルクリック」「ドラッグ＆ドロップ」「コマンドプロンプト」表現

### `scripts/tests/build-portable-zip.Tests.ps1` Describe 'Format-ReadmeContent' (line 133-245)

- Line 163: `'double-click'` → `'ダブルクリック'`
- Line 222: `'Double-click \`?allaganeye\.bat\`?'` → `'\`allaganeye\.bat\`.*ダブルクリック'` (\`allaganeye.bat\` と「ダブルクリック」が併記される #617 の意図を保持)
- Line 235-237 IndexOf section ordering test: `'Double-click'` → `'最も簡単'`, `'Drop a video file'` → `'ドラッグ＆ドロップ'`, `'Command Prompt'` → `'コマンドプロンプトから実行'`
- 他 Describe ブロック (`Get-LauncherTemplate`, `Invoke-Download`, `Assert-FFmpegLayout`, `Get-FFmpegSourceRef`, `New-IntegrityManifest`, `Script parameters`, `GetPip pinning (#681)`, `File encoding (#704)`, `BtbN pinning policy (#705)`, `Integrity manifest encoding (#729)`) は**未変更** (scope 外)
- 法的引用 assertion (`LGPLv3` / `BtbN/FFmpeg-Builds` / `win64-lgpl-shared` / commit hash / build tag / `WebView2 Runtime` / `developer\.microsoft\.com` / `Allagan Eye GUI` / `Tauri 2` / `shared-build DLLs` 等) は原文保持

### Code review fix (commit 394cb3a)

- `Format-ReadmeContent` docstring (line 191-196): rendered 後の日本語見出しと整合 + #749 cross-ref
- `Get-LauncherTemplate` docstring (line 288-293): launcher .bat help text が英語維持 (cmd.exe + CP932 console multi-byte garble 回避) する設計理由を明記、README 本体は日本語 (#749) と cross-ref

## Self-Test Report

### machine-verified

- [x] PowerShell 5.1 (powershell.exe) dot-source parse: OK (Japanese 含む `.ps1` を BOM 経由で正常 parse)
- [x] Pester (PS 5.1 + Pester 5.7.1) full suite: **36/36 passed**, 0 failed, 0 skipped
  - Format-ReadmeContent: 7/7 pass (Japanese assertion 含む)
  - File encoding (#704): 2/2 pass (両ファイル BOM 維持)
  - 他 Describe ブロック (`Get-LauncherTemplate` / `Invoke-Download` / etc.): all green
- [x] BOM check: 両ファイル先頭 3 bytes が `EF BB BF` (UTF-8 BOM、PS 5.1 互換)
- [x] markdownlint: 本 PR では `.md` ファイル変更なしのため対象外
- [x] PR Pre-flight Step 0 (open): `gh pr list --search "749" --state open` → 0 件
- [x] PR Pre-flight Step 2 (base 同期): `git fetch origin develop-0.2.1` → HEAD 同期済
- [x] PR Pre-flight Step 4 (all): `gh pr list --search "749" --state all` → 直接 #749 を扱う過去 PR なし
- [x] Python / GUI / Rust: 該当 path 変更なしのため skip
- [x] commit: 2 件 (`64fea2d` 本実装 + `394cb3a` code review fix)

### machine-unverifiable (Idios 実機検証推奨、merge 後 Track D Release 前に併せて実施)

- Portable ZIP build (`pwsh ./scripts/build-portable-zip.ps1 -Version 0.2.1`) で生成された `README.txt` を Notepad で開いて日本語が正しく表示されること (Iron Law 6 実機検証 trigger)
  - 文字化け (CP932 / Shift-JIS misread) がないこと
  - section ordering (最も簡単 → ドラッグ＆ドロップ → コマンドプロンプト) が rendered output で保たれていること

### 受け入れ条件 (#749、Iron Law 1)

- [x] Portable ZIP `README.txt` の見出し・本文が日本語化されている (Format-ReadmeContent template で対応)
- [x] 法的引用 (license 名 / URL / 固有名詞) は原文保持
- [x] Pester assertion が日本語見出しに対応 (`Should -Match 'ダブルクリック'` 等で日本語見出しを verify)
- [ ] Pester assertion で日本語見出しの存在 assertion (実機 build で確認、merge 後 Idios 検証)

## Code Review

Code quality reviewer subagent によるレビュー: ✅ Approved (2 Important findings は本 PR 内で fix 済、commit `394cb3a`)

- Translation quality: natural、`docs/quickstart.md` 表現に準拠
- 法的引用保持: complete
- Pester 更新が original intent を保持
- BOM 維持
- Scope discipline (他 Describe block / 他関数に未介入)

## 関連

- 元 issue: [#749](https://github.com/Idios/kobutachan-allaganeye/issues/749) ([doc] Portable ZIP 内 README.txt を日本語化 (#106 残タスク))
- 元 spec: [#106](https://github.com/Idios/kobutachan-allaganeye/issues/106) (v0.2.0 Portable ZIP 実装項目 #8 「非開発者向け `README.txt` (日本語)」未達分)
- spec: [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md §6 Track B-3](../blob/develop-0.2.1/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md)

Refs #749