### PR TITLE
ci: gui-rust 所要時間削減 (rust-cache warm-up + scope 絞り) (Refs #767)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,22 @@
 name: CI
 
 on:
+  # #767 -- main / develop-* への push でも CI を走らせて Swatinem/rust-cache の
+  # canonical キャッシュを生成する。pull_request only だと main / develop ブランチ
+  # 上で CI が走らないため GitHub Actions Cache 上に branch 由来のキャッシュが
+  # 存在せず、PR ごとに rust-cache が "No cache found." で毎回フルビルドしていた
+  # (gui-rust 228s)。push で warm された cache を PR が restore-key prefix
+  # fallback で継承することで incremental build (~30-60s) に短縮する。
+  push:
+    branches: [main, "develop-*"]
   pull_request:
     branches: [main, "develop-*"]
+
+concurrency:
+  # 同一 ref への連続 push は前 run を cancel して無駄を省く。ただし main /
+  # develop-* は cache warm-up が目的なので cancel しない (PR の場合のみ cancel)。
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   python:
@@ -150,7 +164,11 @@ jobs:
 
   gui-rust:
     runs-on: windows-latest
-    needs: gui-frontend
+    # #767 -- needs: gui-frontend を削除して並列実行可能に (~60s wall clock 短縮)。
+    # cargo test --lib は frontend assets (gui/dist) を参照しないため、
+    # gui-frontend の build artifact に依存する必要がない (lib test 内に
+    # include_dir! / include_str!(...dist) / frontendDist / AssetResolver の
+    # 使用が無いことを grep で確認済)。
     steps:
       - uses: actions/checkout@v4
 
@@ -170,14 +188,12 @@ jobs:
         working-directory: gui
         run: npm ci
 
-      - name: Download dist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: gui-dist
-          path: gui/dist
-
+      # #767 -- --no-default-features で default feature "custom-protocol"
+      # (tauri release-mode bundling 用) を無効化。lib test は custom_protocol /
+      # asset_resolver / AssetResolver を参照しないことを grep で確認済。
+      # build 時間短縮 + cargo dependency graph 縮小に寄与する。
       - name: Cargo test (lib)
-        run: cargo test --lib --manifest-path gui/src-tauri/Cargo.toml
+        run: cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml
 
   doc-tauri-commands-drift:
     runs-on: ubuntu-latest

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -4165,7 +4165,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -14,7 +14,17 @@ tauri-plugin-fs = "=2.5.1"
 tauri-plugin-shell = "=2.3.5"
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"
-tokio = { version = "=1.52.1", features = ["full"] }
+# #767 -- "full" feature set から実使用分のみに絞ってビルドコストを削減
+# (cargo dep graph 縮小)。grep で確認した実使用箇所:
+#   - rt-multi-thread: tokio::spawn / runtime
+#   - macros: #[tokio::test]
+#   - process: tokio::process::{Command, Child}
+#   - sync: tokio::sync::{Mutex, Semaphore, oneshot}
+#   - io-util: AsyncBufReadExt, BufReader
+#   - net: tokio::net::TcpListener (axum server bind)
+#   - time: tokio::time::{sleep, timeout}
+# bytes / fs / io-std / mio / parking_lot / signal / socket2 / tracing は未使用。
+tokio = { version = "=1.52.1", features = ["rt-multi-thread", "macros", "process", "sync", "io-util", "net", "time"] }
 tokio-util = { version = "=0.7.18", features = ["io"] }
 axum = { version = "=0.8.9", features = ["macros"] }
 tower-http = { version = "=0.6.8", features = ["fs"] }


### PR DESCRIPTION
## Summary

CI gui-rust ジョブの所要時間を 5m28s → 100s 以下に削減することを目的に、以下 4 つの最適化を 1 PR で適用:

- `push: branches: [main, "develop-*"]` トリガー追加 + `concurrency` 設定 (rust-cache を warm)
- gui-rust から `needs: gui-frontend` と `Download dist artifact` step を削除 (並列化、~60s wall clock 短縮)
- gui-rust の cargo test を `--no-default-features` に変更 (custom-protocol を test 時 off)
- `gui/src-tauri/Cargo.toml` の tokio features を `full` から実使用 7 features に絞り込み

根本原因 (rust-cache "No cache found." の理由) と検証データの詳細は #767 を参照。

## 受け入れ条件 (Iron Law 1 担保)

元 issue #767 の作業項目を逐条検証:

- [x] **`.github/workflows/ci.yml` に `push: branches: [main]` トリガーを追加** — `.github/workflows/ci.yml:10-11` で `push: branches: [main, "develop-*"]` を追加 (develop-* も含めて develop branch の cache warm を担保)。`concurrency` block (line 16-19) で PR の連続 push のみ cancel する設定を追加。
- [x] **gui-rust ジョブから `needs: gui-frontend` と `Download dist artifact` step を削除** — `needs: gui-frontend` 行を削除 + `Download dist artifact` step を削除。gui-rust が gui-frontend と並列実行可能になる。
- [x] **gui-rust の cargo test ステップが `cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml` に変更** — `.github/workflows/ci.yml:195` で確認。
- [x] **`gui/src-tauri/Cargo.toml` の tokio dependency が `features = ["full"]` から実使用 features のみに絞られている** — `gui/src-tauri/Cargo.toml:27` で `features = ["rt-multi-thread", "macros", "process", "sync", "io-util", "net", "time"]` に変更。Cargo.lock では tokio が parking_lot を pull しなくなった (1 行削除)。
- [x] **ローカルで `cd gui/src-tauri && cargo test --lib --no-default-features` が pass する** — 199 tests passed, 0 failed, 0.80s で完走 (本 PR 作成セッションで実走確認)。
- [ ] **PR マージ後、次回 PR の gui-rust 実行時間が短縮されていることを CI ログで確認 (目標: 328s → 100s 以下)** — マージ後の `develop-0.2.1` push CI が走り、次の PR が cache 継承するときに効果が実測される (本 PR では検証不能、マージ後検証項目)。

## Self-Test Report

### Machine-verified (ローカル実走済み)

- [x] `cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml`: 199 passed, 0 failed (0.80s)
- [x] `git diff --stat`: 3 files changed (ci.yml +24/-8, Cargo.toml +12/-1, Cargo.lock -1)
- [x] PR pre-flight: Step 0 (open PR for #767: 0 件) / Step 1 (`git fetch origin develop-0.2.1` 成功) / Step 2 (`git log HEAD..origin/develop-0.2.1` 0 件) / Step 4 (並行 PR 重複なし) すべて通過

### Machine-unverifiable

- 本 PR の CI run 自体で gui-rust 時間が短縮するわけではない (初回 push なので cache は依然 cold)。**マージ後の `develop-0.2.1` への push CI が走り、次の PR が cache 継承するときに効果が実測される。**
- ロジック変更なし (CI workflow + Rust deps の feature flags のみ) なので、GPU / audio / Tauri 起動の実機検証は本変更の影響範囲外。

## Test plan

- [x] ローカルで `cargo test --lib --no-default-features` を実走 → 199 pass
- [ ] 本 PR の CI 全 job が green (`gui-rust` 含む) → push 後に GitHub Actions で自動実行
- [ ] マージ後の `develop-0.2.1` への push CI run で rust-cache が "Cache saved" となることを確認
- [ ] 次の PR (develop-0.2.1 base) で gui-rust 所要時間が 100s 以下に短縮されることを確認

## スコープ外 (別 issue 候補)

- ubuntu-latest への gui-rust 移行 (Windows 配布ターゲットの coverage 議論が必要)
- sccache 等の compile cache 外部化

Refs #767
