### PR TITLE
ci(release): build-windows 所要時間削減 (rust-cache warm + npm ci) (Refs #770)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,35 @@
 name: Release
 
 on:
+  # #770 -- main / develop-* への push でも release CI を走らせて
+  # Swatinem/rust-cache の canonical キャッシュを生成する。pull_request + tags
+  # only だと main / develop ブランチ上で CI が走らないため GitHub Actions Cache
+  # 上に branch 由来のキャッシュが存在せず、build-windows の rust-cache が
+  # "No cache found." で毎回フルビルド (398s の tauri build)。push で warm された
+  # cache を PR が restore-key prefix fallback で継承することで incremental
+  # build (~30-60s) に短縮する。
+  #
+  # GitHub Actions の AND 仕様により paths filter は branch push と tag push の
+  # 両方に適用される。release tag commit は pyproject.toml の version bump 等を
+  # 含む (v0.2.0 実績で paths 対象を多数 touch) ため tag push 時の paths filter は
+  # 実用上問題ない。万一 paths にマッチしない tag commit が必要になった場合は
+  # workflow_dispatch で手動実行できる。
   push:
+    branches: [main, "develop-*"]
     tags:
       - 'v*.*.*'
+    paths:
+      - '.github/workflows/release.yml'
+      - 'scripts/build-portable-zip.ps1'
+      - 'scripts/extract_release_notes.py'
+      - 'pyproject.toml'
+      - 'gui/package.json'
+      - 'gui/package-lock.json'
+      - 'gui/src-tauri/**'
+      - 'gui/src/**'
+      - 'gui/index.html'
+      - 'gui/vite.config.ts'
+      - 'gui/tsconfig*.json'
   pull_request:
     paths:
       - '.github/workflows/release.yml'
@@ -82,9 +108,13 @@ jobs:
       # is copied as-is into the Portable ZIP payload by
       # scripts/build-portable-zip.ps1 at packaging time (no rename, the cargo
       # binary name without whitespace is used directly).
+      # #770 -- npm cache を有効化して `npm install` の registry fetch 時間を短縮
+      # (22s → ~10s)。gui-rust ジョブ (ci.yml) と同じ cache key で共有される。
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: gui/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -98,10 +128,13 @@ jobs:
           path: ${{ github.workspace }}/build-cache
           key: btbn-ffmpeg-win64-lgpl-shared-8.1-e27598e612078f25d3e9cf245ce5042990f2602146e5a6f8287b143b0dce0e95
 
+      # #770 -- npm install (lock loose) から npm ci (lock strict) に変更。
+      # release CI では package-lock.json と一致する厳密な再現を保証したい。
+      # npm cache (setup-node) と組み合わせて再現性向上 + 速度向上。
       - name: Install GUI dependencies (#570)
         shell: pwsh
         working-directory: gui
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
 
       - name: Build Tauri GUI binary (#570)
         shell: pwsh
@@ -258,7 +291,12 @@ jobs:
 
       # Upload the expanded payload folder; actions/upload-artifact zips it once
       # on its own, which avoids the previous "zip inside a zip" artifact.
+      #
+      # #770 -- main / develop-* への branch push は rust-cache warm-up が目的で
+      # release artifact は不要なため skip する。tag push (release tag) と
+      # pull_request (build 確認用) では従来通り upload する。
       - uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         with:
           name: allaganeye-windows-v${{ needs.version-check.outputs.version }}
           path: build/portable/allaganeye-v${{ needs.version-check.outputs.version }}


### PR DESCRIPTION
## Summary

release CI の `build-windows` ジョブ (windows-latest) の所要時間を 555s (9m15s) → 200s 以下に削減することを目的に、以下 4 つの最適化を 1 PR で適用:

- `push: branches: [main, "develop-*"]` を `on.push` に追加 (rust-cache を warm)
- `setup-node` に `cache: "npm"` + `cache-dependency-path: gui/package-lock.json` を追加
- `Install GUI dependencies` の `npm install --no-audit --no-fund` → `npm ci --no-audit --no-fund`
- `actions/upload-artifact@v4` に `if:` 条件追加 (main/develop branch push 時は skip)

根本原因 (rust-cache "No cache found." の理由) と検証データは #770 を参照。`gui-rust` #767 と同じ原因 / 同じ戦略の release.yml 版。

## 受け入れ条件 (Iron Law 1 担保)

元 issue #770 の作業項目を逐条検証:

- [x] **`.github/workflows/release.yml` の `on.push` に `branches: [main, "develop-*"]` を追加** — `release.yml:17-18` で `push.branches: [main, "develop-*"]` を追加。`tags: ['v*.*.*']` は維持。`paths` filter は branch push / tag push 双方に AND で適用される (GitHub Actions 仕様)。release tag commit は通常 pyproject.toml の version bump を含むため tag push 時の paths filter は実用上問題ない (v0.2.0 実績で `.github/workflows/release.yml` / `pyproject.toml` 等の paths 対象を多数 touch していることを確認)。万一 paths にマッチしない tag commit が必要になった場合は `workflow_dispatch` で手動実行できる。
- [x] **`setup-node@v4` に `cache: "npm"` と `cache-dependency-path: gui/package-lock.json` を追加** — `release.yml:101-105` で確認。gui-rust ジョブ (ci.yml) と同じ cache key で共有される。
- [x] **`Install GUI dependencies` step の `run` を `npm install --no-audit --no-fund` から `npm ci --no-audit --no-fund` に変更** — `release.yml:121` で確認。package-lock.json strict 遵守。
- [x] **`actions/upload-artifact@v4` step に branch push を skip する `if` 条件が設定されている** — `release.yml:283` で `if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))` を設定。tag push (release) と pull_request では従来通り upload、main / develop branch push (cache warm 目的) では skip。
- [x] **ローカルで `cd gui && npm ci --no-audit --no-fund` が成功する** — ローカル実走で `added 307 packages in 4s` で完走。
- [ ] **PR マージ後、次回 release CI 関連 PR の build-windows 所要時間が短縮されていることを確認 (目標: 555s → 200s 以下)** — マージ後の `develop-0.2.1` への push CI で cache warm-up 確認 → 次の release CI 関連 PR で実測 (本 PR では検証不能、マージ後検証項目)。

## Self-Test Report

### Machine-verified (ローカル実走済み)

- [x] `cd gui && npm ci --no-audit --no-fund`: 307 packages installed in 4s, 0 error
- [x] `git diff --stat`: 1 file changed (release.yml +39 -1)
- [x] PR pre-flight: Step 0 (open PR for #770: 0 件) / Step 1 (`git fetch origin develop-0.2.1` 成功) / Step 2 (`git log HEAD..origin/develop-0.2.1` 0 件) / Step 4 (並行 PR 重複なし、関連 merged PR は #555 #702 #615 で別 scope) すべて通過

### Machine-unverifiable

- 本 PR の CI run 自体で build-windows 時間が短縮するわけではない (初回 push なので cache は依然 cold)。**マージ後の `develop-0.2.1` への push CI で rust-cache が warm され、次の release CI 関連 PR で cache 継承の効果が実測される。**
- `on.push.paths` filter の tag push 時の挙動は GitHub Actions の AND 仕様に基づく。v0.2.0 実績で release tag commit が paths にマッチすることを確認済 (`gh show --name-only v0.2.0` で `.github/workflows/release.yml`, `pyproject.toml`, `gui/package.json` 等を含む)。
- ロジック変更なし (CI workflow + npm install フラグのみ) なので、GPU / audio / Tauri 起動の実機検証は本変更の影響範囲外。

## Test plan

- [x] ローカルで `npm ci --no-audit --no-fund` を実走 → 307 packages installed in 4s
- [ ] 本 PR の CI 全 job が green (`build-windows` 含む) → push 後に GitHub Actions で自動実行
- [ ] マージ後の `develop-0.2.1` への push で release CI が trigger され、build-windows の rust-cache が "Cache saved" となることを確認 (artifact は skip される設計)
- [ ] 次の release CI 関連 PR (develop-0.2.1 base) で build-windows 所要時間が 200s 以下に短縮されることを確認

## 課金影響

main / develop への push は merge 後 1 回のみ。1 日 1-2 回程度。windows-latest 9 min ≈ 月 60-120 min × 2x (windows 倍率) × $0.008/min ≈ $1/月の増。許容範囲。

## スコープ外 (別 issue 候補)

- build-windows と gui-rust の rust-cache 共有 (add-job-id-key 設計議論が必要)
- vite build cache (`node_modules/.vite`) の永続化

## 関連 PR

- #769 (gui-rust 所要時間削減、Refs #767) — 同じ rust-cache warm 戦略を ci.yml の gui-rust ジョブに適用。本 PR は release.yml の build-windows 版。

Refs #770
