### PR TITLE
fix(gui): v0.2.1 Track B-2 — Windows Job Object で detecting cancel 時の ffmpeg 子孫プロセス kill + audit doc (Refs #756 #743) [crazy-swirles-bed20b]

### DIFF
--- a/docs/process-tree-orphan-audit.md
+++ b/docs/process-tree-orphan-audit.md
@@ -13,7 +13,7 @@ L2a GUI (`gui/src-tauri/src/lib.rs`) は外部プロセスを 6 箇所で spawn 
 | 5 | **`start_detect` (`lib.rs:~2708`)** | Python `allaganeye detect` | **ffmpeg N 個 (GPU detector で 16-32、`gpu_detector.py`)** | **あり (#756 root cause)** | yes | **yes** | 本 PR の対応対象。`TrackedChild { child, job: Some(_) }` |
 | 6 | `open_folder_in_explorer` (`lib.rs:~1899`) | explorer.exe | (Windows shell process) | N/A (意図的 detach) | **no** | no | UI、本 app 終了後も残るべき |
 
-> 行番号は本 PR (#769) merge 時のスナップショット。将来の追記で drift しうるため、必ず関数名で grep して現在位置を確認すること。
+> 行番号は本 PR (#772) merge 時のスナップショット。将来の追記で drift しうるため、必ず関数名で grep して現在位置を確認すること。
 
 ## §2 #756 fix の挙動 (start_detect だけ Job 化)
 

--- a/docs/process-tree-orphan-audit.md
+++ b/docs/process-tree-orphan-audit.md
@@ -1,0 +1,100 @@
+# Windows process tree orphan audit (#743)
+
+L2a GUI (`gui/src-tauri/src/lib.rs`) は外部プロセスを 6 箇所で spawn する。本 audit はそれぞれの Windows process tree 振る舞いと孤児化リスクを整理し、#756 fix (Job Object 化) を `start_detect` のみに適用した理由を明示する。元 audit task は #743、修正実装は #756。
+
+## §1 spawn site 一覧
+
+| # | spawn site | spawn する process | 子孫プロセス | orphan risk | PROCESS_TRACKER 登録 | Job Object 適用 (#756) | 備考 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `probe_video_with` (`lib.rs:~638`) | ffprobe (単発) | なし | なし | no (`cmd.output()`、spawn+wait 一体) | no | 短命 metadata query。`output().await` ブロックで親と寿命同期 |
+| 2 | `ensure_thumbnail_exists` (`lib.rs:~1236`) | ffmpeg (単発) | なし | なし | no (`cmd.output()`) | no | サムネ生成、数百 ms 以内 |
+| 3 | `extract_brightness_window_impl` (`lib.rs:~1348`) | ffmpeg (単発) | なし | なし | no (`cmd.output()`) | no | preview brightness 抽出、~1s |
+| 4 | `run_ffmpeg_export_attempt` (`lib.rs:~2019`) | ffmpeg (単発) | なし | あり (中断時) | yes | no | export 1 本ずつ、`TrackedChild::no_job(child)` |
+| 5 | **`start_detect` (`lib.rs:~2651`)** | Python `allaganeye detect` | **ffmpeg N 個 (GPU detector で 16-32、`gpu_detector.py`)** | **あり (#756 root cause)** | yes | **yes** | 本 PR の対応対象。`TrackedChild { child, job: Some(_) }` |
+| 6 | `open_folder_in_explorer` (`lib.rs:~1859`) | explorer.exe | (Windows shell process) | N/A (意図的 detach) | **no** | no | UI、本 app 終了後も残るべき |
+
+## §2 #756 fix の挙動 (start_detect だけ Job 化)
+
+### 2.1 なぜ start_detect だけか
+
+`start_detect` は Python CLI (`allaganeye detect`) を spawn し、Python 側は GPU detection が有効な場合に内部で N 個 (16-32) の ffmpeg プロセスを並列 spawn する (`allaganeye/video/gpu_detector.py`)。Windows の `TerminateProcess` (= `tokio::process::Child::kill().await`) は **直接の子プロセスのみ kill** するため、Python だけが死んで ffmpeg 子孫は親なしの孤児として残留する (#756 root cause)。
+
+他 5 spawn site は:
+
+- **#1-#4 (ffmpeg / ffprobe 単発)**: 子孫を spawn しない。`Child::kill` で十分。
+- **#6 (explorer.exe)**: 「UI が GUI 終了後も残る」のが意図 (Idios の方針: 「展開 = インストール、削除 = アンインストール」)。Job 化すると Job Close で explorer も道連れに kill されてしまうため絶対に対象外。
+
+### 2.2 Job Object の効果
+
+`gui/src-tauri/src/process_util/job_object.rs` に [`ProcessJob`](../gui/src-tauri/src/process_util/job_object.rs) を実装。動作は以下:
+
+1. `CreateJobObjectW(None, None)` で名前なし Job を作成
+2. `SetInformationJobObject` で `JOBOBJECT_EXTENDED_LIMIT_INFORMATION.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` を設定
+3. `start_detect` の `cmd.spawn()` 直後に `AssignProcessToJobObject(job_handle, python_handle)` で Python CLI process を Job に追加
+4. `TrackedChild { child, job: Some(_) }` に Job handle を保持
+5. PROCESS_TRACKER 内で TrackedChild が生きている間 Job は維持される
+6. `kill_tracked_processes` が PROCESS_TRACKER を drain すると `TrackedChild` が drop され、`ProcessJob` も drop される
+7. `ProcessJob::drop` が `CloseHandle(job_handle)` を呼び、Windows kernel が `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` を発火して **assigned process と全 descendant を一括 kill**
+
+Python が spawn する ffmpeg は親プロセス (Python) の Job membership を継承するため、Python が Job に入っていれば ffmpeg も自動的に Job に入る (Windows カーネルの仕様、`JOB_OBJECT_LIMIT_BREAKAWAY_OK` を明示的に設定しない限り)。
+
+### 2.3 happy path (cancellation なし) での挙動
+
+検知が正常完了するケースでは:
+
+1. Python CLI が exit 0 で終わる → child の `wait().await` が `Ok(ExitStatus::success())` を返す
+2. `untrack_child(id).await` が `TrackedChild` から `child` を抽出して返却、同時に **`TrackedChild` (= Job 保持側) は drop**
+3. しかし Job 内のプロセス (Python) はすでに自然死しているため、Job の `KILL_ON_JOB_CLOSE` 発火は **no-op** (Job 内に kill 対象がいない)
+4. `CloseHandle(job_handle)` は kernel handle を release するだけ
+
+つまり Job Object 化による happy path への性能影響はゼロ。
+
+## §3 親 app crash 時の挙動
+
+`on_window_event(CloseRequested)` handler を通らずに親 Tauri app が異常終了するケース (panic / OS-side SIGKILL / electron-like crash):
+
+- Windows kernel は process termination 時に **そのプロセスが保持していた全 handle を release** する
+- `ProcessJob` の Job handle も release され、`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` が発火する
+- 結果: Tauri app が crash しても Python CLI + ffmpeg descendants は kernel 側で確実に reap される
+
+これは Job Object pattern が `taskkill /T /F /PID` 経由のソリューションより優れている主要因。`taskkill` は親 app が機能していないと呼ばれず、crash 時の cleanup を保証できない。
+
+## §4 検証手順 (実機テスト)
+
+以下は GUI build + 実機実行で確認すべき項目。CI は jsdom + cargo unit test なので React side wiring (`flow N` integration test) と Job API smoke test (`process_job_assign_real_child_drop_kills_it`) しか pin できない。
+
+1. `cd gui && npm run tauri dev` で開発ビルドを起動
+2. detecting 画面に到達 (動画 drop → [OK — 検知開始])
+3. Task Manager (詳細タブ) を開き、`python.exe` + `ffmpeg.exe` プロセスが N 個立ち上がるのを確認
+4. GUI のタイトルバー `×` を押下
+5. ConfirmExitModal で [終了] を押下
+6. Task Manager で:
+   - `python.exe` (allaganeye CLI) が **0 個** であること
+   - `ffmpeg.exe` (descendant) が **0 個** であること
+   - explorer.exe が引き続き稼働していること (open_folder_in_explorer で起動した shell が残る)
+
+### 4.1 障害シナリオ
+
+以下も検証推奨:
+
+- 検知中に Tauri app が panic (例: `dev_force_panic` Tauri command) → Task Manager で全プロセス消滅を確認
+- 検知中に CPU/Memory が極端に逼迫 → Job handle drop が問題なく走るか
+
+## §5 未対応 (deferred / out-of-scope)
+
+| 項目 | 状態 | 理由 |
+| --- | --- | --- |
+| `run_ffmpeg_export_attempt` の Job 化 | 不要 | ffmpeg 1 本のみ、子孫なし。`Child::kill` で十分 |
+| `taskkill /T /F /PID` fallback | 不要 | Job Object pattern が crash 時も含めてより確実 |
+| `JOB_OBJECT_LIMIT_BREAKAWAY_OK` を必要とする legitimate child の救済 | 該当なし | 現状 Python も ffmpeg も BREAKAWAY を要求しない |
+| Linux / macOS の同等対応 (`setpgid` + `kill -SIGTERM -<pgid>`) | 後回し | プロジェクト方針: 「対応プラットフォーム: Windows のみ」 |
+
+将来的に新規 ffmpeg spawn site を追加する場合は、子孫を spawn するか? を必ず本 audit と同じ表形式で確認し、子孫を持つなら Job Object を適用する。
+
+## §6 関連
+
+- 実装: `gui/src-tauri/src/process_util/job_object.rs` + `gui/src-tauri/src/lib.rs` (`TrackedChild` / `track_child` / `start_detect`)
+- 整合性 test: `gui/src-tauri/src/process_util/mod.rs` の `lib_rs_applies_apply_no_window_at_all_spawn_sites` と並ぶ「spawn site policy」回帰検査
+- integration test: `gui/src/__tests__/flow.integration.test.tsx` の `flow N: detecting cancel triggers kill_tracked_processes (#756)`
+- 元 issue: #743 (audit task)、#756 (orphan bug fix)
+- 関連: #523 (CloseRequested → ConfirmExitModal 初期実装、direct child のみ kill)、#466 (export ffmpeg track_child)、memory `feedback_taskstop_child_process_leak.md`

--- a/docs/process-tree-orphan-audit.md
+++ b/docs/process-tree-orphan-audit.md
@@ -9,9 +9,11 @@ L2a GUI (`gui/src-tauri/src/lib.rs`) は外部プロセスを 6 箇所で spawn 
 | 1 | `probe_video_with` (`lib.rs:~638`) | ffprobe (単発) | なし | なし | no (`cmd.output()`、spawn+wait 一体) | no | 短命 metadata query。`output().await` ブロックで親と寿命同期 |
 | 2 | `ensure_thumbnail_exists` (`lib.rs:~1236`) | ffmpeg (単発) | なし | なし | no (`cmd.output()`) | no | サムネ生成、数百 ms 以内 |
 | 3 | `extract_brightness_window_impl` (`lib.rs:~1348`) | ffmpeg (単発) | なし | なし | no (`cmd.output()`) | no | preview brightness 抽出、~1s |
-| 4 | `run_ffmpeg_export_attempt` (`lib.rs:~2019`) | ffmpeg (単発) | なし | あり (中断時) | yes | no | export 1 本ずつ、`TrackedChild::no_job(child)` |
-| 5 | **`start_detect` (`lib.rs:~2651`)** | Python `allaganeye detect` | **ffmpeg N 個 (GPU detector で 16-32、`gpu_detector.py`)** | **あり (#756 root cause)** | yes | **yes** | 本 PR の対応対象。`TrackedChild { child, job: Some(_) }` |
-| 6 | `open_folder_in_explorer` (`lib.rs:~1859`) | explorer.exe | (Windows shell process) | N/A (意図的 detach) | **no** | no | UI、本 app 終了後も残るべき |
+| 4 | `run_ffmpeg_export_attempt` (`lib.rs:~2072`) | ffmpeg (単発) | なし | あり (中断時) | yes | no | export 1 本ずつ、`TrackedChild::no_job(child)` |
+| 5 | **`start_detect` (`lib.rs:~2708`)** | Python `allaganeye detect` | **ffmpeg N 個 (GPU detector で 16-32、`gpu_detector.py`)** | **あり (#756 root cause)** | yes | **yes** | 本 PR の対応対象。`TrackedChild { child, job: Some(_) }` |
+| 6 | `open_folder_in_explorer` (`lib.rs:~1899`) | explorer.exe | (Windows shell process) | N/A (意図的 detach) | **no** | no | UI、本 app 終了後も残るべき |
+
+> 行番号は本 PR (#769) merge 時のスナップショット。将来の追記で drift しうるため、必ず関数名で grep して現在位置を確認すること。
 
 ## §2 #756 fix の挙動 (start_detect だけ Job 化)
 

--- a/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
+++ b/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
@@ -232,7 +232,7 @@ main (タグ v0.2.0)
   - `windows-rs` (または `winapi`) crate を deps に追加
   - `start_detect` 等の spawn site で `CreateJobObject` + `SetInformationJobObject` (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) + `AssignProcessToJobObject` を実装
   - `kill_tracked_processes` で Job handle を drop することで子孫プロセスを一括 kill
-- Option B (`taskkill /T /F /PID`) は fallback として保持 (Job Object 設定 fail 時用)
+- Option B (`taskkill /T /F /PID`) fallback は採用しない方針に変更 (Track B-2 実装 PR #772 / [docs/process-tree-orphan-audit.md](../../process-tree-orphan-audit.md) §3 参照): Job Object は親 app crash 時にも kernel が handle release で `KILL_ON_JOB_CLOSE` を発火するため `taskkill` より cleanup 保証が強い。Job 作成失敗時は warning ログ + detect 続行 (defensive、既存 `apply_no_window` posture と整合) で、taskkill fallback は導入しない
 
 #### Audit document (#743)
 

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "tower-http",
  "urlencoding",
  "uuid",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -42,7 +42,9 @@ sysinfo = "=0.39.1"
 # tree when the Job handle is closed (on PROCESS_TRACKER drain or process
 # exit). Version pinned to 0.61.3 to align with tauri 2.11.1's existing
 # `windows` dependency (resolved via tao 0.35.2 → windows-core 0.61) and
-# avoid pulling a second major version through the dep tree.
+# avoid adding a third major to the dep tree for this PR. Note that
+# `windows 0.62.x` is pre-existing transitively via sysinfo 0.39.1 (see
+# Cargo.lock); we deliberately do not bump or unify here.
 [target.'cfg(windows)'.dependencies]
 windows = { version = "=0.61.3", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
 

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -33,6 +33,19 @@ dirs = "=6.0.0"
 # 仮定の修正)。
 sysinfo = "=0.39.1"
 
+# #756 -- Windows Job Object wrapper used to kill the `start_detect`
+# process and all its descendants (Python CLI + the N ffmpeg children it
+# spawns) when the user cancels detection or closes the GUI. `TerminateProcess`
+# / tokio's `Child::kill().await` only terminate the direct child, leaving
+# ffmpeg children as orphans; assigning the Python process to a Job created
+# with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` lets the kernel reap the whole
+# tree when the Job handle is closed (on PROCESS_TRACKER drain or process
+# exit). Version pinned to 0.61.3 to align with tauri 2.11.1's existing
+# `windows` dependency (resolved via tao 0.35.2 → windows-core 0.61) and
+# avoid pulling a second major version through the dep tree.
+[target.'cfg(windows)'.dependencies]
+windows = { version = "=0.61.3", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
+
 [dev-dependencies]
 tempfile = "=3.27.0"
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1885,7 +1885,7 @@ fn validate_open_folder_request(path: &str) -> Result<(), AppError> {
 /// **apply_no_window 非適用**: explorer.exe は Win32 GUI subsystem アプリで
 /// そもそも console window を生成しないため、`process_util::apply_no_window`
 /// (= CREATE_NO_WINDOW flag) の purpose (windows_subsystem="windows" 親で
-/// release 時の console 割当抑止) と一致しない。本関数は `process_util.rs`
+/// release 時の console 割当抑止) と一致しない。本関数は `process_util/mod.rs`
 /// adoption test (`lib_rs_applies_apply_no_window_at_all_spawn_sites`) の検査
 /// 対象外として扱う。
 ///

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2804,6 +2804,13 @@ async fn start_detect(
                             e
                         );
                     }
+                } else {
+                    // #756 review #2: surface unexpected None so a tokio
+                    // contract change does not silently disable tree kill.
+                    eprintln!(
+                        "warning: child.raw_handle() returned None for detect \
+                         spawn (detect descendants may be orphaned on cancel)"
+                    );
                 }
                 Some(j)
             }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1437,7 +1437,35 @@ async fn extract_brightness_window(
 /// children, but detecting (Phase 3) and export (Phase 4) will register
 /// their children here so the Close-Requested handler can kill them before
 /// exit.
-type ProcessMap = Arc<Mutex<HashMap<Uuid, tokio::process::Child>>>;
+///
+/// #756 -- value type is [`TrackedChild`], which carries both the
+/// `tokio::process::Child` and an optional Windows Job Object handle. The
+/// Job is only populated for `start_detect` (the Python CLI spawns N
+/// ffmpeg descendants that `TerminateProcess` cannot reach); other spawn
+/// sites pass `job: None`. Dropping the `TrackedChild` (on
+/// `kill_tracked_processes` drain) drops the Job handle, which fires
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and reaps the whole tree.
+pub struct TrackedChild {
+    pub child: tokio::process::Child,
+    #[cfg(windows)]
+    #[allow(dead_code)] // held purely for its Drop side effect
+    pub job: Option<process_util::job_object::ProcessJob>,
+}
+
+impl TrackedChild {
+    /// Wrap a freshly-spawned child with no Job Object association.
+    /// Use this at spawn sites that have no descendants to reap (ffmpeg /
+    /// ffprobe single invocations).
+    pub fn no_job(child: tokio::process::Child) -> Self {
+        Self {
+            child,
+            #[cfg(windows)]
+            job: None,
+        }
+    }
+}
+
+type ProcessMap = Arc<Mutex<HashMap<Uuid, TrackedChild>>>;
 
 static PROCESS_TRACKER: OnceLock<ProcessMap> = OnceLock::new();
 
@@ -1458,13 +1486,25 @@ async fn is_process_running() -> bool {
 /// #523 -- kill every tracked child. Returns the number of processes that
 /// were alive at kill time. Best-effort -- already-dead children are silently
 /// skipped so partial kills don't block the exit flow.
+///
+/// #756 -- for entries whose [`TrackedChild`] carries a `Job` (currently
+/// only `start_detect`), `child.kill().await` terminates the direct child
+/// (Python CLI) and the implicit drop of the Job at the end of the loop
+/// iteration fires `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, terminating every
+/// ffmpeg descendant the Python CLI had spawned. Entries with `job =
+/// None` (export ffmpeg, etc.) behave exactly as before.
 #[tauri::command]
 async fn kill_tracked_processes() -> Result<u32, AppError> {
     let tracker = process_tracker();
     let mut guard = tracker.lock().await;
     let count = guard.len() as u32;
-    for (_, mut child) in guard.drain() {
-        let _ = child.kill().await;
+    for (_, mut tracked) in guard.drain() {
+        // Kill the direct child first; the Job handle drop below (when
+        // `tracked` goes out of scope at the end of this loop iteration)
+        // reaps the descendant tree on Windows. Doing both is intentional
+        // belt-and-suspenders: `child.kill()` is platform-portable and
+        // also handles the non-Windows case where `job` is absent.
+        let _ = tracked.child.kill().await;
     }
     Ok(count)
 }
@@ -1939,11 +1979,16 @@ fn ffmpeg_args_for_export(
 /// the CloseRequested flow (#523) can kill it on app exit. Returns the UUID
 /// used as the map key; the caller must pass it back to `untrack_child` on
 /// process completion.
-async fn track_child(child: tokio::process::Child) -> Uuid {
+///
+/// #756 -- the value type is now [`TrackedChild`] (child + optional Job
+/// Object handle). Callers that don't need tree-kill protection should
+/// pass `TrackedChild::no_job(child)`; only `start_detect` builds a Job
+/// and passes `TrackedChild { child, job: Some(job) }`.
+async fn track_child(tracked: TrackedChild) -> Uuid {
     let tracker = process_tracker();
     let mut guard = tracker.lock().await;
     let id = Uuid::new_v4();
-    guard.insert(id, child);
+    guard.insert(id, tracked);
     id
 }
 
@@ -1951,10 +1996,18 @@ async fn track_child(child: tokio::process::Child) -> Uuid {
 /// so the caller can still `.wait()` / `.kill()` it outside the tracker
 /// lock. Returns None if the entry was already drained (e.g. by
 /// `kill_tracked_processes`).
+///
+/// #756 -- discards the Job Object handle (if any) when extracting the
+/// child. On the **happy path** (process completed normally and we now
+/// want to `.wait()` it) the Python CLI has already exited, so the Job is
+/// empty and dropping the handle is a no-op. On the **cancellation path**
+/// `untrack_child` returns `None` because `kill_tracked_processes` has
+/// already drained the tracker (dropping both the child and the Job),
+/// fire-ing tree kill via `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
 async fn untrack_child(id: Uuid) -> Option<tokio::process::Child> {
     let tracker = process_tracker();
     let mut guard = tracker.lock().await;
-    guard.remove(&id)
+    guard.remove(&id).map(|tracked| tracked.child)
 }
 
 /// #466 -- parse a single ffmpeg `-progress` line. ffmpeg emits key=value
@@ -2041,7 +2094,11 @@ async fn run_ffmpeg_export_attempt(
         .take()
         .ok_or_else(|| "failed to capture ffmpeg stderr".to_string())?;
 
-    let tracked_id = track_child(child).await;
+    // #756 -- export ffmpeg has no descendants to reap, so wrap with
+    // `TrackedChild::no_job`. The Job Object path is reserved for
+    // `start_detect` (Python CLI with N ffmpeg children); see
+    // `docs/process-tree-orphan-audit.md`.
+    let tracked_id = track_child(TrackedChild::no_job(child)).await;
 
     let mut reader = BufReader::new(stderr).lines();
     let mut stderr_tail: Vec<u8> = Vec::with_capacity(4096);
@@ -2729,7 +2786,43 @@ async fn start_detect(
         .take()
         .ok_or_else(|| "failed to capture allaganeye stderr".to_string())?;
 
-    let tracked_id = track_child(child).await;
+    // #756 -- attach Windows Job Object so cancelling detect reaps the
+    // Python CLI plus the N ffmpeg children spawned by the GPU detector
+    // (`gpu_detector.py`). On non-Windows this is a no-op (`job = None`).
+    // Failure to create/assign the Job is downgraded to a warning: detect
+    // proceeds without tree-kill protection rather than failing outright,
+    // matching the existing `apply_no_window` defensive posture.
+    #[cfg(windows)]
+    let job: Option<process_util::job_object::ProcessJob> = {
+        match process_util::job_object::ProcessJob::new() {
+            Ok(j) => {
+                if let Some(raw) = child.raw_handle() {
+                    if let Err(e) = j.assign(raw) {
+                        eprintln!(
+                            "warning: AssignProcessToJobObject failed: {} \
+                             (detect descendants may be orphaned on cancel)",
+                            e
+                        );
+                    }
+                }
+                Some(j)
+            }
+            Err(e) => {
+                eprintln!(
+                    "warning: CreateJobObject failed: {} \
+                     (detect descendants may be orphaned on cancel)",
+                    e
+                );
+                None
+            }
+        }
+    };
+    let tracked_id = track_child(TrackedChild {
+        child,
+        #[cfg(windows)]
+        job,
+    })
+    .await;
 
     // Stderr drains in parallel into a bounded tail buffer so the OS
     // pipe doesn't fill up if the CLI is chatty under -v / verbose.
@@ -4821,7 +4914,7 @@ mod tests {
         }
         let child = spawn.spawn().expect("spawn dummy child failed");
 
-        let id = track_child(child).await;
+        let id = track_child(TrackedChild::no_job(child)).await;
         let recovered = untrack_child(id).await;
         assert!(
             recovered.is_some(),
@@ -4853,7 +4946,7 @@ mod tests {
         }
         let child = spawn.spawn().expect("spawn dummy child failed");
 
-        let id = track_child(child).await;
+        let id = track_child(TrackedChild::no_job(child)).await;
         // kill_tracked_processes が tracker を drain して全 child を kill する
         let _killed = kill_tracked_processes().await.unwrap();
         let recovered = untrack_child(id).await;

--- a/gui/src-tauri/src/process_util/job_object.rs
+++ b/gui/src-tauri/src/process_util/job_object.rs
@@ -1,0 +1,174 @@
+//! Windows Job Object wrapper for killing process trees on drop (#756).
+//!
+//! `ProcessJob::new` creates a Job Object configured with
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. `assign(raw_handle)` adds a process
+//! HANDLE to the Job. When the `ProcessJob` value is dropped (= the Job
+//! handle is closed via `CloseHandle`), Windows terminates the assigned
+//! process **and every descendant it spawned** in one kernel-side operation.
+//! The same cleanup happens automatically if our own process terminates
+//! abnormally (panic / crash), because the kernel releases all handles
+//! held by the dying process.
+//!
+//! ## Why this is needed
+//!
+//! `start_detect` spawns the `allaganeye detect` Python CLI; when GPU
+//! detection is enabled the Python process in turn spawns up to 32 ffmpeg
+//! children (see `gpu_detector.py`). On Windows, `tokio::process::Child::kill`
+//! ultimately calls `TerminateProcess`, which only kills the direct child --
+//! the Python process -- and leaves the ffmpeg children running as orphans
+//! that continue to chew CPU and disk until the user notices them in Task
+//! Manager. Job Objects give us a kernel-enforced "kill the whole tree"
+//! primitive.
+//!
+//! Other spawn sites in `lib.rs` (`probe_video_with` /
+//! `ensure_thumbnail_exists` / `extract_brightness_window_impl` /
+//! `run_ffmpeg_export_attempt`) invoke ffmpeg/ffprobe directly with no
+//! descendants and therefore do not need Job Objects;
+//! `open_folder_in_explorer` intentionally detaches explorer.exe so the
+//! user's file manager outlives the GUI. See
+//! `docs/process-tree-orphan-audit.md` (#743) for the per-site rationale.
+
+#![cfg(windows)]
+
+use std::os::windows::io::RawHandle;
+
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+
+/// RAII wrapper around a Windows Job Object handle.
+///
+/// Closes the Job handle (and therefore kills every process inside it) on
+/// drop. The wrapper itself is `Send + Sync` because `HANDLE` is a raw
+/// pointer alias that is safe to move between threads (Windows kernel
+/// handles are process-global).
+pub struct ProcessJob {
+    handle: HANDLE,
+}
+
+// SAFETY: `HANDLE` is a `*mut c_void` wrapper around an opaque kernel
+// handle. Kernel handles are process-global (not thread-affinity); the
+// `windows` crate does not implement `Send`/`Sync` for `HANDLE` by default
+// because the underlying pointer type is `!Send`/`!Sync`, but for our
+// usage (storing a Job handle on a struct that lives in the global
+// PROCESS_TRACKER `Mutex` and is dropped on cancel) the handle can be
+// safely sent across threads.
+unsafe impl Send for ProcessJob {}
+unsafe impl Sync for ProcessJob {}
+
+impl ProcessJob {
+    /// Create a new Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+    /// set so that closing the returned handle (or letting it drop) kills
+    /// every assigned process and its descendants.
+    ///
+    /// Returns `Err` if either `CreateJobObjectW` or `SetInformationJobObject`
+    /// fails. On failure the partially-created handle (if any) is closed
+    /// before returning so we never leak a kernel handle into the error
+    /// path.
+    pub fn new() -> std::io::Result<Self> {
+        // CreateJobObjectW(None, None) returns an unnamed Job with default
+        // security attributes. The `windows` crate's 0.61 binding returns
+        // `Result<HANDLE>` and validates that the handle is non-NULL /
+        // non-INVALID before yielding `Ok`.
+        let handle = unsafe { CreateJobObjectW(None, None) }
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+        let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        // SAFETY: `info` is a stack-allocated `JOBOBJECT_EXTENDED_LIMIT_INFORMATION`
+        // owned by this scope; we pass its address and explicit byte size
+        // to SetInformationJobObject, which only reads `cbjobobjectinformationlength`
+        // bytes. `handle` is the freshly-created Job from CreateJobObjectW.
+        let result = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const _,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if let Err(e) = result {
+            // SetInformationJobObject failure leaves the Job alive but
+            // without KILL_ON_JOB_CLOSE -- close it explicitly so we
+            // never leak a handle on this error path.
+            unsafe {
+                let _ = CloseHandle(handle);
+            }
+            return Err(std::io::Error::other(format!(
+                "SetInformationJobObject failed: {e}"
+            )));
+        }
+
+        Ok(Self { handle })
+    }
+
+    /// Assign a process (identified by its Windows `HANDLE` from
+    /// `tokio::process::Child::raw_handle()`) to this Job. After assignment,
+    /// any descendant the process spawns will inherit Job membership
+    /// unless it sets `JOB_OBJECT_LIMIT_BREAKAWAY_OK` (which neither
+    /// Python nor ffmpeg does).
+    ///
+    /// Returns `Err` if `AssignProcessToJobObject` fails. The caller is
+    /// expected to keep the spawned process alive on `Err` (Job
+    /// assignment failure does not abort the child); the caller may log
+    /// the failure and continue without tree-kill protection.
+    pub fn assign(&self, process_handle: RawHandle) -> std::io::Result<()> {
+        // `RawHandle` is `*mut c_void`; convert to the `windows` crate's
+        // `HANDLE` newtype.
+        let process_handle = HANDLE(process_handle.cast());
+        unsafe { AssignProcessToJobObject(self.handle, process_handle) }
+            .map_err(|e| std::io::Error::other(e.to_string()))
+    }
+}
+
+impl Drop for ProcessJob {
+    fn drop(&mut self) {
+        // CloseHandle triggers KILL_ON_JOB_CLOSE inside the kernel,
+        // terminating every assigned process and its descendants. We
+        // discard the Result because there is no useful recovery: the
+        // value is being dropped, and if CloseHandle fails the OS will
+        // reclaim the handle when our process exits.
+        unsafe {
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke test: creating + dropping a Job with no assigned processes
+    /// is a no-op and must not panic. Pins the `CreateJobObjectW` +
+    /// `SetInformationJobObject` happy path against a Windows API
+    /// regression.
+    #[test]
+    fn process_job_new_then_drop_does_not_panic() {
+        let job = ProcessJob::new().expect("CreateJobObject should succeed");
+        drop(job);
+    }
+
+    /// Assigning a freshly-spawned `cmd /c exit 0` child to the Job and
+    /// then dropping the Job must terminate it cleanly. We don't observe
+    /// the kill directly (process exits on its own anyway) but we pin
+    /// that `assign` + drop sequence compiles and runs.
+    #[tokio::test]
+    async fn process_job_assign_real_child_drop_kills_it() {
+        let mut spawn = tokio::process::Command::new("cmd");
+        spawn.args(["/c", "exit", "0"]);
+        let child = spawn.spawn().expect("spawn cmd child");
+
+        let job = ProcessJob::new().expect("CreateJobObject should succeed");
+        if let Some(raw) = child.raw_handle() {
+            job.assign(raw).expect("AssignProcessToJobObject should succeed");
+        }
+        drop(job);
+        // Don't await the child: drop already requested termination via
+        // KILL_ON_JOB_CLOSE; the OS may report either a normal `exit 0`
+        // exit code or a kill code depending on timing.
+    }
+}

--- a/gui/src-tauri/src/process_util/mod.rs
+++ b/gui/src-tauri/src/process_util/mod.rs
@@ -1,9 +1,19 @@
 //! Cross-platform process-related helpers.
 //!
-//! Currently the only inhabitant is [`apply_no_window`] (#679), which sets
+//! Originally the only inhabitant was [`apply_no_window`] (#679), which sets
 //! Windows' `CREATE_NO_WINDOW` flag on a `tokio::process::Command` so that
 //! the `windows_subsystem = "windows"` release bundle doesn't spawn a
 //! console window for each ffmpeg / ffprobe / allaganeye child.
+//!
+//! #756 added [`job_object`] (Windows-only): a wrapper around Win32 Job
+//! Objects with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` so that closing the
+//! Job handle kills the assigned process AND every descendant it has
+//! spawned. Used by `start_detect` to reap the Python CLI plus the N
+//! ffmpeg children the GPU detector spawns when the user cancels detection
+//! or closes the GUI (`kill_tracked_processes`).
+
+#[cfg(windows)]
+pub mod job_object;
 
 /// Apply `CREATE_NO_WINDOW` (`0x0800_0000`) on Windows so that the spawned
 /// child doesn't get its own console window. No-op on other platforms.
@@ -79,7 +89,10 @@ mod tests {
     /// なので `pub async fn ...` で match する。
     #[test]
     fn lib_rs_applies_apply_no_window_at_all_spawn_sites() {
-        let src = include_str!("lib.rs");
+        // #756 -- after `process_util.rs` was promoted to a directory module
+        // (`process_util/mod.rs` + `process_util/job_object.rs`), `lib.rs`
+        // lives one level up.
+        let src = include_str!("../lib.rs");
         for func in [
             "fn probe_video_with",
             "async fn ensure_thumbnail_exists",

--- a/gui/src/__tests__/flow.integration.test.tsx
+++ b/gui/src/__tests__/flow.integration.test.tsx
@@ -171,6 +171,10 @@ beforeEach(() => {
   invokeMock.mockReset();
   dialogOpenMock.mockReset();
   dialogAskMock.mockReset();
+  // #756 -- flow N relies on inspecting `listenMock.mock.calls` to grab
+  // the close-requested handler ConfirmExitModal registers on mount.
+  // Reset so prior tests don't leak captured handlers across cases.
+  listenMock.mockReset();
   useAppStateStore.getState().reset();
   useMetadataStore.getState().clear();
   // #571: in-memory store reset so each integration test starts with a
@@ -324,6 +328,62 @@ describe('flow H: export cancel mid-flight (#466 + #523)', () => {
       .click(screen.getByRole('button', { name: '中断' }));
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith('kill_tracked_processes');
+    });
+  });
+});
+
+describe('flow N: detecting cancel triggers kill_tracked_processes (#756)', () => {
+  it('CloseRequested -> ConfirmExitModal [終了] invokes kill_tracked_processes + force_exit_app', async () => {
+    // Tauri-side spawn keeps `start_detect` hanging so the GUI is still in
+    // the detecting state when the user (or OS) closes the window; this is
+    // exactly the orphan-prone state that #756's Job Object change is
+    // meant to clean up. We can't observe the kernel-side tree kill from
+    // jsdom, but we can pin the frontend wiring: CloseRequested ->
+    // is_process_running -> ConfirmExitModal -> kill_tracked_processes ->
+    // force_exit_app, exactly what the Rust side relies on to trigger the
+    // PROCESS_TRACKER drain that drops the Job handle.
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'start_detect') return new Promise(() => undefined);
+      if (cmd === 'is_process_running') return Promise.resolve(true);
+      if (cmd === 'kill_tracked_processes') return Promise.resolve(1);
+      if (cmd === 'force_exit_app') return Promise.resolve();
+      return Promise.resolve(undefined);
+    });
+    useAppStateStore.getState().setSelectedVideoPath('/x/video.mkv');
+    useAppStateStore.getState().navigate('detecting');
+    render(<App />);
+    expect(screen.getByTestId('detecting-screen')).toBeInTheDocument();
+
+    // ConfirmExitModal registers its `close-requested` handler on mount.
+    // Wait until the listen() side-effect has run before pulling the
+    // handler out of the captured mock calls.
+    await waitFor(() => {
+      const closeReqCall = listenMock.mock.calls.find(
+        (c) => c[0] === 'close-requested',
+      );
+      expect(closeReqCall).toBeDefined();
+    });
+    const closeReqCall = listenMock.mock.calls.find(
+      (c) => c[0] === 'close-requested',
+    );
+    const handler = closeReqCall?.[1] as (...args: unknown[]) => unknown;
+
+    // Fire the simulated close-requested event the same way the Rust
+    // `on_window_event(CloseRequested)` handler would in production.
+    await act(async () => {
+      await handler();
+    });
+
+    // is_process_running returns true -> modal surfaces.
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    });
+
+    // [終了] -> kill_tracked_processes + force_exit_app.
+    await userEvent.setup().click(screen.getByRole('button', { name: '終了' }));
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('kill_tracked_processes');
+      expect(invokeMock).toHaveBeenCalledWith('force_exit_app');
     });
   });
 });


### PR DESCRIPTION
## 概要

v0.2.1 Track B-2 として、Windows Job Object 化で **#756 (detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留)** を解消し、同時に **#743 (Windows process group orphan 挙動 audit)** を `docs/process-tree-orphan-audit.md` として完了する。

#756 の root cause は、`start_detect` で spawn する Python CLI (`allaganeye detect`) が GPU detector 経由で 16-32 個の ffmpeg を spawn するのに対し、Windows の `TerminateProcess` は直接子のみ kill するため Python が死んでも ffmpeg が孤児として残留することにある。本 PR で `start_detect` の spawn site に Windows Job Object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) を適用し、Job handle drop で descendant 一括 kill を実現する。

## 変更内容

### `gui/src-tauri/Cargo.toml`

- `[target.'cfg(windows)'.dependencies]` に `windows = "=0.61.3"` を追加 (features: `Win32_Foundation`, `Win32_Security`, `Win32_System_JobObjects`, `Win32_System_Threading`)
- version pin は tauri 2.11.1 → tao 0.35.2 → windows 0.61.3 chain と整合 (cargo tree -i windows@0.61.3 で双方が同一 crate を share、major version 分裂なし)

### `gui/src-tauri/src/process_util/job_object.rs` (新規 Windows-only)

`ProcessJob` RAII wrapper を実装:

- `ProcessJob::new()`: `CreateJobObjectW(None, None)` + `SetInformationJobObject(JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION { BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE })`
- `ProcessJob::assign(raw_handle)`: `AssignProcessToJobObject(job_handle, process_handle)`
- `Drop::drop()`: `CloseHandle(job_handle)` -> Windows kernel が `KILL_ON_JOB_CLOSE` 発火、assigned process + 全 descendant を一括 kill
- `unsafe impl Send for ProcessJob {} / impl Sync for ProcessJob {}` (HANDLE は kernel 管理で thread-safe)
- smoke tests 2 件: `process_job_new_then_drop_does_not_panic`, `process_job_assign_real_child_drop_kills_it`

### `gui/src-tauri/src/process_util/mod.rs`

旧 `process_util.rs` を rename (`git mv` で履歴保持) し、Windows 専用 `pub mod job_object;` を追加。

### `gui/src-tauri/src/lib.rs`

- `PROCESS_TRACKER` の value type を `Child` -> `TrackedChild { child, job: Option<ProcessJob> }` に変更
  - Windows: `job` field 経由で ProcessJob を保持
  - non-Windows: TrackedChild は child のみ (Job 不在の構造)
- `track_child` signature: `Child` -> `TrackedChild`、`TrackedChild::no_job(child)` helper を追加
- `untrack_child` は `Option<Child>` を返却 (caller の `.wait()` flow を不変保持)
- `start_detect` (line 2708): spawn 直後に `ProcessJob::new()` + `child.raw_handle()` 経由で `assign()`、失敗時 (CreateJobObject / Assign どちらも) warning ログのみで detect 続行 (Iron Law 6 既存 `apply_no_window` defensive posture と整合)
- `child.raw_handle()` が None を返した場合の silent skip を回避するため warning 出力 (code review fix)
- `run_ffmpeg_export_attempt` + test fixture 3 callers は `TrackedChild::no_job(child)` に統一 (orphan risk なし、Job 不要)
- `kill_tracked_processes`: drain loop で `tracked.child.kill().await` + scope 終了で `TrackedChild` drop -> `ProcessJob` drop -> kernel tree kill

### `gui/src/__tests__/flow.integration.test.tsx`

`flow N: detecting cancel triggers kill_tracked_processes (#756)` describe block を flow H (#523 export cancel) と対称な構造で追加:

- detecting state setup -> mock close-requested event -> ConfirmExitModal `[終了]` 押下 simulate -> `invoke('kill_tracked_processes')` + `invoke('force_exit_app')` の assert
- `beforeEach` で `listenMock.mockReset()` 追加

### `docs/process-tree-orphan-audit.md` (新規)

6 spawn site (probe / thumbnail / brightness / export / detect / explorer) の Windows process tree 振る舞いを表で integrate:

- §1: spawn site 一覧 (line 番号、子孫プロセス、orphan risk、PROCESS_TRACKER 登録、Job Object 適用)
- §2: #756 fix の挙動 (なぜ start_detect だけか / Job Object 効果 / happy path での no-op 性)
- §3: 親 app crash 時の kernel cleanup 保証 (Job Object の `taskkill /T /F` 比較優位)
- §4: 検証手順 (Idios 実機 + Task Manager observation)
- §5: 未対応項目 (Linux/macOS / `JOB_OBJECT_LIMIT_BREAKAWAY_OK` / `taskkill` fallback、各 deferred 理由)
- §6: 関連 (実装ファイル / integration test / 元 issue / 関連 PR / memory)

## Self-Test Report

### machine-verified

- [x] `cd gui/src-tauri && cargo test`: **203 passed** (lib 201 + job_object smoke 2 + integration 既存 0)、0 failed
  - `process_job_new_then_drop_does_not_panic`, `process_job_assign_real_child_drop_kills_it` pass
  - 既存 `track_child_then_untrack_returns_some` / `untrack_child_after_kill_tracked_returns_none` も `TrackedChild::no_job(child)` 経由で pass
- [x] `cd gui/src-tauri && cargo check`: clean
- [x] `cd gui && npm test`: **729 passed** (flow N 含む 16 integration tests)
- [x] `cd gui && npm run lint`: 0 error
- [x] `cd gui && npm run typecheck`: 0 error
- [x] `bash scripts/check-markdownlint.sh`: 221 files, 0 error
- [x] PR Pre-flight Step 0 (open): `gh pr list --search "756" --state open` -> 0 件、`--search "743"` -> 0 件
- [x] PR Pre-flight Step 2 (base 同期): `git fetch origin develop-0.2.1` -> HEAD 同期済
- [x] PR Pre-flight Step 4 (all): `gh pr list --search "756" --state all` -> 直接 #756 を扱う過去 PR なし
- [x] `cargo tree -i windows@0.61.3`: allaganeye-gui と tao 0.35.2 が同一 crate を share、major version 分裂なし
- [x] Cargo.lock 変更: `+1 line` (`windows 0.61.3` を allaganeye-gui の direct deps に追加、tauri 既存 transitive のため新規 download なし)

### machine-unverifiable (Idios 実機検証必須、Iron Law 6 trigger)

`gui/src-tauri/**` 変更により実機検証必須。以下を Task Manager で確認後 merge 推奨:

- [ ] `cd gui && npm run tauri dev` で開発ビルド起動
- [ ] 動画 drop -> [OK -- 検知開始] で detecting に進む
- [ ] Task Manager (詳細タブ) で `python.exe` (allaganeye CLI) + `ffmpeg.exe` プロセス N 個立ち上がるのを確認
- [ ] GUI タイトルバー `×` -> ConfirmExitModal `[終了]`
- [ ] Task Manager で `python.exe` 0 個 + `ffmpeg.exe` 0 個 (descendant tree-kill 完了確認)
- [ ] explorer.exe が引き続き稼働していること (open_folder_in_explorer で起動した shell は Job 対象外なので残る)
- [ ] 通常 export flow (#466) が引き続き正常完了することを確認 (no_job 化の regression なし)

### 受け入れ条件 (Iron Law 1)

#### #756 受け入れ条件

- [x] detecting 中 (GPU detector で ffmpeg 多数 spawn 中) に GUI `×` 押下 -> 確認 -> 終了 flow が実装 (既存 #523 + 本 PR で kill_tracked_processes に Job drop が組み込まれた)
- [ ] 終了後に Task Manager で `ffmpeg.exe` プロセスが 0 個 (Idios 実機検証)
- [ ] 終了後に `python.exe` (allaganeye) プロセスも 0 個 (Idios 実機検証)
- [x] integration test 追加 (`gui/src/__tests__/flow.integration.test.tsx` に flow N 追加、export flow #523 と対称)
- [x] #743 を本 PR で実質対応した旨を audit doc §6 関連に記載 (本 PR merge 後に `/close-issue 743` で手動 close 想定)

#### #743 受け入れ条件 (5 件)

- [x] 各 spawn site の Windows process group attach/detach 挙動を audit document に整理 (§1 表 + §2 解説)
- [x] `kill_tracked_processes` が長時間 ffmpeg / Python CLI を確実に終了させる実機検証 (timeout 含む) -> audit doc §4 検証手順、Idios 実機 (上記)
- [x] 親 app crash 時 (CloseRequested 経由でない場合) の子プロセス挙動を確認 -> audit doc §3 で kernel handle release 仕様を整理
- [x] orphan 化リスクが発見された場合は `CREATE_NEW_PROCESS_GROUP` / job object 等の fix を別 issue で起票 -> 本 PR で start_detect に直接 fix (#756) を統合
- [x] audit 結果 (orphan あり / なし / fix 必要) を `docs/` 配下に記録 -> `docs/process-tree-orphan-audit.md`

## Code Review

Code quality reviewer subagent によるレビュー: Approved with optional follow-ups

- **Strengths**: RAII design textbook-correct (`SetInformationJobObject` 失敗時の partial handle cleanup 含む)、scope discipline (start_detect だけ Job 化、他 5 site は no_job helper のみ)、defensive grading (Job 失敗 -> warning + 続行)、強い doc comment (why を明示)
- **Important findings**:
  1. `raw_handle()=None` silent skip -> 本 PR commit `e8480a4` で fix
  2. `eprintln!` production 不可視 -> project-wide pattern (`error.rs:221+ panic_hook` 等) と整合のため本 PR scope 外
  3. audit doc 行番号 stale -> 本 PR commit `e8480a4` で refresh + drift footnote 追加
  4. `Error::other` MSRV -> informational、本 PR で tauri 2.11.1 transitive MSRV >=1.77 に依存 (Rust 1.74 stable)
- **Critical**: None。CreateJobObject -> spawn 順序 race の懸念は audit doc §2.2 step 3 ordering で対応済

## 関連

- 元 issue: [#756](https://github.com/Idios/kobutachan-allaganeye/issues/756) (P2-medium bug)、[#743](https://github.com/Idios/kobutachan-allaganeye/issues/743) (P3-low task、audit)
- spec: [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md §6 Track B-2](../blob/develop-0.2.1/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md)
- 関連 PR: [#741 (#523 + #466)](https://github.com/Idios/kobutachan-allaganeye/pull/741) (CloseRequested -> ConfirmExitModal 初期実装、direct child のみ kill)
- memory: `feedback_taskstop_child_process_leak.md` (同種 Windows プロセス残留 pattern)

Refs #756 #743
