### PR TITLE
chore(release): v0.2.1 Track D — version bump 0.2.0 → 0.2.1 + CHANGELOG [crazy-swirles-bed20b]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-17
+
+v0.2.0 リリース直後の patch リリース。Dependabot security alerts 解消と既存 deferred UX issue 5 件の対応、PR マージ前の cargo/npm audit CI 追加 + Windows process tree orphan の Job Object 化を含む。Track A/B-1/B-2/B-3/B-4/C/D 構成 (`docs/superpowers/specs/2026-05-16-security-alerts-response-design.md`)。
+
+### Security
+
+- tauri 2.10.3 → 2.11.1 (medium: Origin Confusion / Remote→Local IPC invocation、GHSA-7gmj-67g7-phm9) (#760)
+- fast-uri 3.1.0 → 3.1.2 (high × 2: GHSA-v39h-62p7-jpjc / GHSA-q3j6-qgpj-74h6、dev-only deps via ajv) (#760)
+- glib transitive 0.18.5 / rand transitive 0.7.3 は deferred (tauri 上流の kuchikiki / phf_generator 移行待ち、配布物 (Windows Portable ZIP の `allaganeye-gui.exe`) への runtime 影響なし。glib は Linux/macOS GTK 系のみ、rand は build-dep のみ。詳細は `gui/src-tauri/Cargo.lock` および audit log `docs/audit-logs/2026-05-16-v0.2.1-audit.log` 参照) (#760)
+
+### Fixed
+
+- detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留する問題を Windows Job Object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) で解消。`start_detect` の spawn site に `ProcessJob` RAII wrapper を適用し、`kill_tracked_processes` で Job handle drop → kernel が tree kill (#756, #772)
+- `.github/ISSUE_TEMPLATE/bug_report.yml` の `docs/bug-report-guide.md` link を `develop-0.2.0` から `main` に更新、未公開 placeholder を削除 (#458, #764)
+- `docs/design-overview.md` の metadata.json example から stale な `note` 行を削除 (実装本体は #463 で既に retired) (#374, #766)
+
+### Changed
+
+- Portable ZIP 内 `README.txt` を日本語化 (`scripts/build-portable-zip.ps1` Format-ReadmeContent + Pester assertion 更新、法的引用は原文保持) (#749, #768)
+- Windows process tree 6 spawn site の audit document を `docs/process-tree-orphan-audit.md` として整理 (#743, #772)
+
+### CI / Infrastructure
+
+- cargo audit + npm audit を PR マージ前に実行する `.github/workflows/security-audit.yml` を追加 (Track C、tauri 2.11 transitive の 19 deferred warnings を考慮し vulnerability のみ fail 設定) (#763)
+- `docs/ci-security-audit.md` を新設 (workflow 運用 note) (#763)
+
 ## [0.2.0] - 2026-05-16
 
 L2 (GUI + Portable 配布) リリース。Tauri ベースの GUI を新設し、Portable ZIP 配布で zero-environment setup を実現。GPU decode を Intel QSV / AMD d3d11va に拡張、CLI/GUI で metadata.json schema を統一、warnings 基盤を導入。L2 開発プロセスとして markdownlint 導入、Iron Law 6 (PR 作成前ゲート)、`/iterate-review` / `/close-issue` skill 等の workflow / docs / test infra を全般強化。

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allaganeye-gui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allaganeye-gui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "react": "19.2.5",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "allaganeye-gui",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "allaganeye-gui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "dirs",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allaganeye-gui"
-version = "0.2.0"
+version = "0.2.1"
 description = "Allagan Eye GUI shell (Tauri 2 + React)"
 edition = "2021"
 

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Allagan Eye",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "dev.allaganeye.gui",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kobutachan-allaganeye"
-version = "0.2.0"
+version = "0.2.1"
 description = "FF14 Frontline video auto-highlight extraction tool"
 license = "MIT"
 requires-python = ">=3.11"


### PR DESCRIPTION
## 概要

v0.2.1 Track D (リリース直前) として、4 file の version bump + CHANGELOG.md v0.2.1 section 追加を実施する。本 PR を develop-0.2.1 にマージ後、`develop-0.2.1 → main` の Release PR を作成し、v0.2.1 タグ発火で release.yml が Portable ZIP build + GitHub Release を生成する。

## 変更内容

### Version bump (0.2.0 → 0.2.1、4 files)

| File | Field | 旧 | 新 |
| --- | --- | --- | --- |
| `pyproject.toml` | `[project] version` | `"0.2.0"` | `"0.2.1"` |
| `gui/package.json` | `"version"` | `"0.2.0"` | `"0.2.1"` |
| `gui/package-lock.json` | root `"version"` | `"0.2.0"` | `"0.2.1"` (npm install --package-lock-only 自動反映) |
| `gui/src-tauri/Cargo.toml` | `[package] version` | `"0.2.0"` | `"0.2.1"` |
| `gui/src-tauri/Cargo.lock` | `allaganeye-gui` package | `0.2.0` | `0.2.1` (cargo check 自動反映) |
| `gui/src-tauri/tauri.conf.json` | `"version"` | `"0.2.0"` | `"0.2.1"` |

### `CHANGELOG.md` に `[0.2.1] - 2026-05-17` section 追加

v0.2.1 patch release の内容を Keep a Changelog 形式で整理:

- **Security**: tauri 2.10.3 → 2.11.1 (medium Origin Confusion)、fast-uri 3.1.0 → 3.1.2 (high path traversal / host confusion)、glib / rand transitive は deferred (tauri 上流の kuchikiki / phf_generator 移行待ち、配布物影響なし) (#760)
- **Fixed**:
  - #756 Windows Job Object で detecting cancel 時の ffmpeg 子孫プロセス kill (#772)
  - #458 bug_report.yml link を main に更新 (#764)
  - #374 design-overview.md metadata.json example の stale note 行削除 (#766)
- **Changed**:
  - #749 Portable ZIP README.txt 日本語化 (#768)
  - #743 Windows process tree audit document 整理 (#772)
- **CI / Infrastructure**:
  - `.github/workflows/security-audit.yml` (cargo audit + npm audit pre-merge gate) を追加 (#763)
  - `docs/ci-security-audit.md` (workflow 運用 note) を新設 (#763)

## Self-Test Report

### machine-verified

- [x] 4 file version sync 確認 (pyproject.toml / gui/package.json / gui/src-tauri/Cargo.toml / gui/src-tauri/tauri.conf.json すべて `0.2.1`)
- [x] gui/package-lock.json root version: `0.2.1`
- [x] gui/src-tauri/Cargo.lock allaganeye-gui package: `0.2.1`
- [x] markdownlint: 221 file 0 error
- [x] Python (`pyproject.toml` 変更): `ruff check .` All checks passed、`python -m pytest -q` 963 passed / 1 skipped / 37 deselected (slow tests)
- [x] GUI frontend (`gui/package.json` 変更): `npm run lint` 0 error、`npm run typecheck` 0 error、`npm test` 729 passed / 47 files
- [x] GUI Rust (`gui/src-tauri/Cargo.toml` 変更): `cargo test` 201 passed、`cargo check` 完了 (allaganeye-gui v0.2.1 build)
- [x] PR Pre-flight Step 0: `gh pr list --search "v0.2.1" --state open` → 0 件
- [x] PR Pre-flight Step 2: `git log HEAD..origin/develop-0.2.1` empty (base 同期済)
- [x] PR Pre-flight Step 4: `gh pr list --base develop-0.2.1 --state open` → 0 件 (並行 release PR なし)

### machine-unverifiable (本 PR では発生せず)

mechanical version bump + CHANGELOG 追加のみのため、実機検証 trigger は該当なし。本 PR merge 後の develop-0.2.1 → main Release PR で release.yml の Portable ZIP build + smoke test が走り、Iron Law 6 実機検証 trigger は Track A/B-2 段階で既履行 (Idios 実機確認 Pass 済)。

### 受け入れ条件 (spec §7.3 Track D)

- [x] release.yml の version-check job が `pyproject.toml` 0.2.1 を認識
- [x] CHANGELOG.md に v0.2.1 section が記載され Keep a Changelog 形式 + 全 Track 整理済み
- [ ] Portable ZIP build (`scripts/build-portable-zip.ps1 -Version 0.2.1`) で `allaganeye-v0.2.1-windows.zip` artifact 生成 (Release PR で release.yml により自動実行予定)
- [ ] `develop-0.2.1 → main` PR マージ + `v0.2.1` tag push で release.yml が GitHub Release 作成 (Release PR 段階で実施)

## 次のステップ (本 PR merge 後)

1. develop-0.2.1 → main の Release PR 作成 (`/release` skill or 手動)
2. Release PR merge 後、`v0.2.1` タグを main HEAD に付与
3. release.yml が自動実行 → Portable ZIP + GitHub Release 作成
4. Dependabot alerts 5 件のうち #2 #3 #6 (Track A 解消対象) が auto-resolve 確認、#4 #5 (deferred) を手動 dismiss
5. UX issue 5 件 (#374 / #458 / #743 / #749 / #756) を `/close-issue` skill で受け入れ条件再検証 + 手動クローズ (Iron Law 4)
6. main から develop-0.3.0 を新規 cut + version 0.3.0 bump

## 関連

- spec: [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md §6 Track D](../blob/develop-0.2.1/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md) / §7.3 / §8
- v0.2.1 統合 PRs: #759 (spec) / #760 (Track A) / #763 (Track C) / #764 (Track B-4) / #766 (Track B-1) / #768 (Track B-3) / #772 (Track B-2)
- 既存 #769 / #771 (CI 所要時間削減、issue #767/#770 由来) も develop-0.2.1 に取り込み済 (本 PR では touch せず)

Refs spec §6 Track D
