### PR TITLE
Release v0.2.1: develop-0.2.1 → main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
         <!-- ErrorModal 連動 note (Group D #669 マージで rendered 化、それまで外部 reporter には非表示):
         ErrorModal の `[GitHub Issue を作成]` ボタンを使うと一部項目 (実際の動作 / 環境情報 / ログファイル) が自動入力されます。 -->
 
-        詳細は [`docs/bug-report-guide.md`](../../blob/develop-0.2.0/docs/bug-report-guide.md) を参照してください (公開までしばらくお待ちください)。
+        詳細は [`docs/bug-report-guide.md`](../../blob/main/docs/bug-report-guide.md) を参照してください。
 
   - type: textarea
     id: reproduction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,22 @@
 name: CI
 
 on:
+  # #767 -- main / develop-* への push でも CI を走らせて Swatinem/rust-cache の
+  # canonical キャッシュを生成する。pull_request only だと main / develop ブランチ
+  # 上で CI が走らないため GitHub Actions Cache 上に branch 由来のキャッシュが
+  # 存在せず、PR ごとに rust-cache が "No cache found." で毎回フルビルドしていた
+  # (gui-rust 228s)。push で warm された cache を PR が restore-key prefix
+  # fallback で継承することで incremental build (~30-60s) に短縮する。
+  push:
+    branches: [main, "develop-*"]
   pull_request:
     branches: [main, "develop-*"]
+
+concurrency:
+  # 同一 ref への連続 push は前 run を cancel して無駄を省く。ただし main /
+  # develop-* は cache warm-up が目的なので cancel しない (PR の場合のみ cancel)。
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   python:
@@ -150,7 +164,11 @@ jobs:
 
   gui-rust:
     runs-on: windows-latest
-    needs: gui-frontend
+    # #767 -- needs: gui-frontend を削除して並列実行可能に (~60s wall clock 短縮)。
+    # cargo test --lib は frontend assets (gui/dist) を参照しないため、
+    # gui-frontend の build artifact に依存する必要がない (lib test 内に
+    # include_dir! / include_str!(...dist) / frontendDist / AssetResolver の
+    # 使用が無いことを grep で確認済)。
     steps:
       - uses: actions/checkout@v4
 
@@ -170,14 +188,12 @@ jobs:
         working-directory: gui
         run: npm ci
 
-      - name: Download dist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: gui-dist
-          path: gui/dist
-
+      # #767 -- --no-default-features で default feature "custom-protocol"
+      # (tauri release-mode bundling 用) を無効化。lib test は custom_protocol /
+      # asset_resolver / AssetResolver を参照しないことを grep で確認済。
+      # build 時間短縮 + cargo dependency graph 縮小に寄与する。
       - name: Cargo test (lib)
-        run: cargo test --lib --manifest-path gui/src-tauri/Cargo.toml
+        run: cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml
 
   doc-tauri-commands-drift:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,35 @@
 name: Release
 
 on:
+  # #770 -- main / develop-* への push でも release CI を走らせて
+  # Swatinem/rust-cache の canonical キャッシュを生成する。pull_request + tags
+  # only だと main / develop ブランチ上で CI が走らないため GitHub Actions Cache
+  # 上に branch 由来のキャッシュが存在せず、build-windows の rust-cache が
+  # "No cache found." で毎回フルビルド (398s の tauri build)。push で warm された
+  # cache を PR が restore-key prefix fallback で継承することで incremental
+  # build (~30-60s) に短縮する。
+  #
+  # GitHub Actions の AND 仕様により paths filter は branch push と tag push の
+  # 両方に適用される。release tag commit は pyproject.toml の version bump 等を
+  # 含む (v0.2.0 実績で paths 対象を多数 touch) ため tag push 時の paths filter は
+  # 実用上問題ない。万一 paths にマッチしない tag commit が必要になった場合は
+  # workflow_dispatch で手動実行できる。
   push:
+    branches: [main, "develop-*"]
     tags:
       - 'v*.*.*'
+    paths:
+      - '.github/workflows/release.yml'
+      - 'scripts/build-portable-zip.ps1'
+      - 'scripts/extract_release_notes.py'
+      - 'pyproject.toml'
+      - 'gui/package.json'
+      - 'gui/package-lock.json'
+      - 'gui/src-tauri/**'
+      - 'gui/src/**'
+      - 'gui/index.html'
+      - 'gui/vite.config.ts'
+      - 'gui/tsconfig*.json'
   pull_request:
     paths:
       - '.github/workflows/release.yml'
@@ -82,9 +108,13 @@ jobs:
       # is copied as-is into the Portable ZIP payload by
       # scripts/build-portable-zip.ps1 at packaging time (no rename, the cargo
       # binary name without whitespace is used directly).
+      # #770 -- npm cache を有効化して `npm install` の registry fetch 時間を短縮
+      # (22s → ~10s)。gui-rust ジョブ (ci.yml) と同じ cache key で共有される。
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: gui/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -98,10 +128,13 @@ jobs:
           path: ${{ github.workspace }}/build-cache
           key: btbn-ffmpeg-win64-lgpl-shared-8.1-e27598e612078f25d3e9cf245ce5042990f2602146e5a6f8287b143b0dce0e95
 
+      # #770 -- npm install (lock loose) から npm ci (lock strict) に変更。
+      # release CI では package-lock.json と一致する厳密な再現を保証したい。
+      # npm cache (setup-node) と組み合わせて再現性向上 + 速度向上。
       - name: Install GUI dependencies (#570)
         shell: pwsh
         working-directory: gui
-        run: npm install --no-audit --no-fund
+        run: npm ci --no-audit --no-fund
 
       - name: Build Tauri GUI binary (#570)
         shell: pwsh
@@ -258,7 +291,12 @@ jobs:
 
       # Upload the expanded payload folder; actions/upload-artifact zips it once
       # on its own, which avoids the previous "zip inside a zip" artifact.
+      #
+      # #770 -- main / develop-* への branch push は rust-cache warm-up が目的で
+      # release artifact は不要なため skip する。tag push (release tag) と
+      # pull_request (build 確認用) では従来通り upload する。
       - uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         with:
           name: allaganeye-windows-v${{ needs.version-check.outputs.version }}
           path: build/portable/allaganeye-v${{ needs.version-check.outputs.version }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,57 @@
+name: Security Audit
+
+on:
+  pull_request:
+    paths:
+      - 'gui/src-tauri/Cargo.lock'
+      - 'gui/src-tauri/Cargo.toml'
+      - 'gui/package-lock.json'
+      - 'gui/package.json'
+      - '.github/workflows/security-audit.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit (Rust)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version "^0.22"
+
+      - name: Run cargo audit
+        working-directory: gui/src-tauri
+        # default: vulnerability 検出時のみ fail。warning (unmaintained / unsound)
+        # は通過させる (現状 19 件の deferred warnings が存在、tauri 上流 patch 待ち)
+        run: cargo audit
+
+  npm-audit:
+    name: npm audit (JavaScript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: gui
+        run: npm ci
+
+      - name: Run npm audit
+        working-directory: gui
+        # high 以上で fail。dev-only の moderate/low は通過 (現状 ajv moderate
+        # ReDoS が deferred 状態、Track A で fast-uri は 3.1.2 解消済)
+        run: npm audit --audit-level=high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-17
+
+v0.2.0 リリース直後の patch リリース。Dependabot security alerts 解消と既存 deferred UX issue 5 件の対応、PR マージ前の cargo/npm audit CI 追加 + Windows process tree orphan の Job Object 化を含む。Track A/B-1/B-2/B-3/B-4/C/D 構成 (`docs/superpowers/specs/2026-05-16-security-alerts-response-design.md`)。
+
+### Security
+
+- tauri 2.10.3 → 2.11.1 (medium: Origin Confusion / Remote→Local IPC invocation、GHSA-7gmj-67g7-phm9) (#760)
+- fast-uri 3.1.0 → 3.1.2 (high × 2: GHSA-v39h-62p7-jpjc / GHSA-q3j6-qgpj-74h6、dev-only deps via ajv) (#760)
+- glib transitive 0.18.5 / rand transitive 0.7.3 は deferred (tauri 上流の kuchikiki / phf_generator 移行待ち、配布物 (Windows Portable ZIP の `allaganeye-gui.exe`) への runtime 影響なし。glib は Linux/macOS GTK 系のみ、rand は build-dep のみ。詳細は `gui/src-tauri/Cargo.lock` および audit log `docs/audit-logs/2026-05-16-v0.2.1-audit.log` 参照) (#760)
+
+### Fixed
+
+- detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留する問題を Windows Job Object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) で解消。`start_detect` の spawn site に `ProcessJob` RAII wrapper を適用し、`kill_tracked_processes` で Job handle drop → kernel が tree kill (#756, #772)
+- `.github/ISSUE_TEMPLATE/bug_report.yml` の `docs/bug-report-guide.md` link を `develop-0.2.0` から `main` に更新、未公開 placeholder を削除 (#458, #764)
+- `docs/design-overview.md` の metadata.json example から stale な `note` 行を削除 (実装本体は #463 で既に retired) (#374, #766)
+
+### Changed
+
+- Portable ZIP 内 `README.txt` を日本語化 (`scripts/build-portable-zip.ps1` Format-ReadmeContent + Pester assertion 更新、法的引用は原文保持) (#749, #768)
+- Windows process tree 6 spawn site の audit document を `docs/process-tree-orphan-audit.md` として整理 (#743, #772)
+
+### CI / Infrastructure
+
+- cargo audit + npm audit を PR マージ前に実行する `.github/workflows/security-audit.yml` を追加 (Track C、tauri 2.11 transitive の 19 deferred warnings を考慮し vulnerability のみ fail 設定) (#763)
+- `docs/ci-security-audit.md` を新設 (workflow 運用 note) (#763)
+
 ## [0.2.0] - 2026-05-16
 
 L2 (GUI + Portable 配布) リリース。Tauri ベースの GUI を新設し、Portable ZIP 配布で zero-environment setup を実現。GPU decode を Intel QSV / AMD d3d11va に拡張、CLI/GUI で metadata.json schema を統一、warnings 基盤を導入。L2 開発プロセスとして markdownlint 導入、Iron Law 6 (PR 作成前ゲート)、`/iterate-review` / `/close-issue` skill 等の workflow / docs / test infra を全般強化。

--- a/docs/audit-logs/2026-05-16-v0.2.1-audit.log
+++ b/docs/audit-logs/2026-05-16-v0.2.1-audit.log
@@ -1,0 +1,840 @@
+    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
+      Loaded 1090 security advisories (from C:\Users\idios\.cargo\advisory-db)
+    Updating crates.io index
+    Scanning Cargo.lock for vulnerabilities (530 crate dependencies)
+Crate:     atk
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0413
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0413
+Dependency tree:
+atk 0.18.2
+└── gtk 0.18.2
+    ├── wry 0.55.1
+    │   └── tauri-runtime-wry 2.11.1
+    │       └── tauri 2.11.1
+    │           ├── tauri-plugin-shell 2.3.5
+    │           │   └── allaganeye-gui 0.2.0
+    │           ├── tauri-plugin-fs 2.5.1
+    │           │   ├── tauri-plugin-dialog 2.7.1
+    │           │   │   └── allaganeye-gui 0.2.0
+    │           │   └── allaganeye-gui 0.2.0
+    │           ├── tauri-plugin-dialog 2.7.1
+    │           └── allaganeye-gui 0.2.0
+    ├── webkit2gtk 2.0.2
+    │   ├── wry 0.55.1
+    │   ├── tauri-runtime-wry 2.11.1
+    │   ├── tauri-runtime 2.11.1
+    │   │   ├── tauri-runtime-wry 2.11.1
+    │   │   └── tauri 2.11.1
+    │   └── tauri 2.11.1
+    ├── tauri-runtime-wry 2.11.1
+    ├── tauri-runtime 2.11.1
+    ├── tauri 2.11.1
+    ├── tao 0.35.2
+    │   └── tauri-runtime-wry 2.11.1
+    ├── muda 0.19.1
+    │   ├── tray-icon 0.23.1
+    │   │   └── tauri 2.11.1
+    │   └── tauri 2.11.1
+    └── libappindicator 0.9.0
+        └── tray-icon 0.23.1
+
+Crate:     atk-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0416
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0416
+Dependency tree:
+atk-sys 0.18.2
+├── gtk-sys 0.18.2
+│   ├── webkit2gtk-sys 2.0.2
+│   │   ├── wry 0.55.1
+│   │   │   └── tauri-runtime-wry 2.11.1
+│   │   │       └── tauri 2.11.1
+│   │   │           ├── tauri-plugin-shell 2.3.5
+│   │   │           │   └── allaganeye-gui 0.2.0
+│   │   │           ├── tauri-plugin-fs 2.5.1
+│   │   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │   │           │   │   └── allaganeye-gui 0.2.0
+│   │   │           │   └── allaganeye-gui 0.2.0
+│   │   │           ├── tauri-plugin-dialog 2.7.1
+│   │   │           └── allaganeye-gui 0.2.0
+│   │   └── webkit2gtk 2.0.2
+│   │       ├── wry 0.55.1
+│   │       ├── tauri-runtime-wry 2.11.1
+│   │       ├── tauri-runtime 2.11.1
+│   │       │   ├── tauri-runtime-wry 2.11.1
+│   │       │   └── tauri 2.11.1
+│   │       └── tauri 2.11.1
+│   ├── webkit2gtk 2.0.2
+│   ├── rfd 0.16.0
+│   │   └── tauri-plugin-dialog 2.7.1
+│   ├── libappindicator-sys 0.9.0
+│   │   └── libappindicator 0.9.0
+│   │       └── tray-icon 0.23.1
+│   │           └── tauri 2.11.1
+│   ├── libappindicator 0.9.0
+│   └── gtk 0.18.2
+│       ├── wry 0.55.1
+│       ├── webkit2gtk 2.0.2
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       ├── tauri 2.11.1
+│       ├── tao 0.35.2
+│       │   └── tauri-runtime-wry 2.11.1
+│       ├── muda 0.19.1
+│       │   ├── tray-icon 0.23.1
+│       │   └── tauri 2.11.1
+│       └── libappindicator 0.9.0
+└── atk 0.18.2
+    └── gtk 0.18.2
+
+Crate:     fxhash
+Version:   0.2.1
+Warning:   unmaintained
+Title:     fxhash - no longer maintained
+Date:      2025-09-05
+ID:        RUSTSEC-2025-0057
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0057
+Dependency tree:
+fxhash 0.2.1
+└── selectors 0.24.0
+    └── kuchikiki 0.8.8-speedreader
+        └── tauri-utils 2.9.1
+            ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            │       ├── tauri-plugin-shell 2.3.5
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-fs 2.5.1
+            │       │   ├── tauri-plugin-dialog 2.7.1
+            │       │   │   └── allaganeye-gui 0.2.0
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-dialog 2.7.1
+            │       └── allaganeye-gui 0.2.0
+            ├── tauri-runtime 2.11.1
+            │   ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            ├── tauri-plugin-fs 2.5.1
+            ├── tauri-plugin 2.5.4
+            │   ├── tauri-plugin-shell 2.3.5
+            │   ├── tauri-plugin-fs 2.5.1
+            │   └── tauri-plugin-dialog 2.7.1
+            ├── tauri-macros 2.6.1
+            │   └── tauri 2.11.1
+            ├── tauri-codegen 2.6.1
+            │   └── tauri-macros 2.6.1
+            ├── tauri-build 2.6.1
+            │   ├── tauri 2.11.1
+            │   └── allaganeye-gui 0.2.0
+            └── tauri 2.11.1
+
+Crate:     gdk
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0412
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0412
+Dependency tree:
+gdk 0.18.2
+├── webkit2gtk 2.0.2
+│   ├── wry 0.55.1
+│   │   └── tauri-runtime-wry 2.11.1
+│   │       └── tauri 2.11.1
+│   │           ├── tauri-plugin-shell 2.3.5
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-fs 2.5.1
+│   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │           │   │   └── allaganeye-gui 0.2.0
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-dialog 2.7.1
+│   │           └── allaganeye-gui 0.2.0
+│   ├── tauri-runtime-wry 2.11.1
+│   ├── tauri-runtime 2.11.1
+│   │   ├── tauri-runtime-wry 2.11.1
+│   │   └── tauri 2.11.1
+│   └── tauri 2.11.1
+├── gtk 0.18.2
+│   ├── wry 0.55.1
+│   ├── webkit2gtk 2.0.2
+│   ├── tauri-runtime-wry 2.11.1
+│   ├── tauri-runtime 2.11.1
+│   ├── tauri 2.11.1
+│   ├── tao 0.35.2
+│   │   └── tauri-runtime-wry 2.11.1
+│   ├── muda 0.19.1
+│   │   ├── tray-icon 0.23.1
+│   │   │   └── tauri 2.11.1
+│   │   └── tauri 2.11.1
+│   └── libappindicator 0.9.0
+│       └── tray-icon 0.23.1
+└── gdkx11 0.18.2
+    └── wry 0.55.1
+
+Crate:     gdk-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0418
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0418
+Dependency tree:
+gdk-sys 0.18.2
+├── webkit2gtk-sys 2.0.2
+│   ├── wry 0.55.1
+│   │   └── tauri-runtime-wry 2.11.1
+│   │       └── tauri 2.11.1
+│   │           ├── tauri-plugin-shell 2.3.5
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-fs 2.5.1
+│   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │           │   │   └── allaganeye-gui 0.2.0
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-dialog 2.7.1
+│   │           └── allaganeye-gui 0.2.0
+│   └── webkit2gtk 2.0.2
+│       ├── wry 0.55.1
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       │   ├── tauri-runtime-wry 2.11.1
+│       │   └── tauri 2.11.1
+│       └── tauri 2.11.1
+├── webkit2gtk 2.0.2
+├── gtk-sys 0.18.2
+│   ├── webkit2gtk-sys 2.0.2
+│   ├── webkit2gtk 2.0.2
+│   ├── rfd 0.16.0
+│   │   └── tauri-plugin-dialog 2.7.1
+│   ├── libappindicator-sys 0.9.0
+│   │   └── libappindicator 0.9.0
+│   │       └── tray-icon 0.23.1
+│   │           └── tauri 2.11.1
+│   ├── libappindicator 0.9.0
+│   └── gtk 0.18.2
+│       ├── wry 0.55.1
+│       ├── webkit2gtk 2.0.2
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       ├── tauri 2.11.1
+│       ├── tao 0.35.2
+│       │   └── tauri-runtime-wry 2.11.1
+│       ├── muda 0.19.1
+│       │   ├── tray-icon 0.23.1
+│       │   └── tauri 2.11.1
+│       └── libappindicator 0.9.0
+├── gdkx11-sys 0.18.2
+│   ├── tao 0.35.2
+│   └── gdkx11 0.18.2
+│       └── wry 0.55.1
+├── gdkwayland-sys 0.18.2
+│   └── tao 0.35.2
+└── gdk 0.18.2
+    ├── webkit2gtk 2.0.2
+    ├── gtk 0.18.2
+    └── gdkx11 0.18.2
+
+Crate:     gdkwayland-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0411
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0411
+Dependency tree:
+gdkwayland-sys 0.18.2
+└── tao 0.35.2
+    └── tauri-runtime-wry 2.11.1
+        └── tauri 2.11.1
+            ├── tauri-plugin-shell 2.3.5
+            │   └── allaganeye-gui 0.2.0
+            ├── tauri-plugin-fs 2.5.1
+            │   ├── tauri-plugin-dialog 2.7.1
+            │   │   └── allaganeye-gui 0.2.0
+            │   └── allaganeye-gui 0.2.0
+            ├── tauri-plugin-dialog 2.7.1
+            └── allaganeye-gui 0.2.0
+
+Crate:     gdkx11
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0417
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0417
+Dependency tree:
+gdkx11 0.18.2
+└── wry 0.55.1
+    └── tauri-runtime-wry 2.11.1
+        └── tauri 2.11.1
+            ├── tauri-plugin-shell 2.3.5
+            │   └── allaganeye-gui 0.2.0
+            ├── tauri-plugin-fs 2.5.1
+            │   ├── tauri-plugin-dialog 2.7.1
+            │   │   └── allaganeye-gui 0.2.0
+            │   └── allaganeye-gui 0.2.0
+            ├── tauri-plugin-dialog 2.7.1
+            └── allaganeye-gui 0.2.0
+
+Crate:     gdkx11-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0414
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0414
+Dependency tree:
+gdkx11-sys 0.18.2
+├── tao 0.35.2
+│   └── tauri-runtime-wry 2.11.1
+│       └── tauri 2.11.1
+│           ├── tauri-plugin-shell 2.3.5
+│           │   └── allaganeye-gui 0.2.0
+│           ├── tauri-plugin-fs 2.5.1
+│           │   ├── tauri-plugin-dialog 2.7.1
+│           │   │   └── allaganeye-gui 0.2.0
+│           │   └── allaganeye-gui 0.2.0
+│           ├── tauri-plugin-dialog 2.7.1
+│           └── allaganeye-gui 0.2.0
+└── gdkx11 0.18.2
+    └── wry 0.55.1
+        └── tauri-runtime-wry 2.11.1
+
+Crate:     gtk
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0415
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0415
+Dependency tree:
+gtk 0.18.2
+├── wry 0.55.1
+│   └── tauri-runtime-wry 2.11.1
+│       └── tauri 2.11.1
+│           ├── tauri-plugin-shell 2.3.5
+│           │   └── allaganeye-gui 0.2.0
+│           ├── tauri-plugin-fs 2.5.1
+│           │   ├── tauri-plugin-dialog 2.7.1
+│           │   │   └── allaganeye-gui 0.2.0
+│           │   └── allaganeye-gui 0.2.0
+│           ├── tauri-plugin-dialog 2.7.1
+│           └── allaganeye-gui 0.2.0
+├── webkit2gtk 2.0.2
+│   ├── wry 0.55.1
+│   ├── tauri-runtime-wry 2.11.1
+│   ├── tauri-runtime 2.11.1
+│   │   ├── tauri-runtime-wry 2.11.1
+│   │   └── tauri 2.11.1
+│   └── tauri 2.11.1
+├── tauri-runtime-wry 2.11.1
+├── tauri-runtime 2.11.1
+├── tauri 2.11.1
+├── tao 0.35.2
+│   └── tauri-runtime-wry 2.11.1
+├── muda 0.19.1
+│   ├── tray-icon 0.23.1
+│   │   └── tauri 2.11.1
+│   └── tauri 2.11.1
+└── libappindicator 0.9.0
+    └── tray-icon 0.23.1
+
+Crate:     gtk-sys
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0420
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0420
+Dependency tree:
+gtk-sys 0.18.2
+├── webkit2gtk-sys 2.0.2
+│   ├── wry 0.55.1
+│   │   └── tauri-runtime-wry 2.11.1
+│   │       └── tauri 2.11.1
+│   │           ├── tauri-plugin-shell 2.3.5
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-fs 2.5.1
+│   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │           │   │   └── allaganeye-gui 0.2.0
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-dialog 2.7.1
+│   │           └── allaganeye-gui 0.2.0
+│   └── webkit2gtk 2.0.2
+│       ├── wry 0.55.1
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       │   ├── tauri-runtime-wry 2.11.1
+│       │   └── tauri 2.11.1
+│       └── tauri 2.11.1
+├── webkit2gtk 2.0.2
+├── rfd 0.16.0
+│   └── tauri-plugin-dialog 2.7.1
+├── libappindicator-sys 0.9.0
+│   └── libappindicator 0.9.0
+│       └── tray-icon 0.23.1
+│           └── tauri 2.11.1
+├── libappindicator 0.9.0
+└── gtk 0.18.2
+    ├── wry 0.55.1
+    ├── webkit2gtk 2.0.2
+    ├── tauri-runtime-wry 2.11.1
+    ├── tauri-runtime 2.11.1
+    ├── tauri 2.11.1
+    ├── tao 0.35.2
+    │   └── tauri-runtime-wry 2.11.1
+    ├── muda 0.19.1
+    │   ├── tray-icon 0.23.1
+    │   └── tauri 2.11.1
+    └── libappindicator 0.9.0
+
+Crate:     gtk3-macros
+Version:   0.18.2
+Warning:   unmaintained
+Title:     gtk-rs GTK3 bindings - no longer maintained
+Date:      2024-03-04
+ID:        RUSTSEC-2024-0419
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0419
+Dependency tree:
+gtk3-macros 0.18.2
+└── gtk 0.18.2
+    ├── wry 0.55.1
+    │   └── tauri-runtime-wry 2.11.1
+    │       └── tauri 2.11.1
+    │           ├── tauri-plugin-shell 2.3.5
+    │           │   └── allaganeye-gui 0.2.0
+    │           ├── tauri-plugin-fs 2.5.1
+    │           │   ├── tauri-plugin-dialog 2.7.1
+    │           │   │   └── allaganeye-gui 0.2.0
+    │           │   └── allaganeye-gui 0.2.0
+    │           ├── tauri-plugin-dialog 2.7.1
+    │           └── allaganeye-gui 0.2.0
+    ├── webkit2gtk 2.0.2
+    │   ├── wry 0.55.1
+    │   ├── tauri-runtime-wry 2.11.1
+    │   ├── tauri-runtime 2.11.1
+    │   │   ├── tauri-runtime-wry 2.11.1
+    │   │   └── tauri 2.11.1
+    │   └── tauri 2.11.1
+    ├── tauri-runtime-wry 2.11.1
+    ├── tauri-runtime 2.11.1
+    ├── tauri 2.11.1
+    ├── tao 0.35.2
+    │   └── tauri-runtime-wry 2.11.1
+    ├── muda 0.19.1
+    │   ├── tray-icon 0.23.1
+    │   │   └── tauri 2.11.1
+    │   └── tauri 2.11.1
+    └── libappindicator 0.9.0
+        └── tray-icon 0.23.1
+
+Crate:     proc-macro-error
+Version:   1.0.4
+Warning:   unmaintained
+Title:     proc-macro-error is unmaintained
+Date:      2024-09-01
+ID:        RUSTSEC-2024-0370
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0370
+Dependency tree:
+proc-macro-error 1.0.4
+├── gtk3-macros 0.18.2
+│   └── gtk 0.18.2
+│       ├── wry 0.55.1
+│       │   └── tauri-runtime-wry 2.11.1
+│       │       └── tauri 2.11.1
+│       │           ├── tauri-plugin-shell 2.3.5
+│       │           │   └── allaganeye-gui 0.2.0
+│       │           ├── tauri-plugin-fs 2.5.1
+│       │           │   ├── tauri-plugin-dialog 2.7.1
+│       │           │   │   └── allaganeye-gui 0.2.0
+│       │           │   └── allaganeye-gui 0.2.0
+│       │           ├── tauri-plugin-dialog 2.7.1
+│       │           └── allaganeye-gui 0.2.0
+│       ├── webkit2gtk 2.0.2
+│       │   ├── wry 0.55.1
+│       │   ├── tauri-runtime-wry 2.11.1
+│       │   ├── tauri-runtime 2.11.1
+│       │   │   ├── tauri-runtime-wry 2.11.1
+│       │   │   └── tauri 2.11.1
+│       │   └── tauri 2.11.1
+│       ├── tauri-runtime-wry 2.11.1
+│       ├── tauri-runtime 2.11.1
+│       ├── tauri 2.11.1
+│       ├── tao 0.35.2
+│       │   └── tauri-runtime-wry 2.11.1
+│       ├── muda 0.19.1
+│       │   ├── tray-icon 0.23.1
+│       │   │   └── tauri 2.11.1
+│       │   └── tauri 2.11.1
+│       └── libappindicator 0.9.0
+│           └── tray-icon 0.23.1
+└── glib-macros 0.18.5
+    └── glib 0.18.5
+        ├── webkit2gtk 2.0.2
+        ├── soup3 0.5.0
+        │   ├── wry 0.55.1
+        │   └── webkit2gtk 2.0.2
+        ├── pango 0.18.3
+        │   ├── gtk 0.18.2
+        │   └── gdk 0.18.2
+        │       ├── webkit2gtk 2.0.2
+        │       ├── gtk 0.18.2
+        │       └── gdkx11 0.18.2
+        │           └── wry 0.55.1
+        ├── libappindicator 0.9.0
+        ├── javascriptcore-rs 1.1.2
+        │   ├── wry 0.55.1
+        │   └── webkit2gtk 2.0.2
+        ├── gtk 0.18.2
+        ├── gio 0.18.4
+        │   ├── webkit2gtk 2.0.2
+        │   ├── soup3 0.5.0
+        │   ├── pango 0.18.3
+        │   ├── gtk 0.18.2
+        │   ├── gdkx11 0.18.2
+        │   ├── gdk-pixbuf 0.18.5
+        │   │   ├── gtk 0.18.2
+        │   │   └── gdk 0.18.2
+        │   └── gdk 0.18.2
+        ├── gdkx11 0.18.2
+        ├── gdk-pixbuf 0.18.5
+        ├── gdk 0.18.2
+        ├── cairo-rs 0.18.5
+        │   ├── webkit2gtk 2.0.2
+        │   ├── gtk 0.18.2
+        │   └── gdk 0.18.2
+        └── atk 0.18.2
+            └── gtk 0.18.2
+
+Crate:     unic-char-property
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-char-property` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0081
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0081
+Dependency tree:
+unic-char-property 0.9.0
+└── unic-ucd-ident 0.9.0
+    └── urlpattern 0.3.0
+        └── tauri-utils 2.9.1
+            ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            │       ├── tauri-plugin-shell 2.3.5
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-fs 2.5.1
+            │       │   ├── tauri-plugin-dialog 2.7.1
+            │       │   │   └── allaganeye-gui 0.2.0
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-dialog 2.7.1
+            │       └── allaganeye-gui 0.2.0
+            ├── tauri-runtime 2.11.1
+            │   ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            ├── tauri-plugin-fs 2.5.1
+            ├── tauri-plugin 2.5.4
+            │   ├── tauri-plugin-shell 2.3.5
+            │   ├── tauri-plugin-fs 2.5.1
+            │   └── tauri-plugin-dialog 2.7.1
+            ├── tauri-macros 2.6.1
+            │   └── tauri 2.11.1
+            ├── tauri-codegen 2.6.1
+            │   └── tauri-macros 2.6.1
+            ├── tauri-build 2.6.1
+            │   ├── tauri 2.11.1
+            │   └── allaganeye-gui 0.2.0
+            └── tauri 2.11.1
+
+Crate:     unic-char-range
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-char-range` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0075
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0075
+Dependency tree:
+unic-char-range 0.9.0
+├── unic-ucd-ident 0.9.0
+│   └── urlpattern 0.3.0
+│       └── tauri-utils 2.9.1
+│           ├── tauri-runtime-wry 2.11.1
+│           │   └── tauri 2.11.1
+│           │       ├── tauri-plugin-shell 2.3.5
+│           │       │   └── allaganeye-gui 0.2.0
+│           │       ├── tauri-plugin-fs 2.5.1
+│           │       │   ├── tauri-plugin-dialog 2.7.1
+│           │       │   │   └── allaganeye-gui 0.2.0
+│           │       │   └── allaganeye-gui 0.2.0
+│           │       ├── tauri-plugin-dialog 2.7.1
+│           │       └── allaganeye-gui 0.2.0
+│           ├── tauri-runtime 2.11.1
+│           │   ├── tauri-runtime-wry 2.11.1
+│           │   └── tauri 2.11.1
+│           ├── tauri-plugin-fs 2.5.1
+│           ├── tauri-plugin 2.5.4
+│           │   ├── tauri-plugin-shell 2.3.5
+│           │   ├── tauri-plugin-fs 2.5.1
+│           │   └── tauri-plugin-dialog 2.7.1
+│           ├── tauri-macros 2.6.1
+│           │   └── tauri 2.11.1
+│           ├── tauri-codegen 2.6.1
+│           │   └── tauri-macros 2.6.1
+│           ├── tauri-build 2.6.1
+│           │   ├── tauri 2.11.1
+│           │   └── allaganeye-gui 0.2.0
+│           └── tauri 2.11.1
+└── unic-char-property 0.9.0
+    └── unic-ucd-ident 0.9.0
+
+Crate:     unic-common
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-common` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0080
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0080
+Dependency tree:
+unic-common 0.9.0
+└── unic-ucd-version 0.9.0
+    └── unic-ucd-ident 0.9.0
+        └── urlpattern 0.3.0
+            └── tauri-utils 2.9.1
+                ├── tauri-runtime-wry 2.11.1
+                │   └── tauri 2.11.1
+                │       ├── tauri-plugin-shell 2.3.5
+                │       │   └── allaganeye-gui 0.2.0
+                │       ├── tauri-plugin-fs 2.5.1
+                │       │   ├── tauri-plugin-dialog 2.7.1
+                │       │   │   └── allaganeye-gui 0.2.0
+                │       │   └── allaganeye-gui 0.2.0
+                │       ├── tauri-plugin-dialog 2.7.1
+                │       └── allaganeye-gui 0.2.0
+                ├── tauri-runtime 2.11.1
+                │   ├── tauri-runtime-wry 2.11.1
+                │   └── tauri 2.11.1
+                ├── tauri-plugin-fs 2.5.1
+                ├── tauri-plugin 2.5.4
+                │   ├── tauri-plugin-shell 2.3.5
+                │   ├── tauri-plugin-fs 2.5.1
+                │   └── tauri-plugin-dialog 2.7.1
+                ├── tauri-macros 2.6.1
+                │   └── tauri 2.11.1
+                ├── tauri-codegen 2.6.1
+                │   └── tauri-macros 2.6.1
+                ├── tauri-build 2.6.1
+                │   ├── tauri 2.11.1
+                │   └── allaganeye-gui 0.2.0
+                └── tauri 2.11.1
+
+Crate:     unic-ucd-ident
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-ucd-ident` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0100
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0100
+Dependency tree:
+unic-ucd-ident 0.9.0
+└── urlpattern 0.3.0
+    └── tauri-utils 2.9.1
+        ├── tauri-runtime-wry 2.11.1
+        │   └── tauri 2.11.1
+        │       ├── tauri-plugin-shell 2.3.5
+        │       │   └── allaganeye-gui 0.2.0
+        │       ├── tauri-plugin-fs 2.5.1
+        │       │   ├── tauri-plugin-dialog 2.7.1
+        │       │   │   └── allaganeye-gui 0.2.0
+        │       │   └── allaganeye-gui 0.2.0
+        │       ├── tauri-plugin-dialog 2.7.1
+        │       └── allaganeye-gui 0.2.0
+        ├── tauri-runtime 2.11.1
+        │   ├── tauri-runtime-wry 2.11.1
+        │   └── tauri 2.11.1
+        ├── tauri-plugin-fs 2.5.1
+        ├── tauri-plugin 2.5.4
+        │   ├── tauri-plugin-shell 2.3.5
+        │   ├── tauri-plugin-fs 2.5.1
+        │   └── tauri-plugin-dialog 2.7.1
+        ├── tauri-macros 2.6.1
+        │   └── tauri 2.11.1
+        ├── tauri-codegen 2.6.1
+        │   └── tauri-macros 2.6.1
+        ├── tauri-build 2.6.1
+        │   ├── tauri 2.11.1
+        │   └── allaganeye-gui 0.2.0
+        └── tauri 2.11.1
+
+Crate:     unic-ucd-version
+Version:   0.9.0
+Warning:   unmaintained
+Title:     `unic-ucd-version` is unmaintained
+Date:      2025-10-18
+ID:        RUSTSEC-2025-0098
+URL:       https://rustsec.org/advisories/RUSTSEC-2025-0098
+Dependency tree:
+unic-ucd-version 0.9.0
+└── unic-ucd-ident 0.9.0
+    └── urlpattern 0.3.0
+        └── tauri-utils 2.9.1
+            ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            │       ├── tauri-plugin-shell 2.3.5
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-fs 2.5.1
+            │       │   ├── tauri-plugin-dialog 2.7.1
+            │       │   │   └── allaganeye-gui 0.2.0
+            │       │   └── allaganeye-gui 0.2.0
+            │       ├── tauri-plugin-dialog 2.7.1
+            │       └── allaganeye-gui 0.2.0
+            ├── tauri-runtime 2.11.1
+            │   ├── tauri-runtime-wry 2.11.1
+            │   └── tauri 2.11.1
+            ├── tauri-plugin-fs 2.5.1
+            ├── tauri-plugin 2.5.4
+            │   ├── tauri-plugin-shell 2.3.5
+            │   ├── tauri-plugin-fs 2.5.1
+            │   └── tauri-plugin-dialog 2.7.1
+            ├── tauri-macros 2.6.1
+            │   └── tauri 2.11.1
+            ├── tauri-codegen 2.6.1
+            │   └── tauri-macros 2.6.1
+            ├── tauri-build 2.6.1
+            │   ├── tauri 2.11.1
+            │   └── allaganeye-gui 0.2.0
+            └── tauri 2.11.1
+
+Crate:     glib
+Version:   0.18.5
+Warning:   unsound
+Title:     Unsoundness in `Iterator` and `DoubleEndedIterator` impls for `glib::VariantStrIter`
+Date:      2024-03-30
+ID:        RUSTSEC-2024-0429
+URL:       https://rustsec.org/advisories/RUSTSEC-2024-0429
+Dependency tree:
+glib 0.18.5
+├── webkit2gtk 2.0.2
+│   ├── wry 0.55.1
+│   │   └── tauri-runtime-wry 2.11.1
+│   │       └── tauri 2.11.1
+│   │           ├── tauri-plugin-shell 2.3.5
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-fs 2.5.1
+│   │           │   ├── tauri-plugin-dialog 2.7.1
+│   │           │   │   └── allaganeye-gui 0.2.0
+│   │           │   └── allaganeye-gui 0.2.0
+│   │           ├── tauri-plugin-dialog 2.7.1
+│   │           └── allaganeye-gui 0.2.0
+│   ├── tauri-runtime-wry 2.11.1
+│   ├── tauri-runtime 2.11.1
+│   │   ├── tauri-runtime-wry 2.11.1
+│   │   └── tauri 2.11.1
+│   └── tauri 2.11.1
+├── soup3 0.5.0
+│   ├── wry 0.55.1
+│   └── webkit2gtk 2.0.2
+├── pango 0.18.3
+│   ├── gtk 0.18.2
+│   │   ├── wry 0.55.1
+│   │   ├── webkit2gtk 2.0.2
+│   │   ├── tauri-runtime-wry 2.11.1
+│   │   ├── tauri-runtime 2.11.1
+│   │   ├── tauri 2.11.1
+│   │   ├── tao 0.35.2
+│   │   │   └── tauri-runtime-wry 2.11.1
+│   │   ├── muda 0.19.1
+│   │   │   ├── tray-icon 0.23.1
+│   │   │   │   └── tauri 2.11.1
+│   │   │   └── tauri 2.11.1
+│   │   └── libappindicator 0.9.0
+│   │       └── tray-icon 0.23.1
+│   └── gdk 0.18.2
+│       ├── webkit2gtk 2.0.2
+│       ├── gtk 0.18.2
+│       └── gdkx11 0.18.2
+│           └── wry 0.55.1
+├── libappindicator 0.9.0
+├── javascriptcore-rs 1.1.2
+│   ├── wry 0.55.1
+│   └── webkit2gtk 2.0.2
+├── gtk 0.18.2
+├── gio 0.18.4
+│   ├── webkit2gtk 2.0.2
+│   ├── soup3 0.5.0
+│   ├── pango 0.18.3
+│   ├── gtk 0.18.2
+│   ├── gdkx11 0.18.2
+│   ├── gdk-pixbuf 0.18.5
+│   │   ├── gtk 0.18.2
+│   │   └── gdk 0.18.2
+│   └── gdk 0.18.2
+├── gdkx11 0.18.2
+├── gdk-pixbuf 0.18.5
+├── gdk 0.18.2
+├── cairo-rs 0.18.5
+│   ├── webkit2gtk 2.0.2
+│   ├── gtk 0.18.2
+│   └── gdk 0.18.2
+└── atk 0.18.2
+    └── gtk 0.18.2
+
+Crate:     rand
+Version:   0.7.3
+Warning:   unsound
+Title:     Rand is unsound with a custom logger using `rand::rng()`
+Date:      2026-04-09
+ID:        RUSTSEC-2026-0097
+URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097
+Dependency tree:
+rand 0.7.3
+└── phf_generator 0.8.0
+    └── phf_codegen 0.8.0
+        └── selectors 0.24.0
+            └── kuchikiki 0.8.8-speedreader
+                └── tauri-utils 2.9.1
+                    ├── tauri-runtime-wry 2.11.1
+                    │   └── tauri 2.11.1
+                    │       ├── tauri-plugin-shell 2.3.5
+                    │       │   └── allaganeye-gui 0.2.0
+                    │       ├── tauri-plugin-fs 2.5.1
+                    │       │   ├── tauri-plugin-dialog 2.7.1
+                    │       │   │   └── allaganeye-gui 0.2.0
+                    │       │   └── allaganeye-gui 0.2.0
+                    │       ├── tauri-plugin-dialog 2.7.1
+                    │       └── allaganeye-gui 0.2.0
+                    ├── tauri-runtime 2.11.1
+                    │   ├── tauri-runtime-wry 2.11.1
+                    │   └── tauri 2.11.1
+                    ├── tauri-plugin-fs 2.5.1
+                    ├── tauri-plugin 2.5.4
+                    │   ├── tauri-plugin-shell 2.3.5
+                    │   ├── tauri-plugin-fs 2.5.1
+                    │   └── tauri-plugin-dialog 2.7.1
+                    ├── tauri-macros 2.6.1
+                    │   └── tauri 2.11.1
+                    ├── tauri-codegen 2.6.1
+                    │   └── tauri-macros 2.6.1
+                    ├── tauri-build 2.6.1
+                    │   ├── tauri 2.11.1
+                    │   └── allaganeye-gui 0.2.0
+                    └── tauri 2.11.1
+
+warning: 19 allowed warnings found
+exit=0
+# npm audit report
+
+ajv  7.0.0-alpha.0 - 8.17.1
+Severity: moderate
+ajv has ReDoS when using `$data` option - https://github.com/advisories/GHSA-2g4f-4pwh-qvx6
+fix available via `npm audit fix --force`
+Will install ajv@8.20.0, which is outside the stated dependency range
+node_modules/ajv
+
+1 moderate severity vulnerability
+
+To address all issues, run:
+  npm audit fix --force
+npm exit=1

--- a/docs/ci-security-audit.md
+++ b/docs/ci-security-audit.md
@@ -1,0 +1,51 @@
+# CI: Security Audit Workflow
+
+`.github/workflows/security-audit.yml` の運用 note。
+
+## 目的
+
+PR を `develop-x.x.x` や `main` にマージする前に、cargo audit + npm audit を自動実行し、Dependabot より早く脆弱性を検出する。
+
+## 発火条件
+
+- `pull_request` trigger
+- paths: `gui/src-tauri/Cargo.lock`, `gui/src-tauri/Cargo.toml`, `gui/package-lock.json`, `gui/package.json`, `.github/workflows/security-audit.yml`
+- `workflow_dispatch` で手動実行も可能
+
+paths filter により、Python のみ変更の PR では本 workflow は走らない (CI 時間節約)。
+
+## ジョブ
+
+| ジョブ | コマンド | fail 条件 |
+| --- | --- | --- |
+| cargo-audit | `cargo audit` (default) | vulnerability (CVE 相当) 検出のみ fail。warning (unmaintained / unsound) は通過 |
+| npm-audit | `npm audit --audit-level=high` | high 以上の advisory 検出。dev-only の moderate/low は warning として通過 |
+
+### cargo audit を default 設定にした理由 (v0.2.1 Track C)
+
+`--deny warnings` で実行すると、現状 19 件の deferred warnings (tauri 2.11 系の transitive で残る `rand 0.7.3` / `glib 0.18.5` / `atk` 等 gtk-rs GTK3 bindings unmaintained) で fail する。これらは:
+
+- 配布物 (Windows Portable ZIP) には影響しない (build-dep のみ or Linux/macOS 専用)
+- tauri 上流が phf_generator / kuchikiki 等を新版へ移行するのを待つ deferred 判断 (`docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §4 Track A)
+
+CI が常時 fail する状態を避けるため、本 workflow では default 設定 (vulnerability のみ fail) で運用する。warning は log 出力で確認可能。
+
+## 失敗時の対応
+
+1. PR 作者は失敗 log を確認し、影響のある依存を特定
+2. 該当依存の patched version を確認 (cargo upgrade / npm install)
+3. 本 PR 内で修正 commit を追加、または別 PR で先に hotfix
+4. medium/low で warning のみの場合は警告として report し、本 PR では (1) 修正、(2) deferred 起票、(3) ignore 理由を本 PR 本文に明記、のいずれか
+
+## Dependabot との関係
+
+- Dependabot: 既存依存の脆弱性を post-merge で検出 (auto PR で patch を提案)
+- 本 workflow: PR 提案 (Dependabot or 手動) を merge する**前**に検証
+
+両者は補完関係。本 workflow が green でも Dependabot alert は別途出る可能性 (advisory DB の更新タイミング差)。
+
+## 参照
+
+- spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §2.5 / §4 Track C
+- plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md`
+- Track A audit log baseline: `docs/audit-logs/2026-05-16-v0.2.1-audit.log`

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -108,7 +108,6 @@ Allagan Eye は FF14 フロントラインの長時間録画動画を段階的�
   "source": "2026-01-20 22-33-17.mkv",
   "source_duration": 7303.0,
   "source_duration_display": "2:01:43",
-  "note": "Split times are approximate due to keyframe-aligned copy mode. ...",
   "detected_at": "2026-04-19T12:34:56Z",
   "detection_params": {
     "sample_interval": 2.0,

--- a/docs/process-tree-orphan-audit.md
+++ b/docs/process-tree-orphan-audit.md
@@ -1,0 +1,102 @@
+# Windows process tree orphan audit (#743)
+
+L2a GUI (`gui/src-tauri/src/lib.rs`) は外部プロセスを 6 箇所で spawn する。本 audit はそれぞれの Windows process tree 振る舞いと孤児化リスクを整理し、#756 fix (Job Object 化) を `start_detect` のみに適用した理由を明示する。元 audit task は #743、修正実装は #756。
+
+## §1 spawn site 一覧
+
+| # | spawn site | spawn する process | 子孫プロセス | orphan risk | PROCESS_TRACKER 登録 | Job Object 適用 (#756) | 備考 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `probe_video_with` (`lib.rs:~638`) | ffprobe (単発) | なし | なし | no (`cmd.output()`、spawn+wait 一体) | no | 短命 metadata query。`output().await` ブロックで親と寿命同期 |
+| 2 | `ensure_thumbnail_exists` (`lib.rs:~1236`) | ffmpeg (単発) | なし | なし | no (`cmd.output()`) | no | サムネ生成、数百 ms 以内 |
+| 3 | `extract_brightness_window_impl` (`lib.rs:~1348`) | ffmpeg (単発) | なし | なし | no (`cmd.output()`) | no | preview brightness 抽出、~1s |
+| 4 | `run_ffmpeg_export_attempt` (`lib.rs:~2072`) | ffmpeg (単発) | なし | あり (中断時) | yes | no | export 1 本ずつ、`TrackedChild::no_job(child)` |
+| 5 | **`start_detect` (`lib.rs:~2708`)** | Python `allaganeye detect` | **ffmpeg N 個 (GPU detector で 16-32、`gpu_detector.py`)** | **あり (#756 root cause)** | yes | **yes** | 本 PR の対応対象。`TrackedChild { child, job: Some(_) }` |
+| 6 | `open_folder_in_explorer` (`lib.rs:~1899`) | explorer.exe | (Windows shell process) | N/A (意図的 detach) | **no** | no | UI、本 app 終了後も残るべき |
+
+> 行番号は本 PR (#772) merge 時のスナップショット。将来の追記で drift しうるため、必ず関数名で grep して現在位置を確認すること。
+
+## §2 #756 fix の挙動 (start_detect だけ Job 化)
+
+### 2.1 なぜ start_detect だけか
+
+`start_detect` は Python CLI (`allaganeye detect`) を spawn し、Python 側は GPU detection が有効な場合に内部で N 個 (16-32) の ffmpeg プロセスを並列 spawn する (`allaganeye/video/gpu_detector.py`)。Windows の `TerminateProcess` (= `tokio::process::Child::kill().await`) は **直接の子プロセスのみ kill** するため、Python だけが死んで ffmpeg 子孫は親なしの孤児として残留する (#756 root cause)。
+
+他 5 spawn site は:
+
+- **#1-#4 (ffmpeg / ffprobe 単発)**: 子孫を spawn しない。`Child::kill` で十分。
+- **#6 (explorer.exe)**: 「UI が GUI 終了後も残る」のが意図 (Idios の方針: 「展開 = インストール、削除 = アンインストール」)。Job 化すると Job Close で explorer も道連れに kill されてしまうため絶対に対象外。
+
+### 2.2 Job Object の効果
+
+`gui/src-tauri/src/process_util/job_object.rs` に [`ProcessJob`](../gui/src-tauri/src/process_util/job_object.rs) を実装。動作は以下:
+
+1. `CreateJobObjectW(None, None)` で名前なし Job を作成
+2. `SetInformationJobObject` で `JOBOBJECT_EXTENDED_LIMIT_INFORMATION.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` を設定
+3. `start_detect` の `cmd.spawn()` 直後に `AssignProcessToJobObject(job_handle, python_handle)` で Python CLI process を Job に追加
+4. `TrackedChild { child, job: Some(_) }` に Job handle を保持
+5. PROCESS_TRACKER 内で TrackedChild が生きている間 Job は維持される
+6. `kill_tracked_processes` が PROCESS_TRACKER を drain すると `TrackedChild` が drop され、`ProcessJob` も drop される
+7. `ProcessJob::drop` が `CloseHandle(job_handle)` を呼び、Windows kernel が `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` を発火して **assigned process と全 descendant を一括 kill**
+
+Python が spawn する ffmpeg は親プロセス (Python) の Job membership を継承するため、Python が Job に入っていれば ffmpeg も自動的に Job に入る (Windows カーネルの仕様、`JOB_OBJECT_LIMIT_BREAKAWAY_OK` を明示的に設定しない限り)。
+
+### 2.3 happy path (cancellation なし) での挙動
+
+検知が正常完了するケースでは:
+
+1. Python CLI が exit 0 で終わる → child の `wait().await` が `Ok(ExitStatus::success())` を返す
+2. `untrack_child(id).await` が `TrackedChild` から `child` を抽出して返却、同時に **`TrackedChild` (= Job 保持側) は drop**
+3. しかし Job 内のプロセス (Python) はすでに自然死しているため、Job の `KILL_ON_JOB_CLOSE` 発火は **no-op** (Job 内に kill 対象がいない)
+4. `CloseHandle(job_handle)` は kernel handle を release するだけ
+
+つまり Job Object 化による happy path への性能影響はゼロ。
+
+## §3 親 app crash 時の挙動
+
+`on_window_event(CloseRequested)` handler を通らずに親 Tauri app が異常終了するケース (panic / OS-side SIGKILL / electron-like crash):
+
+- Windows kernel は process termination 時に **そのプロセスが保持していた全 handle を release** する
+- `ProcessJob` の Job handle も release され、`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` が発火する
+- 結果: Tauri app が crash しても Python CLI + ffmpeg descendants は kernel 側で確実に reap される
+
+これは Job Object pattern が `taskkill /T /F /PID` 経由のソリューションより優れている主要因。`taskkill` は親 app が機能していないと呼ばれず、crash 時の cleanup を保証できない。
+
+## §4 検証手順 (実機テスト)
+
+以下は GUI build + 実機実行で確認すべき項目。CI は jsdom + cargo unit test なので React side wiring (`flow N` integration test) と Job API smoke test (`process_job_assign_real_child_drop_kills_it`) しか pin できない。
+
+1. `cd gui && npm run tauri dev` で開発ビルドを起動
+2. detecting 画面に到達 (動画 drop → [OK — 検知開始])
+3. Task Manager (詳細タブ) を開き、`python.exe` + `ffmpeg.exe` プロセスが N 個立ち上がるのを確認
+4. GUI のタイトルバー `×` を押下
+5. ConfirmExitModal で [終了] を押下
+6. Task Manager で:
+   - `python.exe` (allaganeye CLI) が **0 個** であること
+   - `ffmpeg.exe` (descendant) が **0 個** であること
+   - explorer.exe が引き続き稼働していること (open_folder_in_explorer で起動した shell が残る)
+
+### 4.1 障害シナリオ
+
+以下も検証推奨:
+
+- 検知中に Tauri app が panic (例: `dev_force_panic` Tauri command) → Task Manager で全プロセス消滅を確認
+- 検知中に CPU/Memory が極端に逼迫 → Job handle drop が問題なく走るか
+
+## §5 未対応 (deferred / out-of-scope)
+
+| 項目 | 状態 | 理由 |
+| --- | --- | --- |
+| `run_ffmpeg_export_attempt` の Job 化 | 不要 | ffmpeg 1 本のみ、子孫なし。`Child::kill` で十分 |
+| `taskkill /T /F /PID` fallback | 不要 | Job Object pattern が crash 時も含めてより確実 |
+| `JOB_OBJECT_LIMIT_BREAKAWAY_OK` を必要とする legitimate child の救済 | 該当なし | 現状 Python も ffmpeg も BREAKAWAY を要求しない |
+| Linux / macOS の同等対応 (`setpgid` + `kill -SIGTERM -<pgid>`) | 後回し | プロジェクト方針: 「対応プラットフォーム: Windows のみ」 |
+
+将来的に新規 ffmpeg spawn site を追加する場合は、子孫を spawn するか? を必ず本 audit と同じ表形式で確認し、子孫を持つなら Job Object を適用する。
+
+## §6 関連
+
+- 実装: `gui/src-tauri/src/process_util/job_object.rs` + `gui/src-tauri/src/lib.rs` (`TrackedChild` / `track_child` / `start_detect`)
+- 整合性 test: `gui/src-tauri/src/process_util/mod.rs` の `lib_rs_applies_apply_no_window_at_all_spawn_sites` と並ぶ「spawn site policy」回帰検査
+- integration test: `gui/src/__tests__/flow.integration.test.tsx` の `flow N: detecting cancel triggers kill_tracked_processes (#756)`
+- 元 issue: #743 (audit task)、#756 (orphan bug fix)
+- 関連: #523 (CloseRequested → ConfirmExitModal 初期実装、direct child のみ kill)、#466 (export ffmpeg track_child)、memory `feedback_taskstop_child_process_leak.md`

--- a/docs/superpowers/plans/2026-05-16-v0.2.1-track-0-branch-cut.md
+++ b/docs/superpowers/plans/2026-05-16-v0.2.1-track-0-branch-cut.md
@@ -1,0 +1,276 @@
+# v0.2.1 Track 0: develop-0.2.1 Branch Cut + Spec/Plan 取り込み Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** main から `develop-0.2.1` 統合ブランチを cut し、現 worktree branch (`claude/crazy-swirles-bed20b`、HEAD = 873a990) の spec / plans 3 commit を PR 経由で develop-0.2.1 にマージする。これで後続 Track A / B-x / C / D が `develop-0.2.1` ベースで進められる。
+
+**Architecture:** git branch / push 操作 + 1 PR の流れのみ。コード変更なし。
+
+**Tech Stack:** git, gh CLI
+
+**Spec reference:** [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md](../specs/2026-05-16-security-alerts-response-design.md) §5 Branch Strategy / §8 Release Flow Step 1
+
+---
+
+## File Structure
+
+- 作成: `develop-0.2.1` branch (origin)
+- 変更なし (本 plan ではコード変更なし、PR mergeで既存 spec / plan ファイルを develop-0.2.1 に取り込むだけ)
+
+## Task 1: main 最新化確認
+
+**Files:** なし (git 操作のみ)
+
+- [ ] **Step 1: origin/main の最新を fetch**
+
+Run:
+
+```bash
+git fetch origin main
+```
+
+Expected: `From github.com:Idios/kobutachan-allaganeye` で main 更新の有無を確認 (0.2.0 リリース直後で更新なし想定)
+
+- [ ] **Step 2: main HEAD が `22031f6` であることを確認**
+
+Run:
+
+```bash
+git log origin/main -1 --format="%H %s"
+```
+
+Expected: `22031f6671e616d25cbb59709fdac58f69c113ec Release v0.2.0: develop-0.2.0 → main (#757)`
+
+main HEAD が予期と違う場合は本 plan を停止し、main の最新を確認してから本 Task 1 を再実行する。
+
+## Task 2: develop-0.2.1 branch を main から cut
+
+**Files:** なし (git 操作のみ)
+
+- [ ] **Step 1: ローカル branch を作成 (main HEAD 起点)**
+
+Run:
+
+```bash
+git branch develop-0.2.1 origin/main
+```
+
+Expected: 出力なし (success)。`git branch --list develop-0.2.1` で確認可能。
+
+- [ ] **Step 2: 作成された branch HEAD が main と同一であることを確認**
+
+Run:
+
+```bash
+git log develop-0.2.1 -1 --format="%H %s"
+```
+
+Expected: `22031f6671e616d25cbb59709fdac58f69c113ec Release v0.2.0: develop-0.2.0 → main (#757)`
+
+- [ ] **Step 3: develop-0.2.1 を origin に push (upstream 設定付き)**
+
+Run:
+
+```bash
+git push -u origin develop-0.2.1
+```
+
+Expected: `* [new branch]      develop-0.2.1 -> develop-0.2.1` + `Branch 'develop-0.2.1' set up to track remote branch 'develop-0.2.1' from 'origin'.`
+
+push fail (権限等) は plan を停止して原因調査。
+
+## Task 3: GitHub default branch / branch protection 設定確認
+
+**Files:** なし (gh 操作のみ)
+
+- [ ] **Step 1: default branch が main であることを確認**
+
+Run:
+
+```bash
+gh repo view Idios/kobutachan-allaganeye --json defaultBranchRef --jq '.defaultBranchRef.name'
+```
+
+Expected: `main`
+
+L2 リリース時のリリース PR は main がターゲット。本 plan では default 変更しない (release-process.md §ブランチ戦略 ルール 1 維持)。
+
+- [ ] **Step 2: develop-0.2.1 が origin に存在することを確認**
+
+Run:
+
+```bash
+gh api repos/Idios/kobutachan-allaganeye/branches/develop-0.2.1 --jq '.name'
+```
+
+Expected: `develop-0.2.1`
+
+## Task 4: worktree branch の spec/plan 3 commit を develop-0.2.1 にマージする PR を作成
+
+**Files:** worktree branch (`claude/crazy-swirles-bed20b`) を develop-0.2.1 にマージ
+
+worktree branch は spec / plan 3 commit を保持している:
+
+- `873a990 docs(spec): add Track B-4 for #458 bug_report.yml link + UI verification`
+- `865bf12 docs(spec): expand v0.2.1 scope to security + UX + CI audit`
+- `d61b8fd docs(spec): v0.2.1 security hotfix response design`
+
+加えて本 plan 自体の Plan 0 / A / C も commit 済みであることを期待 (本 plan を書き終えた writing-plans skill 完了時点で commit される)。
+
+- [ ] **Step 1: 現 worktree branch の commit を確認**
+
+Run:
+
+```bash
+git log claude/crazy-swirles-bed20b --oneline -10
+```
+
+Expected: 873a990 / 865bf12 / d61b8fd の spec commits + Plan 0 / A / C を含む docs commit が存在 (writing-plans skill の terminal でユーザーが選んだ実行 mode により異なる)
+
+- [ ] **Step 2: PR Pre-flight (Iron Law 6)**
+
+Run (Step 0: 既存 open PR check):
+
+```bash
+gh pr list --search "v0.2.1 OR develop-0.2.1" --state open
+```
+
+Expected: 出力空 (並行作業がないことを確認)。出力があれば本 PR と関係するか判定し、必要に応じて plan を停止して相談。
+
+Run (Step 1: base 同期確認):
+
+```bash
+git fetch origin develop-0.2.1 && git log claude/crazy-swirles-bed20b..origin/develop-0.2.1 --oneline
+```
+
+Expected: 出力空 (develop-0.2.1 が worktree branch の祖先と一致)。出力があれば base 取り込み必要。
+
+Run (Step 2: 取り込み未済 commit):
+
+```bash
+git log HEAD..origin/develop-0.2.1 --oneline
+```
+
+Expected: 出力空。
+
+Run (Step 3: touched files):
+
+```bash
+git diff --name-only origin/develop-0.2.1...HEAD
+```
+
+Expected: spec / plan 関連の .md ファイルのみ。
+
+- [ ] **Step 3: PR を develop-0.2.1 ベースで作成**
+
+Run:
+
+```bash
+gh pr create --base develop-0.2.1 --head claude/crazy-swirles-bed20b --title "docs: v0.2.1 patch release design + initial plans (Track 0/A/C) [crazy-swirles-bed20b]" --body-file - <<'EOF'
+## 概要
+
+v0.2.1 patch リリースの設計文書 (spec) と初回作業 plan (Track 0 / A / C) を develop-0.2.1 に取り込む。
+
+## 含まれる commits
+
+- d61b8fd docs(spec): v0.2.1 security hotfix response design
+- 865bf12 docs(spec): expand v0.2.1 scope to security + UX + CI audit
+- 873a990 docs(spec): add Track B-4 for #458 bug_report.yml link + UI verification
+- (writing-plans 完了 commit) Plan 0 (本 plan) + Plan A + Plan C を新規追加
+
+## Refs
+
+- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md`
+- Plans: `docs/superpowers/plans/2026-05-16-v0.2.1-track-0-branch-cut.md` 他
+
+## Self-Test Report
+
+machine-verified:
+- [x] markdownlint pass (`bash scripts/check-markdownlint.sh` で 0 errors)
+
+machine-unverifiable:
+- N/A (docs-only PR)
+
+## Notes
+
+本 PR には実装変更は含まない (spec / plans のみ)。後続の Track A / B / C / D 作業 PR で実装を進める。
+EOF
+```
+
+Expected: PR URL が出力される。
+
+PR 番号を Plan 内のメモ用 ENV var として記録 (例: `export V021_DESIGN_PR=<num>`)、後続 Tasks で参照する。
+
+- [ ] **Step 4: PR を develop-0.2.1 にマージ (squash or merge commit、Idios 判断)**
+
+User confirmation を求める (本 PR は docs-only だが、develop-0.2.1 の最初の merge commit になるため merge 方式を明示する):
+
+`AskUserQuestion` で:
+
+- (a) squash merge (1 commit に集約、Recommended for docs PR)
+- (b) merge commit (3+ commit の history を保持、後で grep しやすい)
+
+Idios の選択に従い:
+
+```bash
+gh pr merge <PR#> --squash --delete-branch=false   # (a) を選んだ場合
+# または
+gh pr merge <PR#> --merge --delete-branch=false    # (b) を選んだ場合
+```
+
+`--delete-branch=false` 理由: worktree branch (`claude/crazy-swirles-bed20b`) はまだ後続 Track 作業に転用可能性があるため、現時点で削除しない。
+
+Expected: PR がマージされる。
+
+## Task 5: develop-0.2.1 の最新化 + 次の Track 作業準備
+
+**Files:** なし
+
+- [ ] **Step 1: develop-0.2.1 を pull**
+
+Run:
+
+```bash
+git checkout develop-0.2.1 && git pull origin develop-0.2.1
+```
+
+Expected: Task 4 の merge commit (squash 1 個 or merge 3 個 + merge commit) が反映される。
+
+- [ ] **Step 2: develop-0.2.1 に spec / plans が含まれていることを確認**
+
+Run:
+
+```bash
+ls docs/superpowers/specs/2026-05-16-security-alerts-response-design.md docs/superpowers/plans/2026-05-16-v0.2.1-*.md
+```
+
+Expected: spec 1 ファイル + plan 3 ファイル (Plan 0 / A / C) が存在。
+
+## Task 6: 完了確認
+
+- [ ] **Step 1: develop-0.2.1 が origin に存在し、spec / plans が含まれている**
+
+Run:
+
+```bash
+gh api repos/Idios/kobutachan-allaganeye/contents/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md?ref=develop-0.2.1 --jq '.name'
+```
+
+Expected: `2026-05-16-security-alerts-response-design.md`
+
+- [ ] **Step 2: 後続 Track の plan 内で `git fetch origin develop-0.2.1 && git checkout -b claude/<scope> origin/develop-0.2.1` で作業 branch を cut 可能になっている**
+
+Expected: Plan A / C 等が前提とする「develop-0.2.1 から作業 branch cut」のフローが利用可能。
+
+## 受け入れ条件 (本 Track 0 完了判定)
+
+- [ ] `develop-0.2.1` branch が origin に存在 (HEAD = main HEAD or merge commit)
+- [ ] `develop-0.2.1` に v0.2.1 patch の spec ファイル + Plan 0 / A / C が含まれる
+- [ ] 後続 Track の作業 branch を develop-0.2.1 から cut 可能 (Plan A Task 1 / Plan C Task 1 の前提)
+- [ ] worktree branch (`claude/crazy-swirles-bed20b`) は削除されず保持 (後続 Track 作業転用可能性のため)
+
+## Out of scope (本 plan で扱わない)
+
+- Track A / B-x / C / D の作業 branch cut (各 Plan の Task 1 で扱う)
+- Plan B-1 / B-2 / B-3 / B-4 / D の生成 (Track A マージ完了後に追加 writing-plans skill invoke で生成)
+- 別 worktree の作成 (本 plan は単一 worktree 内で完結)

--- a/docs/superpowers/plans/2026-05-16-v0.2.1-track-a-security-alerts.md
+++ b/docs/superpowers/plans/2026-05-16-v0.2.1-track-a-security-alerts.md
@@ -1,0 +1,698 @@
+# v0.2.1 Track A: Security Alerts 解消 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dependabot security alerts 5 件 (`#2 fast-uri high` / `#3 fast-uri high` / `#4 glib medium` / `#5 rand low` / `#6 tauri medium`) と PR [#758](https://github.com/Idios/kobutachan-allaganeye/pull/758) を、1 PR (5 commits) で develop-0.2.1 に取り込む。配布物 (Portable ZIP の `allaganeye-gui.exe`) の runtime に影響する medium 脆弱性 (tauri) を消し、dev-only の high 脆弱性 (fast-uri) も併せて解消する。
+
+**Architecture:**
+
+- Cargo.toml の direct dep (`tauri = "=2.11.1"`, `tauri-build = "=2.6.1"`) を変更し、`cargo update --precise` で transitive を含めて確実な version pin に置き換える
+- npm 側は `npm install fast-uri@3.1.2 --package-lock-only` で transitive (devDeps ajv 経由) を package-lock 単独更新
+- 5 commits 分割で各 alert との対応をトレース可能にする
+- PR base = `develop-0.2.1` (Track 0 完了後の統合 branch)
+
+**Tech Stack:** Rust (cargo), npm (Node.js), Tauri 2.x, GitHub Actions CI
+
+**Spec reference:** [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md](../specs/2026-05-16-security-alerts-response-design.md) §4 Track A / §6 Track A 詳細 / §7 Verification
+
+**前提:** Plan 0 (Track 0) 完了済 (`develop-0.2.1` が origin に存在、spec / plans が含まれる)。
+
+---
+
+## File Structure
+
+- 変更: `gui/package-lock.json` (Commit A-1)
+- 変更: `gui/src-tauri/Cargo.toml` (Commit A-2 / A-3)
+- 変更: `gui/src-tauri/Cargo.lock` (Commit A-2 / A-3 / A-4)
+- 作成: `docs/audit-logs/2026-05-16-v0.2.1-audit.log` (Commit A-5、cargo audit + npm audit の出力を残す)
+
+## Task 1: Track A 作業 branch を develop-0.2.1 から cut
+
+**Files:** なし (git 操作のみ)
+
+- [ ] **Step 1: develop-0.2.1 を最新化**
+
+Run:
+
+```bash
+git fetch origin develop-0.2.1 && git checkout develop-0.2.1 && git pull origin develop-0.2.1
+```
+
+Expected: `Already up to date.` または最新化される。
+
+- [ ] **Step 2: 作業 branch を cut**
+
+Run:
+
+```bash
+git checkout -b claude/security-v0.2.1 origin/develop-0.2.1
+```
+
+Expected: `Switched to a new branch 'claude/security-v0.2.1'`
+
+## Task 2: Commit A-1 — fast-uri 3.1.0 → 3.1.2 (alert #2, #3)
+
+**Files:**
+
+- Modify: `gui/package-lock.json` (transitive: ajv → fast-uri)
+
+- [ ] **Step 1: baseline test pass を確認**
+
+Run:
+
+```bash
+cd gui && npm run lint && npm run typecheck && npm run test && npm run build
+```
+
+Expected: すべて pass (現状 gui 側は test 緑のはず)。fail があれば本 plan 開始前に解消。
+
+- [ ] **Step 2: fast-uri を 3.1.2 に bump (lock-only)**
+
+Run:
+
+```bash
+cd gui && npm install fast-uri@3.1.2 --package-lock-only
+```
+
+Expected: `gui/package-lock.json` のみ更新される。`gui/package.json` の direct deps には fast-uri は含まれないので変更なし。
+
+- [ ] **Step 3: 変更ファイル確認**
+
+Run:
+
+```bash
+git status --short gui/
+```
+
+Expected: `M gui/package-lock.json` のみ (gui/package.json に変更なし)。
+
+- [ ] **Step 4: fast-uri version が 3.1.2 になっていることを確認**
+
+Run (Linux/macOS):
+
+```bash
+grep -A2 '"node_modules/fast-uri"' gui/package-lock.json | head -5
+```
+
+Run (Windows PowerShell):
+
+```powershell
+Select-String -Path gui/package-lock.json -Pattern '"node_modules/fast-uri"' -Context 0,2 | Select-Object -First 1
+```
+
+Expected: `"version": "3.1.2"` が表示される。
+
+- [ ] **Step 5: regression test pass を再確認**
+
+Run:
+
+```bash
+cd gui && npm run lint && npm run typecheck && npm run test && npm run build
+```
+
+Expected: すべて pass。1 件でも fail なら本 task を停止し、原因調査 (fast-uri 3.1.2 が ajv との compat を壊した可能性)。
+
+- [ ] **Step 6: commit**
+
+Run:
+
+```bash
+git add gui/package-lock.json && git commit -m "$(cat <<'EOF'
+chore(deps): bump fast-uri 3.1.0 to 3.1.2 (alerts #2 #3) [crazy-swirles-bed20b]
+
+ajv (devDependencies) 経由の transitive を package-lock 単独 update。
+GHSA-q3j6-qgpj-74h6 (path traversal) と GHSA-v39h-62p7-jpjc (host
+confusion) を両方解消。direct deps に変更なし、dev-only の影響範囲。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 3: Commit A-2 — tauri 2.10.3 → 2.11.1 + tauri-build 2.5.6 → 2.6.1 (alert #6)
+
+**Files:**
+
+- Modify: `gui/src-tauri/Cargo.toml` (tauri / tauri-build pin)
+- Modify: `gui/src-tauri/Cargo.lock` (tauri / tauri-build + 関連 transitive)
+
+- [ ] **Step 1: baseline cargo check / test を確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo check && cargo test
+```
+
+Expected: すべて pass。fail があれば本 plan 開始前に解消。
+
+- [ ] **Step 2: Cargo.toml の tauri 行を編集**
+
+Edit `gui/src-tauri/Cargo.toml` の line 11:
+
+Before:
+
+```toml
+tauri = { version = "=2.10.3", features = ["protocol-asset"] }
+```
+
+After:
+
+```toml
+tauri = { version = "=2.11.1", features = ["protocol-asset"] }
+```
+
+(security advisory GHSA-7gmj-67g7-phm9 の first_patched = 2.11.1、2.11.0 ではまだ脆弱)
+
+- [ ] **Step 3: Cargo.toml の tauri-build 行を編集**
+
+Edit `gui/src-tauri/Cargo.toml` の line 8:
+
+Before:
+
+```toml
+tauri-build = { version = "=2.5.6", features = [] }
+```
+
+After:
+
+```toml
+tauri-build = { version = "=2.6.1", features = [] }
+```
+
+(tauri 2.11.0 release notes で tauri-build@2.6.0 への bump 記載、現在 latest は 2.6.1。cargo search 確認済 2026-05-16)
+
+- [ ] **Step 4: cargo update --precise で lock 更新**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo update -p tauri --precise 2.11.1 && cargo update -p tauri-build --precise 2.6.1
+```
+
+Expected: `Updating tauri v2.10.3 -> v2.11.1` + `Updating tauri-build v2.5.6 -> v2.6.1` + 関連 transitive (tauri-codegen / tauri-macros / tauri-runtime 等) も同時 update される。
+
+- [ ] **Step 5: Cargo.lock 内の tauri version 確認**
+
+Run:
+
+```bash
+grep -B1 -A3 '^name = "tauri"$' gui/src-tauri/Cargo.lock | head -10
+```
+
+Expected: `version = "2.11.1"` が表示される。
+
+- [ ] **Step 6: cargo check で compile pass を確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo check
+```
+
+Expected: compile pass (warnings は許容、errors なし)。errors があれば本 task を停止し、tauri 2.11 への migration 要件を確認 (Tauri 2.11 release notes は breaking changes なしを確認済だが、特定 feature が deprecated されている可能性)。
+
+- [ ] **Step 7: cargo test で test pass を確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo test
+```
+
+Expected: すべて pass。
+
+- [ ] **Step 8: commit**
+
+Run:
+
+```bash
+git add gui/src-tauri/Cargo.toml gui/src-tauri/Cargo.lock && git commit -m "$(cat <<'EOF'
+chore(deps): bump tauri 2.10.3 to 2.11.1 + tauri-build 2.5.6 to 2.6.1 (alert #6) [crazy-swirles-bed20b]
+
+tauri Origin Confusion 脆弱性 (GHSA-7gmj-67g7-phm9) を解消。
+first_patched = 2.11.1 (2.11.0 ではまだ脆弱)。
+tauri-build は tauri 2.11.0 release notes の bump 仕様に従い 2.6.1。
+runtime (allaganeye-gui.exe) に直接効く medium severity 脆弱性消化。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 4: Commit A-3 — tauri-plugin-dialog 2.7.0 → 2.7.1 + tauri-plugin-fs 2.5.0 → 2.5.1 (alert なし、互換性整合)
+
+**Files:**
+
+- Modify: `gui/src-tauri/Cargo.toml` (tauri-plugin-dialog / tauri-plugin-fs pin)
+- Modify: `gui/src-tauri/Cargo.lock`
+
+注: tauri-plugin-shell は 2.3.5 で latest と同じため変更なし (cargo search 確認済 2026-05-16)。
+
+- [ ] **Step 1: Cargo.toml の tauri-plugin-dialog 行を編集**
+
+Edit `gui/src-tauri/Cargo.toml` の line 12:
+
+Before:
+
+```toml
+tauri-plugin-dialog = "=2.7.0"
+```
+
+After:
+
+```toml
+tauri-plugin-dialog = "=2.7.1"
+```
+
+- [ ] **Step 2: Cargo.toml の tauri-plugin-fs 行を編集**
+
+Edit `gui/src-tauri/Cargo.toml` の line 13:
+
+Before:
+
+```toml
+tauri-plugin-fs = "=2.5.0"
+```
+
+After:
+
+```toml
+tauri-plugin-fs = "=2.5.1"
+```
+
+- [ ] **Step 3: cargo update で lock 更新**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo update -p tauri-plugin-dialog --precise 2.7.1 && cargo update -p tauri-plugin-fs --precise 2.5.1
+```
+
+Expected: `Updating tauri-plugin-dialog v2.7.0 -> v2.7.1` + `Updating tauri-plugin-fs v2.5.0 -> v2.5.1`
+
+- [ ] **Step 4: cargo check / test 確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo check && cargo test
+```
+
+Expected: すべて pass。
+
+- [ ] **Step 5: commit**
+
+Run:
+
+```bash
+git add gui/src-tauri/Cargo.toml gui/src-tauri/Cargo.lock && git commit -m "$(cat <<'EOF'
+chore(deps): align tauri-plugin-dialog and tauri-plugin-fs with tauri 2.11 [crazy-swirles-bed20b]
+
+tauri-plugin-dialog 2.7.0 -> 2.7.1
+tauri-plugin-fs     2.5.0 -> 2.5.1
+tauri-plugin-shell  2.3.5 (latest と一致のため変更なし)
+
+tauri-plugins-workspace の独自 release cadence に追従。
+本 commit 自体は alert を解消しないが、tauri 2.11 系の compat 整合性を担保。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 5: Commit A-4 — transitive rand 0.8.6 / glib 0.20.0 検証 (alert #4, #5)
+
+**Files:**
+
+- Modify: `gui/src-tauri/Cargo.lock` (該当時のみ)
+
+注: rand 0.7.3 は phf_generator 0.8.0 経由の build-dep。glib 0.18.5 は Windows ビルドでは未使用 (Linux/macOS GTK 系)。tauri 2.11 系の更新で transitive 解決される見込みだが、本 Task で実測確認する。
+
+- [ ] **Step 1: rand 0.7.3 がまだ存在するか確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo tree -i rand@0.7.3 2>&1 | head -5
+```
+
+Expected (もし解決済の場合): `error: package ID specification 'rand@0.7.3' did not match any packages` または `warning: nothing to print.`
+
+Expected (もし残存の場合): `rand v0.7.3` と依存元 trace が表示される。
+
+- [ ] **Step 2: glib version 確認**
+
+Run:
+
+```bash
+grep -B1 -A2 '^name = "glib"$' gui/src-tauri/Cargo.lock | head -10
+```
+
+Expected (もし更新済の場合): `version = "0.20.0"` 以上が表示される。
+Expected (もし未更新の場合): `version = "0.18.5"` が表示される。
+
+- [ ] **Step 3a: rand 0.7.3 が残存している場合のみ実行**
+
+Run (該当時のみ):
+
+```bash
+cd gui/src-tauri && cargo update -p rand@0.7.3 --precise 0.8.6
+```
+
+注: 一部 crate が rand 0.7 系を strict に要求する場合、cargo update が fail する可能性。その場合は依存元 (phf_generator) の新版へ間接的に push する必要 (新 phf_generator が rand 0.8 系を使用)。実行 fail なら本 Task を停止して Idios に escalate。
+
+Expected: `Updating rand v0.7.3 -> v0.8.6`
+
+- [ ] **Step 3b: glib 0.18.5 のままなら実行**
+
+Run (該当時のみ):
+
+```bash
+cd gui/src-tauri && cargo update -p glib --precise 0.20.0
+```
+
+Expected: `Updating glib v0.18.5 -> v0.20.0` または mid version (例 0.19.x 経由)。
+
+- [ ] **Step 4: cargo check / test 確認**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo check && cargo test
+```
+
+Expected: すべて pass。
+
+- [ ] **Step 5: commit (transitive 解決済の場合は CHANGELOG memo として、未解決の場合は実際の lock 変更を含めて)**
+
+Run:
+
+```bash
+git add gui/src-tauri/Cargo.lock 2>/dev/null || true
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(deps): verify transitive rand 0.8.6 and glib 0.20.0 (alerts #4 #5) [crazy-swirles-bed20b]
+
+tauri 2.11 系への bump で transitive に rand と glib が新 version へ
+解決されたことを cargo tree / Cargo.lock で確認 (or 未解決分は個別
+cargo update --precise で patch)。
+- alert #4: glib VariantStrIter unsoundness (GHSA-wrw7-89jp-8q8g)
+- alert #5: rand custom logger unsoundness (GHSA-cq8v-f236-94qc)
+
+rand 0.7.3 は build-dep (phf_generator 経由) のため runtime 不含。
+glib は Windows ビルドでは未使用 (Linux/macOS GTK 系の依存)。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される (空 commit でも `--allow-empty` で OK)。
+
+## Task 6: Commit A-5 — cargo audit + npm audit local 実行 + log 保存
+
+**Files:**
+
+- Create: `docs/audit-logs/2026-05-16-v0.2.1-audit.log`
+
+- [ ] **Step 1: cargo-audit がインストールされているか確認**
+
+Run:
+
+```bash
+cargo audit --version 2>&1 | head -1
+```
+
+Expected: `cargo-audit X.Y.Z` (version が表示される)。未インストールなら次 Step で install。
+
+- [ ] **Step 2: cargo-audit インストール (未インストール時のみ)**
+
+Run (必要時のみ):
+
+```bash
+cargo install cargo-audit --locked
+```
+
+Expected: install success (時間がかかる、数分)。
+
+- [ ] **Step 3: docs/audit-logs/ ディレクトリ作成**
+
+Run:
+
+```bash
+mkdir -p docs/audit-logs
+```
+
+Expected: ディレクトリ作成 or 既存。
+
+- [ ] **Step 4: cargo audit 実行 + log 保存**
+
+Run:
+
+```bash
+cd gui/src-tauri && cargo audit > ../../docs/audit-logs/2026-05-16-v0.2.1-cargo-audit.log 2>&1
+echo "--- exit code: $? ---" >> ../../docs/audit-logs/2026-05-16-v0.2.1-cargo-audit.log
+```
+
+Expected: exit code = 0 (脆弱性 0 件) を期待。1 件でも残るなら本 Task を停止し、Idios に escalate (Track A の transitive 解決を見直す)。
+
+- [ ] **Step 5: npm audit 実行 + log 保存**
+
+Run:
+
+```bash
+cd gui && npm audit > ../docs/audit-logs/2026-05-16-v0.2.1-npm-audit.log 2>&1
+echo "--- exit code: $? ---" >> ../docs/audit-logs/2026-05-16-v0.2.1-npm-audit.log
+```
+
+Expected: exit code = 0 (脆弱性 0 件) を期待。
+
+- [ ] **Step 6: 統合ログとして 1 ファイルにまとめる**
+
+Run:
+
+```bash
+cat docs/audit-logs/2026-05-16-v0.2.1-cargo-audit.log docs/audit-logs/2026-05-16-v0.2.1-npm-audit.log > docs/audit-logs/2026-05-16-v0.2.1-audit.log
+rm docs/audit-logs/2026-05-16-v0.2.1-cargo-audit.log docs/audit-logs/2026-05-16-v0.2.1-npm-audit.log
+```
+
+Expected: 1 つの統合ログファイルが作成される。
+
+- [ ] **Step 7: commit**
+
+Run:
+
+```bash
+git add docs/audit-logs/2026-05-16-v0.2.1-audit.log && git commit -m "$(cat <<'EOF'
+chore(self-test): record cargo audit + npm audit logs for v0.2.1 [crazy-swirles-bed20b]
+
+Track A 完了後の local audit 結果。Track C で追加する CI workflow
+(.github/workflows/security-audit.yml) との突合せ用 baseline。
+脆弱性 0 件であることを記録 (期待)。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 7: 実機検証依頼 (Idios)
+
+**Files:** なし
+
+- [ ] **Step 1: AskUserQuestion で Idios に実機検証を依頼**
+
+Iron Law 6 に従い、`gui/src-tauri/**` の Cargo.toml + Cargo.lock 変更により tauri runtime 動作影響あり。AskUserQuestion で以下の検証を依頼:
+
+検証項目:
+
+```text
+1. cd gui && npm run tauri dev で Tauri GUI が起動する
+2. drop screen に動画ファイルを drop → detecting → complete → preview → export まで通る
+3. export 時の H.264 エンコーダ自動選択が動く (NVENC / QSV / AMF / libx264 fallback、metadata.system_info の gpu_vendors_available 反映)
+4. 既存 <install dir>/recent.json が読み込まれ、recent 履歴が GUI に表示される
+5. 検証中・終了後に GUI が clean に exit (#756 残バグの再現は本 Track A の範囲外、後 Track B-2 で fix)
+```
+
+- [ ] **Step 2: 実機検証結果を AskUserQuestion 回答として受け取り、本 Task を完了 (or 問題発見で Track A を停止)**
+
+検証 fail の場合は本 plan を停止し、原因 (tauri 2.11.1 への bump で何かが破壊された等) を調査する。
+
+## Task 8: PR Pre-flight + PR 作成
+
+**Files:** なし (gh CLI 操作のみ)
+
+- [ ] **Step 1: PR Pre-flight Step 0 (既存 open PR check)**
+
+Run:
+
+```bash
+gh pr list --search "security-v0.2.1 OR develop-0.2.1 security" --state open
+```
+
+Expected: 出力空 (Plan 0 の PR は既マージ、本 Track A の PR は未作成)。
+
+- [ ] **Step 2: PR Pre-flight Step 1 (base 同期)**
+
+Run:
+
+```bash
+git fetch origin develop-0.2.1
+git log claude/security-v0.2.1..origin/develop-0.2.1 --oneline
+```
+
+Expected: 出力空 (Plan 0 直後で develop-0.2.1 は変化なし想定)。出力があれば base 取り込みを実施 (`git rebase origin/develop-0.2.1`)。
+
+- [ ] **Step 3: PR Pre-flight Step 2 (touched files)**
+
+Run:
+
+```bash
+git diff --name-only origin/develop-0.2.1...HEAD
+```
+
+Expected: 4 ファイル (`gui/package-lock.json`, `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`, `docs/audit-logs/2026-05-16-v0.2.1-audit.log`)
+
+- [ ] **Step 4: PR Pre-flight Step 4 (並行 PR 重複確認)**
+
+Run:
+
+```bash
+gh pr list --search "Cargo.lock OR package-lock.json" --state all --limit 5
+```
+
+Expected: 直近 5 件で同 manifest を扱う open PR がないことを確認。
+
+- [ ] **Step 5: branch push**
+
+Run:
+
+```bash
+git push -u origin claude/security-v0.2.1
+```
+
+Expected: `* [new branch]      claude/security-v0.2.1 -> claude/security-v0.2.1` + upstream 設定。
+
+- [ ] **Step 6: PR 作成**
+
+Run:
+
+```bash
+gh pr create --base develop-0.2.1 --head claude/security-v0.2.1 --title "chore(deps): v0.2.1 Track A — security alerts 5 件解消 [crazy-swirles-bed20b]" --body-file - <<'EOF'
+## 概要
+
+v0.2.1 patch Track A。Dependabot security alerts 5 件 + PR #758 を解消。
+
+## 解決 alert
+
+- #2 fast-uri high (GHSA-q3j6-qgpj-74h6, path traversal)
+- #3 fast-uri high (GHSA-v39h-62p7-jpjc, host confusion)
+- #4 glib medium (GHSA-wrw7-89jp-8q8g, VariantStrIter unsoundness)
+- #5 rand low (GHSA-cq8v-f236-94qc, custom logger unsoundness)
+- #6 tauri medium (GHSA-7gmj-67g7-phm9, Origin Confusion → Remote→Local IPC)
+
+## 含まれる commits
+
+- A-1: fast-uri 3.1.0 → 3.1.2 (dev-only)
+- A-2: tauri 2.10.3 → 2.11.1 + tauri-build 2.5.6 → 2.6.1
+- A-3: tauri-plugin-dialog 2.7.0 → 2.7.1, tauri-plugin-fs 2.5.0 → 2.5.1
+- A-4: transitive rand 0.8.6 / glib 0.20.0 検証
+- A-5: cargo audit + npm audit local log
+
+## Refs
+
+- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §4 Track A
+- Plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-a-security-alerts.md`
+- 元 Dependabot PR: #758 (本 PR マージ後 auto-close 期待)
+
+## Self-Test Report
+
+machine-verified:
+- [x] cd gui && npm run lint / typecheck / test / build (全 pass)
+- [x] cd gui/src-tauri && cargo check / cargo test (全 pass)
+- [x] cargo audit / npm audit local 実行で脆弱性 0 件 (docs/audit-logs/2026-05-16-v0.2.1-audit.log)
+
+machine-unverifiable:
+- Idios 実機検証: Tauri GUI 起動 + golden path (drop → detecting → complete → preview → export) + H.264 encoder selection + recent.json load
+- 実機検証ログを本 PR コメントに記載予定
+
+## Notes
+
+- 配布物 (Portable ZIP の allaganeye-gui.exe) に直接効く脆弱性は #6 tauri (medium)
+- #2 #3 fast-uri は dev-only (ajv via devDeps)、配布物には未含
+- #4 glib は Windows ビルドで未使用 (Linux/macOS GTK 系)
+- #5 rand は build-dep のみ (phf_generator 経由)、runtime 不含
+EOF
+```
+
+Expected: PR URL が出力される。PR 番号を後続 Tasks 用に記録。
+
+- [ ] **Step 7: CI green を待つ**
+
+GitHub Actions が走り、ci.yml の全 job が green になるのを待つ。
+
+Run (polling 推奨):
+
+```bash
+gh pr checks <PR#> --watch
+```
+
+Expected: 全 check が pass。fail がある場合は本 Task を停止し、原因調査。
+
+- [ ] **Step 8: Idios レビュー + マージ**
+
+User confirmation で `/review-pr <PR#>` を Idios が実行 (or 別セッション)。LGTM 後にマージ:
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+Expected: PR マージ + claude/security-v0.2.1 branch 削除。
+
+## Task 9: PR マージ後の確認 (Dependabot auto-close 監視)
+
+**Files:** なし
+
+- [ ] **Step 1: Dependabot alerts の auto-close 状態確認 (PR マージ後 24h 以内)**
+
+Run:
+
+```bash
+gh api repos/Idios/kobutachan-allaganeye/dependabot/alerts --jq '.[] | select(.state == "open") | {number, dependency_name: .dependency.package.name}'
+```
+
+Expected: 出力空 (alerts #2 #3 #4 #5 #6 がすべて closed)。残るものがあれば手動 close (reason: "Fixed via v0.2.1 Track A PR")。
+
+- [ ] **Step 2: PR #758 の auto-close 確認**
+
+Run:
+
+```bash
+gh pr view 758 --json state,closedAt
+```
+
+Expected: `state: CLOSED`、`closedAt: <timestamp>`。auto-close されていない場合は手動 close (`gh pr close 758 --comment "Superseded by v0.2.1 Track A PR (alerts #2 #3 解消済)"`)。
+
+## 受け入れ条件 (本 Track A 完了判定)
+
+- [ ] PR `claude/security-v0.2.1 → develop-0.2.1` がマージされる
+- [ ] CI (ci.yml) が全 job green
+- [ ] Idios 実機検証で Tauri GUI golden path が pass
+- [ ] PR マージ後 24h 以内に Dependabot alerts #2, #3, #4, #5, #6 がすべて closed
+- [ ] PR #758 が closed (auto-close or 手動 close)
+- [ ] `docs/audit-logs/2026-05-16-v0.2.1-audit.log` に cargo audit + npm audit の 脆弱性 0 件 log が記録される
+
+## Out of scope (本 plan で扱わない)
+
+- Track C (CI security-audit.yml) — Plan C で扱う
+- Track B-1〜B-4 (UX issue) — 後続 Plan で扱う
+- Track D (version bump + CHANGELOG) — 最後の Plan で扱う
+- `develop-0.2.1 → main` のリリース PR — Track D 完了後に別途
+- Dependabot grouped update 設定見直し — Spec の Out of scope

--- a/docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md
+++ b/docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md
@@ -1,0 +1,382 @@
+# v0.2.1 Track C: Pre-merge Security Audit CI Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR 作成 / push 時に cargo audit + npm audit を自動実行する GitHub Actions workflow (`.github/workflows/security-audit.yml`) を追加し、今後 GitHub から指摘される security advisory を PR マージ前に自前で検出する仕組みを確立する。
+
+**Architecture:**
+
+- 既存 `ci.yml` には触らず、独立 `security-audit.yml` を新規追加 (関心分離)
+- pull_request trigger で manifest 変更 (`Cargo.lock` / `Cargo.toml` / `package-lock.json` / `package.json`) ある PR にのみ実行 (CI 時間節約)
+- 2 ジョブ: `cargo-audit` (Rust) と `npm-audit` (npm)、並列実行
+- fail 条件:
+  - `cargo audit --deny warnings`: warning level 以上で fail (medium severity 以上を捕捉)
+  - `npm audit --audit-level=high`: high 以上で fail (dev-only medium/low は warning 通過)
+- workflow_dispatch も追加し、手動で全 PR baseline 実行可能に
+
+**Tech Stack:** GitHub Actions, `rustsec/audit-check` (alternatively `cargo-audit`), npm audit (built-in)
+
+**Spec reference:** [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md](../specs/2026-05-16-security-alerts-response-design.md) §4 Track C / §6 Track C 詳細
+
+**前提:**
+
+- Plan 0 (Track 0) 完了済 (`develop-0.2.1` が origin に存在)
+- **Plan A (Track A) との関係**: 本 Track C の workflow を `develop-0.2.1` baseline で走らせると、Track A 未マージ時点では脆弱性 5 件で fail する。そのため **Track A のマージを先に行い**、本 Track C はその後に Ready PR にする運用とする (spec §6 「推奨マージ順 C → A」を本 plan では実情に合わせて A → C に補正)
+
+---
+
+## File Structure
+
+- 作成: `.github/workflows/security-audit.yml`
+- 作成: `docs/ci-security-audit.md` (workflow 説明 + 運用 note、optional だが本 plan では追加)
+
+## Task 1: Track C 作業 branch を develop-0.2.1 から cut
+
+**Files:** なし (git 操作のみ)
+
+- [ ] **Step 1: develop-0.2.1 を最新化**
+
+Run:
+
+```bash
+git fetch origin develop-0.2.1 && git checkout develop-0.2.1 && git pull origin develop-0.2.1
+```
+
+Expected: 最新化。Track A マージ後に本 plan を実行するため、Track A の commits が含まれた状態を想定。
+
+- [ ] **Step 2: 作業 branch を cut**
+
+Run:
+
+```bash
+git checkout -b claude/ci-security-audit origin/develop-0.2.1
+```
+
+Expected: `Switched to a new branch 'claude/ci-security-audit'`
+
+## Task 2: `security-audit.yml` の最小 workflow を作成
+
+**Files:**
+
+- Create: `.github/workflows/security-audit.yml`
+
+- [ ] **Step 1: workflow ファイルを作成**
+
+Create `.github/workflows/security-audit.yml`:
+
+```yaml
+name: Security Audit
+
+on:
+  pull_request:
+    paths:
+      - 'gui/src-tauri/Cargo.lock'
+      - 'gui/src-tauri/Cargo.toml'
+      - 'gui/package-lock.json'
+      - 'gui/package.json'
+      - '.github/workflows/security-audit.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit (Rust)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version "^0.20"
+
+      - name: Run cargo audit
+        working-directory: gui/src-tauri
+        run: cargo audit --deny warnings
+
+  npm-audit:
+    name: npm audit (JavaScript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: gui
+        run: npm ci
+
+      - name: Run npm audit
+        working-directory: gui
+        run: npm audit --audit-level=high
+```
+
+- [ ] **Step 2: yaml syntax check (local)**
+
+Run (Linux/macOS):
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/security-audit.yml'))"
+```
+
+Run (Windows PowerShell, if Python 3 available):
+
+```powershell
+python -c "import yaml; yaml.safe_load(open('.github/workflows/security-audit.yml'))"
+```
+
+Expected: 出力なし (success)。エラーが出る場合は YAML syntax 修正。
+
+- [ ] **Step 3: actionlint で workflow syntax を確認 (optional だが推奨)**
+
+Run (actionlint がインストール済の場合):
+
+```bash
+actionlint .github/workflows/security-audit.yml
+```
+
+Expected: 出力なし (no findings)。findings があれば修正。actionlint 未インストールなら skip。
+
+## Task 3: workflow 説明 doc を追加
+
+**Files:**
+
+- Create: `docs/ci-security-audit.md`
+
+- [ ] **Step 1: doc を作成**
+
+Create `docs/ci-security-audit.md`:
+
+```markdown
+# CI: Security Audit Workflow
+
+`.github/workflows/security-audit.yml` の運用 note。
+
+## 目的
+
+PR を `develop-x.x.x` や `main` にマージする前に、cargo audit + npm audit を自動実行し、Dependabot より早く脆弱性を検出する。
+
+## 発火条件
+
+- `pull_request` trigger
+- paths: `gui/src-tauri/Cargo.lock`, `gui/src-tauri/Cargo.toml`, `gui/package-lock.json`, `gui/package.json`, `.github/workflows/security-audit.yml`
+- `workflow_dispatch` で手動実行も可能
+
+paths filter により、Python のみ変更の PR では本 workflow は走らない (CI 時間節約)。
+
+## ジョブ
+
+| ジョブ | コマンド | fail 条件 |
+| --- | --- | --- |
+| cargo-audit | `cargo audit --deny warnings` | warning level 以上の advisory 検出 (= medium severity 相当以上) |
+| npm-audit | `npm audit --audit-level=high` | high 以上の advisory 検出 (dev-only の medium/low は warning 通過) |
+
+## 失敗時の対応
+
+1. PR 作者は失敗 log を確認し、影響のある依存を特定
+2. 該当依存の patched version を確認 (cargo upgrade / npm install)
+3. 本 PR 内で修正 commit を追加、または別 PR で先に hotfix
+4. medium/low で warning のみの場合は警告として report し、本 PR では (1) 修正、(2) deferred 起票、(3) ignore 理由を本 PR 本文に明記、のいずれか
+
+## Dependabot との関係
+
+- Dependabot: 既存依存の脆弱性を post-merge で検出 (auto PR で patch を提案)
+- 本 workflow: PR 提案 (Dependabot or 手動) を merge する**前**に検証
+
+両者は補完関係。本 workflow が green でも Dependabot alert は別途出る可能性 (advisory DB の更新タイミング差)。
+
+## 参照
+
+- spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §2.5 / §4 Track C
+- plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md`
+```
+
+- [ ] **Step 2: markdownlint check (Track C 単独)**
+
+Run:
+
+```bash
+bash scripts/check-markdownlint.sh
+```
+
+Expected: `Summary: 0 error(s)`。errors があれば修正 (MD060 separator style 等は前回事例参照)。
+
+## Task 4: 作業 commit
+
+- [ ] **Step 1: 全変更を 1 commit にまとめる**
+
+Run:
+
+```bash
+git add .github/workflows/security-audit.yml docs/ci-security-audit.md
+git commit -m "$(cat <<'EOF'
+ci: add security-audit.yml for cargo audit + npm audit pre-merge gate [crazy-swirles-bed20b]
+
+PR マージ前に Rust と npm の脆弱性を自動検出する workflow を新規追加。
+- cargo audit --deny warnings (medium 相当以上で fail)
+- npm audit --audit-level=high (high 以上で fail、dev-only medium/low は通過)
+paths filter で manifest 変更時のみ実行し CI 時間を節約。
+docs/ci-security-audit.md に運用 note を併設。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit 1 個追加される。
+
+## Task 5: PR Pre-flight + Ready PR 作成
+
+**Files:** なし (gh CLI 操作のみ)
+
+- [ ] **Step 1: PR Pre-flight Step 0 (既存 open PR check)**
+
+Run:
+
+```bash
+gh pr list --search "security-audit OR ci-security" --state open
+```
+
+Expected: 出力空。
+
+- [ ] **Step 2: PR Pre-flight Step 1 (base 同期)**
+
+Run:
+
+```bash
+git fetch origin develop-0.2.1
+git log claude/ci-security-audit..origin/develop-0.2.1 --oneline
+```
+
+Expected: 出力空 (Track A マージ済の develop-0.2.1 と作業 branch が同期)。出力があれば `git rebase origin/develop-0.2.1`。
+
+- [ ] **Step 3: PR Pre-flight Step 2 (touched files)**
+
+Run:
+
+```bash
+git diff --name-only origin/develop-0.2.1...HEAD
+```
+
+Expected: 2 ファイル (`.github/workflows/security-audit.yml`, `docs/ci-security-audit.md`)
+
+- [ ] **Step 4: branch push**
+
+Run:
+
+```bash
+git push -u origin claude/ci-security-audit
+```
+
+Expected: branch push 成功。
+
+- [ ] **Step 5: PR 作成 (Ready)**
+
+Track A 既マージ前提で、Track C の workflow が現 develop-0.2.1 baseline で green になることを期待:
+
+```bash
+gh pr create --base develop-0.2.1 --head claude/ci-security-audit --title "ci: v0.2.1 Track C — add pre-merge security audit workflow [crazy-swirles-bed20b]" --body-file - <<'EOF'
+## 概要
+
+v0.2.1 patch Track C。PR マージ前に cargo audit + npm audit を自動実行する GitHub Actions workflow を追加。
+
+## 含まれる変更
+
+- `.github/workflows/security-audit.yml` を新規追加
+  - cargo audit (Rust): `cargo audit --deny warnings`
+  - npm audit (JS): `npm audit --audit-level=high`
+  - paths filter で manifest 変更時のみ実行
+  - workflow_dispatch で手動実行も可
+- `docs/ci-security-audit.md` 新規追加 (運用 note)
+
+## Refs
+
+- Spec: `docs/superpowers/specs/2026-05-16-security-alerts-response-design.md` §4 Track C / §6 Track C
+- Plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-c-audit-ci.md`
+
+## マージ前提
+
+本 Track C は **Track A マージ後** に実施する運用 (spec §6 「推奨マージ順 C → A」を本 plan で A → C に補正)。理由: Track A 未マージで本 workflow を走らせると既存 5 件の脆弱性で fail するため。
+
+## Self-Test Report
+
+machine-verified:
+- [x] yaml syntax check (python -c "import yaml; yaml.safe_load(...)" pass)
+- [x] markdownlint pass (`bash scripts/check-markdownlint.sh`)
+- [x] 本 PR の CI で security-audit.yml の cargo-audit + npm-audit が green になる (Track A マージ済 develop-0.2.1 baseline 前提)
+
+machine-unverifiable:
+- N/A (CI 自動化のみ、実機検証不要)
+
+## Notes
+
+- 本 workflow は今後の PR (Track B-1 〜 B-4 / Track D 含む) で manifest 変更があれば自動発火
+- failure 時は PR 作者が対応 (詳細は docs/ci-security-audit.md 参照)
+EOF
+```
+
+Expected: PR URL が出力される。
+
+- [ ] **Step 6: CI green を待つ**
+
+Run:
+
+```bash
+gh pr checks <PR#> --watch
+```
+
+Expected: ci.yml + 新規 security-audit.yml の cargo-audit + npm-audit が全 green。fail があれば原因調査。
+
+- [ ] **Step 7: Idios レビュー + マージ**
+
+`/review-pr <PR#>` で Idios レビュー後にマージ:
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+Expected: PR マージ + claude/ci-security-audit branch 削除。
+
+## Task 6: 後続 PR への影響確認
+
+**Files:** なし
+
+- [ ] **Step 1: security-audit.yml が develop-0.2.1 上で active になっていることを確認**
+
+Run:
+
+```bash
+gh api repos/Idios/kobutachan-allaganeye/contents/.github/workflows/security-audit.yml?ref=develop-0.2.1 --jq '.name'
+```
+
+Expected: `security-audit.yml`
+
+- [ ] **Step 2: 後続 Track B-x / D PR で manifest 変更がある場合、本 workflow が自動発火することを確認 (発火確認は実際の B-x / D PR 作成時に観察)**
+
+メモ: paths filter に該当する変更がない PR (例: Track B-3 の `scripts/build-portable-zip.ps1` のみ変更) では本 workflow は走らない (意図通り)。
+
+## 受け入れ条件 (本 Track C 完了判定)
+
+- [ ] PR `claude/ci-security-audit → develop-0.2.1` がマージされる
+- [ ] CI (ci.yml) が全 job green
+- [ ] **本 PR 自体の CI で security-audit.yml の cargo-audit + npm-audit が green** (Track A マージ済前提で 0 件 expected)
+- [ ] `.github/workflows/security-audit.yml` が develop-0.2.1 上に存在
+- [ ] `docs/ci-security-audit.md` が develop-0.2.1 上に存在
+- [ ] Track B-1 〜 B-4 / D PR (manifest 変更を含む場合) で本 workflow が自動発火
+
+## Out of scope (本 plan で扱わない)
+
+- GitHub CodeQL workflow 新規追加 (spec の Out of scope)
+- Dependabot grouped update 設定見直し (spec の Out of scope、follow-up issue 候補)
+- 既存 ci.yml の改修 (本 plan では touch しない、関心分離)
+- third-party scanner (trivy / grype 等) の導入 (spec の Out of scope)
+- pre-commit hook 化 (spec の Out of scope)

--- a/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
+++ b/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
@@ -232,7 +232,7 @@ main (タグ v0.2.0)
   - `windows-rs` (または `winapi`) crate を deps に追加
   - `start_detect` 等の spawn site で `CreateJobObject` + `SetInformationJobObject` (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) + `AssignProcessToJobObject` を実装
   - `kill_tracked_processes` で Job handle を drop することで子孫プロセスを一括 kill
-- Option B (`taskkill /T /F /PID`) は fallback として保持 (Job Object 設定 fail 時用)
+- Option B (`taskkill /T /F /PID`) fallback は採用しない方針に変更 (Track B-2 実装 PR #772 / [docs/process-tree-orphan-audit.md](../../process-tree-orphan-audit.md) §3 参照): Job Object は親 app crash 時にも kernel が handle release で `KILL_ON_JOB_CLOSE` を発火するため `taskkill` より cleanup 保証が強い。Job 作成失敗時は warning ログ + detect 続行 (defensive、既存 `apply_no_window` posture と整合) で、taskkill fallback は導入しない
 
 #### Audit document (#743)
 

--- a/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
+++ b/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md
@@ -1,0 +1,432 @@
+# v0.2.1 Patch Release Design (Security + UX + CI 強化)
+
+- 日付: 2026-05-16
+- 作成者: Claude (brainstorming skill, with Idios)
+- 対象リリース: v0.2.1 (L2 patch)
+- ベース: `main` (タグ `v0.2.0`)
+- 統合ブランチ: `develop-0.2.1` (本 spec で main から新規 cut)
+
+## 1. Overview / Goal
+
+v0.2.0 リリース後に発生した課題を v0.2.1 patch リリースで一括解消する:
+
+1. **Security alerts (Dependabot) 5 件** + Dependabot PR 1 件 ([#758](https://github.com/Idios/kobutachan-allaganeye/pull/758))
+2. **UX 影響のある deferred bug / task 5 件** ([#374](https://github.com/Idios/kobutachan-allaganeye/issues/374) / [#458](https://github.com/Idios/kobutachan-allaganeye/issues/458) / [#743](https://github.com/Idios/kobutachan-allaganeye/issues/743) / [#749](https://github.com/Idios/kobutachan-allaganeye/issues/749) / [#756](https://github.com/Idios/kobutachan-allaganeye/issues/756))
+3. **今後の GitHub security 指摘を PR マージ前に自前で検出する仕組み**: cargo audit + npm audit を CI workflow に組み込む
+
+`main` から `develop-0.2.1` 統合ブランチを新規 cut し、Track 別作業ブランチからの PR を統合した後、`develop-0.2.1 → main` で v0.2.1 リリースする。
+
+## 2. Context
+
+### 2.1 Open Dependabot alerts (5 件)
+
+| # | Package | Severity | Manifest | Vulnerable | Patched | 配布物影響 | GHSA |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 6 | tauri | medium | gui/src-tauri/Cargo.lock | `=2.10.3` (現状), `<= 2.11.0` | 2.11.1 | あり (runtime) | GHSA-7gmj-67g7-phm9 (Origin Confusion → Remote→Local IPC invocation) |
+| 4 | glib | medium | gui/src-tauri/Cargo.lock | `0.18.5` (現状), `< 0.20.0` | 0.20.0 | なし (Windows ビルド未使用、GTK 系 Linux/macOS deps) | GHSA-wrw7-89jp-8q8g (`VariantStrIter` unsoundness) |
+| 5 | rand | low | gui/src-tauri/Cargo.lock | `0.7.3` (現状), `< 0.8.6` | 0.8.6 | build-dep のみ (runtime 不含) | GHSA-cq8v-f236-94qc (custom logger + `rand::rng()` unsoundness) |
+| 3 | fast-uri | high | gui/package-lock.json | `<= 3.1.1` | 3.1.2 | なし (dev-only: ajv via devDeps) | GHSA-v39h-62p7-jpjc (host confusion via percent-encoded authority delimiters) |
+| 2 | fast-uri | high | gui/package-lock.json | `<= 3.1.0` | 3.1.1 | 同上 | GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments) |
+
+### 2.2 Dependabot PR
+
+- [#758](https://github.com/Idios/kobutachan-allaganeye/pull/758) `chore(deps): bump fast-uri from 3.1.0 to 3.1.2 in /gui in the npm_and_yarn group`
+  - alert #2 + #3 両方を解決
+  - base = `main` (default branch、当 repo の `develop-x.x.x` 統合先規約と齟齬)
+
+### 2.3 配布物影響の評価 (Dependabot alerts)
+
+- **runtime (`.exe` に同梱)**: tauri (medium)
+- **runtime (transitive build only, .exe 不含)**: rand (low)
+- **Windows 配布物に未含 (Linux/macOS GTK 系)**: glib (medium)
+- **dev environment のみ**: fast-uri (high x 2、`ajv` via `devDependencies`)
+
+high severity (fast-uri) は dev-only のため配布ユーザーへの影響なし。runtime ユーザー観点で最重要は tauri (Origin Confusion)。
+
+### 2.4 取り込み対象 UX issue (5 件、すべて deferred)
+
+| # | Severity | Scope | 概要 |
+| --- | --- | --- | --- |
+| 756 | P2-medium, bug | l2a-gui | detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留 (Windows process tree orphan)。Python CLI 経由で spawn された ffmpeg が孫プロセスとして orphan 化し、CPU/disk リソースを消費し続ける |
+| 458 | P2-medium, task | l2-workflow | bug_report.yml UI 動作確認 (L3 初期残作業) + `.github/ISSUE_TEMPLATE/bug_report.yml:18` の link を `../../blob/develop-0.2.0/...` から `../../blob/main/...` に修正 + 「(公開までしばらくお待ちください)」placeholder 削除 (v0.2.0 main マージで bug-report-guide.md は公開済) |
+| 743 | P3-low, task | role:lead-engineer | Windows process group orphan 挙動 audit (#727 派生 (3))。6 spawn site の振る舞いを実機検証 + audit document 作成 |
+| 374 | P3-low, bug | (none) | metadata.json の `note` フィールドが H.264 想定 (2s) で固定。AV1 等の codec で誤情報 |
+| 749 | P3-low, doc | l2b-installer | Portable ZIP 内 `README.txt` が英語のまま。ターゲットユーザー (日本語話者) 向けに日本語化が必要 |
+
+**#743 と #756 の関係**: #756 は #743 の audit 対象 (process orphan) の具体的 bug。#756 の fix で #743 の audit が完了する形にできる (1 Track 内で両方クローズ)。
+
+**#458 の特殊性**: 既に PR #497 / #498 で実装本体は完了し develop-0.2.0 → main マージ済 (v0.2.0)。残作業は (a) bug_report.yml 内 link の `develop-0.2.0` → `main` 更新 + placeholder 削除、(b) GitHub UI での実測検証 (issue template 選択 / 必須項目 block / 自動付与 label / blank 経路併存) の 2 点。前者はコード修正、後者は Idios の実機検証で完了。
+
+### 2.5 Pre-merge security check の現状
+
+| 仕組み | 状態 | 検出範囲 |
+| --- | --- | --- |
+| Dependabot alerts | enabled | npm + Cargo の脆弱性 DB 照会、PR マージ後の post-hoc |
+| Dependabot PRs | enabled (npm grouped, Cargo 個別) | 自動 PR 生成、main base |
+| GitHub CodeQL | **未設定** (`no analysis found`) | - |
+| GitHub Secret scanning | **disabled** | - |
+| CI security audit job | **未実装** | - |
+| cargo audit / npm audit (local) | 手動のみ | - |
+
+→ **gap**: PR マージ前の自動検出がない。Dependabot は post-merge での発見が標準で、マージ前 review でも手動 audit が不要に放置されている。
+
+### 2.6 既存 CI workflows (`.github/workflows/`)
+
+- `ci.yml` (Python + GUI test)
+- `markdownlint.yml`
+- `pr-checklist.yml` / `check-pr-checklist-test.yml`
+- `release.yml`
+
+新規追加 (本 spec): `security-audit.yml` (cargo audit + npm audit を PR ごとに走らせる)
+
+## 3. Decisions
+
+| 判断点 | 選択 | 理由 |
+| --- | --- | --- |
+| Q1: 対応単位とリリース戦略 | **(A) v0.2.1 patch リリースで全部対応** | 配布物の medium 脆弱性 + UX deferred bug を同一 patch リリースで解消。Iron Law 1 / 4 の手動レビュー・close フローと整合 |
+| Q2: Security 部分の PR 構造 | **(C) 細粒度 commit 分割** | 単一 PR (security Track) 内で commit を 5 本に分けて各 alert との対応をトレース可能にする。`cargo update` を 1 段で実行しつつ commit を分離 |
+| Q3: UX 取り込み範囲 | **5 件 (#374 / #458 / #743 / #756 / #749)** | Idios が v0.2.1 に取り込むと判断した deferred bug / task。`docs/release-process.md` §共通項目 deferred ラベル全件レビューと整合。#458 は v0.2.0 main マージ後に link 更新と UI 検証残作業を実施 |
+| Q4: Pre-merge check の仕組み | **cargo audit + npm audit を CI ジョブに追加** | 軽量、既存 Actions 拡張のみ、Dependabot と補完関係。CodeQL や Dependabot 設定見直しは後続検討に deferred |
+| Q5: 統合ブランチ | **`develop-0.2.1` を main から新規 cut** | release-process.md §ブランチ戦略の `develop-x.x.x` 命名規約と整合。複数 Track の PR を統合する標準フロー |
+
+## 4. Scope
+
+### In scope (5 Track)
+
+#### Track A: Security alerts 解消 (元 hotfix 設計)
+
+- Cargo.lock / package-lock.json の脆弱な依存を patched 版に置き換え
+- `Cargo.toml` direct dep の tauri を `=2.11.1` へ pin 更新
+- tauri 2.11 系互換の tauri-build / tauri-plugin-* への bump
+- 解決対象: Dependabot alerts #2, #3, #4, #5, #6 + PR #758
+
+#### Track B-1: #374 metadata note codec 不正確 修正
+
+- `allaganeye/commands/split_matches.py` (`_split_and_write_metadata`) の `note` 文字列定義を案 2 (codec 依存定数の削除) で更新
+- 影響範囲: Python CLI のみ
+
+#### Track B-2: #743 + #756 Windows process tree orphan 一括対応
+
+- **#756 fix**: gui/src-tauri/src/lib.rs の Windows process tree kill 実装 (Option A: Job Object 推奨、または Option B: taskkill /T /F)
+- **#743 audit**: 6 spawn site の振る舞いを実機検証 + `docs/` 配下に audit document 作成 (#756 fix を audit 成果として位置付け)
+- 影響範囲: Tauri Rust + 検証 docs
+
+#### Track B-3: #749 Portable ZIP 内 README.txt 日本語化
+
+- `scripts/build-portable-zip.ps1` の `Format-ReadmeContent` 関数の text template を日本語化
+- `scripts/tests/build-portable-zip.Tests.ps1` の Pester assertion を日本語見出しに更新
+- 影響範囲: PS script + Pester test
+
+#### Track B-4: #458 bug_report.yml link 修正 + UI 検証
+
+- `.github/ISSUE_TEMPLATE/bug_report.yml:18` の link を `../../blob/develop-0.2.0/...` から `../../blob/main/...` に変更
+- 「(公開までしばらくお待ちください)」placeholder を削除 (v0.2.0 main マージで bug-report-guide.md は公開済)
+- L3 初期残作業の UI 動作確認チェックリスト (#458 §「L3 初期残作業」) を Idios 実機で実施し、結果を PR 本文に Self-Test Report として記載
+- 影響範囲: GitHub Issue Template + 実機 UI 検証
+
+#### Track C: Pre-merge security audit CI 追加
+
+- `.github/workflows/security-audit.yml` を新規追加 (cargo audit + npm audit を PR ごとに実行)
+- failure 条件: high severity 以上の脆弱性検出で job fail (medium 以下は warning として report)
+- 取り込み trigger: pull_request (paths: `gui/src-tauri/Cargo.lock`, `gui/package-lock.json`)
+- Track A の Cargo.lock / package-lock.json 更新後に発火し、green を確認できることが事前テスト
+
+#### Track D: Version bump + CHANGELOG (リリース直前)
+
+- version bump (4 ファイル): `pyproject.toml`, `gui/package.json`, `gui/src-tauri/Cargo.toml`, `gui/src-tauri/tauri.conf.json`
+- `CHANGELOG.md` に v0.2.1 セクション追加 (Security / Fixed / Changed / CI)
+
+### Out of scope (別議論 / 別 issue 起票検討)
+
+- GitHub CodeQL workflow 新規有効化 (継続的 static analysis、本 patch では cargo/npm audit のみで開始)
+- Dependabot grouped update 設定の見直し (Rust 側も group 化、schedule daily 化) — Q4 で deferred 判断、follow-up issue 候補
+- Secret scanning 有効化
+- v0.2.0 配布バイナリの差し戻し or 公開警告 (v0.2.0 リリースから日が浅いため、v0.2.1 ZIP 公開で対応十分と判断)
+- L3 (v0.3.0) スコープへの security / UX 機能追加 (本リリースは patch に専念)
+- third-party scanner (trivy / grype 等)、pre-commit hook の導入
+
+## 5. Branch Strategy
+
+`docs/release-process.md` §ブランチ戦略 に従い、`develop-x.x.x` 統合ブランチ + 作業ブランチの標準フローで運用する。
+
+```text
+main (タグ v0.2.0)
+ └── develop-0.2.1 (本 spec で main から新規 cut、v0.2.1 統合ブランチ)
+       ├── claude/<scope>-deps (Track A)            → PR → develop-0.2.1
+       ├── claude/issue-374-codec-note (Track B-1)  → PR → develop-0.2.1
+       ├── claude/issue-743-756-orphan (Track B-2)  → PR → develop-0.2.1
+       ├── claude/issue-749-readme-ja (Track B-3)   → PR → develop-0.2.1
+       ├── claude/issue-458-bug-template (Track B-4) → PR → develop-0.2.1
+       ├── claude/ci-security-audit (Track C)       → PR → develop-0.2.1
+       └── claude/release-v0.2.1 (Track D)          → PR → develop-0.2.1
+              └── 全 Track 統合後 develop-0.2.1 → main PR
+                     └── マージ + git tag v0.2.1
+                            └── release.yml 発火 → Portable ZIP + GitHub Release
+                                   └── main から develop-0.3.0 を新規 cut + version 0.3.0 bump
+```
+
+### 作業ブランチ名候補
+
+- 現 worktree branch (`claude/crazy-swirles-bed20b`、HEAD = `d61b8fd` で main から 1 commit (spec) 先行) を **Track A の作業ブランチに転用**するか、それとも spec commit のみを保持して別 branch で Track A を進めるかは writing-plans 段階で確定
+- 他 Track の作業ブランチは plan 段階で worktree 戦略 (単一 worktree で skill ベース dispatch / per-Track worktree) と合わせて確定
+
+### #743 と #756 の Track 統合理由
+
+両 issue は同じ原因 (Windows process tree orphan) を扱う。#756 が具体的 bug、#743 が audit task。両者を 1 PR で扱うことで:
+
+- fix と audit document を同一 PR でレビュー可能 (前提・対策・検証の整合性確認が容易)
+- `enforce-acceptance-criteria` skill が #743 受け入れ条件 (audit document 作成、kill_tracked_processes 実機検証、orphan risk fix 起票) と #756 受け入れ条件 (Windows tree kill 実装) を同時に検証可能
+
+## 6. Update Plan
+
+### Track A: Security alerts (1 PR、5 commit 構造)
+
+#### Commit A-1: `chore(deps): bump fast-uri 3.1.0 → 3.1.2 (#2, #3)`
+
+- `cd gui && npm install fast-uri@3.1.2 --package-lock-only`
+- 影響: `gui/package-lock.json` のみ
+- 解決 alert: #2, #3
+
+#### Commit A-2: `chore(deps): bump tauri 2.10.3 → 2.11.1 + tauri-build (#6)`
+
+- `gui/src-tauri/Cargo.toml`:
+  - `tauri = "=2.11.1"` (現 `=2.10.3`、`first_patched: 2.11.1`、2.11.0 では未 fix)
+  - `tauri-build = "=2.6.0"` (現 `=2.5.6`、tauri 2.11.0 release notes で bump 記載)
+- `cd gui/src-tauri && cargo update -p tauri --precise 2.11.1`
+- 影響: `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`
+- 解決 alert: #6
+
+#### Commit A-3: `chore(deps): align tauri-plugin-* with tauri 2.11`
+
+- `tauri-plugin-dialog` / `-fs` / `-shell` の tauri 2.11 互換 latest 版を plan 段階で確認後 bump (現状 2.7.0 / 2.5.0 / 2.3.5)
+- 影響: `gui/src-tauri/Cargo.toml`, `gui/src-tauri/Cargo.lock`
+- 解決 alert: なし (互換性整合)
+
+#### Commit A-4: `chore(deps): verify transitive rand 0.8.6 / glib 0.20.0 (#4, #5)`
+
+- Commit A-2 / A-3 後の `Cargo.lock` を確認、transitive で解決されていれば commit 内容は CHANGELOG メモのみ
+- 未解決の場合のみ個別 `cargo update -p rand@0.7.3 --precise 0.8.6` / `cargo update -p glib --precise 0.20.0`
+- 影響: `gui/src-tauri/Cargo.lock` (該当時のみ)
+- 解決 alert: #4, #5
+
+#### Commit A-5: `chore(self-test): security audit local verification`
+
+- `cd gui/src-tauri && cargo audit` で local audit 実行、output を PR 本文に貼付
+- `cd gui && npm audit --omit=dev` (runtime のみ) / `npm audit` (full) の output を PR 本文に貼付
+- Track C で追加する CI workflow との突合せ確認
+
+### Track B-1: #374 metadata note codec 不正確
+
+#### 修正内容
+
+- `allaganeye/commands/split_matches.py` (`_split_and_write_metadata` の note 定義) を case 2 (codec 依存定数の削除) で更新
+- 旧: `"Split times are approximate due to keyframe-aligned copy mode. Actual start/end may differ by up to the source keyframe interval (typically 2s for OBS recordings)."`
+- 新: `"Split times are approximate due to keyframe-aligned copy mode. Actual start/end may differ by up to the source keyframe interval."`
+- pytest unit test (該当 metadata 生成テスト) を更新
+
+### Track B-2: #743 + #756 Windows process tree orphan
+
+#### 修正内容 (#756)
+
+- `gui/src-tauri/src/lib.rs` で Windows Job Object を用いた process tree kill を実装 (Option A 推奨):
+  - `windows-rs` (または `winapi`) crate を deps に追加
+  - `start_detect` 等の spawn site で `CreateJobObject` + `SetInformationJobObject` (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) + `AssignProcessToJobObject` を実装
+  - `kill_tracked_processes` で Job handle を drop することで子孫プロセスを一括 kill
+- Option B (`taskkill /T /F /PID`) は fallback として保持 (Job Object 設定 fail 時用)
+
+#### Audit document (#743)
+
+- `docs/` 配下に `process-tree-orphan-audit.md` を新規追加:
+  - 6 spawn site (`probe_video_with` / `ensure_thumbnail_exists` / `extract_brightness_window_impl` / `run_ffmpeg_export_attempt` / `start_detect` / `open_folder_in_explorer`) の振る舞いを記録
+  - Job Object 適用前 (= 現状) と適用後の挙動差を実機検証で示す
+  - `explorer.exe` 等の意図的 detach プロセスは Job 対象外として明記
+- `enforce-acceptance-criteria` skill で #743 受け入れ条件全件を逐条検証 (1 PR 内に audit doc + fix が揃う)
+
+### Track B-3: #749 Portable ZIP README.txt 日本語化
+
+#### 修正内容
+
+- `scripts/build-portable-zip.ps1` の `Format-ReadmeContent` 関数の text template を日本語化:
+  - 見出し: `## 使い方` / `## ライセンス` / `## トラブルシューティング` 等
+  - 法的引用 (MIT / LGPLv3 / PSF License 文言) は原文保持
+- `scripts/tests/build-portable-zip.Tests.ps1` の Pester assertion を日本語見出しに更新
+
+### Track C: cargo audit + npm audit CI workflow
+
+#### 新規ファイル: `.github/workflows/security-audit.yml`
+
+```yaml
+name: Security Audit
+
+on:
+  pull_request:
+    paths:
+      - 'gui/src-tauri/Cargo.lock'
+      - 'gui/src-tauri/Cargo.toml'
+      - 'gui/package-lock.json'
+      - 'gui/package.json'
+      - '.github/workflows/security-audit.yml'
+  workflow_dispatch:
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo install cargo-audit --locked
+      - run: cd gui/src-tauri && cargo audit --deny warnings
+
+  npm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+      - run: cd gui && npm ci
+      - run: cd gui && npm audit --audit-level=high
+```
+
+- **fail 条件**:
+  - `cargo audit --deny warnings`: medium 以上の advisory 検出で fail (Cargo の audit level)
+  - `npm audit --audit-level=high`: high 以上で fail (dev-only の medium/low は warning として通過)
+- 既存 `ci.yml` には touch せず、独立 workflow として追加 (ci.yml の規模を肥大化させない)
+- pull_request trigger で manifest 変更のある PR にのみ実行 (CI 時間節約)
+
+#### Track A との結合テスト
+
+- Track C を Track A より先にマージすると、Track A の PR で security-audit.yml が走り、Cargo.lock / package-lock.json の更新が green になることを CI で確認できる
+- 推奨マージ順: **Track C → Track A** (Track C で baseline 確立、Track A で確実に脆弱性消化を検証)
+
+### Track D: Version bump + CHANGELOG (リリース直前)
+
+#### Commit D-1: `chore(release): bump version 0.2.0 → 0.2.1`
+
+- 4 ファイル: `pyproject.toml`, `gui/package.json`, `gui/src-tauri/Cargo.toml`, `gui/src-tauri/tauri.conf.json`
+
+#### Commit D-2: `docs(changelog): add v0.2.1 section`
+
+- `CHANGELOG.md` に新規セクション追加:
+
+  ```markdown
+  ## v0.2.1 - 2026-05-?? - Patch release
+
+  ### Security
+
+  - tauri 2.10.3 → 2.11.1 (medium: Origin Confusion, GHSA-7gmj-67g7-phm9)
+  - glib transitive → 0.20.0 (medium: VariantStrIter unsoundness, GHSA-wrw7-89jp-8q8g, Windows build 未使用)
+  - rand transitive 0.7.3 → 0.8.6 (low: rng() unsoundness, GHSA-cq8v-f236-94qc, build-dep のみ)
+  - fast-uri 3.1.0 → 3.1.2 (high: GHSA-v39h-62p7-jpjc / GHSA-q3j6-qgpj-74h6, dev-only deps)
+
+  ### Fixed
+
+  - #756: detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留する問題を Windows Job Object で解消
+  - #374: metadata.json の `note` 文言から codec 依存定数を削除し誤情報を解消
+
+  ### Changed
+
+  - #749: Portable ZIP 内 `README.txt` を日本語化
+  - #458: `.github/ISSUE_TEMPLATE/bug_report.yml` の `docs/bug-report-guide.md` link を `develop-0.2.0` から `main` に更新、未公開 placeholder を削除
+
+  ### CI / Infrastructure
+
+  - cargo audit + npm audit を `.github/workflows/security-audit.yml` で PR ごとに実行
+  - #743: Windows process tree orphan audit を `docs/process-tree-orphan-audit.md` として整理
+  - #458: GitHub Issue Template の UI 動作 (template 選択 / 必須項目 block / 自動付与 / blank 経路併存) を実機検証完了
+  ```
+
+## 7. Verification (Iron Law 6 準拠)
+
+### 7.1 自動チェック (PR 作成前に local + CI 両方で pass)
+
+| 範囲 | コマンド | 該当 Track |
+| --- | --- | --- |
+| Python | `ruff check . / ruff format --check . / pyright / pytest` | A (依存変更時のみ regression check) / B-1 / D |
+| GUI frontend | `cd gui && npm run lint / typecheck / test / build` | A / D |
+| GUI Rust | `cd gui/src-tauri && cargo check / cargo test` | A / B-2 / D |
+| docs | `bash scripts/check-markdownlint.sh` | B-2 (audit doc) / B-3 (README 日本語) / D (CHANGELOG) |
+| Pester | `pwsh scripts/tests/build-portable-zip.Tests.ps1` | B-3 |
+| Security audit | `cargo audit` / `npm audit` (Track C の CI workflow も同等) | A / C |
+
+### 7.2 実機検証 (Idios 依頼、Iron Law 6 で必須)
+
+| Track | 検証項目 |
+| --- | --- |
+| A | Tauri GUI 起動 + golden path (drop → detecting → complete → preview → export) + H.264 エンコーダ自動選択動作 (`select_h264_encoder_for_export`) + 既存 `recent.json` の load |
+| B-1 | 短い MKV (AV1 サンプルあれば) で split → metadata.json の note 文言確認 |
+| B-2 | detecting 中に GUI を × で閉じて ffmpeg 子孫プロセスが Task Manager で 5 秒以内に全消去されることを実機確認。`open_folder_in_explorer` 経由で開いた Explorer は kill されないことも併せて確認 |
+| B-3 | Portable ZIP build → 展開後 README.txt が日本語表示されることを Notepad で確認 |
+| B-4 | `https://github.com/Idios/kobutachan-allaganeye/issues/new/choose` を開いて bug 報告テンプレ表示確認、必須 textarea / checkbox 未入力時の submit block、自動付与 (title prefix / labels / assignees)、blank 経路併存、`docs/bug-report-guide.md` link が 200 で開けることを実測 |
+| D | local Portable ZIP build (`pwsh ./scripts/build-portable-zip.ps1 -Version 0.2.1`) で ZIP 生成 + `docs/l2-e2e-checklist.md §3 T1` smoke |
+
+### 7.3 受け入れ条件 (Iron Law 1 準拠)
+
+#### Security alerts (Track A)
+
+- [ ] Dependabot alert #2, #3, #4, #5, #6 が PR マージ後 24h 以内に auto-resolve
+- [ ] PR #758 が auto-close (or 手動 close、reason: "superseded by v0.2.1 Track A PR")
+
+#### UX issues (Track B)
+
+- [ ] #374 受け入れ条件: metadata.json の note から codec 依存定数 (`typically 2s for OBS recordings`) が削除され、AV1 サンプルで誤情報なし確認
+- [ ] #743 受け入れ条件 (5 件): audit document 作成、kill_tracked_processes 実機検証、親 app crash 時の挙動確認、orphan risk fix を本 PR に統合 (= #756)、audit 結果を `docs/` 配下に記録
+- [ ] #749 受け入れ条件: Portable ZIP README.txt が日本語、Pester assertion で日本語見出し検証
+- [ ] #756 受け入れ条件: ffmpeg 子孫プロセスが GUI 終了時に Windows Task Manager で 5 秒以内に全消去
+- [ ] #458 受け入れ条件: bug_report.yml の link が `main` を指し placeholder 削除済、L3 初期残作業チェックリスト (UI 動作確認 7 項目) すべて pass
+
+#### CI 強化 (Track C)
+
+- [ ] `.github/workflows/security-audit.yml` が PR ごとに cargo audit + npm audit を実行
+- [ ] Track A の PR でこの workflow が green に通る (脆弱性消化の自己テスト)
+- [ ] Track C の PR 自体でも workflow が green (現状の Cargo.lock / package-lock.json が green になっていること、または Track A マージ後に green になることを期待)
+
+#### Release (Track D)
+
+- [ ] [release.yml](.github/workflows/release.yml) が `allaganeye-v0.2.1-windows.zip` を artifact + Release に添付
+- [ ] Portable ZIP の `allaganeye-gui.exe` が起動し、export まで通る (Idios 実機検証)
+- [ ] `main` から `develop-0.3.0` が cut され、version が 0.3.0 に bump
+
+## 8. Release Flow
+
+1. main から `develop-0.2.1` を cut + push (`git checkout main && git pull && git checkout -b develop-0.2.1 && git push -u origin develop-0.2.1`)
+2. 各 Track の作業ブランチ → PR → `develop-0.2.1` マージ (Track 並列実施可能。推奨順: **C → A → B-1 / B-2 / B-3 / B-4 (並列) → D**)
+3. 全 Track 統合後、PR `develop-0.2.1 → main` を作成
+4. PR `develop-0.2.1 → main` をマージ
+5. `main` HEAD にタグ: `git tag -a v0.2.1 -m "Release v0.2.1: Patch release"` + `git push origin v0.2.1`
+6. [release.yml](.github/workflows/release.yml) が以下を自動実行:
+   - Portable ZIP build (`scripts/build-portable-zip.ps1 -Version 0.2.1`)
+   - SHA256 verify (Python embed / get-pip / FFmpeg)
+   - GitHub Release 作成 (`extract_release_notes.py 0.2.1` で CHANGELOG から抽出)
+7. PR 作者 (Claude or Idios) が以下を手動確認:
+   - Dependabot alerts 5 件の auto-close 状態
+   - PR #758 の close 状態
+   - UX issue 5 件 (#374 / #458 / #743 / #749 / #756) の close (`/close-issue` skill で受け入れ条件再検証 + 手動クローズ、Iron Law 4)
+   - GitHub Release ページに ZIP + release notes が掲載
+8. `main` から `develop-0.3.0` 新規 cut + version 0.3.0 bump コミット (release-process.md §レイヤー間移行手順)
+
+## 9. References
+
+### Project docs
+
+- [docs/release-process.md](../../release-process.md) §ブランチ戦略 / §タグ運用 / §レイヤーリリース受け入れゲート (共通項目)
+- [docs/l2-workflow.md](../../l2-workflow.md) §「PR 作成 Pre-flight」 / §「Self-Test Report 規約」 / §「(A) PR 内修正優先 規約」
+- [docs/l2-e2e-checklist.md](../../l2-e2e-checklist.md) §3 T1 (Portable ZIP smoke)
+- [CLAUDE.md](../../../CLAUDE.md) §Iron Law / §PR 作成ルール / §バグ修正時の方針
+
+### Security advisories
+
+- [GHSA-7gmj-67g7-phm9](https://github.com/advisories/GHSA-7gmj-67g7-phm9) — tauri Origin Confusion
+- [GHSA-wrw7-89jp-8q8g](https://github.com/advisories/GHSA-wrw7-89jp-8q8g) — glib VariantStrIter unsoundness
+- [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) — rand custom logger unsoundness
+- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — fast-uri host confusion
+- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — fast-uri path traversal
+
+### GitHub artifacts
+
+- [PR #758](https://github.com/Idios/kobutachan-allaganeye/pull/758) — Dependabot fast-uri 3.1.2 PR
+- [Release v0.2.0](https://github.com/Idios/kobutachan-allaganeye/releases/tag/v0.2.0)
+- [Issue #374](https://github.com/Idios/kobutachan-allaganeye/issues/374) — metadata.json note codec
+- [Issue #458](https://github.com/Idios/kobutachan-allaganeye/issues/458) — bug_report.yml 同意 checkbox 付き UI 検証残作業
+- [Issue #743](https://github.com/Idios/kobutachan-allaganeye/issues/743) — Windows process group orphan audit
+- [Issue #749](https://github.com/Idios/kobutachan-allaganeye/issues/749) — Portable ZIP README.txt 日本語化
+- [Issue #756](https://github.com/Idios/kobutachan-allaganeye/issues/756) — ffmpeg 子孫プロセス残留
+- [docs/bug-report-guide.md](../../bug-report-guide.md) — Track B-4 link 先 (Idios 提供)

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "allaganeye-gui",
       "version": "0.2.0",
       "dependencies": {
-        "@tauri-apps/plugin-dialog": "2.7.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "zod": "4.3.6",
@@ -16,8 +16,8 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@tauri-apps/api": "2.10.1",
-        "@tauri-apps/cli": "2.10.1",
+        "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/cli": "^2.11.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
@@ -30,6 +30,7 @@
         "ajv-formats": "3.0.1",
         "eslint": "10.2.1",
         "eslint-plugin-react-hooks": "7.1.1",
+        "fast-uri": "^3.1.2",
         "globals": "17.5.0",
         "jest-axe": "10.0.0",
         "jsdom": "29.0.2",
@@ -1118,7 +1119,9 @@
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1126,7 +1129,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.10.1",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.1.tgz",
+      "integrity": "sha512-rpEbaJ/HzNb6fwsquwoAbq29/Vt4gADhS423A8fdkwL4edJ0wZmoB8ar7O6JPDL834MUKOCm/rrJ7c9oAaEaYQ==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -1140,23 +1145,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.10.1",
-        "@tauri-apps/cli-darwin-x64": "2.10.1",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
+        "@tauri-apps/cli-darwin-arm64": "2.11.1",
+        "@tauri-apps/cli-darwin-x64": "2.11.1",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.1",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.1",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.1",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.1",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.1",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.1"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.1.tgz",
+      "integrity": "sha512-6eEKMBXsQPCuM1EmvrjT2+aBuxWQuFdKdW8pzNuNQtpq45nEEpBlD5gr8pUeAyOU1DQKlkFaEc/MPBxb/Pfjtg==",
       "cpu": [
         "arm64"
       ],
@@ -1171,9 +1176,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.1.tgz",
+      "integrity": "sha512-LQUO7exfRWjWALNhetph5guWpMeHphRpokOLk0OIbTTExaNwJNFu3I4vb+CCM/4G/QGoZe/5XikZOJdNEFP1ig==",
       "cpu": [
         "x64"
       ],
@@ -1188,9 +1193,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.1.tgz",
+      "integrity": "sha512-5i/awiBCRRhOUG8yjn0fMHXIWD5Ez8eEk5LtvOxyQrKuJkRaZDvnbIjZbE183blAwkoA4xN3aO/prJiqscl02Q==",
       "cpu": [
         "arm"
       ],
@@ -1205,9 +1210,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.1.tgz",
+      "integrity": "sha512-9LrwDw3S9Fygtw/Q6WDhOP+3svJRGAsejeE+GKrc0eO1ThMVhwi2LL6hw4dlKw93IfS7VY1G19sWGxJ/NcU4nA==",
       "cpu": [
         "arm64"
       ],
@@ -1225,9 +1230,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.1.tgz",
+      "integrity": "sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==",
       "cpu": [
         "arm64"
       ],
@@ -1245,9 +1250,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.1.tgz",
+      "integrity": "sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1265,9 +1270,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.1.tgz",
+      "integrity": "sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==",
       "cpu": [
         "x64"
       ],
@@ -1285,9 +1290,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.1.tgz",
+      "integrity": "sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==",
       "cpu": [
         "x64"
       ],
@@ -1305,9 +1310,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.1.tgz",
+      "integrity": "sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==",
       "cpu": [
         "arm64"
       ],
@@ -1322,9 +1327,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.1.tgz",
+      "integrity": "sha512-VBGkuH0eB9K9LLSMv361Gzr5Ou72sCS4+ztpmkWEQ+wd/amhcYOsf3X6qn1RJZDzIhiOYHJEOysZUC3baD01rA==",
       "cpu": [
         "ia32"
       ],
@@ -1339,7 +1344,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.10.1",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.1.tgz",
+      "integrity": "sha512-b3ORhIAKgp9ZYY+zBt7b7r0kLU2kjvyGF0+MS2SBym3emsweGPybEqocJcmtMuxyBhkOKHP4CiuEJEDuAlTx6A==",
       "cpu": [
         "x64"
       ],
@@ -1354,10 +1361,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.7.0",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -2593,7 +2602,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allaganeye-gui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allaganeye-gui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "react": "19.2.5",

--- a/gui/package.json
+++ b/gui/package.json
@@ -15,7 +15,7 @@
     "generate-types": "node scripts/generate-ts.mjs"
   },
   "dependencies": {
-    "@tauri-apps/plugin-dialog": "2.7.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "zod": "4.3.6",
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@tauri-apps/api": "2.10.1",
-    "@tauri-apps/cli": "2.10.1",
+    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/cli": "^2.11.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
@@ -37,6 +37,7 @@
     "ajv-formats": "3.0.1",
     "eslint": "10.2.1",
     "eslint-plugin-react-hooks": "7.1.1",
+    "fast-uri": "^3.1.2",
     "globals": "17.5.0",
     "jest-axe": "10.0.0",
     "jsdom": "29.0.2",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "allaganeye-gui",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -553,13 +553,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -593,6 +599,17 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -667,7 +684,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -756,6 +773,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,7 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1522,7 +1554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1874,6 +1906,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2040,7 +2081,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2060,12 +2101,6 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2158,6 +2193,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2235,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2260,8 +2348,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2310,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2399,7 +2506,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -2500,19 +2606,6 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
@@ -2592,6 +2685,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2975,7 +3081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3389,7 +3495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3584,15 +3690,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.8"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
+checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -3603,13 +3710,14 @@ dependencies = [
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -3639,9 +3747,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3691,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3707,22 +3815,21 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -3740,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3771,9 +3878,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -3789,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
@@ -3807,7 +3914,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
 ]
 
@@ -3834,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -3859,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
@@ -3885,14 +3992,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
  "html5ever 0.29.1",
@@ -3902,7 +4010,8 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -3914,7 +4023,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -3942,7 +4051,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4116,6 +4225,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4271,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -4285,7 +4409,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -4736,7 +4860,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5326,9 +5450,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.54.4"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -4165,7 +4165,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "allaganeye-gui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "dirs",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "tower-http",
  "urlencoding",
  "uuid",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -43,6 +43,21 @@ dirs = "=6.0.0"
 # 仮定の修正)。
 sysinfo = "=0.39.1"
 
+# #756 -- Windows Job Object wrapper used to kill the `start_detect`
+# process and all its descendants (Python CLI + the N ffmpeg children it
+# spawns) when the user cancels detection or closes the GUI. `TerminateProcess`
+# / tokio's `Child::kill().await` only terminate the direct child, leaving
+# ffmpeg children as orphans; assigning the Python process to a Job created
+# with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` lets the kernel reap the whole
+# tree when the Job handle is closed (on PROCESS_TRACKER drain or process
+# exit). Version pinned to 0.61.3 to align with tauri 2.11.1's existing
+# `windows` dependency (resolved via tao 0.35.2 → windows-core 0.61) and
+# avoid adding a third major to the dep tree for this PR. Note that
+# `windows 0.62.x` is pre-existing transitively via sysinfo 0.39.1 (see
+# Cargo.lock); we deliberately do not bump or unify here.
+[target.'cfg(windows)'.dependencies]
+windows = { version = "=0.61.3", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
+
 [dev-dependencies]
 tempfile = "=3.27.0"
 

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allaganeye-gui"
-version = "0.2.0"
+version = "0.2.1"
 description = "Allagan Eye GUI shell (Tauri 2 + React)"
 edition = "2021"
 

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -5,12 +5,12 @@ description = "Allagan Eye GUI shell (Tauri 2 + React)"
 edition = "2021"
 
 [build-dependencies]
-tauri-build = { version = "=2.5.6", features = [] }
+tauri-build = { version = "=2.6.1", features = [] }
 
 [dependencies]
-tauri = { version = "=2.10.3", features = ["protocol-asset"] }
-tauri-plugin-dialog = "=2.7.0"
-tauri-plugin-fs = "=2.5.0"
+tauri = { version = "=2.11.1", features = ["protocol-asset"] }
+tauri-plugin-dialog = "=2.7.1"
+tauri-plugin-fs = "=2.5.1"
 tauri-plugin-shell = "=2.3.5"
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -14,7 +14,17 @@ tauri-plugin-fs = "=2.5.1"
 tauri-plugin-shell = "=2.3.5"
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.149"
-tokio = { version = "=1.52.1", features = ["full"] }
+# #767 -- "full" feature set から実使用分のみに絞ってビルドコストを削減
+# (cargo dep graph 縮小)。grep で確認した実使用箇所:
+#   - rt-multi-thread: tokio::spawn / runtime
+#   - macros: #[tokio::test]
+#   - process: tokio::process::{Command, Child}
+#   - sync: tokio::sync::{Mutex, Semaphore, oneshot}
+#   - io-util: AsyncBufReadExt, BufReader
+#   - net: tokio::net::TcpListener (axum server bind)
+#   - time: tokio::time::{sleep, timeout}
+# bytes / fs / io-std / mio / parking_lot / signal / socket2 / tracing は未使用。
+tokio = { version = "=1.52.1", features = ["rt-multi-thread", "macros", "process", "sync", "io-util", "net", "time"] }
 tokio-util = { version = "=0.7.18", features = ["io"] }
 axum = { version = "=0.8.9", features = ["macros"] }
 tower-http = { version = "=0.6.8", features = ["fs"] }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1437,7 +1437,35 @@ async fn extract_brightness_window(
 /// children, but detecting (Phase 3) and export (Phase 4) will register
 /// their children here so the Close-Requested handler can kill them before
 /// exit.
-type ProcessMap = Arc<Mutex<HashMap<Uuid, tokio::process::Child>>>;
+///
+/// #756 -- value type is [`TrackedChild`], which carries both the
+/// `tokio::process::Child` and an optional Windows Job Object handle. The
+/// Job is only populated for `start_detect` (the Python CLI spawns N
+/// ffmpeg descendants that `TerminateProcess` cannot reach); other spawn
+/// sites pass `job: None`. Dropping the `TrackedChild` (on
+/// `kill_tracked_processes` drain) drops the Job handle, which fires
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and reaps the whole tree.
+pub struct TrackedChild {
+    pub child: tokio::process::Child,
+    #[cfg(windows)]
+    #[allow(dead_code)] // held purely for its Drop side effect
+    pub job: Option<process_util::job_object::ProcessJob>,
+}
+
+impl TrackedChild {
+    /// Wrap a freshly-spawned child with no Job Object association.
+    /// Use this at spawn sites that have no descendants to reap (ffmpeg /
+    /// ffprobe single invocations).
+    pub fn no_job(child: tokio::process::Child) -> Self {
+        Self {
+            child,
+            #[cfg(windows)]
+            job: None,
+        }
+    }
+}
+
+type ProcessMap = Arc<Mutex<HashMap<Uuid, TrackedChild>>>;
 
 static PROCESS_TRACKER: OnceLock<ProcessMap> = OnceLock::new();
 
@@ -1458,13 +1486,25 @@ async fn is_process_running() -> bool {
 /// #523 -- kill every tracked child. Returns the number of processes that
 /// were alive at kill time. Best-effort -- already-dead children are silently
 /// skipped so partial kills don't block the exit flow.
+///
+/// #756 -- for entries whose [`TrackedChild`] carries a `Job` (currently
+/// only `start_detect`), `child.kill().await` terminates the direct child
+/// (Python CLI) and the implicit drop of the Job at the end of the loop
+/// iteration fires `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, terminating every
+/// ffmpeg descendant the Python CLI had spawned. Entries with `job =
+/// None` (export ffmpeg, etc.) behave exactly as before.
 #[tauri::command]
 async fn kill_tracked_processes() -> Result<u32, AppError> {
     let tracker = process_tracker();
     let mut guard = tracker.lock().await;
     let count = guard.len() as u32;
-    for (_, mut child) in guard.drain() {
-        let _ = child.kill().await;
+    for (_, mut tracked) in guard.drain() {
+        // Kill the direct child first; the Job handle drop below (when
+        // `tracked` goes out of scope at the end of this loop iteration)
+        // reaps the descendant tree on Windows. Doing both is intentional
+        // belt-and-suspenders: `child.kill()` is platform-portable and
+        // also handles the non-Windows case where `job` is absent.
+        let _ = tracked.child.kill().await;
     }
     Ok(count)
 }
@@ -1845,7 +1885,7 @@ fn validate_open_folder_request(path: &str) -> Result<(), AppError> {
 /// **apply_no_window 非適用**: explorer.exe は Win32 GUI subsystem アプリで
 /// そもそも console window を生成しないため、`process_util::apply_no_window`
 /// (= CREATE_NO_WINDOW flag) の purpose (windows_subsystem="windows" 親で
-/// release 時の console 割当抑止) と一致しない。本関数は `process_util.rs`
+/// release 時の console 割当抑止) と一致しない。本関数は `process_util/mod.rs`
 /// adoption test (`lib_rs_applies_apply_no_window_at_all_spawn_sites`) の検査
 /// 対象外として扱う。
 ///
@@ -1939,11 +1979,16 @@ fn ffmpeg_args_for_export(
 /// the CloseRequested flow (#523) can kill it on app exit. Returns the UUID
 /// used as the map key; the caller must pass it back to `untrack_child` on
 /// process completion.
-async fn track_child(child: tokio::process::Child) -> Uuid {
+///
+/// #756 -- the value type is now [`TrackedChild`] (child + optional Job
+/// Object handle). Callers that don't need tree-kill protection should
+/// pass `TrackedChild::no_job(child)`; only `start_detect` builds a Job
+/// and passes `TrackedChild { child, job: Some(job) }`.
+async fn track_child(tracked: TrackedChild) -> Uuid {
     let tracker = process_tracker();
     let mut guard = tracker.lock().await;
     let id = Uuid::new_v4();
-    guard.insert(id, child);
+    guard.insert(id, tracked);
     id
 }
 
@@ -1951,10 +1996,18 @@ async fn track_child(child: tokio::process::Child) -> Uuid {
 /// so the caller can still `.wait()` / `.kill()` it outside the tracker
 /// lock. Returns None if the entry was already drained (e.g. by
 /// `kill_tracked_processes`).
+///
+/// #756 -- discards the Job Object handle (if any) when extracting the
+/// child. On the **happy path** (process completed normally and we now
+/// want to `.wait()` it) the Python CLI has already exited, so the Job is
+/// empty and dropping the handle is a no-op. On the **cancellation path**
+/// `untrack_child` returns `None` because `kill_tracked_processes` has
+/// already drained the tracker (dropping both the child and the Job),
+/// fire-ing tree kill via `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
 async fn untrack_child(id: Uuid) -> Option<tokio::process::Child> {
     let tracker = process_tracker();
     let mut guard = tracker.lock().await;
-    guard.remove(&id)
+    guard.remove(&id).map(|tracked| tracked.child)
 }
 
 /// #466 -- parse a single ffmpeg `-progress` line. ffmpeg emits key=value
@@ -2041,7 +2094,11 @@ async fn run_ffmpeg_export_attempt(
         .take()
         .ok_or_else(|| "failed to capture ffmpeg stderr".to_string())?;
 
-    let tracked_id = track_child(child).await;
+    // #756 -- export ffmpeg has no descendants to reap, so wrap with
+    // `TrackedChild::no_job`. The Job Object path is reserved for
+    // `start_detect` (Python CLI with N ffmpeg children); see
+    // `docs/process-tree-orphan-audit.md`.
+    let tracked_id = track_child(TrackedChild::no_job(child)).await;
 
     let mut reader = BufReader::new(stderr).lines();
     let mut stderr_tail: Vec<u8> = Vec::with_capacity(4096);
@@ -2729,7 +2786,50 @@ async fn start_detect(
         .take()
         .ok_or_else(|| "failed to capture allaganeye stderr".to_string())?;
 
-    let tracked_id = track_child(child).await;
+    // #756 -- attach Windows Job Object so cancelling detect reaps the
+    // Python CLI plus the N ffmpeg children spawned by the GPU detector
+    // (`gpu_detector.py`). On non-Windows this is a no-op (`job = None`).
+    // Failure to create/assign the Job is downgraded to a warning: detect
+    // proceeds without tree-kill protection rather than failing outright,
+    // matching the existing `apply_no_window` defensive posture.
+    #[cfg(windows)]
+    let job: Option<process_util::job_object::ProcessJob> = {
+        match process_util::job_object::ProcessJob::new() {
+            Ok(j) => {
+                if let Some(raw) = child.raw_handle() {
+                    if let Err(e) = j.assign(raw) {
+                        eprintln!(
+                            "warning: AssignProcessToJobObject failed: {} \
+                             (detect descendants may be orphaned on cancel)",
+                            e
+                        );
+                    }
+                } else {
+                    // #756 review #2: surface unexpected None so a tokio
+                    // contract change does not silently disable tree kill.
+                    eprintln!(
+                        "warning: child.raw_handle() returned None for detect \
+                         spawn (detect descendants may be orphaned on cancel)"
+                    );
+                }
+                Some(j)
+            }
+            Err(e) => {
+                eprintln!(
+                    "warning: CreateJobObject failed: {} \
+                     (detect descendants may be orphaned on cancel)",
+                    e
+                );
+                None
+            }
+        }
+    };
+    let tracked_id = track_child(TrackedChild {
+        child,
+        #[cfg(windows)]
+        job,
+    })
+    .await;
 
     // Stderr drains in parallel into a bounded tail buffer so the OS
     // pipe doesn't fill up if the CLI is chatty under -v / verbose.
@@ -4821,7 +4921,7 @@ mod tests {
         }
         let child = spawn.spawn().expect("spawn dummy child failed");
 
-        let id = track_child(child).await;
+        let id = track_child(TrackedChild::no_job(child)).await;
         let recovered = untrack_child(id).await;
         assert!(
             recovered.is_some(),
@@ -4853,7 +4953,7 @@ mod tests {
         }
         let child = spawn.spawn().expect("spawn dummy child failed");
 
-        let id = track_child(child).await;
+        let id = track_child(TrackedChild::no_job(child)).await;
         // kill_tracked_processes が tracker を drain して全 child を kill する
         let _killed = kill_tracked_processes().await.unwrap();
         let recovered = untrack_child(id).await;

--- a/gui/src-tauri/src/process_util/job_object.rs
+++ b/gui/src-tauri/src/process_util/job_object.rs
@@ -1,0 +1,174 @@
+//! Windows Job Object wrapper for killing process trees on drop (#756).
+//!
+//! `ProcessJob::new` creates a Job Object configured with
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. `assign(raw_handle)` adds a process
+//! HANDLE to the Job. When the `ProcessJob` value is dropped (= the Job
+//! handle is closed via `CloseHandle`), Windows terminates the assigned
+//! process **and every descendant it spawned** in one kernel-side operation.
+//! The same cleanup happens automatically if our own process terminates
+//! abnormally (panic / crash), because the kernel releases all handles
+//! held by the dying process.
+//!
+//! ## Why this is needed
+//!
+//! `start_detect` spawns the `allaganeye detect` Python CLI; when GPU
+//! detection is enabled the Python process in turn spawns up to 32 ffmpeg
+//! children (see `gpu_detector.py`). On Windows, `tokio::process::Child::kill`
+//! ultimately calls `TerminateProcess`, which only kills the direct child --
+//! the Python process -- and leaves the ffmpeg children running as orphans
+//! that continue to chew CPU and disk until the user notices them in Task
+//! Manager. Job Objects give us a kernel-enforced "kill the whole tree"
+//! primitive.
+//!
+//! Other spawn sites in `lib.rs` (`probe_video_with` /
+//! `ensure_thumbnail_exists` / `extract_brightness_window_impl` /
+//! `run_ffmpeg_export_attempt`) invoke ffmpeg/ffprobe directly with no
+//! descendants and therefore do not need Job Objects;
+//! `open_folder_in_explorer` intentionally detaches explorer.exe so the
+//! user's file manager outlives the GUI. See
+//! `docs/process-tree-orphan-audit.md` (#743) for the per-site rationale.
+
+#![cfg(windows)]
+
+use std::os::windows::io::RawHandle;
+
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+
+/// RAII wrapper around a Windows Job Object handle.
+///
+/// Closes the Job handle (and therefore kills every process inside it) on
+/// drop. The wrapper itself is `Send + Sync` because `HANDLE` is a raw
+/// pointer alias that is safe to move between threads (Windows kernel
+/// handles are process-global).
+pub struct ProcessJob {
+    handle: HANDLE,
+}
+
+// SAFETY: `HANDLE` is a `*mut c_void` wrapper around an opaque kernel
+// handle. Kernel handles are process-global (not thread-affinity); the
+// `windows` crate does not implement `Send`/`Sync` for `HANDLE` by default
+// because the underlying pointer type is `!Send`/`!Sync`, but for our
+// usage (storing a Job handle on a struct that lives in the global
+// PROCESS_TRACKER `Mutex` and is dropped on cancel) the handle can be
+// safely sent across threads.
+unsafe impl Send for ProcessJob {}
+unsafe impl Sync for ProcessJob {}
+
+impl ProcessJob {
+    /// Create a new Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+    /// set so that closing the returned handle (or letting it drop) kills
+    /// every assigned process and its descendants.
+    ///
+    /// Returns `Err` if either `CreateJobObjectW` or `SetInformationJobObject`
+    /// fails. On failure the partially-created handle (if any) is closed
+    /// before returning so we never leak a kernel handle into the error
+    /// path.
+    pub fn new() -> std::io::Result<Self> {
+        // CreateJobObjectW(None, None) returns an unnamed Job with default
+        // security attributes. The `windows` crate's 0.61 binding returns
+        // `Result<HANDLE>` and validates that the handle is non-NULL /
+        // non-INVALID before yielding `Ok`.
+        let handle = unsafe { CreateJobObjectW(None, None) }
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+        let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        // SAFETY: `info` is a stack-allocated `JOBOBJECT_EXTENDED_LIMIT_INFORMATION`
+        // owned by this scope; we pass its address and explicit byte size
+        // to SetInformationJobObject, which only reads `cbjobobjectinformationlength`
+        // bytes. `handle` is the freshly-created Job from CreateJobObjectW.
+        let result = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const _,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if let Err(e) = result {
+            // SetInformationJobObject failure leaves the Job alive but
+            // without KILL_ON_JOB_CLOSE -- close it explicitly so we
+            // never leak a handle on this error path.
+            unsafe {
+                let _ = CloseHandle(handle);
+            }
+            return Err(std::io::Error::other(format!(
+                "SetInformationJobObject failed: {e}"
+            )));
+        }
+
+        Ok(Self { handle })
+    }
+
+    /// Assign a process (identified by its Windows `HANDLE` from
+    /// `tokio::process::Child::raw_handle()`) to this Job. After assignment,
+    /// any descendant the process spawns will inherit Job membership
+    /// unless it sets `JOB_OBJECT_LIMIT_BREAKAWAY_OK` (which neither
+    /// Python nor ffmpeg does).
+    ///
+    /// Returns `Err` if `AssignProcessToJobObject` fails. The caller is
+    /// expected to keep the spawned process alive on `Err` (Job
+    /// assignment failure does not abort the child); the caller may log
+    /// the failure and continue without tree-kill protection.
+    pub fn assign(&self, process_handle: RawHandle) -> std::io::Result<()> {
+        // `RawHandle` is `*mut c_void`; convert to the `windows` crate's
+        // `HANDLE` newtype.
+        let process_handle = HANDLE(process_handle.cast());
+        unsafe { AssignProcessToJobObject(self.handle, process_handle) }
+            .map_err(|e| std::io::Error::other(e.to_string()))
+    }
+}
+
+impl Drop for ProcessJob {
+    fn drop(&mut self) {
+        // CloseHandle triggers KILL_ON_JOB_CLOSE inside the kernel,
+        // terminating every assigned process and its descendants. We
+        // discard the Result because there is no useful recovery: the
+        // value is being dropped, and if CloseHandle fails the OS will
+        // reclaim the handle when our process exits.
+        unsafe {
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke test: creating + dropping a Job with no assigned processes
+    /// is a no-op and must not panic. Pins the `CreateJobObjectW` +
+    /// `SetInformationJobObject` happy path against a Windows API
+    /// regression.
+    #[test]
+    fn process_job_new_then_drop_does_not_panic() {
+        let job = ProcessJob::new().expect("CreateJobObject should succeed");
+        drop(job);
+    }
+
+    /// Assigning a freshly-spawned `cmd /c exit 0` child to the Job and
+    /// then dropping the Job must terminate it cleanly. We don't observe
+    /// the kill directly (process exits on its own anyway) but we pin
+    /// that `assign` + drop sequence compiles and runs.
+    #[tokio::test]
+    async fn process_job_assign_real_child_drop_kills_it() {
+        let mut spawn = tokio::process::Command::new("cmd");
+        spawn.args(["/c", "exit", "0"]);
+        let child = spawn.spawn().expect("spawn cmd child");
+
+        let job = ProcessJob::new().expect("CreateJobObject should succeed");
+        if let Some(raw) = child.raw_handle() {
+            job.assign(raw).expect("AssignProcessToJobObject should succeed");
+        }
+        drop(job);
+        // Don't await the child: drop already requested termination via
+        // KILL_ON_JOB_CLOSE; the OS may report either a normal `exit 0`
+        // exit code or a kill code depending on timing.
+    }
+}

--- a/gui/src-tauri/src/process_util/mod.rs
+++ b/gui/src-tauri/src/process_util/mod.rs
@@ -1,9 +1,19 @@
 //! Cross-platform process-related helpers.
 //!
-//! Currently the only inhabitant is [`apply_no_window`] (#679), which sets
+//! Originally the only inhabitant was [`apply_no_window`] (#679), which sets
 //! Windows' `CREATE_NO_WINDOW` flag on a `tokio::process::Command` so that
 //! the `windows_subsystem = "windows"` release bundle doesn't spawn a
 //! console window for each ffmpeg / ffprobe / allaganeye child.
+//!
+//! #756 added [`job_object`] (Windows-only): a wrapper around Win32 Job
+//! Objects with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` so that closing the
+//! Job handle kills the assigned process AND every descendant it has
+//! spawned. Used by `start_detect` to reap the Python CLI plus the N
+//! ffmpeg children the GPU detector spawns when the user cancels detection
+//! or closes the GUI (`kill_tracked_processes`).
+
+#[cfg(windows)]
+pub mod job_object;
 
 /// Apply `CREATE_NO_WINDOW` (`0x0800_0000`) on Windows so that the spawned
 /// child doesn't get its own console window. No-op on other platforms.
@@ -79,7 +89,10 @@ mod tests {
     /// なので `pub async fn ...` で match する。
     #[test]
     fn lib_rs_applies_apply_no_window_at_all_spawn_sites() {
-        let src = include_str!("lib.rs");
+        // #756 -- after `process_util.rs` was promoted to a directory module
+        // (`process_util/mod.rs` + `process_util/job_object.rs`), `lib.rs`
+        // lives one level up.
+        let src = include_str!("../lib.rs");
         for func in [
             "fn probe_video_with",
             "async fn ensure_thumbnail_exists",

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Allagan Eye",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "dev.allaganeye.gui",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/gui/src/__tests__/flow.integration.test.tsx
+++ b/gui/src/__tests__/flow.integration.test.tsx
@@ -171,6 +171,10 @@ beforeEach(() => {
   invokeMock.mockReset();
   dialogOpenMock.mockReset();
   dialogAskMock.mockReset();
+  // #756 -- flow N relies on inspecting `listenMock.mock.calls` to grab
+  // the close-requested handler ConfirmExitModal registers on mount.
+  // Reset so prior tests don't leak captured handlers across cases.
+  listenMock.mockReset();
   useAppStateStore.getState().reset();
   useMetadataStore.getState().clear();
   // #571: in-memory store reset so each integration test starts with a
@@ -324,6 +328,62 @@ describe('flow H: export cancel mid-flight (#466 + #523)', () => {
       .click(screen.getByRole('button', { name: '中断' }));
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith('kill_tracked_processes');
+    });
+  });
+});
+
+describe('flow N: detecting cancel triggers kill_tracked_processes (#756)', () => {
+  it('CloseRequested -> ConfirmExitModal [終了] invokes kill_tracked_processes + force_exit_app', async () => {
+    // Tauri-side spawn keeps `start_detect` hanging so the GUI is still in
+    // the detecting state when the user (or OS) closes the window; this is
+    // exactly the orphan-prone state that #756's Job Object change is
+    // meant to clean up. We can't observe the kernel-side tree kill from
+    // jsdom, but we can pin the frontend wiring: CloseRequested ->
+    // is_process_running -> ConfirmExitModal -> kill_tracked_processes ->
+    // force_exit_app, exactly what the Rust side relies on to trigger the
+    // PROCESS_TRACKER drain that drops the Job handle.
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === 'start_detect') return new Promise(() => undefined);
+      if (cmd === 'is_process_running') return Promise.resolve(true);
+      if (cmd === 'kill_tracked_processes') return Promise.resolve(1);
+      if (cmd === 'force_exit_app') return Promise.resolve();
+      return Promise.resolve(undefined);
+    });
+    useAppStateStore.getState().setSelectedVideoPath('/x/video.mkv');
+    useAppStateStore.getState().navigate('detecting');
+    render(<App />);
+    expect(screen.getByTestId('detecting-screen')).toBeInTheDocument();
+
+    // ConfirmExitModal registers its `close-requested` handler on mount.
+    // Wait until the listen() side-effect has run before pulling the
+    // handler out of the captured mock calls.
+    await waitFor(() => {
+      const closeReqCall = listenMock.mock.calls.find(
+        (c) => c[0] === 'close-requested',
+      );
+      expect(closeReqCall).toBeDefined();
+    });
+    const closeReqCall = listenMock.mock.calls.find(
+      (c) => c[0] === 'close-requested',
+    );
+    const handler = closeReqCall?.[1] as (...args: unknown[]) => unknown;
+
+    // Fire the simulated close-requested event the same way the Rust
+    // `on_window_event(CloseRequested)` handler would in production.
+    await act(async () => {
+      await handler();
+    });
+
+    // is_process_running returns true -> modal surfaces.
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeInTheDocument();
+    });
+
+    // [終了] -> kill_tracked_processes + force_exit_app.
+    await userEvent.setup().click(screen.getByRole('button', { name: '終了' }));
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('kill_tracked_processes');
+      expect(invokeMock).toHaveBeenCalledWith('force_exit_app');
     });
   });
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kobutachan-allaganeye"
-version = "0.2.0"
+version = "0.2.1"
 description = "FF14 Frontline video auto-highlight extraction tool"
 license = "MIT"
 requires-python = ">=3.11"

--- a/scripts/build-portable-zip.ps1
+++ b/scripts/build-portable-zip.ps1
@@ -189,11 +189,11 @@ function Format-ReadmeContent {
   present without running a full build.
 
   -IncludeGui:$true (when the Tauri-built `allaganeye-gui.exe` is bundled, #570)
-  emits a "Easiest: double-click `allaganeye.bat`" section as the FIRST usage
-  entry, followed by drag-drop and Command Prompt sections (#617). The WebView2
-  Runtime dependency note moves into this section. -IncludeGui:$false (default,
-  CLI-only ZIP) keeps drag-drop as the first usage entry without any GUI
-  references.
+  emits a "最も簡単: `allaganeye.bat` をダブルクリック" section as the FIRST
+  usage entry, followed by drag-drop and Command Prompt sections (#617). The
+  WebView2 Runtime dependency note moves into this section. -IncludeGui:$false
+  (default, CLI-only ZIP) keeps drag-drop as the first usage entry without any
+  GUI references. README body is Japanese since #749 (see PR #768).
   #>
   param(
     [Parameter(Mandatory = $true)][string]$Version,
@@ -205,20 +205,20 @@ function Format-ReadmeContent {
   $guiSection = if ($IncludeGui) {
 @'
 
-### Easiest: double-click `allaganeye.bat`
+### 最も簡単: `allaganeye.bat` をダブルクリック
 
-Double-click `allaganeye.bat` in this folder to launch the GUI
-(`allaganeye-gui.exe`). The GUI lets you drop a video file, review detected
-matches, fine-tune match boundaries, and export each match as MP4.
+このフォルダの `allaganeye.bat` をダブルクリックすると GUI
+(`allaganeye-gui.exe`) が起動します。GUI に動画ファイルをドロップして、
+検出された試合を確認・微調整し、各試合を MP4 でエクスポートできます。
 
-NOTE: The GUI requires Microsoft Edge WebView2 Runtime, which is preinstalled
-on Windows 11 and recent Windows 10 builds. If the GUI fails to start with a
-missing-runtime dialog, install it from:
+NOTE: GUI は Microsoft Edge WebView2 Runtime を必要とします (Windows 11 と
+最近の Windows 10 にはプリインストール済み)。GUI が起動せず runtime missing
+のダイアログが出た場合は以下からインストールしてください:
 
     https://developer.microsoft.com/en-us/microsoft-edge/webview2/
 
-(`Evergreen Standalone Installer` is sufficient and does not require admin
-rights for per-user install.)
+(`Evergreen Standalone Installer` で十分。管理者権限なしで per-user
+インストール可能です。)
 
 '@
   }
@@ -234,45 +234,45 @@ rights for per-user install.)
   else { '' }
 
   return @"
-# allaganeye v$Version (Portable ZIP for Windows)
+# allaganeye v$Version (Windows 向け Portable ZIP)
 
-Python 3.11 and FFmpeg LGPL binaries are bundled alongside allaganeye.
+allaganeye と一緒に Python 3.11 と FFmpeg LGPL バイナリが同梱されています。
 
-## Usage
+## 使い方
 $guiSection
-### Drag-and-drop a video file
+### 動画ファイルをドラッグ＆ドロップ
 
-Drop a video file (.mkv / .mp4 / .avi / .mov) onto ``allaganeye.bat`` and it
-will split the video automatically. The command window stays open at the end so
-you can read the result -- press any key to close it.
+動画ファイル (.mkv / .mp4 / .avi / .mov) を ``allaganeye.bat`` にドロップすると、
+自動で試合分割が始まります。処理結果を確認できるようにコマンドウィンドウは
+終了後も開いたままになります -- 何かキーを押すと閉じます。
 
-Output MP4 files and metadata.json land under ``output\`` inside this folder.
+出力された MP4 と metadata.json はこのフォルダ内の ``output\`` に保存されます。
 
-### From a Command Prompt
+### コマンドプロンプトから実行
 
-If you want to pass options such as --dry-run or -o, open a Command Prompt in
-this folder and run:
+--dry-run や -o などのオプションを指定したい場合は、このフォルダで
+コマンドプロンプトを開き、以下のように実行してください:
 
     allaganeye.bat split "C:\path\to\video.mkv"
     allaganeye.bat split "C:\path\to\video.mkv" --dry-run
     allaganeye.bat --version
 
-See https://github.com/Idios/kobutachan-allaganeye for full documentation.
+詳細なドキュメントは https://github.com/Idios/kobutachan-allaganeye を参照してください。
 
-## Licenses
+## ライセンス
 
-- allaganeye: MIT (see the repository LICENSE file)
+- allaganeye: MIT (リポジトリの LICENSE ファイル参照)
 $guiLicenseLine- Python: PSF License (python\LICENSE.txt)
-- FFmpeg: LGPLv3 (full text in ffmpeg\LICENSE.txt)
+- FFmpeg: LGPLv3 (全文は ffmpeg\LICENSE.txt)
     Build:         ffmpeg n$FFmpegVersion win64-lgpl-shared build (BtbN/FFmpeg-Builds)
     Build tag:     $FFmpegBuildTag
     Source:        https://git.ffmpeg.org/ffmpeg.git (ref $FFmpegSourceRef)
     Build scripts: https://github.com/BtbN/FFmpeg-Builds
 
-allaganeye (MIT) invokes the FFmpeg binary as a separate subprocess only.
-The shared-build DLLs are loaded dynamically by the FFmpeg executables and are
-redistributed under LGPLv3 alongside the license text; LGPLv3 therefore does
-not apply to allaganeye itself.
+allaganeye (MIT) は FFmpeg バイナリを独立したサブプロセスとして呼び出すのみです。
+shared-build DLLs は FFmpeg 実行ファイルが動的にロードし、LGPLv3 のライセンス本文と
+ともに LGPLv3 のもとで再配布しています。したがって LGPLv3 は allaganeye 本体には
+適用されません。
 "@
 }
 
@@ -289,6 +289,9 @@ function Get-LauncherTemplate {
   text that mentions ".bat double-click -> GUI" as the primary entry. -IncludeGui:$false
   (default, CLI-only ZIP) omits the GUI mention so users are not directed to a
   non-existent exe. Symmetric with Format-ReadmeContent -IncludeGui (#570).
+
+  Launcher help text intentionally stays English (cmd.exe + CP932 console can
+  garble multi-byte glyphs); README.txt body is Japanese as of #749 (PR #768).
 
   Branch order in the template (top-down, first match wins, #617):
     1. --help / -h / /?               -> :show_help (explicit help flags always reach help)

--- a/scripts/tests/build-portable-zip.Tests.ps1
+++ b/scripts/tests/build-portable-zip.Tests.ps1
@@ -160,7 +160,7 @@ Describe 'Format-ReadmeContent' {
       -FFmpegBuildTag 'autobuild-2026-04-22-13-15' `
       -FFmpegSourceRef '7f5c90f77e' `
       -IncludeGui:$true
-    $readme | Should -Match 'double-click'
+    $readme | Should -Match 'ダブルクリック'
     $readme | Should -Match 'WebView2 Runtime'
     $readme | Should -Match 'developer\.microsoft\.com'
   }
@@ -210,31 +210,32 @@ Describe 'Format-ReadmeContent' {
 
   It '-IncludeGui:$true README documents .bat double-click as the primary GUI entry (#617)' {
     # README must explain that `.bat` double-click launches the GUI when
-    # GUI exe is bundled. The phrase "Double-click" + "allaganeye.bat" must
+    # GUI exe is bundled. The phrase "ダブルクリック" + "allaganeye.bat" must
     # appear together so the new UX (issue #617) is documented for users
-    # who read README.txt before running anything.
+    # who read README.txt before running anything. README は #749 で日本語化済み。
     $readme = Format-ReadmeContent `
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
       -FFmpegBuildTag 'autobuild-2026-05-06-13-32' `
       -FFmpegSourceRef 'n8.1.1' `
       -IncludeGui:$true
-    $readme | Should -Match 'Double-click `?allaganeye\.bat`?'
+    $readme | Should -Match '`allaganeye\.bat`.*ダブルクリック'
   }
 
   It '-IncludeGui:$true README orders GUI section before drag-drop and Command Prompt sections (#617)' {
     # Per spec §3 + issue #617 doc requirement: ".bat double-click → GUI"
     # comes first, drag-drop and Command Prompt are 2-3.
     # We assert relative ordering by comparing IndexOf positions.
+    # README は #749 で日本語化済みのため IndexOf 検索キーも日本語化。
     $readme = Format-ReadmeContent `
       -Version '0.2.0' `
       -FFmpegVersion '8.1' `
       -FFmpegBuildTag 'autobuild-2026-05-06-13-32' `
       -FFmpegSourceRef 'n8.1.1' `
       -IncludeGui:$true
-    $idxBatDoubleClick = $readme.IndexOf('Double-click')
-    $idxDragDrop = $readme.IndexOf('Drop a video file')
-    $idxCommandPrompt = $readme.IndexOf('Command Prompt')
+    $idxBatDoubleClick = $readme.IndexOf('最も簡単')
+    $idxDragDrop = $readme.IndexOf('ドラッグ＆ドロップ')
+    $idxCommandPrompt = $readme.IndexOf('コマンドプロンプトから実行')
 
     $idxBatDoubleClick | Should -BeGreaterThan -1
     $idxDragDrop | Should -BeGreaterThan -1


### PR DESCRIPTION
## 概要

**v0.2.1 patch release** を `develop-0.2.1 → main` に統合する。v0.2.0 リリース直後に出た Dependabot security alerts 5 件 + 既存 deferred UX issue 5 件を Track A-D (8 PR + 既存 #769/#771 取り込み) で一括解消した。

merge 後、Idios が `v0.2.1` タグを main HEAD に付与すると `release.yml` が自動実行され Portable ZIP build + GitHub Release 作成まで完了する。

詳細は [CHANGELOG.md `[0.2.1]` section](../blob/develop-0.2.1/CHANGELOG.md) および [spec](../blob/develop-0.2.1/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md) 参照。

## 統合 PR 一覧 (10 commits ahead of main)

| Track | PR | 内容 |
| --- | --- | --- |
| Track D | [#773](https://github.com/Idios/kobutachan-allaganeye/pull/773) | version bump 0.2.0 → 0.2.1 + CHANGELOG |
| Track B-2 | [#772](https://github.com/Idios/kobutachan-allaganeye/pull/772) | Windows Job Object で detecting cancel 時の ffmpeg 子孫 kill (#756) + audit doc (#743) |
| (#770) | [#771](https://github.com/Idios/kobutachan-allaganeye/pull/771) | build-windows CI 所要時間削減 (rust-cache warm-up + npm ci) |
| (#767) | [#769](https://github.com/Idios/kobutachan-allaganeye/pull/769) | gui-rust CI 所要時間削減 (rust-cache + tokio features scope 絞り込み) |
| Track B-3 | [#768](https://github.com/Idios/kobutachan-allaganeye/pull/768) | Portable ZIP README.txt 日本語化 (#749) |
| Track B-1 | [#766](https://github.com/Idios/kobutachan-allaganeye/pull/766) | design-overview metadata example の stale note 削除 (#374) |
| Track B-4 | [#764](https://github.com/Idios/kobutachan-allaganeye/pull/764) | bug_report.yml link を main に更新 (#458) |
| Track C | [#763](https://github.com/Idios/kobutachan-allaganeye/pull/763) | security-audit.yml (cargo/npm audit pre-merge gate) 追加 |
| Track A | [#760](https://github.com/Idios/kobutachan-allaganeye/pull/760) | Dependabot security alerts 3 件解消 (tauri 2.11.1 + fast-uri 3.1.2) + 2 件 deferred |
| Track 0 | [#759](https://github.com/Idios/kobutachan-allaganeye/pull/759) | v0.2.1 patch release design spec + initial plans (Track 0/A/C) |

## v0.2.1 リリース内容サマリ

### Security

- **tauri 2.10.3 → 2.11.1** (medium: Origin Confusion / Remote→Local IPC invocation、GHSA-7gmj-67g7-phm9)
- **fast-uri 3.1.0 → 3.1.2** (high × 2: GHSA-v39h-62p7-jpjc / GHSA-q3j6-qgpj-74h6、dev-only via ajv)
- **glib 0.18.5 / rand 0.7.3 transitive は deferred**: tauri 上流の kuchikiki / phf_generator 移行待ち、配布物 (Windows Portable ZIP `allaganeye-gui.exe`) への runtime 影響なし (glib は Linux/macOS GTK 系のみ、rand は build-dep のみ)

### Fixed

- **#756**: detecting 中の GUI 終了で ffmpeg 子孫プロセスが残留する問題を Windows Job Object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) で解消
- **#458**: bug_report.yml link を `develop-0.2.0` から `main` に更新
- **#374**: design-overview.md metadata.json example の stale note 行削除

### Changed

- **#749**: Portable ZIP `README.txt` を日本語化 (法的引用は原文保持)
- **#743**: Windows process tree 6 spawn site の audit document を `docs/process-tree-orphan-audit.md` として整理

### CI / Infrastructure

- `.github/workflows/security-audit.yml` (cargo audit + npm audit pre-merge gate) 追加
- `docs/ci-security-audit.md` (workflow 運用 note) 新設

## Self-Test Report

### machine-verified

- [x] 10 PRs 全 merge 済、develop-0.2.1 = `0787ba6`
- [x] develop-0.2.1 上の全 PR CI 各回 green、本 PR の merge base は CLEAN
- [x] Version sync 確認 (pyproject.toml / gui/package.json / gui/src-tauri/Cargo.toml / gui/src-tauri/tauri.conf.json すべて `0.2.1`)
- [x] CHANGELOG.md `[0.2.1] - 2026-05-17` section 整理済 (Keep a Changelog 形式)
- [x] Track A `cargo audit` 結果: 0 vulnerabilities (warning は 19 件 deferred、`docs/ci-security-audit.md` 参照)
- [x] Track A `npm audit --audit-level=high` 結果: 0 high+ advisory
- [x] Track B-2 Idios 実機検証 (PR #772) 完了:
  - Test 1 (detecting cancel + ffmpeg orphan kill 0 個): Pass
  - Test 2 (export flow regression なし): Pass
  - Test 3 (export cancel ffmpeg kill): Pass

### Iron Law 6 trigger 履行状況

| Track | Trigger | 履行 |
| --- | --- | --- |
| A | gui/src-tauri/** (tauri bump) | Idios 実機 Pass (compact 前 session) |
| B-2 | gui/src-tauri/** (Job Object) | Idios 実機 Test 1/2/3 Pass |
| C | .github/workflows/** | CI 自身で実行 (green) |
| D | mechanical version bump | trigger 該当なし |

### 受け入れ条件 (spec §7.3 全 Track 統合)

#### Security alerts (Track A)

- [x] Dependabot alert #2, #3 (fast-uri) は fast-uri 3.1.2 で patched、main マージ後 24h 以内に auto-resolve 想定
- [x] Dependabot alert #6 (tauri) は tauri 2.11.1 で patched、main マージ後 24h 以内に auto-resolve 想定
- [x] Dependabot alert #4 (glib) / #5 (rand) は deferred、main マージ後手動 dismiss 予定
- [x] Dependabot PR #758 (fast-uri 3.1.2) は本 v0.2.1 で superseded、main マージ後 auto-close 想定

#### UX issues (Track B-1/2/3/4)

- [x] #374 (Track B-1): design-overview note 削除済、`/close-issue 374` 手動 close 予定
- [x] #458 (Track B-4): bug_report.yml link 修正済、L3 UI 動作確認は Idios が `/close-issue 458` 時に実施
- [x] #743 (Track B-2): audit document 完成、本 PR で実質対応 (#756 統合) として `/close-issue 743`
- [x] #749 (Track B-3): README.txt 日本語化済、Portable ZIP build で確認、`/close-issue 749` 手動 close 予定
- [x] #756 (Track B-2): Job Object 実装 + Idios 実機検証 Pass、`/close-issue 756` 手動 close 予定

#### CI 強化 (Track C)

- [x] `.github/workflows/security-audit.yml` が PR ごとに cargo audit + npm audit を実行
- [x] Track A PR #760 + 後続全 PR で本 workflow green

#### Release (Track D)

- [ ] `release.yml` が `allaganeye-v0.2.1-windows.zip` を artifact + Release に添付 (本 Release PR merge + tag push で発火)
- [ ] Portable ZIP の `allaganeye-gui.exe` 起動 + export まで通る (Idios 実機検証、Release PR merge 後の Portable ZIP smoke で確認)
- [ ] `main` から `develop-0.3.0` cut + version 0.3.0 bump (本 PR merge + v0.2.1 タグ後の post-release step)

## 次のステップ (本 PR merge 後)

1. Idios が main HEAD に `v0.2.1` タグ付与 + push (`git tag -a v0.2.1 -m "Release v0.2.1: Patch release" && git push origin v0.2.1`)
2. `release.yml` が自動実行 → Portable ZIP build (`scripts/build-portable-zip.ps1 -Version 0.2.1`) + SHA256 verify + GitHub Release 作成 (`extract_release_notes.py 0.2.1` で CHANGELOG から抽出)
3. Idios が以下を手動確認:
   - Dependabot alerts 5 件の auto-close 状態 (#2 #3 #6) + #4 #5 manual dismiss
   - PR #758 の close 状態 (auto-close 予定)
   - UX issue 5 件 (#374 / #458 / #743 / #749 / #756) を `/close-issue` skill で受け入れ条件再検証 + 手動クローズ (Iron Law 4)
   - GitHub Release ページに ZIP + release notes が掲載されていること
4. `main` から `develop-0.3.0` 新規 cut + version 0.3.0 bump コミット (`docs/release-process.md` §レイヤー間移行手順)

## 関連

- spec: [docs/superpowers/specs/2026-05-16-security-alerts-response-design.md](../blob/develop-0.2.1/docs/superpowers/specs/2026-05-16-security-alerts-response-design.md)
- 各 Track plan: `docs/superpowers/plans/2026-05-16-v0.2.1-track-*.md`
- CHANGELOG: [`CHANGELOG.md`](../blob/develop-0.2.1/CHANGELOG.md)
- 関連 v0.2.0 リリース: [#755](https://github.com/Idios/kobutachan-allaganeye/pull/755) (元 base、Release タグ `v0.2.0`)

Refs spec §8 Release Flow
