### PR TITLE
feat(tests): v0.3.0 baseline regression infrastructure (compare-baseline + ground truth)

### DIFF
--- a/scripts/compare-baseline.py
+++ b/scripts/compare-baseline.py
@@ -22,10 +22,16 @@ from pathlib import Path
 
 
 def normalize_metadata(raw: dict) -> dict:
-    """Return a copy of `raw` with the time-varying `detected_at` field removed."""
-    result = dict(raw)
-    result.pop("detected_at", None)
-    return result
+    """Project `raw` to the baseline surface defined in spec §8.2.
+
+    Spec §8.2 defines the metadata baseline as `matches` + `gaps`, excluding
+    `detected_at` and all other top-level fields (which may evolve independently
+    of detection regression — e.g., `source`, `detection_params`, `system_info`).
+    """
+    return {
+        "matches": raw.get("matches", []),
+        "gaps": raw.get("gaps", []),
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -45,7 +51,9 @@ def main(argv: list[str] | None = None) -> int:
     norm_current = normalize_metadata(current)
 
     if norm_baseline == norm_current:
-        print("MATCH: baseline and current are bit-exact (excluding detected_at).")
+        print(
+            "MATCH: baseline and current are bit-exact on spec §8.2 surface (matches + gaps)."
+        )
         return 0
 
     print("DIFF: baseline and current differ.", file=sys.stderr)

--- a/scripts/compare-baseline.py
+++ b/scripts/compare-baseline.py
@@ -1,0 +1,56 @@
+"""Compare detection result JSON files for regression testing.
+
+Compares metadata.json files (baseline vs current) bit-exactly after dropping
+the time-varying `detected_at` field. Used for v0.3.0 L3 Pillar 3 (perf) and
+Phase 2b (scorebar ROI) regression detection.
+
+Usage:
+    python scripts/compare-baseline.py <baseline.json> <current.json>
+
+Exit codes:
+    0: bit-exact match
+    1: any difference detected
+    2: file load error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def normalize_metadata(raw: dict) -> dict:
+    """Return a copy of `raw` with the time-varying `detected_at` field removed."""
+    result = dict(raw)
+    result.pop("detected_at", None)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("baseline", type=Path)
+    parser.add_argument("current", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+        current = json.loads(args.current.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    norm_baseline = normalize_metadata(baseline)
+    norm_current = normalize_metadata(current)
+
+    if norm_baseline == norm_current:
+        print("MATCH: baseline and current are bit-exact (excluding detected_at).")
+        return 0
+
+    print("DIFF: baseline and current differ.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/baselines/v0.3.0/vtuber-primary-ground-truth.json
+++ b/tests/baselines/v0.3.0/vtuber-primary-ground-truth.json
@@ -1,0 +1,15 @@
+{
+  "source_file": "2772549129-151803977-da21c691-9ed6-4068-9a8b-4726a8a519a8.mp4",
+  "source_size_bytes": 7554775607,
+  "source_dir_label": "gyawa_vatos",
+  "ground_truth_provider": "user (manual)",
+  "ground_truth_provided_at": "2026-05-18",
+  "tolerance_sec": 10,
+  "matches": [
+    {"index": 1, "start_time": 1433, "end_time": 2361, "duration": 928, "type": "fl_match"},
+    {"index": 2, "start_time": 2624, "end_time": 3635, "duration": 1011, "type": "fl_match"},
+    {"index": 3, "start_time": 4253, "end_time": 5242, "duration": 989, "type": "fl_match"},
+    {"index": 4, "start_time": 5684, "end_time": 6379, "duration": 695, "type": "fl_match"},
+    {"index": 5, "start_time": 6609, "end_time": 7537, "duration": 928, "type": "fl_match"}
+  ]
+}

--- a/tests/scripts/test_compare_baseline.py
+++ b/tests/scripts/test_compare_baseline.py
@@ -1,0 +1,93 @@
+"""Tests for scripts/compare-baseline.py (v0.3.0 L3 baseline comparison)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+# Import the module under test (scripts/compare-baseline.py — hyphenated name
+# requires importlib.util.spec_from_file_location)
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+_spec = importlib.util.spec_from_file_location(
+    "compare_baseline", SCRIPTS_DIR / "compare-baseline.py"
+)
+assert _spec is not None and _spec.loader is not None
+compare_baseline = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(compare_baseline)
+
+
+def test_normalize_drops_detected_at() -> None:
+    """normalize_metadata must remove `detected_at` field for comparability."""
+    raw = {
+        "source": "video.mp4",
+        "detected_at": "2026-05-18T12:34:56Z",
+        "matches": [{"index": 1, "start_time": 0, "end_time": 100}],
+    }
+    result = compare_baseline.normalize_metadata(raw)
+    assert "detected_at" not in result
+    assert result["source"] == "video.mp4"
+    assert result["matches"] == raw["matches"]
+
+
+def test_main_returns_0_on_identical_metadata(tmp_path: Path) -> None:
+    """main() must return 0 when baseline and current are identical (modulo detected_at)."""
+    baseline = {
+        "source": "video.mp4",
+        "detected_at": "2026-01-01T00:00:00Z",
+        "matches": [{"index": 1, "start_time": 0, "end_time": 100}],
+    }
+    current = {
+        "source": "video.mp4",
+        "detected_at": "2026-05-18T12:34:56Z",
+        "matches": [{"index": 1, "start_time": 0, "end_time": 100}],
+    }
+
+    baseline_path = tmp_path / "baseline.json"
+    current_path = tmp_path / "current.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+    current_path.write_text(json.dumps(current), encoding="utf-8")
+
+    exit_code = compare_baseline.main([str(baseline_path), str(current_path)])
+    assert exit_code == 0
+
+
+def test_main_returns_1_on_match_diff(tmp_path: Path) -> None:
+    """main() must return 1 when match list differs."""
+    baseline = {
+        "source": "video.mp4",
+        "matches": [{"index": 1, "start_time": 0, "end_time": 100}],
+    }
+    current = {
+        "source": "video.mp4",
+        "matches": [{"index": 1, "start_time": 5, "end_time": 100}],
+    }
+
+    baseline_path = tmp_path / "baseline.json"
+    current_path = tmp_path / "current.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+    current_path.write_text(json.dumps(current), encoding="utf-8")
+
+    exit_code = compare_baseline.main([str(baseline_path), str(current_path)])
+    assert exit_code == 1
+
+
+def test_main_returns_2_on_missing_file(tmp_path: Path) -> None:
+    """main() must return 2 when baseline file doesn't exist."""
+    nonexistent = tmp_path / "nope.json"
+    current = tmp_path / "current.json"
+    current.write_text("{}", encoding="utf-8")
+
+    exit_code = compare_baseline.main([str(nonexistent), str(current)])
+    assert exit_code == 2
+
+
+def test_main_returns_2_on_invalid_json(tmp_path: Path) -> None:
+    """main() must return 2 when JSON parse fails."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    good = tmp_path / "good.json"
+    good.write_text("{}", encoding="utf-8")
+
+    exit_code = compare_baseline.main([str(bad), str(good)])
+    assert exit_code == 2

--- a/tests/scripts/test_compare_baseline.py
+++ b/tests/scripts/test_compare_baseline.py
@@ -6,7 +6,7 @@ import importlib.util
 import json
 from pathlib import Path
 
-# Import the module under test (scripts/compare-baseline.py — hyphenated name
+# Import the module under test (scripts/compare-baseline.py -- hyphenated name
 # requires importlib.util.spec_from_file_location)
 SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
 _spec = importlib.util.spec_from_file_location(
@@ -18,7 +18,7 @@ _spec.loader.exec_module(compare_baseline)
 
 
 def test_normalize_projects_to_matches_and_gaps_only() -> None:
-    """normalize_metadata must project to spec §8.2 baseline surface (matches + gaps).
+    """normalize_metadata must project to spec section 8.2 baseline surface (matches + gaps).
 
     Excludes `detected_at` and all other non-baseline top-level fields
     (e.g., `source`, `detection_params`, `system_info`).
@@ -103,7 +103,7 @@ def test_main_returns_2_on_invalid_json(tmp_path: Path) -> None:
 def test_main_returns_0_when_only_non_baseline_fields_differ(tmp_path: Path) -> None:
     """main() must return 0 when only non-baseline top-level fields differ.
 
-    Spec §8.2 defines baseline as `matches` + `gaps`. Other top-level fields
+    Spec section 8.2 defines baseline as `matches` + `gaps`. Other top-level fields
     (e.g., `source`, `detection_params`, `system_info`) may evolve independently
     and must NOT trigger a regression alarm.
     """

--- a/tests/scripts/test_compare_baseline.py
+++ b/tests/scripts/test_compare_baseline.py
@@ -17,17 +17,24 @@ compare_baseline = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(compare_baseline)
 
 
-def test_normalize_drops_detected_at() -> None:
-    """normalize_metadata must remove `detected_at` field for comparability."""
+def test_normalize_projects_to_matches_and_gaps_only() -> None:
+    """normalize_metadata must project to spec §8.2 baseline surface (matches + gaps).
+
+    Excludes `detected_at` and all other non-baseline top-level fields
+    (e.g., `source`, `detection_params`, `system_info`).
+    """
     raw = {
         "source": "video.mp4",
+        "source_duration": 7303.0,
         "detected_at": "2026-05-18T12:34:56Z",
+        "detection_params": {"sample_interval": 2.0},
         "matches": [{"index": 1, "start_time": 0, "end_time": 100}],
+        "gaps": [{"start_time": 200, "end_time": 300}],
     }
     result = compare_baseline.normalize_metadata(raw)
-    assert "detected_at" not in result
-    assert result["source"] == "video.mp4"
+    assert set(result.keys()) == {"matches", "gaps"}
     assert result["matches"] == raw["matches"]
+    assert result["gaps"] == raw["gaps"]
 
 
 def test_main_returns_0_on_identical_metadata(tmp_path: Path) -> None:
@@ -91,3 +98,35 @@ def test_main_returns_2_on_invalid_json(tmp_path: Path) -> None:
 
     exit_code = compare_baseline.main([str(bad), str(good)])
     assert exit_code == 2
+
+
+def test_main_returns_0_when_only_non_baseline_fields_differ(tmp_path: Path) -> None:
+    """main() must return 0 when only non-baseline top-level fields differ.
+
+    Spec §8.2 defines baseline as `matches` + `gaps`. Other top-level fields
+    (e.g., `source`, `detection_params`, `system_info`) may evolve independently
+    and must NOT trigger a regression alarm.
+    """
+    baseline = {
+        "source": "video.mp4",
+        "source_duration": 7303.0,
+        "detection_params": {"sample_interval": 2.0},
+        "matches": [{"index": 1, "start_time": 0, "end_time": 100}],
+        "gaps": [],
+    }
+    current = {
+        "source": "video-renamed.mp4",  # source changed
+        "source_duration": 7303.5,  # source_duration changed
+        "detection_params": {"sample_interval": 1.5},  # detection_params changed
+        "system_info": {"gpu_vendor_used": "nvidia"},  # new field added
+        "matches": [{"index": 1, "start_time": 0, "end_time": 100}],  # SAME
+        "gaps": [],  # SAME
+    }
+
+    baseline_path = tmp_path / "baseline.json"
+    current_path = tmp_path / "current.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+    current_path.write_text(json.dumps(current), encoding="utf-8")
+
+    exit_code = compare_baseline.main([str(baseline_path), str(current_path)])
+    assert exit_code == 0


### PR DESCRIPTION
## Summary

- `scripts/compare-baseline.py` を新規追加 (metadata.json bit-exact 比較、spec §8.2 baseline surface = matches + gaps のみ projection)
- `tests/baselines/v0.3.0/vtuber-primary-ground-truth.json` を追加 (gyawa 提供 VTuber 動画の 5 試合 ground truth、user 手動検証済み 2026-05-18)
- `tests/scripts/test_compare_baseline.py` で TDD 6 test (normalize projection / identical / diff / missing / invalid JSON / non-baseline fields differ)
- /codex:adversarial-review medium finding (normalize logic が spec §8.2 より広い contract) を in-PR 修正 (3d38b2d)

Phase 1 (Pillar 3) Wave 1a (#576 detect 改修) 着手前の必須インフラ。Phase 2b (scorebar ROI 適応) でも使用。

## Test plan

- [x] `pytest tests/scripts/test_compare_baseline.py -v` — 6 pass
- [x] `ruff check .` / `ruff format --check .` / `pyright` — 0 violations
- [x] ground truth JSON の duration 整合性 (end - start == duration) を Python 検証
- [x] /codex:adversarial-review needs-attention finding を address (3d38b2d)
- machine-unverifiable:
- [ ] reviewer 目視: compare-baseline.py の API 設計が後続 Wave (#576 等) で必要十分か
- [ ] reviewer 目視: ground truth JSON の 5 試合 timestamp が VTuber 動画と一致するか (実機検証ベース)

spec: [docs/superpowers/specs/2026-05-18-v030-l3-redefinition-design.md](docs/superpowers/specs/2026-05-18-v030-l3-redefinition-design.md) §8
plan: [docs/superpowers/plans/2026-05-18-v030-l3-redefinition-plan.md](docs/superpowers/plans/2026-05-18-v030-l3-redefinition-plan.md) Wave C

🤖 Generated with [Claude Code](https://claude.com/claude-code)
