### PR TITLE
docs(tests): v0.3.0 OBS baseline 動画セット選定 5 本 (#778)

### DIFF
--- a/tests/baselines/v0.3.0/README.md
+++ b/tests/baselines/v0.3.0/README.md
@@ -1,0 +1,72 @@
+# v0.3.0 Regression Baseline Set
+
+> **Status**: selection finalized (#778) / generation pending (#779)
+> **Spec**: [docs/superpowers/specs/2026-05-18-v030-l3-redefinition-design.md](../../../docs/superpowers/specs/2026-05-18-v030-l3-redefinition-design.md) §8
+
+## 目的
+
+v0.3.0 L3 Pillar 3 (perf 改善) と Phase 2b (scorebar ROI 適応) の regression 検出用に固定する **改修前 snapshot**。Phase 1 Wave 1a (#576 detect fps filter 廃止) を含む全 perf 改修 PR の Self-Test Report で「baseline diff 0」を `scripts/compare-baseline.py` で証明するために使用する。
+
+検証 surface は spec §8.2 で定義される `matches` + `gaps` のみ (bit-exact)。`detected_at` 等の time-varying field は projection で除外される。
+
+## 種類
+
+| 種別 | ファイル | 内容 | 比較方法 |
+| --- | --- | --- | --- |
+| OBS baseline | `obs-<label>.metadata.json` | 改修前の `allaganeye detect` 出力 (snapshot) | bit-exact (Phase 1) |
+| OBS baseline (split) | `obs-<label>.split.json` | 改修前の `allaganeye split --from-metadata` 出力の SHA-256 + size | bit-exact (Phase 1) |
+| VTuber ground truth | `vtuber-primary-ground-truth.json` | user 手動検証済みの "正解" 試合 timestamp | ±10s 一致 (Phase 2b) |
+
+OBS baseline は「現状検知の固定 snapshot」、VTuber ground truth は「目視正解」という別概念。OBS は **perf 改修で挙動が変わらないこと** を確認、VTuber は **scorebar ROI 適応化で正解に近づくこと** を確認する。
+
+## OBS baseline 動画セット (#778 選定)
+
+### 選定基準
+
+- **サイズ多様性**: 短尺 (~1h) / 中尺 (~2h) / 長尺 (~2.5h) を含み、detect 処理時間が perf 改修でどう変わるかを scale 別に観測できること
+- **試合数多様性**: 1 試合 / 中 (3-6) / 多 (7-9) を含み、splitter / metadata 書出し系の regression を match 数の異なる場面で確認できること
+- **代表性**: 既に `tests/baselines/{20260116,20260118,20260119}.json` で scorebar V2 (#522 / #529) を validate 済みの 3 本を含み、過去の検出挙動との連続性を保つこと
+- **再現性**: Idios 個人 OBS 録画 (`ALLAGANEYE_SAMPLE_VIDEO_DIR` 配下) で deterministic に再検知可能であること
+
+全動画とも 1920x1080 / 60fps / AV1 codec (OBS NVENC AV1 録画) で、入力多様性は duration と match count に集約される。VTuber / Game DVR 等の異種入力は Phase 2 (Pillar 1) 着手時に別途追加検討。
+
+### 選定リスト (5 本)
+
+| Label | Source path (相対: `$ALLAGANEYE_SAMPLE_VIDEO_DIR`) | Duration | Size | Matches (legacy) | 採択理由 |
+| --- | --- | --- | --- | --- | --- |
+| `obs-20260209` | `2026-02-09 23-12-24.mkv` | 57m06s (3426.5s) | 19.2 GiB | 3 | 最短 / fast smoke 用。既存 detect snapshot あり |
+| `obs-20260127` | `20260127/2026-01-27 21-59-15.mkv` | 1h01m11s (3671.3s) | 22.9 GiB | 1 (推定) | 単一試合 edge / 短尺枠の 2 本目 |
+| `obs-20260116` | `20260116/2026-01-16 22-12-57.mkv` | 2h01m43s (7303.5s) | 37.0 GiB | 7 (うち 1 件 `unknown`) | scorebar V2 validated / 末尾 `unknown` 分類 edge |
+| `obs-20260118` | `20260118/2026-01-18 22-15-18.mkv` | 2h17m14s (8234.7s) | 34.2 GiB | 6 | scorebar V2 validated / Limsa 待機暗転含む (#529) |
+| `obs-20260119` | `20260119/2026-01-19 22-09-07.mkv` | 2h33m54s (9234.0s) | 59.1 GiB | 9 | scorebar V2 validated / 高 match 数 |
+
+合計 detect 時間 (改修前) 概算: ~55-90 分 (RTX-class GPU、`--gpu` モード)。
+
+### 不採用候補と理由
+
+| 候補 | 理由 |
+| --- | --- |
+| `20260123/2026-01-23 22-27-10.mkv` (2h21m, 62.5GB) | 採択した `obs-20260118` / `obs-20260119` と duration / match 帯が重複し、追加情報量小 |
+| `20260219/2026-02-18 21-55-03.mkv` (5h05m, 104.6GB) | 単独で detect 30 分超を要し、全 PR の Self-Test Report で常用するには重い。Phase 1 完了後の長尺枠強化フェーズで再評価 |
+| Root 直下の長尺 MKV (`2026-01-20 22-33-17.mkv` 他、14 本) | scorebar V2 validation 履歴がなく、選定済み subdir 5 本で size × match の代表性は満たせている |
+| Root の `2026-03-05 17-13-29.mkv` (5MB) | 試用試写 fragment と推定、FL match を含まない可能性高い |
+
+## ファイル命名規約
+
+- OBS baseline: `obs-<YYYYMMDD>.metadata.json` / `obs-<YYYYMMDD>.split.json`
+  - `<YYYYMMDD>` は subdir 名 (`20260116` 等)、または root MKV の場合は録画開始日 (`20260209` 等)
+- VTuber ground truth: `vtuber-<provider>-ground-truth.json` (例: `vtuber-primary-ground-truth.json`)
+
+## Schema 参照
+
+- `obs-<label>.metadata.json`: `allaganeye detect` の standard `metadata.json` 出力 ([`docs/cli-spec.md`](../../../docs/cli-spec.md) §metadata.json)。比較は spec §8.2 で定義された `matches` + `gaps` projection (`scripts/compare-baseline.py` が実装)
+- `obs-<label>.split.json`: #779 で確定する schema (`splits[].output_file` / `size_bytes` / `sha256`)
+- `vtuber-*-ground-truth.json`: spec §8.6 (`matches[].index` / `start_time` / `end_time` / `duration` / `type` / `tolerance_sec`)
+
+## 関連
+
+- spec: [§8 Regression prevention baseline](../../../docs/superpowers/specs/2026-05-18-v030-l3-redefinition-design.md)
+- 選定 issue: [#778](https://github.com/Idios/kobutachan-allaganeye/issues/778)
+- 生成 issue: [#779](https://github.com/Idios/kobutachan-allaganeye/issues/779)
+- 比較スクリプト: [`scripts/compare-baseline.py`](../../../scripts/compare-baseline.py) (#777)
+- baseline drift (別軸 / ffmpeg version 依存): [`docs/testing-guide.md` §baseline drift の判定](../../../docs/testing-guide.md)

--- a/tests/baselines/v0.3.0/README.md
+++ b/tests/baselines/v0.3.0/README.md
@@ -5,9 +5,24 @@
 
 ## 目的
 
-v0.3.0 L3 Pillar 3 (perf 改善) と Phase 2b (scorebar ROI 適応) の regression 検出用に固定する **改修前 snapshot**。Phase 1 Wave 1a (#576 detect fps filter 廃止) を含む全 perf 改修 PR の Self-Test Report で「baseline diff 0」を `scripts/compare-baseline.py` で証明するために使用する。
+v0.3.0 L3 Pillar 3 (perf 改善) と Phase 2b (scorebar ROI 適応) のうち **detect / split (`-c copy`) 系統の regression 検出** 用に固定する改修前 snapshot。Phase 1 Wave 1a (#576 detect fps filter 廃止) のような検知ロジック改修 PR の Self-Test Report で「baseline diff 0」を `scripts/compare-baseline.py` で証明するために使用する。
 
 検証 surface は spec §8.2 で定義される `matches` + `gaps` のみ (bit-exact)。`detected_at` 等の time-varying field は projection で除外される。
+
+### Scope (本 baseline が covers すること)
+
+- `allaganeye detect <video>` の `metadata.json` 出力 (matches + gaps) bit-exact
+- `allaganeye split --from-metadata` の出力 MP4 (FFmpeg `-c copy` remux) の SHA-256 + size bit-exact
+
+### Out of scope (本 baseline は covers しないこと)
+
+| 領域 | 理由 | 別の検証ルート |
+| --- | --- | --- |
+| GUI H264 再エンコード (#591) | 入力 codec / GPU vendor / driver で出力 byte が変動 = 元々 deterministic regression に向かない | Tauri Rust 側の `select_h264_encoder` / `is_gpu_encoder_failure` unit test (`gui/src-tauri/`) |
+| 非 OBS 録画 (Game DVR / VTuber / Twitch) | Pillar 2 (input adapt) の scope。形式別に別 baseline を要する | `vtuber-primary-ground-truth.json` (VTuber 用 ±10s 比較、Pillar 2b で commit 済) |
+| 非 AV1 codec 入力 (h.264 / hevc) | サンプルは OBS NVENC AV1 統一。codec パスごとの regression は別 baseline | 別途 codec multi-baseline (#576 完了後の Pillar 3 後続枠で再評価) |
+| 非 NVIDIA GPU 環境 (AMD / Intel / CPU only) | 検知パスでは `--gpu` の vendor 選択は metadata.json `system_info.gpu_vendor_used` に記録されるのみ。出力 surface (`matches` / `gaps`) は同一の boundary 抽出結果になる想定 | 必要なら別 vendor 環境で同一動画を再検知して `compare-baseline.py` を re-run (env-specific verification は Self-Test Report の machine-unverifiable 行で扱う) |
+| Portable ZIP size (#752) / GUI HTTP server (#670) | 検知出力に無関係 | 各 PR で個別検証 |
 
 ## 種類
 
@@ -17,7 +32,7 @@ v0.3.0 L3 Pillar 3 (perf 改善) と Phase 2b (scorebar ROI 適応) の regressi
 | OBS baseline (split) | `obs-<label>.split.json` | 改修前の `allaganeye split --from-metadata` 出力の SHA-256 + size | bit-exact (Phase 1) |
 | VTuber ground truth | `vtuber-primary-ground-truth.json` | user 手動検証済みの "正解" 試合 timestamp | ±10s 一致 (Phase 2b) |
 
-OBS baseline は「現状検知の固定 snapshot」、VTuber ground truth は「目視正解」という別概念。OBS は **perf 改修で挙動が変わらないこと** を確認、VTuber は **scorebar ROI 適応化で正解に近づくこと** を確認する。
+OBS baseline は「現状検知の固定 snapshot」、VTuber ground truth は「目視正解」という別概念。OBS は **検知ロジック改修 PR で detect / split 出力が変わらないこと** を確認、VTuber は **scorebar ROI 適応化で正解に近づくこと** を確認する。本 OBS baseline は GUI H264 再エンコードや encoding fallback など別の regression を担保しない (§Out of scope 参照)。
 
 ## OBS baseline 動画セット (#778 選定)
 


### PR DESCRIPTION
## Summary

- #778 受け入れ条件 (i) OBS baseline 動画セット選定 を実施
- `tests/baselines/v0.3.0/README.md` を新規作成し、5 本の選定リスト + 不採用候補 + 基準 + Scope / Out of scope を明文化
- N = 5 で確定 (spec §11 open question #2 を本 PR で resolve)

選定: `obs-20260209` (57m / 3 matches) / `obs-20260127` (1h / 1) / `obs-20260116` (2h / 7) / `obs-20260118` (2h17m / 6) / `obs-20260119` (2h34m / 9)。全 1920x1080 / 60fps / AV1。`tests/baselines/{20260116,20260118,20260119}.json` の scorebar V2 (#522 / #529) validate 履歴のある 3 本に、短尺 (smoke) / 単一試合 edge の 2 本を追加。

選定理由詳細は README §選定基準 + §選定リスト + §不採用候補と理由 を参照。

`/codex:adversarial-review` (Pre-flight Step 5) で出た coverage overclaim 指摘を fix し、Out of scope セクション (GUI H264 再エンコード / 非 OBS / 非 AV1 / 非 NVIDIA / ZIP size) を明示追加。

## 受け入れ条件 逐条検証 (Iron Law 1)

#778 `## 確認項目 / 作業項目`:

- [x] `ALLAGANEYE_SAMPLE_VIDEO_DIR` 配下から候補を列挙 (MKV / MP4) — `tests/baselines/v0.3.0/README.md` §選定リスト + §不採用候補 に root MKV 14 本 + subdir 6 系列を整理
- [x] 各候補の特性を整理 (動画長 / codec / 解像度 / 試合数 / 既知の検出 quirk) — README の選定表 + 不採用候補表に duration / size / matches を記載。全動画とも 1920x1080 / 60fps / AV1 で codec / 解像度差分なし (ffprobe で確認済み)
- [x] N 本選定の基準確定 (サイズ・代表性・再現性) — README §選定基準 (4 項目) を明文化
- [x] 選定リストを `tests/baselines/v0.3.0/README.md` (新規) に commit — `tests/baselines/v0.3.0/README.md:34-44` (5 本の table)
- [ ] 選定理由を本 issue にコメント記録 — マージ後に手動で post (Iron Law 4: Closes 禁止 + manual close 規約と同様の handoff)

## 対応方針

> 選定のみ。実際の baseline 生成は次 issue (Phase 1 prep (ii)) で実行。

本 PR は selection のみ。実生成 + split.json schema 確定は #779 で実行。

## Self-Test Report

machine-verified:

- [x] `bash scripts/check-markdownlint.sh` → 0 errors (177 file チェック、本 PR 追加分含む)
- [x] `git diff --stat origin/develop-0.3.0..HEAD` → `tests/baselines/v0.3.0/README.md | 87 ++++++++++++++` (新規 1 file のみ)
- [x] `/codex:adversarial-review --wait --base origin/develop-0.3.0` → finding #1 (coverage overclaim) を 2 commit 目で fix。finding #2 (PS 5.1 default mojibake) は repo 全体 (177 .md) が UTF-8 BOMless 統一の established norm で fix 不要 (`-Encoding UTF8` 指定で読める、`docs/testing-guide.md` 等も同条件)
- [x] Pre-flight Step 0: `gh pr list --search "778" --state open` → 0 件
- [x] Pre-flight Step 1-2: `git fetch origin develop-0.3.0` → `git log HEAD..origin/develop-0.3.0` 0 件 (base 同期確認)
- [x] Pre-flight Step 3: touched file `tests/baselines/v0.3.0/README.md` 新規のみ、merged PR との交差なし
- [x] Pre-flight Step 4: `gh pr list --search "778" --state all` → 関連 PR なし

machine-unverifiable:

- reviewer 目視: 選定 5 本の duration / match count 帯のカバレッジが Pillar 3 perf regression 検出に十分か
- reviewer 目視: §Out of scope の境界線が Phase 1 後続 (Wave 1a #576 等) PR 作成時に運用可能か
- ロジック変更を含まないため、実機検証 (GPU / audio / 長時間動画 / GUI Tauri) は不要 (docs-only)

## 関連

- spec: [docs/superpowers/specs/2026-05-18-v030-l3-redefinition-design.md](docs/superpowers/specs/2026-05-18-v030-l3-redefinition-design.md) §8.7 (i)
- 前置 PR: #777 (compare-baseline.py + vtuber ground truth、Phase 1 prep (iii))
- 後続: #779 (Phase 1 prep (ii) 実生成、本 PR の選定リストに従う)

session-id: `serene-gauss-2bffa3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
