### PR TITLE
feat(audit): #800 audit-prepare transactional crash recovery

### DIFF
--- a/docs/superpowers/plans/2026-05-21-audit-prepare-tx-recovery.md
+++ b/docs/superpowers/plans/2026-05-21-audit-prepare-tx-recovery.md
@@ -1,0 +1,1507 @@
+# audit-prepare transactional crash recovery (Issue #800) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `audit-prepare` の publish 3-op swap (rmtree + rename + replace) に tx-state sidecar (`<label>.tx.json`) を追加し、crash 時に次 run が auto-recover する。
+
+**Architecture:** `<label>.tx.json` が単一 canonical state (`"consistent"` / `"swapping"`)。Step 3 開始時に "swapping" を atomic 書き込み (`.tx.json.new` → `os.replace`)、3-op swap 完了後に "consistent" に更新。Step 0 で "swapping" を検出したら artifacts (`<label>/` + `<label>.csv` + `<label>.tx.json`) を全消去して regenerate。`audit-compare` は worksheet を読まないため tx-state を見る必要なし。
+
+**Tech Stack:** Python 3.13 / pathlib / json / pytest / monkeypatch (failure injection) / ruff / pyright
+
+**Spec:** [docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md](../specs/2026-05-20-audit-prepare-tx-recovery-design.md)
+
+**Branch:** `claude/audit-tx-recovery-800` (already created, base = `origin/develop-0.3.0`)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `scripts/audit-prepare.py` | tx-state 定数 + 3 helpers (`_read_tx_state` / `_write_tx_state_atomic` / `_recover_stale_artifacts`) + `main()` Step 0/3a/3e の組み込み。step (3) コメントブロック更新 |
+| `tests/test_audit_prepare.py` | helpers 単体テスト (Task 1-3) + main() 統合テスト (Task 4-5) + failure-injection tests (Task 6) |
+| `docs/v030-baseline-audit.md` | "Known limitation (Issue #800)" 節を「解消済み」に更新 |
+| `docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md` | (既 commit、変更なし) |
+
+---
+
+## Task 1: `_read_tx_state` helper
+
+**Files:**
+
+- Modify: `scripts/audit-prepare.py` (add constants + helper near top, after imports)
+- Test: `tests/test_audit_prepare.py` (add unit tests at end of file)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_audit_prepare.py`:
+
+```python
+# --- Issue #800: tx-state helpers ---
+
+
+def test_read_tx_state_returns_none_when_missing(tmp_path, capsys):
+    """File-not-exist is legacy / first-run case; no warning."""
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    assert mod._read_tx_state(tx_path) is None
+    assert capsys.readouterr().err == ""
+
+
+def test_read_tx_state_returns_consistent_state(tmp_path):
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    tx_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "state": "consistent",
+                "updated_at": "2026-05-21T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = mod._read_tx_state(tx_path)
+    assert result is not None
+    assert result["state"] == "consistent"
+
+
+def test_read_tx_state_returns_swapping_state(tmp_path):
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    tx_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "state": "swapping",
+                "updated_at": "2026-05-21T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = mod._read_tx_state(tx_path)
+    assert result is not None
+    assert result["state"] == "swapping"
+
+
+@pytest.mark.parametrize(
+    "payload,variant",
+    [
+        ("not valid json{{{", "invalid_json"),
+        ('["a", "b"]', "non_dict"),
+        ('{"schema_version": 2, "state": "consistent"}', "unknown_schema_version"),
+        ('{"schema_version": 1, "state": "unknown"}', "unknown_state"),
+    ],
+)
+def test_tx_state_corrupted_treated_as_missing(tmp_path, capsys, payload, variant):
+    """All 4 corrupted variants return None + warn on stderr."""
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    tx_path.write_text(payload, encoding="utf-8")
+    result = mod._read_tx_state(tx_path)
+    assert result is None, f"variant={variant}"
+    err = capsys.readouterr().err
+    assert "WARNING" in err, f"variant={variant} stderr: {err!r}"
+    assert str(tx_path) in err, f"variant={variant} stderr: {err!r}"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_audit_prepare.py::test_read_tx_state_returns_none_when_missing -v`
+Expected: `FAILED` with `AttributeError: module 'audit_prepare' has no attribute '_read_tx_state'`
+
+- [ ] **Step 3: Add constants + `_read_tx_state` to `scripts/audit-prepare.py`**
+
+In `scripts/audit-prepare.py`, after line 42 (`_DEFAULT_WORKSHEET_DIR = ...`), add:
+
+```python
+
+# Issue #800: tx-state sidecar for transactional crash recovery.
+# `<label>.tx.json` holds the single canonical state of the last publish;
+# crash mid-publish is detected by next run via state == "swapping" and
+# recovered by wiping artifacts before regenerating.
+_TX_SCHEMA_VERSION = 1
+_TX_STATE_CONSISTENT = "consistent"
+_TX_STATE_SWAPPING = "swapping"
+```
+
+Then after `build_worksheet_rows` (around line 124), add:
+
+```python
+
+
+def _read_tx_state(tx_path: Path) -> dict[str, Any] | None:
+    """Return parsed tx-state, or None if file missing / corrupted / unknown shape.
+
+    Returning None means "no committed transactional state" (= no recovery
+    needed). File-not-exist is the legacy / first-run case (silent); all
+    other "missing-equivalent" cases warn on stderr so the operator can
+    debug why their tx-state was ignored.
+    """
+    if not tx_path.exists():
+        return None
+    try:
+        data = json.loads(tx_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(
+            f"WARNING: {tx_path} is unreadable ({exc}); treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if not isinstance(data, dict):
+        print(
+            f"WARNING: {tx_path} top-level is not an object; treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if data.get("schema_version") != _TX_SCHEMA_VERSION:
+        print(
+            f"WARNING: {tx_path} has unsupported schema_version "
+            f"{data.get('schema_version')!r} (expected {_TX_SCHEMA_VERSION}); "
+            "treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if data.get("state") not in (_TX_STATE_CONSISTENT, _TX_STATE_SWAPPING):
+        print(
+            f"WARNING: {tx_path} has unknown state {data.get('state')!r}; "
+            "treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    return data
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_prepare.py -k "tx_state or read_tx_state" -v`
+Expected: All 7 tests PASS (1 returns_none + 2 returns_state + 4 parametrized corrupted)
+
+- [ ] **Step 5: Run lint + type checks**
+
+Run: `ruff check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: `All checks passed!`
+
+Run: `ruff format --check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: no diff. If format errors, run `ruff format scripts/audit-prepare.py tests/test_audit_prepare.py` to fix.
+
+Run: `pyright scripts/audit-prepare.py`
+Expected: `0 errors, 0 warnings, 0 informations`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/audit-prepare.py tests/test_audit_prepare.py
+git commit -m "$(cat <<'EOF'
+feat(audit): #800 add _read_tx_state helper + tx-state constants
+
+backwards-compat: file-not-exist は silent, JSON parse fail / non-dict /
+unknown schema_version / unknown state は WARNING + None。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `_write_tx_state_atomic` helper
+
+**Files:**
+
+- Modify: `scripts/audit-prepare.py` (add `datetime` import + helper after `_read_tx_state`)
+- Test: `tests/test_audit_prepare.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_audit_prepare.py`:
+
+```python
+
+
+def test_write_tx_state_atomic_creates_file(tmp_path):
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+    assert tx_path.exists()
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["schema_version"] == 1
+    assert data["state"] == "consistent"
+    assert data["updated_at"].endswith("Z")  # ISO 8601 UTC
+
+
+def test_write_tx_state_atomic_overwrites_existing(tmp_path):
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    mod._write_tx_state_atomic(tx_path, state="swapping")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+
+
+def test_write_tx_state_atomic_cleans_up_new_suffix(tmp_path):
+    """No `.tx.json.new` should remain after successful write."""
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+    assert tx_path.exists()
+    assert not (tmp_path / "obs.tx.json.new").exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_audit_prepare.py::test_write_tx_state_atomic_creates_file -v`
+Expected: `FAILED` with `AttributeError: module 'audit_prepare' has no attribute '_write_tx_state_atomic'`
+
+- [ ] **Step 3: Add `datetime` import + helper to `scripts/audit-prepare.py`**
+
+In `scripts/audit-prepare.py`, after `from concurrent.futures import ThreadPoolExecutor, as_completed` (around line 19), add:
+
+```python
+from datetime import datetime, timezone
+```
+
+After `_read_tx_state`, add:
+
+```python
+
+
+def _write_tx_state_atomic(tx_path: Path, *, state: str) -> None:
+    """Atomically write tx-state via temp file + os.replace.
+
+    On POSIX and Windows, replace() of a single file is atomic, so the
+    on-disk tx-state is never partially-written. The temp file uses the
+    `.new` suffix to match the existing artifact-staging convention.
+    """
+    payload = {
+        "schema_version": _TX_SCHEMA_VERSION,
+        "state": state,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    tx_new = tx_path.parent / (tx_path.name + ".new")
+    tx_new.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tx_new.replace(tx_path)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_prepare.py -k "write_tx_state_atomic" -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Verify existing tests still pass**
+
+Run: `python -m pytest tests/test_audit_prepare.py -v`
+Expected: All tests PASS (existing + new Task 1/2).
+
+- [ ] **Step 6: Run lint + type checks**
+
+Run: `ruff check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: `All checks passed!`
+
+Run: `ruff format --check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: no diff.
+
+Run: `pyright scripts/audit-prepare.py`
+Expected: `0 errors`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/audit-prepare.py tests/test_audit_prepare.py
+git commit -m "$(cat <<'EOF'
+feat(audit): #800 add _write_tx_state_atomic helper
+
+`.tx.json.new` 経由の os.replace で single-file atomic 書き込み。
+payload は schema_version=1 + state + ISO 8601 UTC updated_at。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `_recover_stale_artifacts` helper
+
+**Files:**
+
+- Modify: `scripts/audit-prepare.py` (add helper after `_write_tx_state_atomic`)
+- Test: `tests/test_audit_prepare.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_audit_prepare.py`:
+
+```python
+
+
+def test_recover_stale_artifacts_removes_all(tmp_path):
+    mod = _load_module()
+    per_boundary_dir = tmp_path / "obs"
+    worksheet_csv = tmp_path / "obs.csv"
+    tx_path = tmp_path / "obs.tx.json"
+
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "a.png").write_bytes(b"PNG")
+    worksheet_csv.write_text("HEADER\n", encoding="utf-8")
+    tx_path.write_text("{}", encoding="utf-8")
+
+    mod._recover_stale_artifacts(
+        per_boundary_dir=per_boundary_dir,
+        worksheet_csv=worksheet_csv,
+        tx_path=tx_path,
+    )
+
+    assert not per_boundary_dir.exists()
+    assert not worksheet_csv.exists()
+    assert not tx_path.exists()
+
+
+def test_recover_stale_artifacts_idempotent_on_missing(tmp_path):
+    """Helper must not raise when paths are already absent."""
+    mod = _load_module()
+    per_boundary_dir = tmp_path / "obs"
+    worksheet_csv = tmp_path / "obs.csv"
+    tx_path = tmp_path / "obs.tx.json"
+
+    # All absent
+    mod._recover_stale_artifacts(
+        per_boundary_dir=per_boundary_dir,
+        worksheet_csv=worksheet_csv,
+        tx_path=tx_path,
+    )
+
+
+def test_recover_stale_artifacts_partial_state(tmp_path):
+    """Helper handles 'dir exists but csv/tx absent' without error."""
+    mod = _load_module()
+    per_boundary_dir = tmp_path / "obs"
+    worksheet_csv = tmp_path / "obs.csv"
+    tx_path = tmp_path / "obs.tx.json"
+
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "a.png").write_bytes(b"PNG")
+
+    mod._recover_stale_artifacts(
+        per_boundary_dir=per_boundary_dir,
+        worksheet_csv=worksheet_csv,
+        tx_path=tx_path,
+    )
+
+    assert not per_boundary_dir.exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_audit_prepare.py::test_recover_stale_artifacts_removes_all -v`
+Expected: `FAILED` with `AttributeError: module 'audit_prepare' has no attribute '_recover_stale_artifacts'`
+
+- [ ] **Step 3: Add `_recover_stale_artifacts` to `scripts/audit-prepare.py`**
+
+After `_write_tx_state_atomic`, add:
+
+```python
+
+
+def _recover_stale_artifacts(
+    *,
+    per_boundary_dir: Path,
+    worksheet_csv: Path,
+    tx_path: Path,
+) -> None:
+    """Wipe artifacts when tx-state == swapping on startup.
+
+    Idempotent. Does not raise on missing paths. Called from main() Step 0
+    after _read_tx_state returns a swapping-state dict.
+    """
+    shutil.rmtree(per_boundary_dir, ignore_errors=True)
+    worksheet_csv.unlink(missing_ok=True)
+    tx_path.unlink(missing_ok=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_prepare.py -k "recover_stale_artifacts" -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Run lint + type checks + full test sweep**
+
+Run: `ruff check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: `All checks passed!`
+
+Run: `ruff format --check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: no diff.
+
+Run: `pyright scripts/audit-prepare.py`
+Expected: `0 errors`
+
+Run: `python -m pytest tests/test_audit_prepare.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/audit-prepare.py tests/test_audit_prepare.py
+git commit -m "$(cat <<'EOF'
+feat(audit): #800 add _recover_stale_artifacts helper
+
+`<label>/` + `<label>.csv` + `<label>.tx.json` を ignore_errors / missing_ok で
+全消去するヘルパ。idempotent + 部分状態安全。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire tx-state marker into main() Step 3
+
+**Files:**
+
+- Modify: `scripts/audit-prepare.py` (main() — add `tx_path` + Step 3a/3e)
+- Test: `tests/test_audit_prepare.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audit_prepare.py`:
+
+```python
+
+
+def test_main_writes_tx_state_consistent_after_publish(tmp_path, monkeypatch):
+    """After successful main() the tx-state file exists with state=consistent (#800)."""
+    mod = _load_module()
+    baseline_dir = tmp_path / "baselines"
+    baseline_dir.mkdir()
+    metadata = {
+        "schema_version": "1",
+        "source": "20260116/fake.mkv",
+        "matches": [
+            {
+                "index": 1,
+                "start_time": 49.125,
+                "end_time": 1054.5,
+                "duration": 1005.375,
+                "type": "fl_match",
+            },
+        ],
+        "gaps": [],
+    }
+    (baseline_dir / "obs-fake.metadata.json").write_text(
+        json.dumps(metadata), encoding="utf-8"
+    )
+    video_dir = tmp_path / "videos"
+    (video_dir / "20260116").mkdir(parents=True)
+    (video_dir / "20260116" / "fake.mkv").write_bytes(b"")
+    monkeypatch.setenv("ALLAGANEYE_SAMPLE_VIDEO_DIR", str(video_dir))
+    monkeypatch.setattr(mod, "export_brightness_csv", lambda **kw: None)
+    monkeypatch.setattr(mod, "export_sample_frames", lambda **kw: None)
+
+    worksheet_dir = tmp_path / "audit-worksheet"
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+    assert tx_path.exists()
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["schema_version"] == 1
+    assert data["state"] == "consistent"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_audit_prepare.py::test_main_writes_tx_state_consistent_after_publish -v`
+Expected: `FAILED` because `obs-fake.tx.json` does not exist (main() does not yet write it)
+
+- [ ] **Step 3: Modify `main()` in `scripts/audit-prepare.py`**
+
+Find this block (around line 266-269):
+
+```python
+    per_boundary_dir = args.worksheet_dir / args.recording_label
+    per_boundary_dir_new = args.worksheet_dir / f"{args.recording_label}.new"
+    worksheet_csv = args.worksheet_dir / f"{args.recording_label}.csv"
+    worksheet_csv_new = args.worksheet_dir / f"{args.recording_label}.csv.new"
+```
+
+Add a new line after it:
+
+```python
+    tx_path = args.worksheet_dir / f"{args.recording_label}.tx.json"
+```
+
+Find the step (3) swap block (around line 333-336):
+
+```python
+    if per_boundary_dir.exists():
+        shutil.rmtree(per_boundary_dir)
+    per_boundary_dir_new.rename(per_boundary_dir)
+    worksheet_csv_new.replace(worksheet_csv)
+```
+
+Wrap it with tx-state markers:
+
+```python
+    args.worksheet_dir.mkdir(parents=True, exist_ok=True)
+    _write_tx_state_atomic(tx_path, state=_TX_STATE_SWAPPING)
+    if per_boundary_dir.exists():
+        shutil.rmtree(per_boundary_dir)
+    per_boundary_dir_new.rename(per_boundary_dir)
+    worksheet_csv_new.replace(worksheet_csv)
+    _write_tx_state_atomic(tx_path, state=_TX_STATE_CONSISTENT)
+```
+
+The `args.worksheet_dir.mkdir(parents=True, exist_ok=True)` line is required because `_write_tx_state_atomic` writes into `args.worksheet_dir`, which may not exist yet on first run (Step 1 only creates `<label>.new` subdir, not the parent). Without this, the test `test_main_writes_tx_state_consistent_after_publish` fails on first run with FileNotFoundError.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_audit_prepare.py::test_main_writes_tx_state_consistent_after_publish -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify all existing tests still pass**
+
+Run: `python -m pytest tests/test_audit_prepare.py -v`
+Expected: All tests PASS (existing 3 atomic-flow tests + Task 1/2/3 unit tests + this new test).
+
+In particular, the existing tests `test_main_atomic_success_replaces_old_artifacts` and `test_main_recovers_from_stale_new_dir` should continue to pass (they don't read tx-state so they don't care about its presence).
+
+- [ ] **Step 6: Run lint + type checks**
+
+Run: `ruff check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: `All checks passed!`
+
+Run: `ruff format --check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: no diff.
+
+Run: `pyright scripts/audit-prepare.py`
+Expected: `0 errors`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/audit-prepare.py tests/test_audit_prepare.py
+git commit -m "$(cat <<'EOF'
+feat(audit): #800 wire tx-state marker into main() Step 3
+
+Step 3a で "swapping" を atomic 書き込み、3-op swap 完了後 Step 3e で "consistent"
+に更新。worksheet_dir.mkdir を Step 3 直前に追加 (`.tx.json` 親 dir 不在対応)。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Wire Step 0 recovery + backwards-compat tests
+
+**Files:**
+
+- Modify: `scripts/audit-prepare.py` (main() — add Step 0 before Step 1)
+- Test: `tests/test_audit_prepare.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_audit_prepare.py`:
+
+```python
+
+
+def _seed_baseline_for_main(tmp_path, monkeypatch, label="obs-fake"):
+    """Helper: build a minimal baseline + video tree usable by main()."""
+    mod = _load_module()
+    baseline_dir = tmp_path / "baselines"
+    baseline_dir.mkdir(exist_ok=True)
+    metadata = {
+        "schema_version": "1",
+        "source": "20260116/fake.mkv",
+        "matches": [
+            {
+                "index": 1,
+                "start_time": 49.125,
+                "end_time": 1054.5,
+                "duration": 1005.375,
+                "type": "fl_match",
+            },
+        ],
+        "gaps": [],
+    }
+    (baseline_dir / f"{label}.metadata.json").write_text(
+        json.dumps(metadata), encoding="utf-8"
+    )
+    video_dir = tmp_path / "videos"
+    (video_dir / "20260116").mkdir(parents=True, exist_ok=True)
+    (video_dir / "20260116" / "fake.mkv").write_bytes(b"")
+    monkeypatch.setenv("ALLAGANEYE_SAMPLE_VIDEO_DIR", str(video_dir))
+    monkeypatch.setattr(mod, "export_brightness_csv", lambda **kw: None)
+    monkeypatch.setattr(mod, "export_sample_frames", lambda **kw: None)
+    return mod, baseline_dir
+
+
+def test_main_step0_recovers_from_swapping_state(tmp_path, monkeypatch, capsys):
+    """tx-state == 'swapping' on startup -> wipe + regenerate + WARNING (#800)."""
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed mid-crash state: tx="swapping", stale dir, stale csv
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "old.txt").write_text("OLD", encoding="utf-8")
+    worksheet_csv.write_text("OLD_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="swapping")
+
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Recovery happened: old wiped, new regenerated, tx="consistent"
+    assert not (per_boundary_dir / "old.txt").exists()
+    assert per_boundary_dir.exists()
+    assert "OLD_HEADER" not in worksheet_csv.read_text(encoding="utf-8")
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+
+    # WARNING was emitted on stderr
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err
+
+
+def test_tx_state_missing_legacy_compat(tmp_path, monkeypatch, capsys):
+    """tx.json absent (legacy baseline) -> no recovery, normal regenerate (#800)."""
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+
+    # Seed legacy state: dir + csv exist but NO tx.json
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "legacy.txt").write_text("LEGACY", encoding="utf-8")
+    worksheet_csv.write_text("LEGACY_HEADER\n", encoding="utf-8")
+
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Normal regenerate (legacy content overwritten by atomic swap)
+    assert not (per_boundary_dir / "legacy.txt").exists()
+    # No recovery WARNING in stderr
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" not in err
+
+    # tx.json is now created with state=consistent
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+
+
+def test_no_recovery_when_state_consistent(tmp_path, monkeypatch, capsys):
+    """tx-state == 'consistent' on startup -> no recovery, normal regenerate (#800)."""
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed clean prior-run state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "prev.txt").write_text("PREV", encoding="utf-8")
+    worksheet_csv.write_text("PREV_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Normal regenerate (prev content overwritten by atomic swap)
+    assert not (per_boundary_dir / "prev.txt").exists()
+    # No recovery WARNING in stderr
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" not in err
+
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_audit_prepare.py::test_main_step0_recovers_from_swapping_state -v`
+Expected: `FAILED` — recovery does not happen (Step 0 not yet wired); the swapping state is overwritten without the recovery WARNING being emitted, and the test fails on `assert "crashed mid-publish" in err`.
+
+- [ ] **Step 3: Add Step 0 recovery to `main()` in `scripts/audit-prepare.py`**
+
+Find this block in `main()` (after path setup, before Step 1 pre-clean — around line 270):
+
+```python
+    tx_path = args.worksheet_dir / f"{args.recording_label}.tx.json"
+
+    # (1) Pre-clean any stale temp residue from a prior crashed run.
+```
+
+Insert Step 0 between `tx_path = ...` and the `# (1)` comment:
+
+```python
+    tx_path = args.worksheet_dir / f"{args.recording_label}.tx.json"
+
+    # (0) Recovery-on-start: if a prior run crashed mid-publish, the
+    # tx-state will be "swapping" and the on-disk artifacts are in an
+    # unknown state. Wipe everything so Step 2 regenerates from scratch.
+    # Backwards-compat: tx.json absent (legacy baseline) or "consistent"
+    # (clean prior run) skips recovery.
+    tx = _read_tx_state(tx_path)
+    if tx is not None and tx["state"] == _TX_STATE_SWAPPING:
+        print(
+            f"WARNING: previous {args.recording_label} run crashed mid-publish; "
+            "cleaning up stale artifacts before regenerating",
+            file=sys.stderr,
+        )
+        _recover_stale_artifacts(
+            per_boundary_dir=per_boundary_dir,
+            worksheet_csv=worksheet_csv,
+            tx_path=tx_path,
+        )
+
+    # (1) Pre-clean any stale temp residue from a prior crashed run.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_prepare.py -k "step0 or legacy_compat or no_recovery_when" -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Verify all existing + new tests still pass**
+
+Run: `python -m pytest tests/test_audit_prepare.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Run lint + type checks**
+
+Run: `ruff check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: `All checks passed!`
+
+Run: `ruff format --check scripts/audit-prepare.py tests/test_audit_prepare.py`
+Expected: no diff.
+
+Run: `pyright scripts/audit-prepare.py`
+Expected: `0 errors`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/audit-prepare.py tests/test_audit_prepare.py
+git commit -m "$(cat <<'EOF'
+feat(audit): #800 wire Step 0 recovery into main()
+
+tx.state == "swapping" を検出したら artifacts (`<label>/` + `<label>.csv` +
+`<label>.tx.json`) を全消去 + WARNING を stderr に 1 行出力。tx.json 不在
+(legacy baseline) と "consistent" は recovery skip (backwards compat)。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Failure-injection tests for crash points W1 / W2 / before-commit
+
+**Files:**
+
+- Test: `tests/test_audit_prepare.py` (add 3 failure-injection tests)
+
+これらの test は実装変更を伴わない (impl は Task 1-5 で完了済)。Task 1-5 の helpers / wiring が正しければ、失敗注入で crash → recovery cycle が成立することを確認する。test が落ちた場合は Task 1-5 の bug を意味するので、test 修正でなく impl 修正に回す。
+
+- [ ] **Step 1: Write the 3 failure-injection tests**
+
+Append to `tests/test_audit_prepare.py`:
+
+```python
+
+
+def test_recovers_from_crash_after_rmtree(tmp_path, monkeypatch, capsys):
+    """W1 window: crash AFTER rmtree old per_boundary_dir, BEFORE rename .new.
+
+    Mid-crash state: dir gone, csv old, tx.json "swapping".
+    Next run: Step 0 sees "swapping" + wipes + regenerates.
+    """
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed clean prior-run state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "old.txt").write_text("OLD", encoding="utf-8")
+    worksheet_csv.write_text("OLD_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+
+    # Inject crash: shutil.rmtree raises AFTER deleting per_boundary_dir once
+    original_rmtree = mod.shutil.rmtree
+    crashed = {"value": False}
+
+    def crashing_rmtree(path, *args, **kwargs):
+        original_rmtree(path, *args, **kwargs)
+        if not crashed["value"] and Path(path) == per_boundary_dir:
+            crashed["value"] = True
+            raise RuntimeError("simulated crash after rmtree")
+
+    monkeypatch.setattr(mod.shutil, "rmtree", crashing_rmtree)
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        mod.main(
+            [
+                "obs-fake",
+                "--baseline-dir",
+                str(baseline_dir),
+                "--worksheet-dir",
+                str(worksheet_dir),
+            ]
+        )
+
+    # Mid-crash state: tx="swapping", dir gone, csv still old
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "swapping"
+    assert not per_boundary_dir.exists()
+    assert worksheet_csv.read_text(encoding="utf-8") == "OLD_HEADER\n"
+
+    # Restore rmtree for recovery run
+    monkeypatch.setattr(mod.shutil, "rmtree", original_rmtree)
+
+    # Re-run audit-prepare: Step 0 recovery
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Recovered state: tx="consistent", regenerated artifacts
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+    assert per_boundary_dir.exists()
+    assert worksheet_csv.exists()
+    assert "OLD_HEADER" not in worksheet_csv.read_text(encoding="utf-8")
+
+    # WARNING was emitted
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err
+
+
+def test_recovers_from_crash_after_dir_rename(tmp_path, monkeypatch, capsys):
+    """W2 window: crash AFTER per_boundary_dir_new.rename, BEFORE csv replace.
+
+    Mid-crash state: new dir + old csv, tx.json "swapping".
+    Next run: Step 0 wipes new dir + old csv + tx, regenerates.
+    """
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    per_boundary_dir_new = worksheet_dir / "obs-fake.new"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed clean prior-run state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "old.txt").write_text("OLD", encoding="utf-8")
+    worksheet_csv.write_text("OLD_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+
+    # Inject crash: Path.rename raises AFTER renaming per_boundary_dir_new -> per_boundary_dir
+    original_rename = Path.rename
+    crashed = {"value": False}
+
+    def crashing_rename(self, target, *args, **kwargs):
+        result = original_rename(self, target, *args, **kwargs)
+        if (
+            not crashed["value"]
+            and Path(self) == per_boundary_dir_new
+            and Path(target) == per_boundary_dir
+        ):
+            crashed["value"] = True
+            raise RuntimeError("simulated crash after dir rename")
+        return result
+
+    monkeypatch.setattr(Path, "rename", crashing_rename)
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        mod.main(
+            [
+                "obs-fake",
+                "--baseline-dir",
+                str(baseline_dir),
+                "--worksheet-dir",
+                str(worksheet_dir),
+            ]
+        )
+
+    # Mid-crash state: tx="swapping", new dir present, old csv still there
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "swapping"
+    assert per_boundary_dir.exists()
+    assert not (per_boundary_dir / "old.txt").exists()  # new content
+    assert worksheet_csv.read_text(encoding="utf-8") == "OLD_HEADER\n"
+
+    # Restore rename for recovery run
+    monkeypatch.setattr(Path, "rename", original_rename)
+
+    # Re-run audit-prepare: Step 0 recovery
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Recovered state
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+    assert per_boundary_dir.exists()
+    assert worksheet_csv.exists()
+    assert "OLD_HEADER" not in worksheet_csv.read_text(encoding="utf-8")
+
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err
+
+
+def test_recovers_from_crash_before_tx_commit(tmp_path, monkeypatch, capsys):
+    """crash AFTER csv replace, BEFORE final tx="consistent" write.
+
+    Mid-crash state: new dir + new csv, tx.json still "swapping" (= wasteful regenerate).
+    Next run: Step 0 wipes everything + regenerates (content correct but tx not committed).
+    """
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed clean prior-run state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "old.txt").write_text("OLD", encoding="utf-8")
+    worksheet_csv.write_text("OLD_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+
+    # Inject crash: _write_tx_state_atomic raises on the 2nd call (consistent commit)
+    original_write = mod._write_tx_state_atomic
+    call_count = {"value": 0}
+
+    def crashing_write(path, *, state):
+        call_count["value"] += 1
+        if call_count["value"] == 2 and state == "consistent":
+            raise RuntimeError("simulated crash before tx commit")
+        original_write(path, state=state)
+
+    monkeypatch.setattr(mod, "_write_tx_state_atomic", crashing_write)
+
+    with pytest.raises(RuntimeError, match="simulated crash before tx commit"):
+        mod.main(
+            [
+                "obs-fake",
+                "--baseline-dir",
+                str(baseline_dir),
+                "--worksheet-dir",
+                str(worksheet_dir),
+            ]
+        )
+
+    # Mid-crash state: tx still "swapping", new dir + new csv on disk
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "swapping"
+    assert per_boundary_dir.exists()
+    assert not (per_boundary_dir / "old.txt").exists()  # new content
+    assert "OLD_HEADER" not in worksheet_csv.read_text(encoding="utf-8")
+
+    # Restore for recovery run
+    monkeypatch.setattr(mod, "_write_tx_state_atomic", original_write)
+
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Recovered state
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+    assert per_boundary_dir.exists()
+    assert worksheet_csv.exists()
+
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_audit_prepare.py -k "recovers_from_crash" -v`
+Expected: All 3 tests PASS.
+
+If any test FAILS, do NOT modify the test — that signals a bug in Task 1-5 impl. Trace the failure back to the relevant task and fix the impl.
+
+- [ ] **Step 3: Run full test sweep to confirm no regression**
+
+Run: `python -m pytest tests/test_audit_prepare.py -v`
+Expected: All tests PASS (existing 3 atomic-flow tests + Task 1/2/3 unit tests + Task 4/5 integration tests + Task 6 failure-injection tests).
+
+Total test count after this task: 3 (existing) + 4 (Task 1) + 3 (Task 2) + 3 (Task 3) + 1 (Task 4) + 3 (Task 5) + 3 (Task 6) = 20 tests in the audit_prepare module. Plus the pre-existing tests for `build_worksheet_rows` / `_format_timestamp` / `resolve_video_path` / `write_worksheet_csv` / `test_main_writes_worksheet_csv` (existing before this task).
+
+- [ ] **Step 4: Run lint + type checks**
+
+Run: `ruff check tests/test_audit_prepare.py`
+Expected: `All checks passed!`
+
+Run: `ruff format --check tests/test_audit_prepare.py`
+Expected: no diff.
+
+Run: `pyright scripts/audit-prepare.py`
+Expected: `0 errors`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_audit_prepare.py
+git commit -m "$(cat <<'EOF'
+test(audit): #800 failure-injection tests for W1 / W2 / before-tx-commit
+
+3 つの crash point each で「crash 注入 → mid-crash state assert → recovery
+run → recovered state assert」のフルサイクルを検証。monkeypatch で
+shutil.rmtree / Path.rename / _write_tx_state_atomic を path filter 付き wrap。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Update step (3) comment block + v030 audit doc
+
+**Files:**
+
+- Modify: `scripts/audit-prepare.py:304-332` (step (3) コメントブロック)
+- Modify: `docs/v030-baseline-audit.md` ("Known limitation (Issue #800)" 節)
+
+- [ ] **Step 1: Update step (3) comment block in `scripts/audit-prepare.py`**
+
+After Task 4 + 5 the swap block now looks like:
+
+```python
+    args.worksheet_dir.mkdir(parents=True, exist_ok=True)
+    _write_tx_state_atomic(tx_path, state=_TX_STATE_SWAPPING)
+    if per_boundary_dir.exists():
+        shutil.rmtree(per_boundary_dir)
+    per_boundary_dir_new.rename(per_boundary_dir)
+    worksheet_csv_new.replace(worksheet_csv)
+    _write_tx_state_atomic(tx_path, state=_TX_STATE_CONSISTENT)
+```
+
+The existing 29-line `ATOMICITY LIMITATIONS` comment block (currently between `# (3) All-success: swap temp into final position.` and the `if per_boundary_dir.exists():` line) was added in #798 to document that the swap is non-transactional. After #800, the crash windows are detectable + auto-recoverable via tx-state, so this comment needs to be rewritten.
+
+Open `scripts/audit-prepare.py` and find the line `# (3) All-success: swap temp into final position.` (current line 302). Replace the entire block from that line through the end of the `ATOMICITY LIMITATIONS` comment (which ends around line 332 with `# §9 Risks #1.`) with this updated block:
+
+```python
+    # (3) All-success: swap temp into final position.
+    #
+    # The 3-op swap (rmtree + rename + replace) is non-atomic, so a crash
+    # between any two ops leaves filesystem state inconsistent. Issue #800
+    # added a tx-state sidecar (`<label>.tx.json`) that is marked
+    # "swapping" before the swap starts and "consistent" only after csv
+    # replace succeeds. Step 0 of the next `audit-prepare` run reads the
+    # tx-state, and if it is still "swapping" wipes all artifacts before
+    # regenerating from scratch (`_recover_stale_artifacts`).
+    #
+    # Both Codex-flagged windows are now detect + auto-recover safe:
+    #   - After rmtree, before rename (W1):
+    #       Mid-crash: per_boundary_dir gone, worksheet_csv still old.
+    #       Next run: tx="swapping" -> wipe old csv + tx -> regenerate.
+    #   - After rename, before replace (W2):
+    #       Mid-crash: per_boundary_dir new, worksheet_csv still old.
+    #       Next run: tx="swapping" -> wipe new dir + old csv + tx -> regenerate.
+    #
+    # The tx-state file itself is published via `.tx.json.new` + os.replace
+    # so its write is single-file atomic on Windows + POSIX.
+```
+
+- [ ] **Step 2: Update `docs/v030-baseline-audit.md`**
+
+Find the "Known limitation (Issue #800)" subsection (added in PR #801 / commit `78d0cdf`). Read the current content first:
+
+```bash
+grep -n "Known limitation" docs/v030-baseline-audit.md
+```
+
+Open the file, locate the heading `### Known limitation (Issue #800)`, and prepend a "解消" notice plus replace the body to reflect the fix. The new section should read:
+
+```markdown
+### Known limitation (Issue #800) — RESOLVED 2026-05-21
+
+`audit-prepare.main()` の step (3) atomic swap には 3-op (rmtree + rename + replace) で構成された crash window があったが、Issue #800 で `<label>.tx.json` sidecar (tx-state) を導入して検出 + 次 run auto-recover を実装した。
+
+- W1 (`rmtree` 後 / `rename` 前) と W2 (`rename` 後 / `replace` 前) は次 `audit-prepare` 実行時に `state == "swapping"` が読み取られ、artifacts を全消去してから regenerate する
+- tx-state 自身は `.tx.json.new` 経由の `os.replace` で single-file atomic 書き込み
+- backwards-compat: tx.json 不在 (legacy baseline) / "consistent" は recovery skip
+
+詳細仕様は `docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md`、実装は PR #<新 PR 番号> (Task 8 で番号確定)。
+```
+
+`<新 PR 番号>` は Task 8 で確定する。Task 7 commit 段階では `#<PR-pending>` 等のプレースホルダで commit せず、Task 8 で PR 作成後にこの番号を埋めて再 commit する。
+
+- [ ] **Step 3: Verify markdownlint passes**
+
+Run: `bash scripts/check-markdownlint.sh docs/v030-baseline-audit.md`
+Expected: `Summary: 0 error(s)`
+
+If errors, refer to `docs/markdownlint-guide.md` §typical fixes.
+
+- [ ] **Step 4: Verify no regression in test suite**
+
+Run: `python -m pytest tests/test_audit_prepare.py -v`
+Expected: All tests PASS (comment changes do not affect behavior).
+
+- [ ] **Step 5: Run lint + type checks on script**
+
+Run: `ruff check scripts/audit-prepare.py`
+Expected: `All checks passed!`
+
+Run: `ruff format --check scripts/audit-prepare.py`
+Expected: no diff.
+
+- [ ] **Step 6: Commit (placeholder PR number)**
+
+```bash
+git add scripts/audit-prepare.py docs/v030-baseline-audit.md
+git commit -m "$(cat <<'EOF'
+docs(audit): #800 update step (3) comment + v030 audit doc
+
+step (3) コメントブロックを「ATOMICITY LIMITATIONS (Issue #800 で
+manifest / epoch / atomic pointer pattern を tracking 中)」から
+「tx-state で detect + auto-recover」に書き換え。
+docs/v030-baseline-audit.md の "Known limitation (Issue #800)"
+subsection に RESOLVED notice を追加。
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Task 8 で PR 番号確定後、必要なら `gh pr comment` で fix の reference を補足する (commit を amend しない、新規 commit で対応)。
+
+---
+
+## Task 8: PR creation (Iron Law 6 Pre-flight + Codex adversarial-review)
+
+> このタスクは Idios の手動操作を含む。subagent では Step 5 (Codex adversarial-review handoff) を実行せず、prompt を準備して Idios に提示する。
+
+**Files:**
+
+- (none — git/gh commands only)
+
+- [ ] **Step 1: Iron Law 6 Pre-flight Step 0 — parallel PR check (<1s hard gate)**
+
+Run:
+
+```bash
+gh pr list --search "800" --state open --repo Idios/kobutachan-allaganeye
+```
+
+Expected: 0 件 (本 PR を出す前なので open は無し)。1 件以上ある場合は STOP し AskUserQuestion で「同 issue 並行 PR が既にある。続けるか調整するか」を user に問う。
+
+- [ ] **Step 2: Iron Law 6 Pre-flight Step 1 — base 同期**
+
+Run:
+
+```bash
+git fetch origin develop-0.3.0
+```
+
+- [ ] **Step 3: Iron Law 6 Pre-flight Step 2 — 取り込み未済 commit 確認**
+
+Run:
+
+```bash
+git log HEAD..origin/develop-0.3.0 --oneline
+```
+
+Expected: 0 行 (branch を新規に `origin/develop-0.3.0` から切ったため、base に未済 commit は無いはず)。1 行以上ある場合は `git merge origin/develop-0.3.0` でマージ + コンフリクトがあれば解消。
+
+- [ ] **Step 4: Iron Law 6 Pre-flight Step 3 — touched files 交差判定**
+
+Run:
+
+```bash
+git diff origin/develop-0.3.0 --name-only
+```
+
+Expected:
+
+```text
+docs/superpowers/plans/2026-05-21-audit-prepare-tx-recovery.md
+docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md
+docs/v030-baseline-audit.md
+scripts/audit-prepare.py
+tests/test_audit_prepare.py
+```
+
+(plan は本 Task 8 開始前に commit 済を想定。未 commit ならまず plan も commit する)
+
+- [ ] **Step 5: Iron Law 6 Pre-flight Step 4 — 並行 PR 重複再確認**
+
+Run:
+
+```bash
+gh pr list --search "800" --state all --repo Idios/kobutachan-allaganeye
+```
+
+Expected: 0 件 (本 PR がまだ無いため)。Step 0 と同じ search だが state が `all` で closed merged も含む。
+
+- [ ] **Step 6: Iron Law 6 Pre-flight Step 5 — Codex adversarial-review handoff to Idios**
+
+> Codex CLI invocation は subagent からは行えない (project rule で skill 経由のみ)。本 step は Idios が手動で `/codex:adversarial-review` を invoke する handoff prompt を準備するに留まる。
+
+push 前に PR 作成予定の summary を準備:
+
+Branch: `claude/audit-tx-recovery-800`
+Base: `develop-0.3.0`
+Summary: `feat(audit): #800 audit-prepare transactional crash recovery (tx-state sidecar)`
+
+Idios に提示する Codex adversarial-review prompt template:
+
+```text
+EXECUTOR: dispatch (origin=claude/audit-tx-recovery-800, generated=2026-05-21)
+
+Please invoke the following review before PR creation:
+
+/codex:adversarial-review focus="Issue #800 implementation on claude/audit-tx-recovery-800 -- verify tx-state sidecar (`<label>.tx.json`) design covers all 3 crash points (W1: after rmtree before rename / W2: after rename before csv replace / before-tx-commit: after csv replace before final 'consistent' write). Probe for: Iron Law 3 scope creep, encoding boundary issues (Windows MSYS / cp932 in tx.json read/write), Windows file-rename atomicity gaps for the tx.json.new -> tx.json replace, race conditions between _read_tx_state and concurrent main() invocations (out-of-scope but call it out), residual silent-skip paths in _read_tx_state error branches, WARNING message stderr/stdout segregation, backwards compat behavior when tx.json is missing vs corrupted vs unknown schema_version / unknown state. Verify spec §6 acceptance criteria 1-11 are satisfied." --wait
+```
+
+Idios の指示待ち:
+
+- (A) Codex finding ゼロ → Step 7 で push + PR 作成
+- (B) Codex finding あり → 各 finding を分類 ((A) PR 内修正 / (B) 別 issue / (C) 既存 issue 追記) して対応 (`docs/l2-workflow.md` §「(A) PR 内修正優先 規約」)。本 PR の解決後に Step 7 へ
+- (C) Codex 不在 (token 枯渇等) → fallback で superpowers `requesting-code-review` subagent を起動 (`docs/l2-workflow.md` §「Codex fallback」)。fallback notice を PR 本文に必須記載
+
+- [ ] **Step 7: Push branch**
+
+Codex review が clean (or 全 finding 解消) になったら:
+
+```bash
+git push -u origin claude/audit-tx-recovery-800
+```
+
+- [ ] **Step 8: Create PR**
+
+```bash
+gh pr create \
+  --base develop-0.3.0 \
+  --repo Idios/kobutachan-allaganeye \
+  --title "feat(audit): #800 audit-prepare transactional crash recovery" \
+  --body "$(cat <<'EOF'
+## 期待値
+
+`scripts/audit-prepare.main()` step (3) の 3-op swap (rmtree + rename + replace) で発生しうる W1 / W2 crash window を検出 + 次 run auto-recover する。
+
+## 現状
+
+Issue #798 (PR #801) で W1 / W2 を `docs/superpowers/specs/2026-05-20-audit-script-hardening-design.md` §3.2 / §9 で trade-off として明示し、`scripts/audit-prepare.py:304-332` でも文書化した。Codex adversarial-review が W1 / W2 を指摘し、Issue #800 として follow-up を tracking していた。
+
+## 修正内容
+
+- `scripts/audit-prepare.py`: tx-state 定数 + 3 helpers (`_read_tx_state` / `_write_tx_state_atomic` / `_recover_stale_artifacts`) を追加。`main()` に Step 0 (recovery-on-start) と Step 3a/3e (tx-state marker) を組み込み
+- `<label>.tx.json` schema = `{schema_version: 1, state: "consistent"|"swapping", updated_at: ISO 8601 UTC}`
+- 書き込みは `.tx.json.new` 経由の `os.replace` で single-file atomic
+- backwards-compat: tx.json 不在 / JSON parse fail / non-dict / unknown schema_version / unknown state は通常 flow を許容 (file 不在以外は WARNING を stderr に 1 行)
+- `tests/test_audit_prepare.py`: 13 件の新規 test 追加 (helpers 単体 9 件 + main() 統合 3 件 + failure-injection 3 件)
+- `scripts/audit-prepare.py:304-332` step (3) コメントブロックを「detect + auto-recover」に書き換え
+- `docs/v030-baseline-audit.md` "Known limitation (Issue #800)" subsection を RESOLVED に更新
+
+## 受け入れ条件 (spec §6 と同一)
+
+- [x] Step 3 開始時に `<label>.tx.json` を state="swapping" で atomic 書き込み
+- [x] Step 3 完了時 (csv replace 直後) に state="consistent" で atomic 書き込み
+- [x] main() Step 0 で state=="swapping" 検出 → artifacts + tx.json 全消去 + WARNING 出力
+- [x] tx.json 不在 / parse fail / non-dict / 未知 schema_version / 未知 state を backwards-compat で通常 flow (file 不在以外は WARNING)
+- [x] tx-state 書き込みは `.tx.json.new` + `os.replace` で single-file atomic
+- [x] failure-injection tests 6 件 green (W1 / W2 / before-tx-commit / no-recovery-consistent / legacy-compat / corrupted-parametrize)
+- [x] 既存 `test_audit_prepare.py` 3 件 (atomic_success / atomic_failure / recovers_from_stale_new_dir) 引き続き green
+- [x] ruff check / ruff format --check / pyright / pytest 全 green
+- [x] `docs/v030-baseline-audit.md` "Known limitation" を RESOLVED 更新
+- [x] step (3) コメントブロックを「detect + auto-recover」に更新
+- [ ] PR 作成 Pre-flight Step 5 `/codex:adversarial-review` で additional crash window 指摘ゼロ
+
+## Self-Test Report
+
+machine-verified:
+- [x] `python -m pytest tests/test_audit_prepare.py -v` (20+ tests passed)
+- [x] `ruff check scripts/audit-prepare.py tests/test_audit_prepare.py` clean
+- [x] `ruff format --check scripts/audit-prepare.py tests/test_audit_prepare.py` clean
+- [x] `pyright scripts/audit-prepare.py` 0 errors
+- [x] `bash scripts/check-markdownlint.sh docs/v030-baseline-audit.md` clean
+- [x] Iron Law 6 Pre-flight Step 0-5 通過
+
+machine-unverifiable:
+- 実機 audit-prepare 実行による operator 視点 UX 確認 (Idios 検証推奨、複数 boundary で `.tx.json` cleanup 動作確認)
+
+## 関連
+
+- Refs #800 (本 PR で対応)
+- Refs #796 (親 audit issue) / #798 (predecessor hardening PR #801)
+- spec: `docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md`
+- plan: `docs/superpowers/plans/2026-05-21-audit-prepare-tx-recovery.md`
+
+[hopeful-germain-8ffc43]
+EOF
+)"
+```
+
+(注: PR 本文は HEREDOC + `cat << 'EOF' ... EOF` で日本語 UTF-8 保護、`feedback_gh_command_ja_heredoc.md` 準拠)
+
+- [ ] **Step 9: PR 番号確定後、v030 audit doc の `<新 PR 番号>` を実 PR 番号で置換 (Task 7 placeholder を解決)**
+
+```bash
+# 実際の PR 番号を確認
+gh pr view --repo Idios/kobutachan-allaganeye --json number,url
+```
+
+`docs/v030-baseline-audit.md` の `<新 PR 番号>` を実 PR 番号で置換 → 新規 commit:
+
+```bash
+git add docs/v030-baseline-audit.md
+git commit -m "$(cat <<'EOF'
+docs: #800 v030 audit doc PR 番号を確定値に置換
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push origin claude/audit-tx-recovery-800
+```
+
+- [ ] **Step 10: `/iterate-review <PR#>` 自走呼出 を Idios に handoff**
+
+> Codex adversarial-review (Step 6) は PR 作成前の Iron Law 6 Pre-flight Step 5。これとは別に PR 作成後 `/iterate-review` で review-fix ループを回す。本 skill (writing-plans / subagent-driven-development) からは invoke せず、Idios の手動操作。
+
+Idios に handoff:
+
+```text
+EXECUTOR: dispatch (origin=claude/audit-tx-recovery-800, generated=2026-05-21)
+
+PR #<PR番号> 作成完了。次のステップを invoke してください:
+
+/iterate-review <PR番号>
+```
+
+`<PR番号>` は Step 8 で確定する番号。
+
+---
+
+## Self-Review
+
+After writing this plan, checking against the spec:
+
+### 1. Spec coverage
+
+| Spec section | Plan task |
+| --- | --- |
+| §3.1 ファイル構造 (`<label>.tx.json` + `.tx.json.new` 追加) | Task 1 (定数 + read), Task 2 (write), Task 4 (main 統合) |
+| §3.2 tx-state schema (schema_version=1, state, updated_at) | Task 1 (read validation), Task 2 (write payload) |
+| §3.3 主要フロー (Step 0 + 3a + 3e) | Task 4 (Step 3a/3e), Task 5 (Step 0) |
+| §3.4 Recovery 表 (全 crash point) | Task 5 + Task 6 で全 case test 化 |
+| §3.5 audit-compare 変更なし | (touched files に audit-compare.py 含めず、無対応で正解) |
+| §4 components table | Task 1-3 (helpers), Task 4-5 (main), Task 7 (docs + comment) |
+| §4.1 helper sketch | Task 1-3 で完全実装 (sketch の通り) |
+| §4.2 main() 改修 | Task 4 (Step 3), Task 5 (Step 0) |
+| §5 failure-injection (3 crash + 1 no-crash + 1 legacy + 1 corrupted) | Task 6 (3 crash) + Task 5 (legacy + no_recovery) + Task 1 (corrupted parametrize) |
+| §5.1 injection 手法 | Task 6 step 1 の 3 個別 test 各々で `monkeypatch.setattr` wrap |
+| §5.2 既存 test regression | Task 4 step 5 + Task 5 step 5 で `pytest -v` 全 run |
+| §6 受け入れ条件 #1-#11 | Task 8 step 8 PR 本文の `## 受け入れ条件` で逐条チェック |
+| §7 Out of scope | Plan 全タスクは scope 内、Issue #797 / multi-process lock / 真の atomic publish は Out of scope §7 で除外宣言 |
+| §8 関連 | Task 8 step 8 PR 本文 `## 関連` で参照 |
+| §9 Risks register | 各 risk の mitigation は impl + test で担保 (risk #1 = §3.2 atomic write / risk #2 = §3.2 fallback / risk #3-4 = §3.4 recovery table / risk #5 = §7 Out of scope / risk #6 = Task 5 test_tx_state_missing_legacy_compat / risk #7 = Task 6 deterministic injection) |
+
+Gap: なし。spec の全 section が plan の task でカバーされている。
+
+### 2. Placeholder scan
+
+- "TBD" / "TODO" / "implement later" / "fill in details" / "Add appropriate error handling" / "handle edge cases" / "Write tests for the above" → 全 task で actual code を記載済
+- `<新 PR 番号>` placeholder は Task 7 step 2 で commit 直後に Task 8 step 9 で確定値に置換する明示的な後処理が定義されている (= placeholder 残置ではなく時系列的に解決される設計)
+- `<PR番号>` placeholder は Task 8 step 8 の出力で確定 → step 9 / step 10 で参照する流れ (= 時系列的に解決される)
+- "Similar to Task N" の reference は 0 件 (全 task に独立した code block を含めている)
+
+### 3. Type consistency
+
+- `_read_tx_state(tx_path: Path) -> dict[str, Any] | None` (Task 1 で定義) → Task 5 で `tx = _read_tx_state(tx_path)` として使用、`tx["state"]` の引き方も一致 ✓
+- `_write_tx_state_atomic(tx_path: Path, *, state: str) -> None` (Task 2 で定義) → Task 4 / Task 5 / Task 6 で `state=_TX_STATE_SWAPPING` / `state=_TX_STATE_CONSISTENT` / `state="swapping"` (test 内) / `state="consistent"` (test 内) として使用 ✓
+- `_recover_stale_artifacts(*, per_boundary_dir, worksheet_csv, tx_path) -> None` (Task 3 で定義) → Task 5 で同じ keyword arg で呼出 ✓
+- 定数 `_TX_SCHEMA_VERSION=1`, `_TX_STATE_CONSISTENT="consistent"`, `_TX_STATE_SWAPPING="swapping"` (Task 1 で定義) → Task 2 (payload), Task 4 / Task 5 (main wiring) で参照、Task 6 (test 内では文字列リテラル "swapping" / "consistent" を使用)。test 内で `mod._TX_STATE_SWAPPING` を使ってもよいが、リテラルでも equivalent ✓
+- `tx_path = args.worksheet_dir / f"{args.recording_label}.tx.json"` (Task 4 で定義) → Task 5 で同じ tx_path を使用 ✓
+
+Inconsistency: なし。
+
+### 4. Architecture coherence
+
+- 「読み手は人間のみ」(spec §2.1) → audit-compare 側無変更 (Task の touched files に含めず) ✓
+- 「3 helpers + main() 2 拡張点」 → Task 1-3 + Task 4-5 で対応 ✓
+- 「tx-state は single source of truth」 → 全 recovery 判定が `_read_tx_state` 経由 (Task 5 Step 0) ✓
+- 「`.tx.json.new` 経由 atomic write」 → Task 2 で `tx_new.replace(tx_path)` ✓
+- 「Iron Law 6 Pre-flight」 → Task 8 で Step 0-5 + handoff prompt ✓
+
+---
+
+## Plan complete — execution choice
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-21-audit-prepare-tx-recovery.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md
+++ b/docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md
@@ -1,0 +1,358 @@
+# audit-prepare transactional crash recovery (Issue #800)
+
+> brainstorming output: 2026-05-20
+> follow-up to: Issue #798 / PR #801 (audit-{prepare,compare} reproducibility hardening)
+> Codex finding origin: `/codex:adversarial-review` on `claude/audit-hardening-798` (2026-05-20)
+
+## 1. 背景
+
+Issue #798 で `scripts/audit-prepare.main()` を `<label>.new/` + `<label>.csv.new` 経由の atomic rename flow に書き直した (`scripts/audit-prepare.py:261-336`)。Codex adversarial-review が以下 2 つの crash window を指摘した:
+
+- **W1**: `shutil.rmtree(per_boundary_dir)` 直後 / `per_boundary_dir_new.rename(per_boundary_dir)` 前
+  - filesystem state: `per_boundary_dir` 不在 + 旧 `worksheet_csv`
+  - 影響: 旧 worksheet が存在しない artifact dir を参照
+- **W2**: `per_boundary_dir_new.rename(per_boundary_dir)` 直後 / `worksheet_csv_new.replace(worksheet_csv)` 前
+  - filesystem state: 新 `per_boundary_dir` + 旧 `worksheet_csv`
+  - 影響: 旧 worksheet が新 artifact dir を参照 (filesystem 上は consistent に見えるが内容 mismatch)
+
+Issue #798 spec §3.2 / §9 で「Windows directory rename atomicity 限界は trade-off として受容」と記録し、`scripts/audit-prepare.py:304-332` のコメントブロックで明示済み。本 spec はその follow-up として transactional crash recovery を実装する。
+
+## 2. 戦略
+
+### 2.1 読み手の性質
+
+`scripts/audit-compare.py` は `<label>/` も `<label>.csv` も読まない (`tests/baselines/v0.3.0/<label>.metadata.json` と `ground-truth/<label>.json` のみ消費)。worksheet を読むのは Idios (operator) のみ。これにより「機械が誤判定する」リスクは存在せず、設計目標は以下 2 点に絞れる:
+
+- crash 発生を確実に検出する (filesystem state からは W2 を見分けられないため、別途 marker が必要)
+- 次 `audit-prepare` run で auto-recover する (operator が `--verify` 等を手で叩く workflow は要らない)
+
+### 2.2 採用案: tx-state sidecar + recovery-on-start (案 D)
+
+`<label>.tx.json` を single source of truth として publish の進行状態を記録する。crash 後の次 run が `state == "swapping"` を検出したら artifacts + tx を全消去して regenerate する。
+
+### 2.3 検討した代替案
+
+| 案 | atomicity | UX 影響 | 実装複雑度 | 採否理由 |
+| --- | --- | --- | --- | --- |
+| A: manifest pointer (canonical file) | true atomic | operator path 変更 (`<label>-uuid/`) | 中 | dir browse ergonomics が壊れる |
+| B: symlink/junction swap | near-atomic | Windows symlink 制限 (admin/dev mode 要) | 中 | cross-platform 信頼性低 |
+| C: single archive (zip/tar) per epoch | true atomic | dir browse 不可 (operator 直接 PNG 参照不能) | 小 | operator UX を壊す |
+| **D: tx-state sidecar + recovery-on-start** | detect+recover | 既存 layout 維持 | 小 | **採用** |
+
+「真の atomic publish」(A/B/C) は人間 operator の workflow を壊す。読み手が機械でなく頻度も低いため、「crash 検出 + 次 run auto-recover」で十分。
+
+## 3. 設計
+
+### 3.1 ファイル構造
+
+```text
+worksheet/
+├── obs-20260116/                # 既存: per-boundary artifact dir
+├── obs-20260116.csv             # 既存: worksheet CSV
+├── obs-20260116.tx.json         # 新規: transaction state (single source of truth)
+├── obs-20260116.new/            # 既存: 生成中 temp dir
+├── obs-20260116.csv.new         # 既存: 生成中 temp CSV
+└── obs-20260116.tx.json.new     # 新規: tx-state 書き換え中 temp
+```
+
+### 3.2 tx-state schema (`<label>.tx.json`)
+
+```json
+{
+  "schema_version": 1,
+  "state": "consistent",
+  "updated_at": "2026-05-20T12:34:56Z"
+}
+```
+
+- `schema_version` (int): 将来 schema 変更時の forward compat
+- `state` (str): `"consistent"` または `"swapping"` のいずれか
+- `updated_at` (str): ISO 8601 UTC、debug / forensic 用 (recovery 判定には未使用)
+
+以下のいずれも backwards-compat の観点で「不在扱い (= recovery 不要)」とする。warning は stderr に 1 行出力する (operator が「なぜ tx-state が無視されたか」を debug できるように):
+
+- JSON parse fail (file 自体は存在するが parse 不能)
+- top-level が dict でない
+- `schema_version` が `1` でない (forward compat: 将来 schema_version=2 の baseline を v1 tool で読む場合に「too old」を通知)
+- `state` が `"consistent"` / `"swapping"` 以外
+
+file 自体が不在の場合は warn 不要 (legacy baseline / 初回 run の正常ケース)。
+
+### 3.3 主要フロー (`audit-prepare.main()` 改修後)
+
+```text
+Step 0: Recovery-on-start (新規)
+  tx = _read_tx_state(tx_path)
+  if tx and tx.state == "swapping":
+      # 前回 crash したので artifacts は信頼不能
+      shutil.rmtree(per_boundary_dir, ignore_errors=True)
+      worksheet_csv.unlink(missing_ok=True)
+      tx_path.unlink(missing_ok=True)
+  # `.new` 系は Step 1 で常に cleanup される
+
+Step 1: Pre-clean .new residue (既存、変更なし)
+  rmtree(per_boundary_dir_new, ignore_errors=True)
+  worksheet_csv_new.unlink(missing_ok=True)
+  per_boundary_dir_new.mkdir(parents=True, exist_ok=True)
+
+Step 2: Generate into temp (既存、変更なし)
+  [brightness CSV + PNG + worksheet CSV を .new に生成]
+  on exception: cleanup .new + raise (既存)
+
+Step 3: Atomic publish (改修)
+  3a: _write_tx_state_atomic(tx_path, state="swapping")    # marker (atomic)
+  3b: rmtree(per_boundary_dir) if exists                   # W1 window 開始
+  3c: per_boundary_dir_new.rename(per_boundary_dir)        # W2 window 開始
+  3d: worksheet_csv_new.replace(worksheet_csv)             # W2 window 終了
+  3e: _write_tx_state_atomic(tx_path, state="consistent")  # commit (atomic)
+```
+
+`<label>.tx.json` 自身の書き込みは `<label>.tx.json.new` に書いてから `os.replace` する single-file atomic op (Windows + POSIX で保証)。これにより tx-state 自体は partial-write 不能。
+
+### 3.4 Recovery 表 (全 crash point)
+
+| crash 発生点 | filesystem state | tx.state | 次 run の振る舞い |
+| --- | --- | --- | --- |
+| Step 2 中 | `.new/` あり (または try/except で cleanup 済) | absent or "consistent" | Step 1 で `.new` 消去 → 通常通り再生成 |
+| Step 3a 直後 | 旧 dir + 旧 csv + tx="swapping" | "swapping" | Step 0 で旧 dir + 旧 csv + tx 消去 → 再生成 |
+| Step 3b 後 (W1) | dir 不在 + 旧 csv + tx="swapping" | "swapping" | Step 0 で旧 csv + tx 消去 → 再生成 |
+| Step 3c 後 (W2) | 新 dir + 旧 csv + tx="swapping" | "swapping" | Step 0 で新 dir + 旧 csv + tx 消去 → 再生成 (新 dir も信頼しない) |
+| Step 3d 後 (publish 直前) | 新 dir + 新 csv + tx="swapping" | "swapping" | Step 0 で全消去 → 再生成 (内容は正しいが tx 未 commit のため捨てる、wasteful だが safe) |
+| Step 3e 後 (正常完了) | 新 dir + 新 csv + tx="consistent" | "consistent" | Step 0 何もしない、通常上書きで再生成 |
+| tx.json corrupted (parse fail / 未知 state) | 任意 | unparseable | warn + None 扱い (= 無視)、通常 flow |
+| tx.json 不在 (legacy baseline) | 旧 dir + 旧 csv | absent | Step 0 何もしない、通常上書きで再生成 (backwards compat) |
+
+Step 3d 後 / 3e 前の "wasteful regenerate" は許容: audit-prepare の所要時間は 12 boundary × 数 100ms オーダーで再生成コストは低い。複雑な「正しさ判定」を入れるより単純 cleanup のほうが test しやすい。
+
+### 3.5 audit-compare 側の変更
+
+なし。worksheet を読まないため tx-state を見る必要がない。将来 audit-compare が worksheet を消費する場合に備えて helper を提供してもよいが、本 spec の scope 外 (YAGNI)。
+
+## 4. 実装コンポーネント
+
+| 場所 | 変更内容 |
+| --- | --- |
+| `scripts/audit-prepare.py` | `_read_tx_state` / `_write_tx_state_atomic` / `_recover_stale_artifacts` 関数を追加。`main()` に Step 0 と Step 3a/3e を組み込む |
+| `tests/test_audit_prepare.py` | failure-injection tests を 6 件追加 (§5 参照) |
+| `docs/v030-baseline-audit.md` | "Known limitation (Issue #800)" 節を「解消済み (#新 PR で fix)」に更新 |
+| `scripts/audit-prepare.py:304-332` | step (3) コメントブロックを更新 (W1/W2 が tx-state で検出 + recover 可能になった旨を追記) |
+
+### 4.1 Helper 関数 sketch
+
+```python
+_TX_STATE_FILENAME = "{label}.tx.json"
+_TX_SCHEMA_VERSION = 1
+_TX_STATE_CONSISTENT = "consistent"
+_TX_STATE_SWAPPING = "swapping"
+
+
+def _read_tx_state(tx_path: Path) -> dict[str, Any] | None:
+    """Return parsed tx-state, or None if file missing / corrupted / unknown shape.
+
+    Returning None always means "no committed transactional state" (= no
+    recovery needed). Callers must not use None to distinguish "file missing"
+    from "file corrupted"; both fall back to legacy behavior.
+
+    Warns on stderr for any malformed case (parse fail / type mismatch /
+    schema version mismatch / unknown state value) so the operator can
+    debug why their tx-state was ignored. File-not-exist is the legacy /
+    first-run case and is NOT warned.
+    """
+    if not tx_path.exists():
+        return None
+    try:
+        data = json.loads(tx_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(
+            f"WARNING: {tx_path} is unreadable ({exc}); treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if not isinstance(data, dict):
+        print(
+            f"WARNING: {tx_path} top-level is not an object; treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if data.get("schema_version") != _TX_SCHEMA_VERSION:
+        print(
+            f"WARNING: {tx_path} has unsupported schema_version "
+            f"{data.get('schema_version')!r} (expected {_TX_SCHEMA_VERSION}); "
+            "treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if data.get("state") not in (_TX_STATE_CONSISTENT, _TX_STATE_SWAPPING):
+        print(
+            f"WARNING: {tx_path} has unknown state {data.get('state')!r}; "
+            "treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    return data
+
+
+def _write_tx_state_atomic(tx_path: Path, *, state: str) -> None:
+    """Atomically write tx-state via temp file + os.replace.
+
+    On POSIX and Windows, replace() of a single file is atomic, so the
+    on-disk tx-state is never partially-written.
+    """
+    payload = {
+        "schema_version": _TX_SCHEMA_VERSION,
+        "state": state,
+        "updated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    tx_new = tx_path.with_suffix(tx_path.suffix + ".new")
+    tx_new.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tx_new.replace(tx_path)
+
+
+def _recover_stale_artifacts(
+    *,
+    per_boundary_dir: Path,
+    worksheet_csv: Path,
+    tx_path: Path,
+) -> None:
+    """When tx-state == swapping on startup, wipe all artifacts.
+
+    Called from main() Step 0. Idempotent. Does not raise on missing paths.
+    """
+    shutil.rmtree(per_boundary_dir, ignore_errors=True)
+    worksheet_csv.unlink(missing_ok=True)
+    tx_path.unlink(missing_ok=True)
+```
+
+### 4.2 `main()` 改修箇所
+
+```python
+def main(argv: list[str] | None = None) -> int:
+    # ... (既存 argparse / metadata load / rows build) ...
+
+    per_boundary_dir = args.worksheet_dir / args.recording_label
+    per_boundary_dir_new = args.worksheet_dir / f"{args.recording_label}.new"
+    worksheet_csv = args.worksheet_dir / f"{args.recording_label}.csv"
+    worksheet_csv_new = args.worksheet_dir / f"{args.recording_label}.csv.new"
+    tx_path = args.worksheet_dir / f"{args.recording_label}.tx.json"
+
+    # Step 0: Recovery-on-start (新規)
+    tx = _read_tx_state(tx_path)
+    if tx is not None and tx["state"] == _TX_STATE_SWAPPING:
+        print(
+            f"WARNING: previous {args.recording_label} run crashed mid-publish; "
+            "cleaning up stale artifacts before regenerating",
+            file=sys.stderr,
+        )
+        _recover_stale_artifacts(
+            per_boundary_dir=per_boundary_dir,
+            worksheet_csv=worksheet_csv,
+            tx_path=tx_path,
+        )
+
+    # Step 1: Pre-clean .new residue (既存)
+    # ...
+
+    # Step 2: Generate into temp (既存)
+    # ...
+
+    # Step 3: Atomic publish (改修)
+    _write_tx_state_atomic(tx_path, state=_TX_STATE_SWAPPING)
+    if per_boundary_dir.exists():
+        shutil.rmtree(per_boundary_dir)
+    per_boundary_dir_new.rename(per_boundary_dir)
+    worksheet_csv_new.replace(worksheet_csv)
+    _write_tx_state_atomic(tx_path, state=_TX_STATE_CONSISTENT)
+
+    print(f"Worksheet: {worksheet_csv}", file=sys.stderr)
+    print(f"Per-boundary artifacts: {per_boundary_dir}", file=sys.stderr)
+    return 0
+```
+
+## 5. Testing (failure-injection)
+
+`tests/test_audit_prepare.py` に以下を追加:
+
+| test 名 | 注入点 | 期待 recovery |
+| --- | --- | --- |
+| `test_recovers_from_crash_after_rmtree` | Step 3b 後 (W1) | 次 run で全消去 → 完全 regenerate、最終 state は "consistent" |
+| `test_recovers_from_crash_after_dir_rename` | Step 3c 後 (W2) | 次 run で全消去 → 完全 regenerate、最終 state は "consistent" |
+| `test_recovers_from_crash_before_tx_commit` | Step 3d 後 (publish 直前) | 次 run で全消去 → 完全 regenerate、最終 state は "consistent" |
+| `test_no_recovery_when_state_consistent` | crash なし | 通常上書き、最終 state は "consistent"、recovery WARNING ログなし |
+| `test_tx_state_missing_legacy_compat` | tx.json 削除した古 baseline | 通常上書き、recovery WARNING ログなし |
+| `test_tx_state_corrupted_treated_as_missing` | tx.json に invalid JSON / non-dict / 未知 schema_version / 未知 state の 4 variants (parametrize) | warn ログ出力 + 通常 flow |
+
+### 5.1 Failure injection 手法
+
+`monkeypatch.setattr` で `shutil.rmtree` / `Path.rename` / `Path.replace` をラップし、特定 path で 1 回だけ `RuntimeError("simulated crash")` を上げる。
+
+```python
+def _make_crashing_rmtree(target_path, original_rmtree):
+    """Wrap shutil.rmtree to crash AFTER deleting target_path once."""
+    crashed = {"value": False}
+
+    def crashing_rmtree(path, *args, **kwargs):
+        original_rmtree(path, *args, **kwargs)
+        if not crashed["value"] and Path(path) == Path(target_path):
+            crashed["value"] = True
+            raise RuntimeError("simulated crash after rmtree")
+    return crashing_rmtree
+```
+
+Step 3b 後 W1 のテストでは:
+
+1. fixture で旧 dir + 旧 csv + tx="consistent" を準備
+2. `shutil.rmtree` をラップし `per_boundary_dir` の削除直後に crash
+3. `pytest.raises(RuntimeError): main([...])`
+4. assert: tx.state == "swapping" / per_boundary_dir 不在 / worksheet_csv は旧のまま
+5. monkeypatch を解除して `main([...])` を再度実行
+6. assert: tx.state == "consistent" / per_boundary_dir + worksheet_csv が新しい内容で存在
+7. WARNING ログに「previous ... crashed mid-publish」が含まれる
+
+`test_recovers_from_crash_after_dir_rename` は `Path.rename` をラップ、`test_recovers_from_crash_before_tx_commit` は `Path.replace` をラップ (= csv replace 完了直後に crash) する。
+
+### 5.2 既存 test の regression check
+
+`tests/test_audit_prepare.py` の既存 3 件 (`test_main_atomic_success_replaces_old_artifacts` / `test_main_atomic_failure_preserves_old_artifacts` / `test_main_recovers_from_stale_new_dir`) は引き続き green であること。特に第 2 件は「失敗時に既存 artifacts が保持される」を確認しており、tx-state が swapping のまま残るので次 run で消去される動作と整合性確認が必要。
+
+## 6. 受け入れ条件
+
+1. `scripts/audit-prepare.main()` Step 3 開始時に `<label>.tx.json` を `state: "swapping"` で atomic 書き込みする
+2. Step 3 完了時 (csv replace 直後) に `state: "consistent"` で atomic 書き込みする
+3. `main()` Step 0 で tx.state == "swapping" を検出したら artifacts (`<label>/` + `<label>.csv` + `<label>.tx.json`) を全消去し、stderr に WARNING を出力する
+4. tx.json 不在 / JSON parse fail / top-level non-dict / 未知 schema_version / 未知 state は backwards-compat で通常 flow を許容する (file 不在以外は stderr に WARNING 1 行を出力する)
+5. tx-state 書き込みは `<label>.tx.json.new` 経由の `os.replace` で single-file atomic を保証する
+6. failure-injection tests 6 件すべて green (W1 / W2 / before commit / no-crash / legacy / corrupted)
+7. 既存 `test_audit_prepare.py` の 3 件が引き続き green
+8. ruff check / ruff format --check / pyright / pytest tests/test_audit_prepare.py が全 green
+9. `docs/v030-baseline-audit.md` の "Known limitation (Issue #800)" 節を「解消済み (#新 PR で fix)」に更新する
+10. `scripts/audit-prepare.py:304-332` の step (3) コメントブロックを更新し、W1/W2 が tx-state で検出 + recover 可能になった旨を追記する
+11. PR 作成 Pre-flight Step 5 で `/codex:adversarial-review` を実行し、additional crash window 指摘がゼロであることを確認する
+
+## 7. Out of scope
+
+- 「真の atomic publish」(manifest pointer / symlink / archive 案 A/B/C) — 案 D で要件を満たすため
+- audit-compare 側の tx-state 読み込み — 現状 audit-compare は worksheet を読まないため YAGNI
+- automatic cleanup of old `.tx.json` files — 1 ファイル per label で増えない、cleanup 不要
+- multi-process concurrent `audit-prepare` の lock / coordination — 現状 operator が単一 process で順次実行する想定
+- tx-state を audit doc / PR コメント等の外部に export する機能 — debug 時は手で `cat <label>.tx.json` すれば足りる
+- Issue #797 (M6 end miss) — 別 issue、本 spec の scope 外
+- M6 end miss を含む detector 改修一般 — Issue #797 系で別管理
+
+## 8. 関連
+
+- 親 audit issue: #796 (`docs/v030-baseline-audit.md`)
+- predecessor hardening issue: #798 (PR #801 = merged commit `4cd3044`)
+- predecessor spec: `docs/superpowers/specs/2026-05-20-audit-script-hardening-design.md` §3.2 Recovery 性 table / §9 Risks #1
+- 該当コード: `scripts/audit-prepare.py:261-336` (atomic swap flow)
+
+## 9. Risks register
+
+| # | risk | mitigation |
+| --- | --- | --- |
+| 1 | tx-state file が部分書き込みされる | `.new` 経由の `os.replace` で single-file atomic を保証 (cross-platform) |
+| 2 | tx-state が腐敗して通常 flow に戻れない | parse fail / 未知 schema / 未知 state は warn + None 扱い (= 通常 flow) で fallback |
+| 3 | recovery が誤って正常 artifacts を消す | tx.state == "swapping" のときのみ recovery 実行。正常完了時は "consistent" を書くため発動しない |
+| 4 | 単純な regeneration ループ (failure 後の retry も失敗) | Step 2 の生成失敗は try/except で `.new` cleanup + raise (= 既存挙動)。tx-state は "swapping" のまま残り、次 run の Step 0 で再度 cleanup される |
+| 5 | concurrent `audit-prepare` 実行 | scope 外 (Out of scope §7)。operator は単一 process 想定 |
+| 6 | legacy baseline (tx.json 不在) の動作変更 | 受け入れ条件 #4 で「通常 flow を許容」を明示。test `test_tx_state_missing_legacy_compat` で担保 |
+| 7 | failure injection test が flaky になる | monkeypatch で deterministic に crash を注入。`Path.rename` / `Path.replace` の wrap は path 一致でのみ発動するため side-effect なし |

--- a/docs/v030-baseline-audit.md
+++ b/docs/v030-baseline-audit.md
@@ -172,6 +172,6 @@ PR #799 merge 後の Codex Round 3 finding 2 件を Issue #798 で消化:
 - tx-state 自身は `.tx.json.new` 経由の `os.replace` で single-file atomic 書き込み
 - backwards-compat: tx.json 不在 (legacy baseline) / "consistent" は recovery skip
 
-詳細仕様は `docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md`、実装は PR #<新 PR 番号> (Task 8 で番号確定)。
+詳細仕様は `docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md`、実装は [PR #802](https://github.com/Idios/kobutachan-allaganeye/pull/802)。
 
 なお Iteration 1 retrospect item 4 の "adjacent boundary PNG overwriting" は本 follow-up の scope 外 (低 impact + Iron Law 3 scope 維持、Issue #798 §7 out of scope 明記)。

--- a/docs/v030-baseline-audit.md
+++ b/docs/v030-baseline-audit.md
@@ -164,15 +164,14 @@ PR #799 merge 後の Codex Round 3 finding 2 件を Issue #798 で消化:
 1. **R3#1 source_size validation tightening** — `_REQUIRED_GROUND_TRUTH_FIELDS` に `source_size_bytes` を追加し REQUIRED 化。`audit-compare.py` main は video 未解決時に exit 3 で fail-close、operator escape は `--skip-source-size-check` flag 経由 (stderr に WARNING)。`validate_ground_truth_against_baseline` に `skip_source_size_check` parameter 追加
 2. **R3#2 atomic re-run** — `audit-prepare.main()` を `<label>.new/` + `<label>.csv.new` 経由の atomic flow に書き直し。mid-run failure 時は旧 artifacts intact、success 時に rename / replace で swap、前 run crash 由来の stale `.new` も次 run の pre-cleanup で recover
 
-### Known limitation (Issue #800)
+### Known limitation (Issue #800) — RESOLVED 2026-05-21
 
-Issue #798 PR の Iron Law 6 Pre-flight Step 5 (Codex adversarial-review) が R3#2 の step (3) 最終 swap に残る crash window を指摘:
+`audit-prepare.main()` の step (3) atomic swap には 3-op (rmtree + rename + replace) で構成された crash window があったが、Issue #800 で `<label>.tx.json` sidecar (tx-state) を導入して検出 + 次 run auto-recover を実装した。
 
-- `per_boundary_dir` rmtree 直後 / dir rename 前 crash → old worksheet が missing artifact dir を refer
-- `per_boundary_dir_new` rename 後 / `worksheet_csv_new.replace` 前 crash → new artifact dir + old worksheet (mismatch)
+- W1 (`rmtree` 後 / `rename` 前) と W2 (`rename` 後 / `replace` 前) は次 `audit-prepare` 実行時に `state == "swapping"` が読み取られ、artifacts を全消去してから regenerate する
+- tx-state 自身は `.tx.json.new` 経由の `os.replace` で single-file atomic 書き込み
+- backwards-compat: tx.json 不在 (legacy baseline) / "consistent" は recovery skip
 
-これらは spec §3.2 Recovery 性 table + §9 Risks #1 で trade-off として受容済の窓だが、次 run の pre-cleanup では detect / repair されない。実発生条件は process kill / OS crash / AV file lock / 電源断のみで window は filesystem rename 速度 (ミリ秒オーダー) と短く、operator は worksheet と artifact dir の不整合を即座に視認できるため P3-low 扱い。
-
-manifest / epoch / atomic pointer pattern による transactional crash recovery は [Issue #800](https://github.com/Idios/kobutachan-allaganeye/issues/800) で別途扱う (#798 PR の scope 外)。実装 `scripts/audit-prepare.py` の step (3) コメントブロックにも本制約を明示。
+詳細仕様は `docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md`、実装は PR #<新 PR 番号> (Task 8 で番号確定)。
 
 なお Iteration 1 retrospect item 4 の "adjacent boundary PNG overwriting" は本 follow-up の scope 外 (低 impact + Iron Law 3 scope 維持、Issue #798 §7 out of scope 明記)。

--- a/scripts/audit-prepare.py
+++ b/scripts/audit-prepare.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -172,6 +173,23 @@ def _read_tx_state(tx_path: Path) -> dict[str, Any] | None:
         )
         return None
     return data
+
+
+def _write_tx_state_atomic(tx_path: Path, *, state: str) -> None:
+    """Atomically write tx-state via temp file + os.replace.
+
+    On POSIX and Windows, replace() of a single file is atomic, so the
+    on-disk tx-state is never partially-written. The temp file uses the
+    `.new` suffix to match the existing artifact-staging convention.
+    """
+    payload = {
+        "schema_version": _TX_SCHEMA_VERSION,
+        "state": state,
+        "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+    tx_new = tx_path.parent / (tx_path.name + ".new")
+    tx_new.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tx_new.replace(tx_path)
 
 
 def resolve_video_path(source_relative: str) -> Path:

--- a/scripts/audit-prepare.py
+++ b/scripts/audit-prepare.py
@@ -404,35 +404,24 @@ def main(argv: list[str] | None = None) -> int:
 
     # (3) All-success: swap temp into final position.
     #
-    # ATOMICITY LIMITATIONS (Issue #800 tracks the proper fix):
+    # The 3-op swap (rmtree + rename + replace) is non-atomic, so a crash
+    # between any two ops leaves filesystem state inconsistent. Issue #800
+    # added a tx-state sidecar (`<label>.tx.json`) that is marked
+    # "swapping" before the swap starts and "consistent" only after csv
+    # replace succeeds. Step 0 of the next `audit-prepare` run reads the
+    # tx-state, and if it is still "swapping" wipes all artifacts before
+    # regenerating from scratch (`_recover_stale_artifacts`).
     #
-    # The swap is 3 non-atomic operations: rmtree -> rename -> replace.
-    # A crash / AV lock / process kill between any two leaves observable
-    # mixed state that next-run pre-clean does NOT detect or repair:
+    # Both Codex-flagged windows are now detect + auto-recover safe:
+    #   - After rmtree, before rename (W1):
+    #       Mid-crash: per_boundary_dir gone, worksheet_csv still old.
+    #       Next run: tx="swapping" -> wipe old csv + tx -> regenerate.
+    #   - After rename, before replace (W2):
+    #       Mid-crash: per_boundary_dir new, worksheet_csv still old.
+    #       Next run: tx="swapping" -> wipe new dir + old csv + tx -> regenerate.
     #
-    #   - After rmtree, before rename:
-    #       per_boundary_dir gone, worksheet_csv still old.
-    #       Reader sees old worksheet referencing a missing artifact dir.
-    #   - After rename, before replace:
-    #       per_boundary_dir is new, worksheet_csv still old.
-    #       Reader sees old worksheet referencing the new artifact dir.
-    #
-    # POSIX `rename(2)` semantics make each individual op atomic, but the
-    # 3-op sequence as a whole is not transactional. Windows additionally
-    # cannot atomically rename onto an existing directory, which is why
-    # rmtree happens first.
-    #
-    # Recovery today: operator notices the inconsistency (worksheet
-    # references files that do not exist, or the audit doc disagrees with
-    # the generated frames) and re-runs `audit-prepare`. The crash window
-    # is very short (filesystem rename is milliseconds) so the practical
-    # impact is low for an interactive operator workflow.
-    #
-    # Tracked for future hardening in Issue #800 (manifest / epoch / atomic
-    # pointer pattern). See `docs/v030-baseline-audit.md` "Codex round 3
-    # follow-up" section + spec `docs/superpowers/specs/
-    # 2026-05-20-audit-script-hardening-design.md` §3.2 Recovery table /
-    # §9 Risks #1.
+    # The tx-state file itself is published via `.tx.json.new` + os.replace
+    # so its write is single-file atomic on Windows + POSIX.
     _write_tx_state_atomic(tx_path, state=_TX_STATE_SWAPPING)
     if per_boundary_dir.exists():
         shutil.rmtree(per_boundary_dir)

--- a/scripts/audit-prepare.py
+++ b/scripts/audit-prepare.py
@@ -337,16 +337,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    metadata_path = args.baseline_dir / f"{args.recording_label}.metadata.json"
-    if not metadata_path.exists():
-        print(f"ERROR: {metadata_path} not found", file=sys.stderr)
-        return 2
-
-    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    rows = build_worksheet_rows(metadata)
-
-    video_path = resolve_video_path(metadata["source"])
-
+    # Path setup (used by recovery + downstream steps). Resolved up-front so
+    # Step 0 below can run BEFORE any metadata/video loading that may exit
+    # early.
     per_boundary_dir = args.worksheet_dir / args.recording_label
     per_boundary_dir_new = args.worksheet_dir / f"{args.recording_label}.new"
     worksheet_csv = args.worksheet_dir / f"{args.recording_label}.csv"
@@ -358,6 +351,12 @@ def main(argv: list[str] | None = None) -> int:
     # unknown state. Wipe everything so Step 2 regenerates from scratch.
     # Backwards-compat: tx.json absent (legacy baseline) or "consistent"
     # (clean prior run) skips recovery.
+    #
+    # MUST run before metadata/video loading so a missing baseline or
+    # unset ALLAGANEYE_SAMPLE_VIDEO_DIR does not block recovery of a
+    # prior crashed run. Otherwise tx="swapping" would persist indefinitely
+    # whenever the operator regenerates the baseline / changes sample dir
+    # between the crash and the next invocation (Codex #800 follow-up).
     tx = _read_tx_state(tx_path)
     if tx is not None and tx["state"] == _TX_STATE_SWAPPING:
         print(
@@ -370,6 +369,19 @@ def main(argv: list[str] | None = None) -> int:
             worksheet_csv=worksheet_csv,
             tx_path=tx_path,
         )
+
+    # Now load metadata + resolve video. These can return 2 / raise
+    # FileNotFoundError / raise OSError, but recovery has already happened
+    # above so a stale tx="swapping" will not persist.
+    metadata_path = args.baseline_dir / f"{args.recording_label}.metadata.json"
+    if not metadata_path.exists():
+        print(f"ERROR: {metadata_path} not found", file=sys.stderr)
+        return 2
+
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    rows = build_worksheet_rows(metadata)
+
+    video_path = resolve_video_path(metadata["source"])
 
     # (1) Pre-clean any stale temp residue from a prior crashed run.
     # Existing final artifacts are untouched until step (3).

--- a/scripts/audit-prepare.py
+++ b/scripts/audit-prepare.py
@@ -41,6 +41,14 @@ from allaganeye.video.detector import (  # noqa: E402
 _DEFAULT_BASELINE_DIR = Path("tests/baselines/v0.3.0")
 _DEFAULT_WORKSHEET_DIR = Path("tests/baselines/v0.3.0/audit-worksheet")
 
+# Issue #800: tx-state sidecar for transactional crash recovery.
+# `<label>.tx.json` holds the single canonical state of the last publish;
+# crash mid-publish is detected by next run via state == "swapping" and
+# recovered by wiping artifacts before regenerating.
+_TX_SCHEMA_VERSION = 1
+_TX_STATE_CONSISTENT = "consistent"
+_TX_STATE_SWAPPING = "swapping"
+
 _WORKSHEET_FIELDS = [
     "index",
     "boundary_type",
@@ -122,6 +130,48 @@ def build_worksheet_rows(metadata: dict[str, Any]) -> list[dict[str, Any]]:
             )
 
     return rows
+
+
+def _read_tx_state(tx_path: Path) -> dict[str, Any] | None:
+    """Return parsed tx-state, or None if file missing / corrupted / unknown shape.
+
+    Returning None means "no committed transactional state" (= no recovery
+    needed). File-not-exist is the legacy / first-run case (silent); all
+    other "missing-equivalent" cases warn on stderr so the operator can
+    debug why their tx-state was ignored.
+    """
+    if not tx_path.exists():
+        return None
+    try:
+        data = json.loads(tx_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(
+            f"WARNING: {tx_path} is unreadable ({exc}); treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if not isinstance(data, dict):
+        print(
+            f"WARNING: {tx_path} top-level is not an object; treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if data.get("schema_version") != _TX_SCHEMA_VERSION:
+        print(
+            f"WARNING: {tx_path} has unsupported schema_version "
+            f"{data.get('schema_version')!r} (expected {_TX_SCHEMA_VERSION}); "
+            "treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    if data.get("state") not in (_TX_STATE_CONSISTENT, _TX_STATE_SWAPPING):
+        print(
+            f"WARNING: {tx_path} has unknown state {data.get('state')!r}; "
+            "treating as missing",
+            file=sys.stderr,
+        )
+        return None
+    return data
 
 
 def resolve_video_path(source_relative: str) -> Path:

--- a/scripts/audit-prepare.py
+++ b/scripts/audit-prepare.py
@@ -192,6 +192,22 @@ def _write_tx_state_atomic(tx_path: Path, *, state: str) -> None:
     tx_new.replace(tx_path)
 
 
+def _recover_stale_artifacts(
+    *,
+    per_boundary_dir: Path,
+    worksheet_csv: Path,
+    tx_path: Path,
+) -> None:
+    """Wipe artifacts when tx-state == swapping on startup.
+
+    Idempotent. Does not raise on missing paths. Called from main() Step 0
+    after _read_tx_state returns a swapping-state dict.
+    """
+    shutil.rmtree(per_boundary_dir, ignore_errors=True)
+    worksheet_csv.unlink(missing_ok=True)
+    tx_path.unlink(missing_ok=True)
+
+
 def resolve_video_path(source_relative: str) -> Path:
     """Resolve metadata.json `source` field to an absolute video path.
 

--- a/scripts/audit-prepare.py
+++ b/scripts/audit-prepare.py
@@ -351,6 +351,7 @@ def main(argv: list[str] | None = None) -> int:
     per_boundary_dir_new = args.worksheet_dir / f"{args.recording_label}.new"
     worksheet_csv = args.worksheet_dir / f"{args.recording_label}.csv"
     worksheet_csv_new = args.worksheet_dir / f"{args.recording_label}.csv.new"
+    tx_path = args.worksheet_dir / f"{args.recording_label}.tx.json"
 
     # (1) Pre-clean any stale temp residue from a prior crashed run.
     # Existing final artifacts are untouched until step (3).
@@ -414,10 +415,13 @@ def main(argv: list[str] | None = None) -> int:
     # follow-up" section + spec `docs/superpowers/specs/
     # 2026-05-20-audit-script-hardening-design.md` §3.2 Recovery table /
     # §9 Risks #1.
+    args.worksheet_dir.mkdir(parents=True, exist_ok=True)
+    _write_tx_state_atomic(tx_path, state=_TX_STATE_SWAPPING)
     if per_boundary_dir.exists():
         shutil.rmtree(per_boundary_dir)
     per_boundary_dir_new.rename(per_boundary_dir)
     worksheet_csv_new.replace(worksheet_csv)
+    _write_tx_state_atomic(tx_path, state=_TX_STATE_CONSISTENT)
 
     print(f"Worksheet: {worksheet_csv}", file=sys.stderr)
     print(f"Per-boundary artifacts: {per_boundary_dir}", file=sys.stderr)

--- a/scripts/audit-prepare.py
+++ b/scripts/audit-prepare.py
@@ -415,7 +415,6 @@ def main(argv: list[str] | None = None) -> int:
     # follow-up" section + spec `docs/superpowers/specs/
     # 2026-05-20-audit-script-hardening-design.md` §3.2 Recovery table /
     # §9 Risks #1.
-    args.worksheet_dir.mkdir(parents=True, exist_ok=True)
     _write_tx_state_atomic(tx_path, state=_TX_STATE_SWAPPING)
     if per_boundary_dir.exists():
         shutil.rmtree(per_boundary_dir)

--- a/scripts/audit-prepare.py
+++ b/scripts/audit-prepare.py
@@ -353,6 +353,24 @@ def main(argv: list[str] | None = None) -> int:
     worksheet_csv_new = args.worksheet_dir / f"{args.recording_label}.csv.new"
     tx_path = args.worksheet_dir / f"{args.recording_label}.tx.json"
 
+    # (0) Recovery-on-start: if a prior run crashed mid-publish, the
+    # tx-state will be "swapping" and the on-disk artifacts are in an
+    # unknown state. Wipe everything so Step 2 regenerates from scratch.
+    # Backwards-compat: tx.json absent (legacy baseline) or "consistent"
+    # (clean prior run) skips recovery.
+    tx = _read_tx_state(tx_path)
+    if tx is not None and tx["state"] == _TX_STATE_SWAPPING:
+        print(
+            f"WARNING: previous {args.recording_label} run crashed mid-publish; "
+            "cleaning up stale artifacts before regenerating",
+            file=sys.stderr,
+        )
+        _recover_stale_artifacts(
+            per_boundary_dir=per_boundary_dir,
+            worksheet_csv=worksheet_csv,
+            tx_path=tx_path,
+        )
+
     # (1) Pre-clean any stale temp residue from a prior crashed run.
     # Existing final artifacts are untouched until step (3).
     if per_boundary_dir_new.exists():

--- a/tests/test_audit_prepare.py
+++ b/tests/test_audit_prepare.py
@@ -444,3 +444,71 @@ def test_main_writes_worksheet_csv(tmp_path, monkeypatch):
     assert lines[0].startswith("index,boundary_type,timestamp_sec,")
     assert "match_start" in lines[1]
     assert "match_end" in lines[2]
+
+
+# --- Issue #800: tx-state helpers ---
+
+
+def test_read_tx_state_returns_none_when_missing(tmp_path, capsys):
+    """File-not-exist is legacy / first-run case; no warning."""
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    assert mod._read_tx_state(tx_path) is None
+    assert capsys.readouterr().err == ""
+
+
+def test_read_tx_state_returns_consistent_state(tmp_path):
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    tx_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "state": "consistent",
+                "updated_at": "2026-05-21T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = mod._read_tx_state(tx_path)
+    assert result is not None
+    assert result["state"] == "consistent"
+
+
+def test_read_tx_state_returns_swapping_state(tmp_path):
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    tx_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "state": "swapping",
+                "updated_at": "2026-05-21T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = mod._read_tx_state(tx_path)
+    assert result is not None
+    assert result["state"] == "swapping"
+
+
+@pytest.mark.parametrize(
+    "payload,variant",
+    [
+        ("not valid json{{{", "invalid_json"),
+        ('["a", "b"]', "non_dict"),
+        ('{"schema_version": 2, "state": "consistent"}', "unknown_schema_version"),
+        ('{"schema_version": 1, "state": "unknown"}', "unknown_state"),
+    ],
+)
+def test_tx_state_corrupted_treated_as_missing(tmp_path, capsys, payload, variant):
+    """All 4 corrupted variants return None + warn on stderr."""
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    tx_path.write_text(payload, encoding="utf-8")
+    result = mod._read_tx_state(tx_path)
+    assert result is None, f"variant={variant}"
+    err = capsys.readouterr().err
+    assert "WARNING" in err, f"variant={variant} stderr: {err!r}"
+    assert str(tx_path) in err, f"variant={variant} stderr: {err!r}"

--- a/tests/test_audit_prepare.py
+++ b/tests/test_audit_prepare.py
@@ -541,3 +541,59 @@ def test_write_tx_state_atomic_cleans_up_new_suffix(tmp_path):
     mod._write_tx_state_atomic(tx_path, state="consistent")
     assert tx_path.exists()
     assert not (tmp_path / "obs.tx.json.new").exists()
+
+
+def test_recover_stale_artifacts_removes_all(tmp_path):
+    mod = _load_module()
+    per_boundary_dir = tmp_path / "obs"
+    worksheet_csv = tmp_path / "obs.csv"
+    tx_path = tmp_path / "obs.tx.json"
+
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "a.png").write_bytes(b"PNG")
+    worksheet_csv.write_text("HEADER\n", encoding="utf-8")
+    tx_path.write_text("{}", encoding="utf-8")
+
+    mod._recover_stale_artifacts(
+        per_boundary_dir=per_boundary_dir,
+        worksheet_csv=worksheet_csv,
+        tx_path=tx_path,
+    )
+
+    assert not per_boundary_dir.exists()
+    assert not worksheet_csv.exists()
+    assert not tx_path.exists()
+
+
+def test_recover_stale_artifacts_idempotent_on_missing(tmp_path):
+    """Helper must not raise when paths are already absent."""
+    mod = _load_module()
+    per_boundary_dir = tmp_path / "obs"
+    worksheet_csv = tmp_path / "obs.csv"
+    tx_path = tmp_path / "obs.tx.json"
+
+    # All absent
+    mod._recover_stale_artifacts(
+        per_boundary_dir=per_boundary_dir,
+        worksheet_csv=worksheet_csv,
+        tx_path=tx_path,
+    )
+
+
+def test_recover_stale_artifacts_partial_state(tmp_path):
+    """Helper handles 'dir exists but csv/tx absent' without error."""
+    mod = _load_module()
+    per_boundary_dir = tmp_path / "obs"
+    worksheet_csv = tmp_path / "obs.csv"
+    tx_path = tmp_path / "obs.tx.json"
+
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "a.png").write_bytes(b"PNG")
+
+    mod._recover_stale_artifacts(
+        per_boundary_dir=per_boundary_dir,
+        worksheet_csv=worksheet_csv,
+        tx_path=tx_path,
+    )
+
+    assert not per_boundary_dir.exists()

--- a/tests/test_audit_prepare.py
+++ b/tests/test_audit_prepare.py
@@ -1015,3 +1015,110 @@ def test_recovers_from_crash_before_tx_commit(tmp_path, monkeypatch, capsys):
 
     err = capsys.readouterr().err
     assert "crashed mid-publish" in err
+
+
+def test_step0_recovery_runs_even_when_metadata_missing(tmp_path, monkeypatch, capsys):
+    """Recovery (#800 Codex follow-up): tx="swapping" cleanup must NOT be gated by
+    metadata.json existence. Even if metadata is missing and main() returns 2,
+    stale artifacts must still be wiped first.
+    """
+    mod = _load_module()
+    # baseline_dir exists but metadata.json does NOT (no _seed_baseline_for_main)
+    baseline_dir = tmp_path / "baselines"
+    baseline_dir.mkdir()
+
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed mid-crash state: tx="swapping" + stale artifacts
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "stale.txt").write_text("STALE", encoding="utf-8")
+    worksheet_csv.write_text("STALE_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="swapping")
+
+    # main() should exit 2 (missing metadata) BUT still wipe stale artifacts first
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 2
+
+    # Critical: recovery happened despite the metadata bailout
+    assert not per_boundary_dir.exists()
+    assert not worksheet_csv.exists()
+    assert not tx_path.exists()
+
+    # WARNING was emitted before the metadata error
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err
+
+
+def test_step0_recovery_runs_even_when_video_unresolvable(
+    tmp_path, monkeypatch, capsys
+):
+    """Recovery (#800 Codex follow-up): tx="swapping" cleanup must NOT be gated by
+    ALLAGANEYE_SAMPLE_VIDEO_DIR being set. Even if resolve_video_path raises,
+    stale artifacts must still be wiped first.
+    """
+    mod = _load_module()
+    baseline_dir = tmp_path / "baselines"
+    baseline_dir.mkdir()
+    metadata = {
+        "schema_version": "1",
+        "source": "20260116/fake.mkv",
+        "matches": [
+            {
+                "index": 1,
+                "start_time": 49.125,
+                "end_time": 1054.5,
+                "duration": 1005.375,
+                "type": "fl_match",
+            },
+        ],
+        "gaps": [],
+    }
+    (baseline_dir / "obs-fake.metadata.json").write_text(
+        json.dumps(metadata), encoding="utf-8"
+    )
+    # Deliberately DO NOT set ALLAGANEYE_SAMPLE_VIDEO_DIR -> resolve_video_path will raise OSError
+    monkeypatch.delenv("ALLAGANEYE_SAMPLE_VIDEO_DIR", raising=False)
+
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed mid-crash state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "stale.txt").write_text("STALE", encoding="utf-8")
+    worksheet_csv.write_text("STALE_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="swapping")
+
+    # main() should raise OSError (video env unset) BUT recovery must run first
+    with pytest.raises(OSError, match="ALLAGANEYE_SAMPLE_VIDEO_DIR"):
+        mod.main(
+            [
+                "obs-fake",
+                "--baseline-dir",
+                str(baseline_dir),
+                "--worksheet-dir",
+                str(worksheet_dir),
+            ]
+        )
+
+    # Critical: recovery happened despite the video bailout
+    assert not per_boundary_dir.exists()
+    assert not worksheet_csv.exists()
+    assert not tx_path.exists()
+
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err

--- a/tests/test_audit_prepare.py
+++ b/tests/test_audit_prepare.py
@@ -645,3 +645,144 @@ def test_main_writes_tx_state_consistent_after_publish(tmp_path, monkeypatch):
     data = json.loads(tx_path.read_text(encoding="utf-8"))
     assert data["schema_version"] == 1
     assert data["state"] == "consistent"
+
+
+def _seed_baseline_for_main(tmp_path, monkeypatch, label="obs-fake"):
+    """Helper: build a minimal baseline + video tree usable by main()."""
+    mod = _load_module()
+    baseline_dir = tmp_path / "baselines"
+    baseline_dir.mkdir(exist_ok=True)
+    metadata = {
+        "schema_version": "1",
+        "source": "20260116/fake.mkv",
+        "matches": [
+            {
+                "index": 1,
+                "start_time": 49.125,
+                "end_time": 1054.5,
+                "duration": 1005.375,
+                "type": "fl_match",
+            },
+        ],
+        "gaps": [],
+    }
+    (baseline_dir / f"{label}.metadata.json").write_text(
+        json.dumps(metadata), encoding="utf-8"
+    )
+    video_dir = tmp_path / "videos"
+    (video_dir / "20260116").mkdir(parents=True, exist_ok=True)
+    (video_dir / "20260116" / "fake.mkv").write_bytes(b"")
+    monkeypatch.setenv("ALLAGANEYE_SAMPLE_VIDEO_DIR", str(video_dir))
+    monkeypatch.setattr(mod, "export_brightness_csv", lambda **kw: None)
+    monkeypatch.setattr(mod, "export_sample_frames", lambda **kw: None)
+    return mod, baseline_dir
+
+
+def test_main_step0_recovers_from_swapping_state(tmp_path, monkeypatch, capsys):
+    """tx-state == 'swapping' on startup -> wipe + regenerate + WARNING (#800)."""
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed mid-crash state: tx="swapping", stale dir, stale csv
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "old.txt").write_text("OLD", encoding="utf-8")
+    worksheet_csv.write_text("OLD_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="swapping")
+
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Recovery happened: old wiped, new regenerated, tx="consistent"
+    assert not (per_boundary_dir / "old.txt").exists()
+    assert per_boundary_dir.exists()
+    assert "OLD_HEADER" not in worksheet_csv.read_text(encoding="utf-8")
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+
+    # WARNING was emitted on stderr
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err
+
+
+def test_tx_state_missing_legacy_compat(tmp_path, monkeypatch, capsys):
+    """tx.json absent (legacy baseline) -> no recovery, normal regenerate (#800)."""
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+
+    # Seed legacy state: dir + csv exist but NO tx.json
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "legacy.txt").write_text("LEGACY", encoding="utf-8")
+    worksheet_csv.write_text("LEGACY_HEADER\n", encoding="utf-8")
+
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Normal regenerate (legacy content overwritten by atomic swap)
+    assert not (per_boundary_dir / "legacy.txt").exists()
+    # No recovery WARNING in stderr
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" not in err
+
+    # tx.json is now created with state=consistent
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+
+
+def test_no_recovery_when_state_consistent(tmp_path, monkeypatch, capsys):
+    """tx-state == 'consistent' on startup -> no recovery, normal regenerate (#800)."""
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed clean prior-run state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "prev.txt").write_text("PREV", encoding="utf-8")
+    worksheet_csv.write_text("PREV_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Normal regenerate (prev content overwritten by atomic swap)
+    assert not (per_boundary_dir / "prev.txt").exists()
+    # No recovery WARNING in stderr
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" not in err
+
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"

--- a/tests/test_audit_prepare.py
+++ b/tests/test_audit_prepare.py
@@ -512,3 +512,32 @@ def test_tx_state_corrupted_treated_as_missing(tmp_path, capsys, payload, varian
     err = capsys.readouterr().err
     assert "WARNING" in err, f"variant={variant} stderr: {err!r}"
     assert str(tx_path) in err, f"variant={variant} stderr: {err!r}"
+
+
+def test_write_tx_state_atomic_creates_file(tmp_path):
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+    assert tx_path.exists()
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["schema_version"] == 1
+    assert data["state"] == "consistent"
+    assert data["updated_at"].endswith("Z")  # ISO 8601 UTC
+
+
+def test_write_tx_state_atomic_overwrites_existing(tmp_path):
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    mod._write_tx_state_atomic(tx_path, state="swapping")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+
+
+def test_write_tx_state_atomic_cleans_up_new_suffix(tmp_path):
+    """No `.tx.json.new` should remain after successful write."""
+    mod = _load_module()
+    tx_path = tmp_path / "obs.tx.json"
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+    assert tx_path.exists()
+    assert not (tmp_path / "obs.tx.json.new").exists()

--- a/tests/test_audit_prepare.py
+++ b/tests/test_audit_prepare.py
@@ -786,3 +786,232 @@ def test_no_recovery_when_state_consistent(tmp_path, monkeypatch, capsys):
 
     data = json.loads(tx_path.read_text(encoding="utf-8"))
     assert data["state"] == "consistent"
+
+
+def test_recovers_from_crash_after_rmtree(tmp_path, monkeypatch, capsys):
+    """W1 window: crash AFTER rmtree old per_boundary_dir, BEFORE rename .new.
+
+    Mid-crash state: dir gone, csv old, tx.json "swapping".
+    Next run: Step 0 sees "swapping" + wipes + regenerates.
+    """
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed clean prior-run state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "old.txt").write_text("OLD", encoding="utf-8")
+    worksheet_csv.write_text("OLD_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+
+    # Inject crash: shutil.rmtree raises AFTER deleting per_boundary_dir once
+    original_rmtree = mod.shutil.rmtree
+    crashed = {"value": False}
+
+    def crashing_rmtree(path, *args, **kwargs):
+        original_rmtree(path, *args, **kwargs)
+        if not crashed["value"] and Path(path) == per_boundary_dir:
+            crashed["value"] = True
+            raise RuntimeError("simulated crash after rmtree")
+
+    monkeypatch.setattr(mod.shutil, "rmtree", crashing_rmtree)
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        mod.main(
+            [
+                "obs-fake",
+                "--baseline-dir",
+                str(baseline_dir),
+                "--worksheet-dir",
+                str(worksheet_dir),
+            ]
+        )
+
+    # Mid-crash state: tx="swapping", dir gone, csv still old
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "swapping"
+    assert not per_boundary_dir.exists()
+    assert worksheet_csv.read_text(encoding="utf-8") == "OLD_HEADER\n"
+
+    # Restore rmtree for recovery run
+    monkeypatch.setattr(mod.shutil, "rmtree", original_rmtree)
+
+    # Re-run audit-prepare: Step 0 recovery
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Recovered state: tx="consistent", regenerated artifacts
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+    assert per_boundary_dir.exists()
+    assert worksheet_csv.exists()
+    assert "OLD_HEADER" not in worksheet_csv.read_text(encoding="utf-8")
+
+    # WARNING was emitted
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err
+
+
+def test_recovers_from_crash_after_dir_rename(tmp_path, monkeypatch, capsys):
+    """W2 window: crash AFTER per_boundary_dir_new.rename, BEFORE csv replace.
+
+    Mid-crash state: new dir + old csv, tx.json "swapping".
+    Next run: Step 0 wipes new dir + old csv + tx, regenerates.
+    """
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    per_boundary_dir_new = worksheet_dir / "obs-fake.new"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed clean prior-run state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "old.txt").write_text("OLD", encoding="utf-8")
+    worksheet_csv.write_text("OLD_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+
+    # Inject crash: Path.rename raises AFTER renaming per_boundary_dir_new -> per_boundary_dir
+    original_rename = Path.rename
+    crashed = {"value": False}
+
+    def crashing_rename(self, target, *args, **kwargs):
+        result = original_rename(self, target, *args, **kwargs)
+        if (
+            not crashed["value"]
+            and Path(self) == per_boundary_dir_new
+            and Path(target) == per_boundary_dir
+        ):
+            crashed["value"] = True
+            raise RuntimeError("simulated crash after dir rename")
+        return result
+
+    monkeypatch.setattr(Path, "rename", crashing_rename)
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        mod.main(
+            [
+                "obs-fake",
+                "--baseline-dir",
+                str(baseline_dir),
+                "--worksheet-dir",
+                str(worksheet_dir),
+            ]
+        )
+
+    # Mid-crash state: tx="swapping", new dir present, old csv still there
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "swapping"
+    assert per_boundary_dir.exists()
+    assert not (per_boundary_dir / "old.txt").exists()  # new content
+    assert worksheet_csv.read_text(encoding="utf-8") == "OLD_HEADER\n"
+
+    # Restore rename for recovery run
+    monkeypatch.setattr(Path, "rename", original_rename)
+
+    # Re-run audit-prepare: Step 0 recovery
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Recovered state
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+    assert per_boundary_dir.exists()
+    assert worksheet_csv.exists()
+    assert "OLD_HEADER" not in worksheet_csv.read_text(encoding="utf-8")
+
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err
+
+
+def test_recovers_from_crash_before_tx_commit(tmp_path, monkeypatch, capsys):
+    """crash AFTER csv replace, BEFORE final tx="consistent" write.
+
+    Mid-crash state: new dir + new csv, tx.json still "swapping" (= wasteful regenerate).
+    Next run: Step 0 wipes everything + regenerates (content correct but tx not committed).
+    """
+    mod, baseline_dir = _seed_baseline_for_main(tmp_path, monkeypatch)
+    worksheet_dir = tmp_path / "audit-worksheet"
+    worksheet_dir.mkdir()
+    per_boundary_dir = worksheet_dir / "obs-fake"
+    worksheet_csv = worksheet_dir / "obs-fake.csv"
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+
+    # Seed clean prior-run state
+    per_boundary_dir.mkdir()
+    (per_boundary_dir / "old.txt").write_text("OLD", encoding="utf-8")
+    worksheet_csv.write_text("OLD_HEADER\n", encoding="utf-8")
+    mod._write_tx_state_atomic(tx_path, state="consistent")
+
+    # Inject crash: _write_tx_state_atomic raises on the 2nd call (consistent commit)
+    original_write = mod._write_tx_state_atomic
+    call_count = {"value": 0}
+
+    def crashing_write(path, *, state):
+        call_count["value"] += 1
+        if call_count["value"] == 2 and state == "consistent":
+            raise RuntimeError("simulated crash before tx commit")
+        original_write(path, state=state)
+
+    monkeypatch.setattr(mod, "_write_tx_state_atomic", crashing_write)
+
+    with pytest.raises(RuntimeError, match="simulated crash before tx commit"):
+        mod.main(
+            [
+                "obs-fake",
+                "--baseline-dir",
+                str(baseline_dir),
+                "--worksheet-dir",
+                str(worksheet_dir),
+            ]
+        )
+
+    # Mid-crash state: tx still "swapping", new dir + new csv on disk
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "swapping"
+    assert per_boundary_dir.exists()
+    assert not (per_boundary_dir / "old.txt").exists()  # new content
+    assert "OLD_HEADER" not in worksheet_csv.read_text(encoding="utf-8")
+
+    # Restore for recovery run
+    monkeypatch.setattr(mod, "_write_tx_state_atomic", original_write)
+
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    # Recovered state
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["state"] == "consistent"
+    assert per_boundary_dir.exists()
+    assert worksheet_csv.exists()
+
+    err = capsys.readouterr().err
+    assert "crashed mid-publish" in err

--- a/tests/test_audit_prepare.py
+++ b/tests/test_audit_prepare.py
@@ -597,3 +597,51 @@ def test_recover_stale_artifacts_partial_state(tmp_path):
     )
 
     assert not per_boundary_dir.exists()
+
+
+def test_main_writes_tx_state_consistent_after_publish(tmp_path, monkeypatch):
+    """After successful main() the tx-state file exists with state=consistent (#800)."""
+    mod = _load_module()
+    baseline_dir = tmp_path / "baselines"
+    baseline_dir.mkdir()
+    metadata = {
+        "schema_version": "1",
+        "source": "20260116/fake.mkv",
+        "matches": [
+            {
+                "index": 1,
+                "start_time": 49.125,
+                "end_time": 1054.5,
+                "duration": 1005.375,
+                "type": "fl_match",
+            },
+        ],
+        "gaps": [],
+    }
+    (baseline_dir / "obs-fake.metadata.json").write_text(
+        json.dumps(metadata), encoding="utf-8"
+    )
+    video_dir = tmp_path / "videos"
+    (video_dir / "20260116").mkdir(parents=True)
+    (video_dir / "20260116" / "fake.mkv").write_bytes(b"")
+    monkeypatch.setenv("ALLAGANEYE_SAMPLE_VIDEO_DIR", str(video_dir))
+    monkeypatch.setattr(mod, "export_brightness_csv", lambda **kw: None)
+    monkeypatch.setattr(mod, "export_sample_frames", lambda **kw: None)
+
+    worksheet_dir = tmp_path / "audit-worksheet"
+    rc = mod.main(
+        [
+            "obs-fake",
+            "--baseline-dir",
+            str(baseline_dir),
+            "--worksheet-dir",
+            str(worksheet_dir),
+        ]
+    )
+    assert rc == 0
+
+    tx_path = worksheet_dir / "obs-fake.tx.json"
+    assert tx_path.exists()
+    data = json.loads(tx_path.read_text(encoding="utf-8"))
+    assert data["schema_version"] == 1
+    assert data["state"] == "consistent"


### PR DESCRIPTION
## 期待値

`scripts/audit-prepare.main()` step (3) の 3-op swap (rmtree + rename + replace) で発生しうる W1 / W2 crash window を検出 + 次 run auto-recover する。

## 現状

Issue #798 (PR #801) で W1 / W2 を `docs/superpowers/specs/2026-05-20-audit-script-hardening-design.md` §3.2 / §9 で trade-off として明示し、`scripts/audit-prepare.py:304-332` (旧) でも文書化した。Codex adversarial-review が W1 / W2 を指摘し、Issue #800 として follow-up を tracking していた。

## 修正内容

- `scripts/audit-prepare.py`: tx-state 定数 + 3 helpers (`_read_tx_state` / `_write_tx_state_atomic` / `_recover_stale_artifacts`) を追加。`main()` に Step 0 (recovery-on-start) と Step 3a/3e (tx-state marker) を組み込み
- `<label>.tx.json` schema = `{schema_version: 1, state: "consistent"|"swapping", updated_at: ISO 8601 UTC}`
- 書き込みは `.tx.json.new` 経由の `os.replace` で single-file atomic
- backwards-compat: tx.json 不在 / JSON parse fail / non-dict / unknown schema_version / unknown state は通常 flow を許容 (file 不在以外は WARNING を stderr に 1 行)
- Codex adversarial-review medium finding 反映: Step 0 recovery を metadata / video 読み込みより**前**に移動 (missing baseline / unset ALLAGANEYE_SAMPLE_VIDEO_DIR 時にも recovery が走るよう保証)
- `tests/test_audit_prepare.py`: 15 件の新規 test 追加 (helpers 単体 9 件 + main() 統合 4 件 + failure-injection 3 件 + Codex follow-up regression 2 件、注: 数件は parametrize で 4 variants)
- `scripts/audit-prepare.py:405-423` step (3) コメントブロックを「detect + auto-recover」に書き換え
- `docs/v030-baseline-audit.md` "Known limitation (Issue #800)" subsection を RESOLVED に更新

## 受け入れ条件 (spec §6 と同一)

- [x] Step 3 開始時に `<label>.tx.json` を state="swapping" で atomic 書き込み
- [x] Step 3 完了時 (csv replace 直後) に state="consistent" で atomic 書き込み
- [x] main() Step 0 で state=="swapping" 検出 → artifacts + tx.json 全消去 + WARNING 出力
- [x] tx.json 不在 / parse fail / non-dict / 未知 schema_version / 未知 state を backwards-compat で通常 flow (file 不在以外は WARNING)
- [x] tx-state 書き込みは `.tx.json.new` + `os.replace` で single-file atomic
- [x] failure-injection tests 6 件 green (W1 / W2 / before-tx-commit / no-recovery-consistent / legacy-compat / corrupted-parametrize)
- [x] 既存 `test_audit_prepare.py` 3 件 (atomic_success / atomic_failure / recovers_from_stale_new_dir) 引き続き green
- [x] ruff check / ruff format --check / pyright / pytest 全 green
- [x] `docs/v030-baseline-audit.md` "Known limitation" を RESOLVED 更新
- [x] step (3) コメントブロックを「detect + auto-recover」に更新
- [x] PR 作成 Pre-flight Step 5 `/codex:adversarial-review` で additional crash window 指摘 (1 medium finding ありを `4582bbb` で解消)

## Self-Test Report

machine-verified:
- [x] `python -m pytest tests/test_audit_prepare.py -v` (36 tests passed: 13 existing + 23 new)
- [x] `python -m ruff check scripts/audit-prepare.py tests/test_audit_prepare.py` clean
- [x] `python -m ruff format --check scripts/audit-prepare.py tests/test_audit_prepare.py` clean
- [x] `python -m pyright scripts/audit-prepare.py` 0 errors
- [x] `bash scripts/check-markdownlint.sh docs/v030-baseline-audit.md` clean (full repo 201 files scanned)
- [x] Iron Law 6 Pre-flight Step 0-5 通過 (Codex adversarial-review 1 medium finding 解消)

machine-unverifiable:
- 実機 audit-prepare 実行による operator 視点 UX 確認 (Idios 検証推奨、複数 boundary で `.tx.json` cleanup 動作確認)

## 関連

- Refs #800 (本 PR で対応)
- Refs #796 (親 audit issue) / #798 (predecessor hardening PR #801)
- spec: `docs/superpowers/specs/2026-05-20-audit-prepare-tx-recovery-design.md`
- plan: `docs/superpowers/plans/2026-05-21-audit-prepare-tx-recovery.md`

[hopeful-germain-8ffc43]