### PR TITLE
feat(l3): VTuber game-capture region detection algorithm (Phase 2a)

### DIFF
--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -180,23 +180,6 @@ _BAND_Y_MAX_FRAC = 0.55
 _GAME_ASPECT = 16.0 / 9.0
 """FF14 game capture のアスペクト比 (帯幅から game 高さを逆算)。"""
 
-_BAND_SNAP_GW = 0.85
-"""S2 専用 full-frame snap のスコアバー幅しきい値。
-
-_SNAP_FULL_FRAME_WH=0.92 はアスペクト比ベースの h 計算と組み合わせると
-OBS 相当のほぼ全幅 scorebar (gw~0.88) を snap できない。S2 では scorebar
-幅比が 0.85 以上 (bar_w >= 1632px at 1920px frame) かつ gy が _BAND_SNAP_Y_MAX
-以下 (= frame 上端付近) の場合に OBS 相当と判断し FULL_FRAME に snap する。
-4K Game DVR の narrow scorebar (gw~0.32) は対象外。
-"""
-
-_BAND_SNAP_Y_MAX = 0.10
-"""full-frame snap を許す scorebar 上端 y の上限 (frame 高さ比)。
-
-OBS の scorebar は frame 上端付近 (gy~0)。gw が大きくても gy がこれを超える
-場合 (= 画面途中に widget) は inset とみなし snap しない。
-"""
-
 
 def detect_region_scorebar_band(
     frame: np.ndarray,
@@ -207,7 +190,8 @@ def detect_region_scorebar_band(
 
     *frame* は 1920x1080 RGB (H,W,3) uint8。検出帯を GC 紋章 3 点 AND で
     FL と検証してから返す。FL 帯が見つからなければ None (試合外フレーム
-    や opencv 未導入)。OBS 相当 (帯が y~0, 全幅) は FULL_FRAME に snap。
+    や opencv 未導入)。OBS の全体縮退は coarse 検出器 (S1/S3) の責務であり、
+    scorebar 幅 > detector._SCOREBAR_SCAN_MAX_WIDTH_PX (1440, #806) の広帯は None。
     """
     try:
         import cv2
@@ -253,8 +237,6 @@ def detect_region_scorebar_band(
         gy = y / H
         gh = (bar_w / _GAME_ASPECT) / H
         region = CaptureRegion(gx, gy, gw, gh, confidence=0.9, source="tierB").clamp()
-        if gw >= _BAND_SNAP_GW and gy <= _BAND_SNAP_Y_MAX:
-            return FULL_FRAME
         return region
     return None
 

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import numpy as np
+
 
 @dataclass(frozen=True)
 class CaptureRegion:
@@ -101,3 +103,46 @@ def _maybe_snap_full_frame(region: CaptureRegion) -> CaptureRegion:
     if region.w >= _SNAP_FULL_FRAME_WH and region.h >= _SNAP_FULL_FRAME_WH:
         return FULL_FRAME
     return region
+
+
+_VAR_THRESHOLD = 80.0
+"""グレースケール時間分散がこの値超で「動きあり」画素とみなす (tunable)。"""
+
+_MIN_REGION_AREA_FRAC = 0.08
+"""検出矩形の最小面積比。これ未満は誤検出として FULL_FRAME に fallback。"""
+
+
+def detect_region_variance(
+    frames: list[np.ndarray],
+    *,
+    var_threshold: float = _VAR_THRESHOLD,
+    min_area_frac: float = _MIN_REGION_AREA_FRAC,
+) -> CaptureRegion:
+    """S1: 時間分散の最大連結成分を game 領域とみなす (Tier A coarse)。
+
+    *frames* は同形状の 2D グレースケール (H,W) uint8。OBS 録画は全域が
+    動くため最大成分が frame 全域 → FULL_FRAME に snap。分散が無ければ
+    (静止) FULL_FRAME に fallback。
+    """
+    import cv2
+
+    if len(frames) < 2:
+        return FULL_FRAME
+    stack = np.stack(frames).astype(np.float32)
+    var = stack.var(axis=0)
+    h, w = var.shape
+    mask = (var > var_threshold).astype(np.uint8)
+    n, _labels, stats, _c = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    if n <= 1:
+        return FULL_FRAME
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    idx = 1 + int(np.argmax(areas))
+    bx, by = int(stats[idx, cv2.CC_STAT_LEFT]), int(stats[idx, cv2.CC_STAT_TOP])
+    bw, bh = int(stats[idx, cv2.CC_STAT_WIDTH]), int(stats[idx, cv2.CC_STAT_HEIGHT])
+    if bw * bh < min_area_frac * w * h:
+        return FULL_FRAME
+    fill = float(areas[idx - 1]) / (bw * bh)
+    region = CaptureRegion(
+        bx / w, by / h, bw / w, bh / h, confidence=fill, source="tierA"
+    ).clamp()
+    return _maybe_snap_full_frame(region)

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -200,6 +200,8 @@ def detect_region_scorebar_band(
     from allaganeye.video.detector import (
         _SCOREBAR_V2_PROBE_WIDTH,
         _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_SCAN_Y_START,
+        _SCOREBAR_SCAN_Y_END,
         _EMBLEM_RELATIVE_POSITIONS,
         _emblem_and_check,
         _find_scorebar_horizontal_range,
@@ -209,10 +211,12 @@ def detect_region_scorebar_band(
     W = _SCOREBAR_V2_PROBE_WIDTH
     if frame.shape[:2] != (H, W):
         return None
+    # _find_scorebar_horizontal_range は内部で y=_SCOREBAR_SCAN_Y_START.._END を
+    # 走査するため、その窓高に合わせて band を切り出す (定数 drift 防止)。
+    band_h = _SCOREBAR_SCAN_Y_END - _SCOREBAR_SCAN_Y_START
     y_max = int(H * _BAND_Y_MAX_FRAC)
     shifted = np.zeros_like(frame)
     for y in range(0, y_max, stride):
-        band_h = 45  # always 45 within the scan range (y_max << H-45); guard not needed
         shifted[band_h:] = 0
         shifted[0:band_h] = frame[y : y + band_h]
         span = _find_scorebar_horizontal_range(shifted.tobytes())

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -1,0 +1,103 @@
+"""Game capture region detection for overlay-heavy (VTuber) recordings (#753).
+
+Normalized-coordinate region contract + geometry helpers + candidate
+detectors (S1 variance / S2 scorebar-band / S3 blackout-overlap).
+On standard OBS recordings every detector resolves to ``FULL_FRAME`` so
+downstream brightness/scorebar behavior is unchanged (v0.3.0 baseline
+bit-exact; see spec §3.4 / M4).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CaptureRegion:
+    """Game capture rectangle in normalized [0,1] frame coordinates."""
+
+    x: float
+    y: float
+    w: float
+    h: float
+    confidence: float = 1.0
+    source: str = "fallback"  # "tierA" | "tierB" | "fallback"
+
+    def clamp(self) -> CaptureRegion:
+        x = min(max(self.x, 0.0), 1.0)
+        y = min(max(self.y, 0.0), 1.0)
+        w = min(max(self.w, 0.0), 1.0 - x)
+        h = min(max(self.h, 0.0), 1.0 - y)
+        return CaptureRegion(x, y, w, h, self.confidence, self.source)
+
+    def to_dict(self) -> dict:
+        return {
+            "x": self.x,
+            "y": self.y,
+            "w": self.w,
+            "h": self.h,
+            "confidence": self.confidence,
+            "source": self.source,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> CaptureRegion:
+        return cls(
+            d["x"],
+            d["y"],
+            d["w"],
+            d["h"],
+            d.get("confidence", 1.0),
+            d.get("source", "fallback"),
+        )
+
+
+FULL_FRAME = CaptureRegion(0.0, 0.0, 1.0, 1.0, confidence=1.0, source="fallback")
+
+
+@dataclass
+class RegionTimeline:
+    """Coarse region (Pass 1) + per-segment precise regions (#480/#481)."""
+
+    coarse: CaptureRegion
+    segments: list[tuple[tuple[float, float], CaptureRegion]] = field(
+        default_factory=list
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "coarse": self.coarse.to_dict(),
+            "segments": [
+                {"time_range": [t0, t1], "region": r.to_dict()}
+                for (t0, t1), r in self.segments
+            ],
+        }
+
+
+_SNAP_FULL_FRAME_WH = 0.92
+"""w と h が共にこの比率以上なら FULL_FRAME に snap。
+
+OBS 録画では game = frame 全体のため検出器は frame 全域に近い矩形を返す。
+わずかな端の欠けで IoU<1.0 になり baseline を壊すのを防ぐため full-frame
+に snap し、Pass 1 輝度を現行と数値一致させる (spec §3.4 / M4)。
+"""
+
+
+def iou(a: CaptureRegion, b: CaptureRegion) -> float:
+    ax2, ay2 = a.x + a.w, a.y + a.h
+    bx2, by2 = b.x + b.w, b.y + b.h
+    ix1, iy1 = max(a.x, b.x), max(a.y, b.y)
+    ix2, iy2 = min(ax2, bx2), min(ay2, by2)
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    union = a.w * a.h + b.w * b.h - inter
+    return inter / union if union > 0 else 0.0
+
+
+def top_edge_error_px(a: CaptureRegion, b: CaptureRegion, frame_h: int) -> float:
+    return abs(a.y - b.y) * frame_h
+
+
+def _maybe_snap_full_frame(region: CaptureRegion) -> CaptureRegion:
+    if region.w >= _SNAP_FULL_FRAME_WH and region.h >= _SNAP_FULL_FRAME_WH:
+        return FULL_FRAME
+    return region

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -171,6 +171,85 @@ _OVERLAP_DARK = 20.0
 """「暗転で暗くなる」とみなす画素の最小輝度しきい (tunable)。"""
 
 
+_BAND_SCAN_STRIDE = 6
+"""y 方向の走査刻み (px)。scorebar 帯の高さ ~45px に対し十分細かい。"""
+
+_BAND_Y_MAX_FRAC = 0.55
+"""scorebar を探す y の上限 (frame 高さ比)。game は frame 上〜中央寄り。"""
+
+_GAME_ASPECT = 16.0 / 9.0
+"""FF14 game capture のアスペクト比 (帯幅から game 高さを逆算)。"""
+
+_BAND_SNAP_GW = 0.85
+"""S2 専用 full-frame snap しきい値 (gw)。
+
+_SNAP_FULL_FRAME_WH=0.92 はアスペクト比ベースの h 計算と組み合わせると
+OBS 相当のほぼ全幅 scorebar (gw~0.88) を snap できない。S2 では scorebar
+幅比が 0.85 以上 (bar_w >= 1632px at 1920px frame) を OBS 相当と判断し
+FULL_FRAME に snap する。4K Game DVR の narrow scorebar (gw~0.32) は対象外。
+"""
+
+
+def detect_region_scorebar_band(
+    frame: np.ndarray,
+    *,
+    stride: int = _BAND_SCAN_STRIDE,
+) -> CaptureRegion | None:
+    """S2: FL scorebar 帯を全 y で探し、game 矩形を逆算 (Tier B precise)。
+
+    *frame* は 1920x1080 RGB (H,W,3) uint8。検出帯を GC 紋章 3 点 AND で
+    FL と検証してから返す。FL 帯が見つからなければ None (試合外フレーム
+    や opencv 未導入)。OBS 相当 (帯が y~0, 全幅) は FULL_FRAME に snap。
+    """
+    try:
+        import cv2
+    except ImportError:
+        return None
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_WIDTH,
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _EMBLEM_RELATIVE_POSITIONS,
+        _emblem_and_check,
+        _find_scorebar_horizontal_range,
+    )
+
+    H = _SCOREBAR_V2_PROBE_HEIGHT
+    W = _SCOREBAR_V2_PROBE_WIDTH
+    if frame.shape[:2] != (H, W):
+        return None
+    y_max = int(H * _BAND_Y_MAX_FRAC)
+    for y in range(0, y_max, stride):
+        shifted = np.zeros_like(frame)
+        band_h = min(45, H - y)
+        shifted[0:band_h] = frame[y : y + band_h]
+        span = _find_scorebar_horizontal_range(shifted.tobytes())
+        if span is None:
+            continue
+        x_left, x_right = span
+        bar_w = x_right - x_left
+        positions = [
+            (
+                name,
+                int(x_left + cx_rel * bar_w - hw_rel * bar_w),
+                y + ey1,
+                int(x_left + cx_rel * bar_w + hw_rel * bar_w),
+                y + ey2,
+            )
+            for name, cx_rel, hw_rel, ey1, ey2 in _EMBLEM_RELATIVE_POSITIONS
+        ]
+        if not _emblem_and_check(frame, positions, f"band y={y}", cv2):
+            continue
+        gw = bar_w / W
+        gx = x_left / W
+        gy = y / H
+        gh = (bar_w / _GAME_ASPECT) / H
+        region = CaptureRegion(gx, gy, gw, gh, confidence=0.9, source="tierB").clamp()
+        if gw >= _BAND_SNAP_GW:
+            return FULL_FRAME
+        return region
+    return None
+
+
 def detect_region_blackout_overlap(
     frames: list[np.ndarray],
     *,

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -112,6 +112,38 @@ _MIN_REGION_AREA_FRAC = 0.08
 """検出矩形の最小面積比。これ未満は誤検出として FULL_FRAME に fallback。"""
 
 
+def _largest_component_region(
+    mask: np.ndarray,
+    *,
+    min_area_frac: float,
+    source: str,
+    confidence: float | None = None,
+) -> CaptureRegion:
+    """連結成分の最大 bbox を正規化 CaptureRegion 化 (S1/S3 共通)。
+
+    *mask* は uint8 2D。最大の非背景成分の bbox を返す。成分なし / 面積が
+    min_area_frac 未満 / frame 全域に近い場合は FULL_FRAME。confidence が
+    None なら成分の充填率 (画素数/bbox面積) を使う。
+    """
+    import cv2
+
+    h, w = mask.shape
+    n, _labels, stats, _c = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    if n <= 1:
+        return FULL_FRAME
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    idx = 1 + int(np.argmax(areas))
+    bx, by = int(stats[idx, cv2.CC_STAT_LEFT]), int(stats[idx, cv2.CC_STAT_TOP])
+    bw, bh = int(stats[idx, cv2.CC_STAT_WIDTH]), int(stats[idx, cv2.CC_STAT_HEIGHT])
+    if bw * bh < min_area_frac * w * h:
+        return FULL_FRAME
+    conf = float(areas[idx - 1]) / (bw * bh) if confidence is None else confidence
+    region = CaptureRegion(
+        bx / w, by / h, bw / w, bh / h, confidence=conf, source=source
+    ).clamp()
+    return _maybe_snap_full_frame(region)
+
+
 def detect_region_variance(
     frames: list[np.ndarray],
     *,
@@ -124,32 +156,16 @@ def detect_region_variance(
     動くため最大成分が frame 全域 → FULL_FRAME に snap。分散が無ければ
     (静止) FULL_FRAME に fallback。
     """
-    import cv2
-
     if len(frames) < 2:
         return FULL_FRAME
     stack = np.stack(frames).astype(np.float32)
     var = stack.var(axis=0)
-    h, w = var.shape
     mask = (var > var_threshold).astype(np.uint8)
-    n, _labels, stats, _c = cv2.connectedComponentsWithStats(mask, connectivity=8)
-    if n <= 1:
-        return FULL_FRAME
-    areas = stats[1:, cv2.CC_STAT_AREA]
-    idx = 1 + int(np.argmax(areas))
-    bx, by = int(stats[idx, cv2.CC_STAT_LEFT]), int(stats[idx, cv2.CC_STAT_TOP])
-    bw, bh = int(stats[idx, cv2.CC_STAT_WIDTH]), int(stats[idx, cv2.CC_STAT_HEIGHT])
-    if bw * bh < min_area_frac * w * h:
-        return FULL_FRAME
-    fill = float(areas[idx - 1]) / (bw * bh)
-    region = CaptureRegion(
-        bx / w, by / h, bw / w, bh / h, confidence=fill, source="tierA"
-    ).clamp()
-    return _maybe_snap_full_frame(region)
+    return _largest_component_region(mask, min_area_frac=min_area_frac, source="tierA")
 
 
 _OVERLAP_BRIGHT = 60.0
-"""「試合中は明るい」とみなす画素の最大輝度しきい (tunable)。"""
+"""画素の最大輝度がこの値を超えれば「試合中は明るい画素」とみなす下限しきい (tunable)。"""
 
 _OVERLAP_DARK = 20.0
 """「暗転で暗くなる」とみなす画素の最小輝度しきい (tunable)。"""
@@ -167,25 +183,12 @@ def detect_region_blackout_overlap(
     overlay は常時明るい (min が下がらない) ため除外される。OBS は全画面が
     暗転する (mask が全域) → FULL_FRAME。
     """
-    import cv2
-
     if len(frames) < 2:
         return FULL_FRAME
     stack = np.stack(frames).astype(np.float32)
     pmax = stack.max(axis=0)
     pmin = stack.min(axis=0)
-    h, w = pmax.shape
     mask = ((pmax > bright_thresh) & (pmin < dark_thresh)).astype(np.uint8)
-    n, _labels, stats, _c = cv2.connectedComponentsWithStats(mask, connectivity=8)
-    if n <= 1:
-        return FULL_FRAME
-    areas = stats[1:, cv2.CC_STAT_AREA]
-    idx = 1 + int(np.argmax(areas))
-    bx, by = int(stats[idx, cv2.CC_STAT_LEFT]), int(stats[idx, cv2.CC_STAT_TOP])
-    bw, bh = int(stats[idx, cv2.CC_STAT_WIDTH]), int(stats[idx, cv2.CC_STAT_HEIGHT])
-    if bw * bh < min_area_frac * w * h:
-        return FULL_FRAME
-    region = CaptureRegion(
-        bx / w, by / h, bw / w, bh / h, confidence=0.8, source="tierA"
-    ).clamp()
-    return _maybe_snap_full_frame(region)
+    return _largest_component_region(
+        mask, min_area_frac=min_area_frac, source="tierA", confidence=0.8
+    )

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -146,3 +146,46 @@ def detect_region_variance(
         bx / w, by / h, bw / w, bh / h, confidence=fill, source="tierA"
     ).clamp()
     return _maybe_snap_full_frame(region)
+
+
+_OVERLAP_BRIGHT = 60.0
+"""「試合中は明るい」とみなす画素の最大輝度しきい (tunable)。"""
+
+_OVERLAP_DARK = 20.0
+"""「暗転で暗くなる」とみなす画素の最小輝度しきい (tunable)。"""
+
+
+def detect_region_blackout_overlap(
+    frames: list[np.ndarray],
+    *,
+    bright_thresh: float = _OVERLAP_BRIGHT,
+    dark_thresh: float = _OVERLAP_DARK,
+    min_area_frac: float = _MIN_REGION_AREA_FRAC,
+) -> CaptureRegion:
+    """S3: 「明るい時もあるが暗転で暗くなる」画素 = game 領域 (spec finding #4)。
+
+    overlay は常時明るい (min が下がらない) ため除外される。OBS は全画面が
+    暗転する (mask が全域) → FULL_FRAME。
+    """
+    import cv2
+
+    if len(frames) < 2:
+        return FULL_FRAME
+    stack = np.stack(frames).astype(np.float32)
+    pmax = stack.max(axis=0)
+    pmin = stack.min(axis=0)
+    h, w = pmax.shape
+    mask = ((pmax > bright_thresh) & (pmin < dark_thresh)).astype(np.uint8)
+    n, _labels, stats, _c = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    if n <= 1:
+        return FULL_FRAME
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    idx = 1 + int(np.argmax(areas))
+    bx, by = int(stats[idx, cv2.CC_STAT_LEFT]), int(stats[idx, cv2.CC_STAT_TOP])
+    bw, bh = int(stats[idx, cv2.CC_STAT_WIDTH]), int(stats[idx, cv2.CC_STAT_HEIGHT])
+    if bw * bh < min_area_frac * w * h:
+        return FULL_FRAME
+    region = CaptureRegion(
+        bx / w, by / h, bw / w, bh / h, confidence=0.8, source="tierA"
+    ).clamp()
+    return _maybe_snap_full_frame(region)

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -181,12 +181,20 @@ _GAME_ASPECT = 16.0 / 9.0
 """FF14 game capture のアスペクト比 (帯幅から game 高さを逆算)。"""
 
 _BAND_SNAP_GW = 0.85
-"""S2 専用 full-frame snap しきい値 (gw)。
+"""S2 専用 full-frame snap のスコアバー幅しきい値。
 
 _SNAP_FULL_FRAME_WH=0.92 はアスペクト比ベースの h 計算と組み合わせると
 OBS 相当のほぼ全幅 scorebar (gw~0.88) を snap できない。S2 では scorebar
-幅比が 0.85 以上 (bar_w >= 1632px at 1920px frame) を OBS 相当と判断し
-FULL_FRAME に snap する。4K Game DVR の narrow scorebar (gw~0.32) は対象外。
+幅比が 0.85 以上 (bar_w >= 1632px at 1920px frame) かつ gy が _BAND_SNAP_Y_MAX
+以下 (= frame 上端付近) の場合に OBS 相当と判断し FULL_FRAME に snap する。
+4K Game DVR の narrow scorebar (gw~0.32) は対象外。
+"""
+
+_BAND_SNAP_Y_MAX = 0.10
+"""full-frame snap を許す scorebar 上端 y の上限 (frame 高さ比)。
+
+OBS の scorebar は frame 上端付近 (gy~0)。gw が大きくても gy がこれを超える
+場合 (= 画面途中に widget) は inset とみなし snap しない。
 """
 
 
@@ -218,9 +226,10 @@ def detect_region_scorebar_band(
     if frame.shape[:2] != (H, W):
         return None
     y_max = int(H * _BAND_Y_MAX_FRAC)
+    shifted = np.zeros_like(frame)
     for y in range(0, y_max, stride):
-        shifted = np.zeros_like(frame)
-        band_h = min(45, H - y)
+        band_h = 45  # always 45 within the scan range (y_max << H-45); guard not needed
+        shifted[band_h:] = 0
         shifted[0:band_h] = frame[y : y + band_h]
         span = _find_scorebar_horizontal_range(shifted.tobytes())
         if span is None:
@@ -244,7 +253,7 @@ def detect_region_scorebar_band(
         gy = y / H
         gh = (bar_w / _GAME_ASPECT) / H
         region = CaptureRegion(gx, gy, gw, gh, confidence=0.9, source="tierB").clamp()
-        if gw >= _BAND_SNAP_GW:
+        if gw >= _BAND_SNAP_GW and gy <= _BAND_SNAP_Y_MAX:
             return FULL_FRAME
         return region
     return None

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -4,7 +4,7 @@ Normalized-coordinate region contract + geometry helpers + candidate
 detectors (S1 variance / S2 scorebar-band / S3 blackout-overlap).
 On standard OBS recordings every detector resolves to ``FULL_FRAME`` so
 downstream brightness/scorebar behavior is unchanged (v0.3.0 baseline
-bit-exact; see spec §3.4 / M4).
+bit-exact; see spec section 3.4 / M4).
 """
 
 from __future__ import annotations
@@ -81,7 +81,7 @@ _SNAP_FULL_FRAME_WH = 0.92
 
 OBS 録画では game = frame 全体のため検出器は frame 全域に近い矩形を返す。
 わずかな端の欠けで IoU<1.0 になり baseline を壊すのを防ぐため full-frame
-に snap し、Pass 1 輝度を現行と数値一致させる (spec §3.4 / M4)。
+に snap し、Pass 1 輝度を現行と数値一致させる (spec section 3.4 / M4)。
 """
 
 
@@ -153,7 +153,7 @@ def detect_region_variance(
     """S1: 時間分散の最大連結成分を game 領域とみなす (Tier A coarse)。
 
     *frames* は同形状の 2D グレースケール (H,W) uint8。OBS 録画は全域が
-    動くため最大成分が frame 全域 → FULL_FRAME に snap。分散が無ければ
+    動くため最大成分が frame 全域 -> FULL_FRAME に snap。分散が無ければ
     (静止) FULL_FRAME に fallback。
     """
     if len(frames) < 2:
@@ -269,7 +269,7 @@ def detect_region_blackout_overlap(
     """S3: 「明るい時もあるが暗転で暗くなる」画素 = game 領域 (spec finding #4)。
 
     overlay は常時明るい (min が下がらない) ため除外される。OBS は全画面が
-    暗転する (mask が全域) → FULL_FRAME。
+    暗転する (mask が全域) -> FULL_FRAME。
     """
     if len(frames) < 2:
         return FULL_FRAME

--- a/docs/superpowers/plans/2026-05-26-vtuber-capture-region-detection-plan.md
+++ b/docs/superpowers/plans/2026-05-26-vtuber-capture-region-detection-plan.md
@@ -1,0 +1,919 @@
+# VTuber game capture 領域検出 Implementation Plan (Phase 2a)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** VTuber 配信動画の game capture 矩形を自動検出するアルゴリズム候補 (S1/S2/S3) を実装し、実験 harness で gyawa benchmark に対し比較選定できる状態にする (scorebar #480 / minimap #481 / Pass1 本番 wiring は下流)。
+
+**Architecture:** 純関数の領域検出器 (`allaganeye/video/capture_region.py`) を 3 候補実装 (TDD、synthetic frame)。正規化矩形 contract + 幾何メトリクス (IoU / 上端 px 誤差) を同モジュールに置く。`scripts/vtuber_region_experiment.py` が候補を benchmark + OBS baseline に適用して M1–M4 比較表を出力、`scripts/vtuber_region_spike.py` が crop→Pass1→scorebar の ±10s 実現可能性を実証。OBS では各検出器が `FULL_FRAME` に snap し回帰安全。最終選定は実測 (machine-unverifiable) で行い spec に追記。
+
+**Tech Stack:** Python 3.12 / numpy / opencv-python-headless (`cv2`) / pytest (slow marker) / ffmpeg (frame probe)。既存 `allaganeye/video/detector.py` の `_EMBLEM_RELATIVE_POSITIONS` / `_emblem_and_check` / `_probe_frame_rgb_hires` / `_SCOREBAR_SCAN_*` を再利用。
+
+**Spec:** [docs/superpowers/specs/2026-05-26-vtuber-capture-region-detection-design.md](../specs/2026-05-26-vtuber-capture-region-detection-design.md)
+
+---
+
+## 前提・規約 (実装者向け)
+
+- **作業場所**: worktree `.claude/worktrees/l3-vtuber-capture-region/` (branch `claude/l3-vtuber-capture-region`)。main checkout ではない。Bash は `git -C <worktree>` か `cd <worktree> &&` で worktree を明示 (cwd ドリフト注意)。
+- **commit**: 各タスク末尾。メッセージ末尾に空行 + `session: l3-vtuber-capture-region` + 空行 + `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`。issue 参照は `Refs #753` のみ (Closes/Fixes 禁止 = Iron Law 4)。日本語本文は `git commit -F <utf8-file>` で渡す (Windows Git Bash の inline 破損回避)。
+- **TDD 厳守**: 各実装は failing test を先に書き、fail 確認 → 最小実装 → pass 確認 → commit。
+- **lint/型**: タスク完了ごとに `ruff check .` / `ruff format --check .` / `pyright` / `pytest` (slow 除外) を pass させる (Iron Law 6)。Python のみの変更なので GUI チェックは不要。
+- **machine-unverifiable**: gyawa benchmark / OBS baseline の実走を要するタスク (Wave D) は実機 (real video + GPU) と user 確認が必要。PR 本文では plain bullet `-` で記載し `[x]` を付けない (`docs/l2-workflow.md` §Self-Test Report 規約)。
+- **guard**: gyawa benchmark は external だが trusted 扱い (user 確認 2026-05-26)。新規 external 動画を足す場合のみ `allaganeye-guard verify` 必須。
+
+## File Structure
+
+| ファイル | 責務 | 区分 |
+| --- | --- | --- |
+| `allaganeye/video/capture_region.py` | `CaptureRegion`/`RegionTimeline` 型、`FULL_FRAME`、幾何 (`iou`/`top_edge_error_px`/`_maybe_snap_full_frame`)、候補検出器 S1/S2/S3 | 新規 (production) |
+| `tests/test_capture_region.py` | 上記の単体テスト (synthetic frame) | 新規 |
+| `scripts/vtuber_region_experiment.py` | 実験 harness: 候補を動画に適用し M1–M4 比較表を出力 (importable, underscore 名) | 新規 |
+| `tests/scripts/test_vtuber_region_experiment.py` | harness の集計・整形ロジック単体テスト | 新規 |
+| `scripts/vtuber_region_spike.py` | e2e spike: crop→Pass1→scorebar の ±10s 実現可能性 | 新規 (spike) |
+| `tests/scripts/test_vtuber_region_spike.py` | `match_within_tolerance` の単体テスト | 新規 |
+| `tests/baselines/v0.3.0/vtuber-primary-regions.json` | proxy 正解矩形 (annotation 成果物) | 新規 (data) |
+| `docs/superpowers/specs/2026-05-26-...-design.md` | §6.3/§11 に実測値・選定結果を追記 (Wave D) | 既存修正 |
+
+---
+
+## Wave 0: proxy 正解矩形 (annotation)
+
+### Task 0.1: gyawa benchmark の正解矩形を作成
+
+proxy メトリクス (M1) の ground truth。抽出済みフレーム (`%TEMP%\allaganeye-vtuber-frames\*.jpg`、なければ再抽出) を目視し、各レイアウトの game capture 矩形を正規化座標で記録する。
+
+**Files:**
+
+- Create: `tests/baselines/v0.3.0/vtuber-primary-regions.json`
+
+- [ ] **Step 1: フレームを (再) 抽出して目視**
+
+Run (worktree から、ffmpeg path は環境に合わせる):
+
+```bash
+FF="C:/Users/idios/AppData/Local/Microsoft/WinGet/Packages/Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe/ffmpeg-8.1-full_build/bin/ffmpeg.exe"
+VID="E:/videos/gyawa_vatos/2772549129-151803977-da21c691-9ed6-4068-9a8b-4726a8a519a8.mp4"
+OUT="$TEMP/allaganeye-vtuber-frames"; mkdir -p "$OUT"
+for t in 1900 2361 4700 6900; do "$FF" -nostdin -v error -ss $t -i "$VID" -frames:v 1 -q:v 2 -y "$OUT/f$t.jpg"; done
+```
+
+レイアウト A (試合1 = 小さめ inset): `f1900`/`f2361`。レイアウト B (試合3/5 = 大きめ): `f4700`/`f6900`。各フレームの game 矩形 (cyan 帯の下端〜hotbar 下端、左 chat strip の右〜右 panel の左) を画像目視で px 推定 → 正規化 (px / 1920, px / 1080)。
+
+- [ ] **Step 2: JSON を作成**
+
+```jsonc
+{
+  "source_file": "2772549129-151803977-da21c691-9ed6-4068-9a8b-4726a8a519a8.mp4",
+  "frame_width": 1920,
+  "frame_height": 1080,
+  "annotation_provider": "agent (visual estimate) + user verify",
+  "annotated_at": "2026-05-26",
+  "regions": [
+    {"timestamp": 1900, "layout": "A", "x": 0.00, "y": 0.00, "w": 0.00, "h": 0.00},
+    {"timestamp": 2361, "layout": "A", "x": 0.00, "y": 0.00, "w": 0.00, "h": 0.00},
+    {"timestamp": 4700, "layout": "B", "x": 0.00, "y": 0.00, "w": 0.00, "h": 0.00},
+    {"timestamp": 6900, "layout": "B", "x": 0.00, "y": 0.00, "w": 0.00, "h": 0.00}
+  ]
+}
+```
+
+(0.00 は目視推定値で置換すること。空欄を残さない。)
+
+- [ ] **Step 3: user 確認 (machine-unverifiable)**
+
+矩形を user (Idios) に提示し補正を受ける。これは目視成果物なので機械検証不可。確認後の値を JSON に確定。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "<worktree>" add tests/baselines/v0.3.0/vtuber-primary-regions.json
+git -C "<worktree>" commit -F <utf8-msg>   # "test(l3): vtuber primary 正解矩形 annotation (Refs #753)"
+```
+
+---
+
+## Wave A: 領域 contract + 幾何メトリクス (TDD)
+
+### Task A.1: `CaptureRegion` / `RegionTimeline` / `FULL_FRAME`
+
+**Files:**
+
+- Create: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```python
+# tests/test_capture_region.py
+from allaganeye.video.capture_region import CaptureRegion, RegionTimeline, FULL_FRAME
+
+
+def test_full_frame_is_unit_square():
+    assert (FULL_FRAME.x, FULL_FRAME.y, FULL_FRAME.w, FULL_FRAME.h) == (0.0, 0.0, 1.0, 1.0)
+
+
+def test_clamp_bounds_region_into_unit_square():
+    r = CaptureRegion(-0.1, 0.2, 1.5, 0.5).clamp()
+    assert r.x == 0.0 and r.y == 0.2
+    assert r.x + r.w <= 1.0 + 1e-9 and r.y + r.h <= 1.0 + 1e-9
+
+
+def test_round_trip_dict():
+    r = CaptureRegion(0.1, 0.2, 0.3, 0.4, confidence=0.8, source="tierB")
+    assert CaptureRegion.from_dict(r.to_dict()) == r
+
+
+def test_region_timeline_to_dict_shape():
+    tl = RegionTimeline(coarse=FULL_FRAME, segments=[((10.0, 20.0), FULL_FRAME)])
+    d = tl.to_dict()
+    assert d["coarse"]["w"] == 1.0
+    assert d["segments"][0]["time_range"] == [10.0, 20.0]
+```
+
+- [ ] **Step 2: fail 確認** — Run: `pytest tests/test_capture_region.py -q` → FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: 最小実装**
+
+```python
+# allaganeye/video/capture_region.py
+"""Game capture region detection for overlay-heavy (VTuber) recordings (#753).
+
+Normalized-coordinate region contract + geometry helpers + candidate
+detectors (S1 variance / S2 scorebar-band / S3 blackout-overlap).
+On standard OBS recordings every detector resolves to ``FULL_FRAME`` so
+downstream brightness/scorebar behavior is unchanged (v0.3.0 baseline
+bit-exact; see spec §3.4 / M4).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CaptureRegion:
+    """Game capture rectangle in normalized [0,1] frame coordinates."""
+
+    x: float
+    y: float
+    w: float
+    h: float
+    confidence: float = 1.0
+    source: str = "fallback"  # "tierA" | "tierB" | "fallback"
+
+    def clamp(self) -> "CaptureRegion":
+        x = min(max(self.x, 0.0), 1.0)
+        y = min(max(self.y, 0.0), 1.0)
+        w = min(max(self.w, 0.0), 1.0 - x)
+        h = min(max(self.h, 0.0), 1.0 - y)
+        return CaptureRegion(x, y, w, h, self.confidence, self.source)
+
+    def to_dict(self) -> dict:
+        return {
+            "x": self.x, "y": self.y, "w": self.w, "h": self.h,
+            "confidence": self.confidence, "source": self.source,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "CaptureRegion":
+        return cls(d["x"], d["y"], d["w"], d["h"],
+                   d.get("confidence", 1.0), d.get("source", "fallback"))
+
+
+FULL_FRAME = CaptureRegion(0.0, 0.0, 1.0, 1.0, confidence=1.0, source="fallback")
+
+
+@dataclass
+class RegionTimeline:
+    """Coarse region (Pass 1) + per-segment precise regions (#480/#481)."""
+
+    coarse: CaptureRegion
+    segments: list[tuple[tuple[float, float], CaptureRegion]] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "coarse": self.coarse.to_dict(),
+            "segments": [
+                {"time_range": [t0, t1], "region": r.to_dict()}
+                for (t0, t1), r in self.segments
+            ],
+        }
+```
+
+- [ ] **Step 4: pass 確認** — Run: `pytest tests/test_capture_region.py -q` → PASS
+
+- [ ] **Step 5: Commit** — `feat(l3): CaptureRegion/RegionTimeline 領域 contract (Refs #753)`
+
+### Task A.2: 幾何メトリクス `iou` / `top_edge_error_px` / `_maybe_snap_full_frame`
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: 失敗するテストを追加**
+
+```python
+from allaganeye.video.capture_region import iou, top_edge_error_px, _maybe_snap_full_frame
+
+
+def test_iou_identical_is_one():
+    r = CaptureRegion(0.1, 0.1, 0.5, 0.5)
+    assert iou(r, r) == 1.0
+
+
+def test_iou_disjoint_is_zero():
+    a = CaptureRegion(0.0, 0.0, 0.2, 0.2)
+    b = CaptureRegion(0.5, 0.5, 0.2, 0.2)
+    assert iou(a, b) == 0.0
+
+
+def test_top_edge_error_px_scales_by_height():
+    a = CaptureRegion(0.0, 0.10, 1.0, 0.5)
+    b = CaptureRegion(0.0, 0.12, 1.0, 0.5)
+    assert round(top_edge_error_px(a, b, 1080)) == round(0.02 * 1080)
+
+
+def test_snap_full_frame_when_region_covers_most_of_frame():
+    near_full = CaptureRegion(0.01, 0.01, 0.97, 0.97, source="tierA")
+    assert _maybe_snap_full_frame(near_full) == FULL_FRAME
+
+
+def test_snap_keeps_small_inset_unchanged():
+    inset = CaptureRegion(0.2, 0.1, 0.5, 0.5, source="tierA")
+    assert _maybe_snap_full_frame(inset) is inset
+```
+
+- [ ] **Step 2: fail 確認** — Run: `pytest tests/test_capture_region.py -q` → FAIL (ImportError)
+
+- [ ] **Step 3: 実装を追加**
+
+```python
+_SNAP_FULL_FRAME_WH = 0.92
+"""w と h が共にこの比率以上なら FULL_FRAME に snap。
+
+OBS 録画では game = frame 全体のため検出器は frame 全域に近い矩形を返す。
+わずかな端の欠けで IoU<1.0 になり baseline を壊すのを防ぐため full-frame
+に snap し、Pass 1 輝度を現行と数値一致させる (spec §3.4 / M4)。
+"""
+
+
+def iou(a: CaptureRegion, b: CaptureRegion) -> float:
+    ax2, ay2 = a.x + a.w, a.y + a.h
+    bx2, by2 = b.x + b.w, b.y + b.h
+    ix1, iy1 = max(a.x, b.x), max(a.y, b.y)
+    ix2, iy2 = min(ax2, bx2), min(ay2, by2)
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    union = a.w * a.h + b.w * b.h - inter
+    return inter / union if union > 0 else 0.0
+
+
+def top_edge_error_px(a: CaptureRegion, b: CaptureRegion, frame_h: int) -> float:
+    return abs(a.y - b.y) * frame_h
+
+
+def _maybe_snap_full_frame(region: CaptureRegion) -> CaptureRegion:
+    if region.w >= _SNAP_FULL_FRAME_WH and region.h >= _SNAP_FULL_FRAME_WH:
+        return FULL_FRAME
+    return region
+```
+
+- [ ] **Step 4: pass 確認** — Run: `pytest tests/test_capture_region.py -q` → PASS
+
+- [ ] **Step 5: Commit** — `feat(l3): 領域 IoU/上端誤差/full-frame snap (Refs #753)`
+
+---
+
+## Wave B: 候補検出器 (TDD on synthetic frames)
+
+各検出器は `np.ndarray` フレームを受け、`CaptureRegion` を返す。OBS 相当の合成フレームでは `FULL_FRAME` に縮退することをテストで保証する (M4)。
+
+### Task B.1: S1 時間分散検出器 `detect_region_variance`
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```python
+import numpy as np
+from allaganeye.video.capture_region import detect_region_variance
+
+
+def _stack_static_bg_with_moving_inset(n=12, h=180, w=320,
+                                       inset=(0.30, 0.20, 0.40, 0.50)):
+    """静止 bg (一定値) + inset 内だけフレームごとに乱数 = 高分散."""
+    rng = np.random.default_rng(0)
+    x0, y0, ww, hh = (int(inset[0] * w), int(inset[1] * h),
+                      int(inset[2] * w), int(inset[3] * h))
+    frames = []
+    for _ in range(n):
+        f = np.full((h, w), 50, dtype=np.uint8)  # static overlay-ish bg
+        f[y0:y0 + hh, x0:x0 + ww] = rng.integers(0, 256, (hh, ww), dtype=np.uint8)
+        frames.append(f)
+    return frames, inset
+
+
+def test_variance_finds_moving_inset():
+    frames, inset = _stack_static_bg_with_moving_inset()
+    r = detect_region_variance(frames)
+    assert r.source == "tierA"
+    # 検出矩形が inset を概ね包含 (中心が inset 内)
+    assert inset[0] <= r.x + r.w / 2 <= inset[0] + inset[2]
+    assert inset[1] <= r.y + r.h / 2 <= inset[1] + inset[3]
+
+
+def test_variance_full_frame_motion_snaps_full():
+    rng = np.random.default_rng(1)
+    frames = [rng.integers(0, 256, (180, 320), dtype=np.uint8) for _ in range(12)]
+    assert detect_region_variance(frames) == FULL_FRAME
+
+
+def test_variance_static_frames_fall_back_full():
+    frames = [np.full((180, 320), 50, dtype=np.uint8) for _ in range(12)]
+    assert detect_region_variance(frames) == FULL_FRAME
+```
+
+- [ ] **Step 2: fail 確認** — Run: `pytest tests/test_capture_region.py -k variance -q` → FAIL (ImportError)
+
+- [ ] **Step 3: 実装**
+
+```python
+import numpy as np  # ファイル先頭の import 群へ移動
+
+_VAR_THRESHOLD = 80.0
+"""グレースケール時間分散がこの値超で「動きあり」画素とみなす (tunable)。"""
+
+_MIN_REGION_AREA_FRAC = 0.08
+"""検出矩形の最小面積比。これ未満は誤検出として FULL_FRAME に fallback。"""
+
+
+def detect_region_variance(
+    frames: list["np.ndarray"],
+    *,
+    var_threshold: float = _VAR_THRESHOLD,
+    min_area_frac: float = _MIN_REGION_AREA_FRAC,
+) -> CaptureRegion:
+    """S1: 時間分散の最大連結成分を game 領域とみなす (Tier A coarse)。
+
+    *frames* は同形状の 2D グレースケール (H,W) uint8。OBS 録画は全域が
+    動くため最大成分が frame 全域 → FULL_FRAME に snap。分散が無ければ
+    (静止) FULL_FRAME に fallback。
+    """
+    import cv2
+
+    if len(frames) < 2:
+        return FULL_FRAME
+    stack = np.stack(frames).astype(np.float32)
+    var = stack.var(axis=0)
+    h, w = var.shape
+    mask = (var > var_threshold).astype(np.uint8)
+    n, _labels, stats, _c = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    if n <= 1:
+        return FULL_FRAME
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    idx = 1 + int(np.argmax(areas))
+    bx, by = int(stats[idx, cv2.CC_STAT_LEFT]), int(stats[idx, cv2.CC_STAT_TOP])
+    bw, bh = int(stats[idx, cv2.CC_STAT_WIDTH]), int(stats[idx, cv2.CC_STAT_HEIGHT])
+    if bw * bh < min_area_frac * w * h:
+        return FULL_FRAME
+    fill = float(areas[idx - 1]) / (bw * bh)
+    region = CaptureRegion(bx / w, by / h, bw / w, bh / h,
+                           confidence=fill, source="tierA").clamp()
+    return _maybe_snap_full_frame(region)
+```
+
+- [ ] **Step 4: pass 確認** — Run: `pytest tests/test_capture_region.py -k variance -q` → PASS
+
+- [ ] **Step 5: Commit** — `feat(l3): S1 時間分散 game 領域検出器 (Refs #753)`
+
+### Task B.2: S2 scorebar 帯検出器 `detect_region_scorebar_band`
+
+既存 `_find_scorebar_horizontal_range` (y=0..45 固定) を全 y 走査に一般化し、検出した帯を `_emblem_and_check` (GC 紋章 3 点 AND) で FL scorebar と検証してから game 矩形を逆算する。cyan 帯のような単色帯は紋章チェックで弾かれる (R2)。game は 16:9 前提で帯幅から高さを逆算。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: 失敗するテストを書く** (既存 `test_scorebar_v2.py` の合成フレーム作法を流用)
+
+```python
+from allaganeye.video.capture_region import detect_region_scorebar_band
+
+
+def _hires_with_scorebar_at(y_top: int, x_left: int, x_right: int):
+    """1920x1080 RGB: y_top 行に saturated 帯 + 3 紋章 (striped) を描く。
+
+    紋章位置は detector._EMBLEM_RELATIVE_POSITIONS を帯 span に投影。
+    """
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT,
+        _EMBLEM_RELATIVE_POSITIONS,
+    )
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    bar_w = x_right - x_left
+    # saturated blue 帯 (45px 高)
+    f[y_top:y_top + 45, x_left:x_right + 1] = (50, 50, 200)
+    for _name, cx_rel, hw_rel, ey1, ey2 in _EMBLEM_RELATIVE_POSITIONS:
+        cx = int(x_left + cx_rel * bar_w)
+        hw = max(2, int(hw_rel * bar_w))
+        region = f[y_top + ey1:y_top + ey2, cx - hw:cx + hw]
+        for col in range(region.shape[1]):  # 2px 縞 = 高 sat + 高 edge
+            region[:, col] = (200, 30, 30) if (col // 2) % 2 == 0 else (0, 0, 0)
+    return f
+
+
+def test_scorebar_band_at_offset_y_returns_inset_top():
+    # game 上端を frame の y=120 付近にした VTuber 風レイアウト
+    f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
+    r = detect_region_scorebar_band(f)
+    assert r is not None and r.source == "tierB"
+    assert abs(r.y - 120 / 1080) < 0.03   # 上端が帯 y 付近
+
+
+def test_scorebar_band_full_width_top_snaps_full():
+    # OBS 相当: 帯が y=2 で frame 全幅 → FULL_FRAME
+    f = _hires_with_scorebar_at(y_top=2, x_left=120, x_right=1810)
+    assert detect_region_scorebar_band(f) == FULL_FRAME
+
+
+def test_scorebar_band_uniform_cyan_banner_rejected():
+    from allaganeye.video.detector import _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    f[0:55, :] = (60, 200, 200)  # 単色 cyan 帯 (紋章なし)
+    assert detect_region_scorebar_band(f) is None
+```
+
+- [ ] **Step 2: fail 確認** — Run: `pytest tests/test_capture_region.py -k scorebar_band -q` → FAIL
+
+- [ ] **Step 3: 実装**
+
+```python
+_BAND_SCAN_STRIDE = 6
+"""y 方向の走査刻み (px)。scorebar 帯の高さ ~45px に対し十分細かい。"""
+
+_BAND_Y_MAX_FRAC = 0.55
+"""scorebar を探す y の上限 (frame 高さ比)。game は frame 上〜中央寄り。"""
+
+_GAME_ASPECT = 16.0 / 9.0
+"""FF14 game capture のアスペクト比 (帯幅から game 高さを逆算)。"""
+
+
+def detect_region_scorebar_band(
+    frame: "np.ndarray",
+    *,
+    stride: int = _BAND_SCAN_STRIDE,
+) -> CaptureRegion | None:
+    """S2: FL scorebar 帯を全 y で探し、game 矩形を逆算 (Tier B precise)。
+
+    *frame* は 1920x1080 RGB (H,W,3) uint8。検出帯を GC 紋章 3 点 AND で
+    FL と検証してから返す。FL 帯が見つからなければ None (試合外フレーム
+    や opencv 未導入)。OBS 相当 (帯が y~0, 全幅) は FULL_FRAME に snap。
+    """
+    try:
+        import cv2  # noqa: F401
+    except ImportError:
+        return None
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT,
+        _EMBLEM_RELATIVE_POSITIONS, _emblem_and_check,
+        _find_scorebar_horizontal_range,
+    )
+    import cv2
+
+    H = _SCOREBAR_V2_PROBE_HEIGHT
+    W = _SCOREBAR_V2_PROBE_WIDTH
+    if frame.shape[:2] != (H, W):
+        return None
+    y_max = int(H * _BAND_Y_MAX_FRAC)
+    for y in range(0, y_max, stride):
+        # 既存ヘルパは y=0..45 固定なので、その band を切り出して再利用する
+        # ために frame を上方シフトした view を渡す。
+        shifted = np.zeros_like(frame)
+        band_h = min(45, H - y)
+        shifted[0:band_h] = frame[y:y + band_h]
+        span = _find_scorebar_horizontal_range(shifted.tobytes())
+        if span is None:
+            continue
+        x_left, x_right = span
+        bar_w = x_right - x_left
+        positions = [
+            (name,
+             int(x_left + cx_rel * bar_w - hw_rel * bar_w), y + ey1,
+             int(x_left + cx_rel * bar_w + hw_rel * bar_w), y + ey2)
+            for name, cx_rel, hw_rel, ey1, ey2 in _EMBLEM_RELATIVE_POSITIONS
+        ]
+        if not _emblem_and_check(frame, positions, f"band y={y}", cv2):
+            continue
+        # FL scorebar 確定 -> game 矩形を逆算。scorebar 幅 ~= game 幅、
+        # 上端 ~= game 上端。game 高さは 16:9 で逆算。
+        gw = bar_w / W
+        gx = x_left / W
+        gy = y / H
+        gh = (bar_w / _GAME_ASPECT) / H
+        region = CaptureRegion(gx, gy, gw, gh, confidence=0.9, source="tierB").clamp()
+        return _maybe_snap_full_frame(region)
+    return None
+```
+
+> **実装注意**: `_find_scorebar_horizontal_range` に band を渡すため `shifted` view を作る方式は素朴。実装時に既存関数へ `y_start`/`y_end` 引数を足してゼロコピー化する案も可 (その場合は detector.py 側の変更となり、既存 V2 path に影響しないことを `test_scorebar_v2.py` 全 pass で確認すること)。
+
+- [ ] **Step 4: pass 確認** — Run: `pytest tests/test_capture_region.py -k scorebar_band -q` → PASS。さらに既存 `pytest tests/test_scorebar_v2.py -q` が全 pass (detector.py を触った場合の回帰確認)。
+
+- [ ] **Step 5: Commit** — `feat(l3): S2 scorebar 帯 game 領域検出器 (Refs #753)`
+
+### Task B.3: S3 暗転重なり検出器 `detect_region_blackout_overlap`
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+```python
+from allaganeye.video.capture_region import detect_region_blackout_overlap
+
+
+def test_blackout_overlap_finds_region_that_goes_dark():
+    h, w = 180, 320
+    inset = (0.30, 0.20, 0.40, 0.50)
+    x0, y0 = int(inset[0] * w), int(inset[1] * h)
+    ww, hh = int(inset[2] * w), int(inset[3] * h)
+    bright = np.full((h, w), 120, dtype=np.uint8)          # 全部明るい (試合中)
+    dark_inset = bright.copy()
+    dark_inset[y0:y0 + hh, x0:x0 + ww] = 2                  # inset だけ暗転、overlay は明るいまま
+    frames = [bright, bright, dark_inset, dark_inset]
+    r = detect_region_blackout_overlap(frames)
+    assert r.source == "tierA"
+    assert inset[0] <= r.x + r.w / 2 <= inset[0] + inset[2]
+    assert inset[1] <= r.y + r.h / 2 <= inset[1] + inset[3]
+
+
+def test_blackout_overlap_obs_full_frame_blackout_snaps_full():
+    h, w = 180, 320
+    bright = np.full((h, w), 120, dtype=np.uint8)
+    dark = np.full((h, w), 2, dtype=np.uint8)              # 全画面暗転 = OBS
+    assert detect_region_blackout_overlap([bright, bright, dark]) == FULL_FRAME
+```
+
+- [ ] **Step 2: fail 確認** — Run: `pytest tests/test_capture_region.py -k blackout_overlap -q` → FAIL
+
+- [ ] **Step 3: 実装**
+
+```python
+_OVERLAP_BRIGHT = 60.0
+"""「試合中は明るい」とみなす画素の最大輝度しきい (tunable)。"""
+
+_OVERLAP_DARK = 20.0
+"""「暗転で暗くなる」とみなす画素の最小輝度しきい (tunable)。"""
+
+
+def detect_region_blackout_overlap(
+    frames: list["np.ndarray"],
+    *,
+    bright_thresh: float = _OVERLAP_BRIGHT,
+    dark_thresh: float = _OVERLAP_DARK,
+    min_area_frac: float = _MIN_REGION_AREA_FRAC,
+) -> CaptureRegion:
+    """S3: 「明るい時もあるが暗転で暗くなる」画素 = game 領域 (spec finding #4)。
+
+    overlay は常時明るい (min が下がらない) ため除外される。OBS は全画面が
+    暗転する (mask が全域) → FULL_FRAME。
+    """
+    import cv2
+
+    if len(frames) < 2:
+        return FULL_FRAME
+    stack = np.stack(frames).astype(np.float32)
+    pmax = stack.max(axis=0)
+    pmin = stack.min(axis=0)
+    h, w = pmax.shape
+    mask = ((pmax > bright_thresh) & (pmin < dark_thresh)).astype(np.uint8)
+    n, _labels, stats, _c = cv2.connectedComponentsWithStats(mask, connectivity=8)
+    if n <= 1:
+        return FULL_FRAME
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    idx = 1 + int(np.argmax(areas))
+    bx, by = int(stats[idx, cv2.CC_STAT_LEFT]), int(stats[idx, cv2.CC_STAT_TOP])
+    bw, bh = int(stats[idx, cv2.CC_STAT_WIDTH]), int(stats[idx, cv2.CC_STAT_HEIGHT])
+    if bw * bh < min_area_frac * w * h:
+        return FULL_FRAME
+    region = CaptureRegion(bx / w, by / h, bw / w, bh / h,
+                           confidence=0.8, source="tierA").clamp()
+    return _maybe_snap_full_frame(region)
+```
+
+- [ ] **Step 4: pass 確認** — Run: `pytest tests/test_capture_region.py -k blackout_overlap -q` → PASS
+
+- [ ] **Step 5: Commit** — `feat(l3): S3 暗転重なり game 領域検出器 (Refs #753)`
+
+---
+
+## Wave C: 実験 harness + e2e spike
+
+### Task C.1: harness — 候補ランナー + 比較表
+
+**Files:**
+
+- Create: `scripts/vtuber_region_experiment.py`
+- Test: `tests/scripts/test_vtuber_region_experiment.py`
+
+- [ ] **Step 1: 失敗するテスト (集計・整形ロジックのみ)**
+
+```python
+# tests/scripts/test_vtuber_region_experiment.py
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "vtuber_region_experiment",
+    Path(__file__).resolve().parents[2] / "scripts" / "vtuber_region_experiment.py",
+)
+mod = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mod)
+
+
+def test_format_comparison_table_marks_best_iou():
+    rows = [
+        {"candidate": "S1", "mean_iou": 0.81, "mean_top_err_px": 30.0, "cost_s": 5.0},
+        {"candidate": "S2", "mean_iou": 0.94, "mean_top_err_px": 8.0, "cost_s": 9.0},
+    ]
+    out = mod.format_comparison_table(rows)
+    assert "S2" in out and "0.94" in out
+    assert mod.pick_winner(rows)["candidate"] == "S2"  # 最大 IoU
+
+
+def test_pick_winner_requires_obs_passing():
+    rows = [
+        {"candidate": "S1", "mean_iou": 0.99, "mean_top_err_px": 2.0, "obs_full_frame": False},
+        {"candidate": "S2", "mean_iou": 0.90, "mean_top_err_px": 9.0, "obs_full_frame": True},
+    ]
+    # OBS hard gate: obs_full_frame=False は IoU が高くても不採用
+    assert mod.pick_winner(rows)["candidate"] == "S2"
+```
+
+- [ ] **Step 2: fail 確認** — Run: `pytest tests/scripts/test_vtuber_region_experiment.py -q` → FAIL
+
+- [ ] **Step 3: 実装 (集計ロジック + 実走 CLI)**
+
+```python
+# scripts/vtuber_region_experiment.py
+"""VTuber game capture 領域検出 候補の実験 harness (#753, spec §6)。
+
+候補 (S1/S2/S3) を gyawa benchmark + OBS baseline に適用し、proxy 矩形
+(tests/baselines/v0.3.0/vtuber-primary-regions.json) に対する M1 (IoU /
+上端 px 誤差)、M2 (cost)、M4 (OBS で FULL_FRAME か) を比較表で出力する。
+
+Usage:
+    python scripts/vtuber_region_experiment.py --benchmark <mp4> --obs <mkv>...
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def pick_winner(rows: list[dict]) -> dict | None:
+    """OBS hard gate (M4) を通過した候補のうち mean_iou 最大を返す。"""
+    eligible = [r for r in rows if r.get("obs_full_frame", True)]
+    if not eligible:
+        return None
+    return max(eligible, key=lambda r: r["mean_iou"])
+
+
+def format_comparison_table(rows: list[dict]) -> str:
+    header = f"{'candidate':<10}{'mean_iou':>10}{'top_err_px':>12}{'cost_s':>10}"
+    lines = [header, "-" * len(header)]
+    for r in rows:
+        lines.append(
+            f"{r['candidate']:<10}{r.get('mean_iou', 0):>10.3f}"
+            f"{r.get('mean_top_err_px', 0):>12.1f}{r.get('cost_s', 0):>10.1f}"
+        )
+    return "\n".join(lines)
+
+
+def _run_on_benchmark(...):  # 実走部 (ffmpeg sampling + 各検出器呼び出し)
+    """machine-unverifiable: real video を要するため CI では走らせない。
+    実装時に Task D.1 で手動実行する。下記を行う:
+    - benchmark から annotation timestamp 近傍フレームを抽出
+    - S1/S3 はグレースケール stack、S2 は 1920x1080 RGB を渡す
+    - detect_* を呼び iou()/top_edge_error_px() で M1 を集計、時間で M2
+    - OBS baseline で各検出器が FULL_FRAME を返すか (M4)
+    """
+    raise NotImplementedError("Task D.1 で実走部を実装・手動実行")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark", type=Path, required=True)
+    parser.add_argument("--obs", type=Path, nargs="*", default=[])
+    parser.add_argument(
+        "--regions",
+        type=Path,
+        default=Path("tests/baselines/v0.3.0/vtuber-primary-regions.json"),
+    )
+    args = parser.parse_args(argv)
+    rows = _run_on_benchmark(args)  # noqa: F841 (Task D.1)
+    print(format_comparison_table(rows))
+    winner = pick_winner(rows)
+    print(f"\nWINNER (M4 gate + max IoU): {winner['candidate'] if winner else 'NONE'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+> `_run_on_benchmark` の本体は Task D.1 (実走) で埋める。Wave C では集計・整形・選定ロジック (`pick_winner`/`format_comparison_table`) のみ TDD 対象とし、実走は機械検証不可として分離する。
+
+- [ ] **Step 4: pass 確認** — Run: `pytest tests/scripts/test_vtuber_region_experiment.py -q` → PASS
+
+- [ ] **Step 5: Commit** — `feat(l3): 領域検出 実験 harness 集計ロジック (Refs #753)`
+
+### Task C.2: e2e spike — crop→Pass1→scorebar ±10s
+
+**Files:**
+
+- Create: `scripts/vtuber_region_spike.py`
+- Test: `tests/scripts/test_vtuber_region_spike.py`
+
+- [ ] **Step 1: 失敗するテスト (±10s 照合ロジック)**
+
+```python
+# tests/scripts/test_vtuber_region_spike.py
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "vtuber_region_spike",
+    Path(__file__).resolve().parents[2] / "scripts" / "vtuber_region_spike.py",
+)
+mod = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mod)
+
+
+def test_match_within_tolerance_all_hit():
+    gt = [1433, 2624, 4253, 5684, 6609]
+    detected = [1435, 2620, 4258, 5680, 6612]   # 全て ±10s 内
+    matched, misses = mod.match_within_tolerance(detected, gt, tol=10)
+    assert matched == 5 and misses == []
+
+
+def test_match_within_tolerance_reports_miss():
+    gt = [1433, 2624]
+    detected = [1435]                            # 2624 は未検出
+    matched, misses = mod.match_within_tolerance(detected, gt, tol=10)
+    assert matched == 1 and misses == [2624]
+```
+
+- [ ] **Step 2: fail 確認** — Run: `pytest tests/scripts/test_vtuber_region_spike.py -q` → FAIL
+
+- [ ] **Step 3: 実装**
+
+```python
+# scripts/vtuber_region_spike.py
+"""e2e 実現可能性 spike: crop→Pass1→scorebar の ±10s 実証 (#753, spec §7 M3)。
+
+選定 (または annotation) 領域で frame を crop し、領域内輝度で Pass 1 暗転
+検知 → 試合 start/end を抽出し、vtuber-primary-ground-truth.json と ±10s で
+照合する。本番 Pass1 wiring ではなく feasibility 確認 (machine-unverifiable)。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def match_within_tolerance(
+    detected: list[float], ground_truth: list[float], tol: float = 10.0
+) -> tuple[int, list[float]]:
+    """各 ground_truth 時刻に ±tol 内の detected があれば matched。
+
+    Returns (matched_count, [未検出の gt 時刻])。
+    """
+    matched = 0
+    misses: list[float] = []
+    for g in ground_truth:
+        if any(abs(d - g) <= tol for d in detected):
+            matched += 1
+        else:
+            misses.append(g)
+    return matched, misses
+
+
+def _run_spike(...):  # 実走部 (machine-unverifiable)
+    """benchmark を sampling → region で crop → 輝度 → 暗転 → segment 抽出。
+    Task D.1 で実装・手動実行。Pass 1 本体は再利用せず最小再実装 (feasibility)。
+    """
+    raise NotImplementedError("Task D.1 で実走部を実装・手動実行")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark", type=Path, required=True)
+    parser.add_argument(
+        "--ground-truth",
+        type=Path,
+        default=Path("tests/baselines/v0.3.0/vtuber-primary-ground-truth.json"),
+    )
+    parser.add_argument("--tol", type=float, default=10.0)
+    args = parser.parse_args(argv)
+    gt_data = json.loads(args.ground_truth.read_text(encoding="utf-8"))
+    starts = [m["start_time"] for m in gt_data["matches"]]
+    detected = _run_spike(args)  # Task D.1
+    matched, misses = match_within_tolerance(detected, starts, args.tol)
+    print(f"matched {matched}/{len(starts)} within +-{args.tol}s; misses={misses}")
+    return 0 if matched == len(starts) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: pass 確認** — Run: `pytest tests/scripts/test_vtuber_region_spike.py -q` → PASS
+
+- [ ] **Step 5: Commit** — `feat(l3): e2e spike ±10s 照合ロジック (Refs #753)`
+
+### Task C.3: M4 OBS 回帰 — full-frame 縮退の単体保証
+
+Wave B の各 `*_full_frame*` / `*_snaps_full` テストで合成 OBS フレームの FULL_FRAME 縮退は既に保証済み。本タスクは「全検出器が FULL_FRAME を返す」横断テストを 1 本足し、回帰ゲートを明示する。
+
+**Files:**
+
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: 失敗するテスト**
+
+```python
+import pytest
+from allaganeye.video.capture_region import (
+    detect_region_variance, detect_region_blackout_overlap, FULL_FRAME,
+)
+
+
+def test_all_grayscale_detectors_snap_full_on_obs_like_input():
+    rng = np.random.default_rng(2)
+    motion = [rng.integers(0, 256, (180, 320), dtype=np.uint8) for _ in range(8)]
+    assert detect_region_variance(motion) == FULL_FRAME
+    bright = np.full((180, 320), 120, dtype=np.uint8)
+    dark = np.full((180, 320), 2, dtype=np.uint8)
+    assert detect_region_blackout_overlap([bright, bright, dark]) == FULL_FRAME
+```
+
+- [ ] **Step 2: fail 確認 → Step 3: (実装済みなので) pass 確認** — Run: `pytest tests/test_capture_region.py -k obs_like -q` → PASS (Wave B 実装で満たされる; fail する場合は閾値/ snap を調整)
+
+- [ ] **Step 4: Commit** — `test(l3): OBS full-frame 縮退 横断回帰ゲート (Refs #753)`
+
+> **machine-unverifiable (M4 完全版)**: 合成フレームの縮退に加え、実 OBS baseline での bit-exact は Task D.1 で `scripts/compare-baseline.py` を使って確認する (real video 要)。
+
+---
+
+## Wave D: 実験実走 + 選定 + 記録 (machine-unverifiable)
+
+> 以降は real video (gyawa benchmark + OBS baseline 5 本) + GPU + user 確認を要する。CI では走らない。PR 本文では plain bullet で記載。
+
+### Task D.1: harness/spike 実走部の実装と計測
+
+- [ ] `vtuber_region_experiment.py::_run_on_benchmark` と `vtuber_region_spike.py::_run_spike` の実走部を実装 (ffmpeg sampling、`_probe_frame_rgb_hires` 流用、crop 輝度の Pass1 最小再実装)。
+- [ ] `python scripts/vtuber_region_experiment.py --benchmark <gyawa> --obs <obs5本>` を実行し M1/M2/M4 比較表を取得。
+- [ ] `python scripts/vtuber_region_spike.py --benchmark <gyawa>` を実行し ±10s/index 1-5 (M3) を確認。
+- [ ] OBS baseline 5 本で `compare-baseline.py` により detect 出力 bit-exact (M4 完全版) を確認。
+- [ ] 計測ログを worktree に保存 (PR の Self-Test Report に添付)。
+
+### Task D.2: 勝者確定 + 敗者刈り込み
+
+- [ ] `pick_winner` 結果と spec §6.3 選定手順 (M4 gate → M1 → M2 → M3) に基づき採用候補を確定。
+- [ ] 不採用候補の検出器関数を `capture_region.py` から削除 (または `# experimental` として残すか user 判断)。
+- [ ] 閾値定数 (`_VAR_THRESHOLD` 等) を実測に合わせて調整し、Wave B テストの許容値を必要なら更新。
+
+### Task D.3: spec へ実測・選定を追記
+
+- [ ] `docs/superpowers/specs/2026-05-26-...-design.md` §6.3 に M1–M4 実測表、§11 決定ログに採用候補を追記。
+- [ ] §10 Open question 1 (検出シグナル最終選定) / 2 (再検出粒度) を実測に基づき close。
+- [ ] Commit: `docs(l3): 領域検出 実験結果と選定を spec に追記 (Refs #753)`
+
+### Task D.4: 下流 child issue 起票案の記録 (Iron Law 2 — 作成は user 確認後)
+
+- [ ] spec §8.2 の issue 分解 (Pass1 wiring / #480 / #481 / metadata スキーマ) を起票文面案として worktree のメモか PR 本文に記録。
+- [ ] **実際の `gh issue create` は行わない**。3 件以上の issue 操作になるため user 確認後に別途実施。
+
+---
+
+## 実機検証 trigger (PR 作成時に AskUserQuestion で依頼)
+
+- 本 issue は新規モジュール中心で `detector.py` 本体ロジックは原則変更しない。ただし Task B.2 で `_find_scorebar_horizontal_range` に `y_start/y_end` 引数を足す改修を選んだ場合、既存 V2 path への回帰がないことを実 OBS 動画で確認 (`test_scorebar_v2.py` + baseline) する必要があり、実機検証 trigger に該当。
+- Wave D の harness/spike 実走は GPU + 長尺動画 (gyawa 2h43m / OBS 5 本) を要し mock 不可 → user (Idios) に実機実行を依頼。
+
+## Self-Review (この plan を書いた直後の自己点検)
+
+- **Spec coverage**: spec §4 contract → Task A.1 / §5 S1-S3 → Task B.1-B.3 / §6 harness+M1-M4 → Task C.1,C.3,D.1 / §7 e2e spike → Task C.2,D.1 / §6.4 annotation → Task 0.1 / §8.2 issue 分解 → Task D.4 / §11 決定ログ更新 → Task D.3。全項目に対応タスクあり。
+- **Placeholder**: `_run_on_benchmark`/`_run_spike` の本体は意図的に Task D.1 へ分離 (real-video 依存で TDD 不可)。それ以外に TODO/TBD なし。annotation JSON の 0.00 は「目視値で必ず置換」と明記。
+- **型整合**: `CaptureRegion(x,y,w,h,confidence,source)` / `iou`/`top_edge_error_px`/`_maybe_snap_full_frame` / `detect_region_variance|scorebar_band|blackout_overlap` / `pick_winner`/`format_comparison_table` / `match_within_tolerance` — 全タスクで名称・引数一貫。検出器は S1/S3=グレースケール stack、S2=1920x1080 RGB 単フレームで統一。

--- a/docs/superpowers/specs/2026-05-26-vtuber-capture-region-detection-design.md
+++ b/docs/superpowers/specs/2026-05-26-vtuber-capture-region-detection-design.md
@@ -154,12 +154,41 @@ RegionTimeline = {
 | M3 | e2e (±10s) | crop→Pass1→scorebar spike が 5 試合を検出し start/end が ground truth ±10s・index 1-5 一致 | Phase 2b 完了基準と同値 |
 | M4 | OBS 回帰 | OBS baseline で領域 = frame 全体 & detect 出力 bit-exact | 5 本すべて pass (**hard gate**) |
 
-### 6.3 選定手順 (実測値は実験後に本 spec へ追記)
+### 6.3 選定手順 (実測済み 2026-05-27)
 
 1. **M4 (OBS 回帰) pass を hard gate** — fail する候補は不採用。
 2. VTuber 領域精度 (M1) 最大。
 3. コスト (M2) 許容。
 4. e2e (M3) ±10s 達成。
+
+### 6.3.1 実測結果 (2026-05-27, gyawa benchmark + OBS baseline 5 本)
+
+`scripts/vtuber_region_experiment.py` / `scripts/vtuber_region_spike.py` を実機
+(Windows, ffmpeg 8.1) で手動実行した結果。proxy 矩形は `vtuber-primary-regions.json`
+(レイアウト A=B static、正規化 0.1302 / 0.0898 / 0.8698 / 0.8667)。
+
+| 候補 | tier | M1 IoU | M1 上端誤差 | M2 cost | M4 OBS 縮退 |
+| --- | --- | --- | --- | --- | --- |
+| S1 時間分散 | A coarse | 0.846 | 11px | ~0s (probe 除く) | FULL_FRAME x5 = PASS |
+| S2 scorebar 帯 | B precise | 0.188 (注1) | 上端 15.7px (注2) | ~1.8s / 4 frame | inset 誤検出 x5 = coarse 不適 (注3) |
+| S3 暗転重なり | A coarse | **0.851** | **11px** | ~0s (probe 除く) | FULL_FRAME x5 = PASS |
+
+- 注1: S2 の full-rect IoU が低いのは設計上の帰結。FL scorebar は game 全幅ではなく中央 ~835px の HUD であり、帯幅からの 16:9 game 逆算が成立しない。
+- 注2: S2 の主指標は上端 px 誤差 (scorebar ROI #480 が要求するのは精密な上端 / y-band)。検出できた frame では上端 1-23px (平均 15.7px)、検出率 3/4。
+- 注3: 単一 scorebar frame では OBS (game = 全画面) と VTuber (game = inset) を区別できない (scorebar は両者で同一の中央 HUD)。S2 は OBS で誤った inset を主張するため coarse には使えず、Tier B precise 限定が hard constraint。
+
+**M3 spike (crop -> Pass1 -> ±10s)**:
+
+- full-frame 輝度 Pass1: **start 0/5** (overlay により暗転中も平均輝度 ~52 に張り付き、threshold 15 で 1 件も検出できず = finding #4 を実測再現)。
+- 領域 crop 輝度 Pass1: **start 4/5 + end 5/5** (threshold 30, interval 2.0s, tol ±10s)。9/10 境界を ±10s で検出。
+- 唯一の miss (試合 3 start) は fade-in recover (~4264s) と手動 gt start (4253s) の ~11s 較正差であり検出失敗ではない (Open Q4)。
+- 追加 finding: game 領域 crop の暗転 floor は ~17-20 (FF14 の load 画面は純黒でなく薄い UI / 背景を含む)。full-frame OBS の `blackout_threshold=15` より高い閾値 (~30) が領域 crop には必要。Pass1 wiring child issue の直接の入力。
+
+**選定結論**:
+
+- **Tier A coarse (Pass1 領域輝度へ供給)** = **S3 暗転重なり**。IoU 0.851 で S1 (0.846) を僅かに上回り、overlay は暗転しないため webcam / chat の動き混入 (R3) に対し S1 時間分散より頑健。S1 は近接候補として残置 (1-source 過学習 R6 回避、削除可否は別途 user 判断)。
+- **Tier B precise (scorebar ROI #480 へ供給)** = **S2 scorebar 帯**。ただし full-rect ではなく**上端 px (y-band) のみ**を消費し、横 extent は Tier A から取得する。
+- **M4 hard gate**: 本 issue は detector.py 本体を変更しないため production detect 出力は構造的に bit-exact (region 検出を wiring しない)。S1 / S3 の OBS FULL_FRAME 縮退は将来 wiring 時の前方互換性として実測確認した。
 
 ### 6.4 proxy ground truth (新規 annotation 成果物)
 
@@ -207,10 +236,10 @@ RegionTimeline = {
 
 ## 10. Open questions (writing-plans / 実装で解決)
 
-1. **検出シグナルの最終選定**: §6 harness の実測後に確定 (本 spec へ追記)。
-2. **再検出粒度**: per-blackout / per-segment / 固定時間窓 のいずれか (M2 コストと R4 のトレードオフで決定)。
-3. **本番 metadata.json スキーマ**: consumer (Pass1 wiring / #480 / #481) と整合して別途確定。
-4. **annotation tolerance の具体値**: M1 の IoU / 上端 px 閾値を実データで較正。
+1. **検出シグナルの最終選定**: **CLOSED (2026-05-27, §6.3.1)** — Tier A coarse = S3 暗転重なり、Tier B precise = S2 scorebar 帯 (上端 y-band のみ)。
+2. **再検出粒度**: **CLOSED (暫定)** — gyawa は A=B static のため coarse 1 領域で十分 (実測)。per-segment 再検出は layout が変化する他 VOD 向けの一般 capability として contract (`RegionTimeline.segments`) に保持。本ベンチでは static のため発火せず。
+3. **本番 metadata.json スキーマ**: consumer (Pass1 wiring / #480 / #481) と整合して別途確定 (下流のまま)。
+4. **annotation tolerance の具体値**: **CLOSED (暫定, §6.3.1)** — M1 上端 <=~15px は S2 / S3 とも満たす。M3 試合 3 start の ~11s 較正差は Pass1 wiring issue で「試合 start = fade-in recover」と定義を確定して解消する。
 
 ## 11. 決定ログ (本ブレストの選択)
 
@@ -220,6 +249,9 @@ RegionTimeline = {
 | 本 issue の検証 | **proxy metric (IoU/px) + thin e2e spike** (full wiring でも harness-only でもない) |
 | Pass 1 の扱い | **第一級利用者として設計に含める + e2e spike で ±10s 実証** (別 issue 分離でも #480 統合でもない)。本番 wiring は別 child issue |
 | 検出アルゴリズム | **spec で固定せず harness で実験選定** |
+| 検出アルゴリズム (実測選定 2026-05-27) | **Tier A coarse = S3 暗転重なり** (IoU 0.851, OBS FULL_FRAME), **Tier B precise = S2 scorebar 帯の上端 y-band のみ** (上端 15.7px)。S1 は近接候補として残置 |
+| S2 の使い方 (実測) | full-rect ではなく**上端のみ**消費 (横 extent は Tier A から)。OBS で inset 誤検出するため coarse 不可 = Tier B 限定が hard constraint |
+| Pass1 領域 crop の閾値 (実測) | 領域 crop の暗転 floor ~17-20 のため OBS の `blackout_threshold=15` より高い ~30 が必要 (Pass1 wiring child issue へ申し送り) |
 | guard | gyawa benchmark は trusted 扱い (user 確認 2026-05-26) |
 
 ## 12. 参照

--- a/docs/superpowers/specs/2026-05-26-vtuber-capture-region-detection-design.md
+++ b/docs/superpowers/specs/2026-05-26-vtuber-capture-region-detection-design.md
@@ -167,6 +167,17 @@ RegionTimeline = {
 (Windows, ffmpeg 8.1) で手動実行した結果。proxy 矩形は `vtuber-primary-regions.json`
 (レイアウト A=B static、正規化 0.1302 / 0.0898 / 0.8698 / 0.8667)。
 
+再現コマンド (worktree root を `PYTHONPATH` に通して実行):
+
+```bash
+# M1/M2/M4: 実験 harness
+python scripts/vtuber_region_experiment.py --benchmark <gyawa.mp4> --obs-dir <ALLAGANEYE_SAMPLE_VIDEO_DIR>
+# M3: e2e spike (threshold/interval を明示。default は threshold 15 = production 値)
+python scripts/vtuber_region_spike.py --benchmark <gyawa.mp4> --threshold 30 --interval 2.0
+```
+
+下表および M3 の `start 4/5 + end 5/5` は上記コマンド (spike は threshold 30 / interval 2.0) の結果。spike を default (threshold 15) で実行すると crop start は 1/5 に留まり、これが「領域 crop の暗転 floor ~17-20 に対し ~30 の閾値が必要」という finding の根拠そのものになる。
+
 | 候補 | tier | M1 IoU | M1 上端誤差 | M2 cost | M4 OBS 縮退 |
 | --- | --- | --- | --- | --- | --- |
 | S1 時間分散 | A coarse | 0.846 | 11px | ~0s (probe 除く) | FULL_FRAME x5 = PASS |

--- a/docs/superpowers/specs/2026-05-26-vtuber-capture-region-detection-design.md
+++ b/docs/superpowers/specs/2026-05-26-vtuber-capture-region-detection-design.md
@@ -1,0 +1,231 @@
+# L3: VTuber game capture 領域検出アルゴリズム設計 (Phase 2a) (2026-05-26)
+
+> **Status**: brainstorming 完了 / implementation plan は writing-plans で別途作成
+> **Parent**: [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753)
+> **上位 spec**: [docs/superpowers/specs/2026-05-18-v030-l3-redefinition-design.md](2026-05-18-v030-l3-redefinition-design.md) §3 (Pillar 1+2), §8.4 (VTuber Ground Truth)
+> **検証対象**: `tests/baselines/v0.3.0/vtuber-primary-ground-truth.json` (5 試合, ±10s)
+
+## 1. 背景と目的
+
+### 1.1 きっかけ
+
+- L3 Pillar 1 (VTuber 配信動画対応) の最初の技術タスク (Phase 2a)。
+- VTuber 配信動画は frame 内に overlay (webcam / 枠装飾 / alert / chat) と一緒に gameplay が小さく **inset** で映る。
+- 現状 scorebar V2 検出 (`allaganeye/video/scorebar.py`, `allaganeye/video/detector.py` の `_has_scorebar_v2`) は 1920x1080 frame **全体**の固定/準固定座標を前提とし、overlay があると完全に break する。
+  - Primary path `_EMBLEM_POSITIONS` は絶対 px 座標 (detector.py:928)。
+  - Rescue path `_find_scorebar_horizontal_range` も走査行を `y=0..45` (`_SCOREBAR_SCAN_Y_START/END`, detector.py:986) に限定しており、frame 上端しか見ない。
+- 本 issue は **gameplay 矩形 (game capture region) の自動検出アルゴリズム** を設計・実装・実験選定する。検出矩形は Pass 1 暗転検知 / scorebar (#480) / minimap (#481) が共有利用する。
+
+### 1.2 前提
+
+- Phase 1 (Pillar 3) 完了、`tests/baselines/v0.3.0/` baseline 確定済。
+- primary benchmark: gyawa 提供 VTuber VOD
+  `E:\videos\gyawa_vatos\2772549129-151803977-da21c691-9ed6-4068-9a8b-4726a8a519a8.mp4`
+  (7,554,775,607 bytes, **H.264 1920x1080 60fps, 約 2h43m**)。guard は trusted 扱い (user 確認 2026-05-26)。
+- ground truth: `tests/baselines/v0.3.0/vtuber-primary-ground-truth.json` (5 試合, `tolerance_sec=10`)。
+
+### 1.3 scope guard
+
+- 本 issue = **検出アルゴリズムの設計・実装・実験選定 + proxy 検証 + e2e spike** まで。
+- 下流 (別 issue): scorebar 検出本体 (#480) / minimap 切抜き (#481) / Pass 1 本番 wiring / metadata.json 本番スキーマ確定。
+
+## 2. 実証で確定した前提 (gyawa benchmark grounding)
+
+2026-05-26、benchmark から代表フレーム (`t=300/1900/2361/2490/4700/6900`) を抽出して目視確認し、さらに輝度プローブを実行した。以降の設計はこの実測に基づく。
+
+### 2.1 レイアウト観察 (frame 目視)
+
+1. **ゲーム画面は inset 矩形、周囲は明るい overlay、黒帯なし。** シアン帯 (上, 全幅) / アバター webcam (左) / 装飾カード (右) / フォロワーバー (下) に囲まれる。
+   → **letterbox / pillarbox 黒帯検出 (元案 a) は適用不可。**
+2. **scorebar は帯の下** = ゲーム領域の上端にあり、frame 上端 `y=0..45` ではない。現 V2 両 path が break する直接原因。
+3. **VOD 内でレイアウトが変化する。** 試合1 (`t=1900/2361`) は小さめ + 装飾多め、ウォームアップ (`t=300`) と試合3/5 (`t=4700/6900`) は大きめのゲーム領域。
+   → 領域は時刻範囲に紐づく必要があり、単一の global 矩形は不適 (per-segment 再検出の根拠)。
+
+### 2.2 輝度プローブ — Pass 1 の決定的問題 (finding #4)
+
+window `[2330, 2670]` (試合1終 2361 / 試合2始 2624 を含む) を `fps=1, scale=320:180, format=gray` で抽出し、full-frame 平均と中央 crop (`x∈[30%,70%], y∈[15%,80%]`) 平均を比較:
+
+| 区間 | 内容 | full-frame 平均 | 中央(game) 平均 |
+| --- | --- | --- | --- |
+| 2330–2360 | 試合中 | ≈128 | ≈164 |
+| 2361–2363 | 試合1終 暗転 | **52–66** | **0.1–19** |
+| 2370–2610 | results / lobby | 90–106 | 50–86 |
+| 2615–2629 | 試合2 load-in 暗転 (~15s) | **52–55** | **0.0** |
+
+**結論**: 実暗転中の full-frame 輝度下限は **≈52**。default `blackout_threshold = 15.0` ([config.py:15](../../../allaganeye/config.py)) の **3.5 倍**であり、Pass 1 (full-frame 輝度) は**境界を検出できない**。一方ゲーム領域だけなら **0.0** まで落ち、明確に検出可能。
+→ **領域検出は scorebar/minimap だけでなく Pass 1 暗転検知そのものの前提条件**であり、当初スコープ ("scorebar + minimap の基盤") に無かった論点。再現スクリプトは §6 harness に取り込む。
+
+### 2.3 candidate 評価 (実証ベース)
+
+| 案 | 判定 | 根拠 |
+| --- | --- | --- |
+| (a) letterbox / pillarbox | ❌ | 黒帯が無い (§2.1-1) |
+| (c) 汎用 FF14 UI テンプレート | ❌ | スケール未知で脆い。FL 固有アンカーは scorebar の方が確実 |
+| (b-1) **時間分散** (S1) | ✅ | ゲーム=動き大 / overlay=静止。レイアウト非依存、OBS で frame 全体を覆う = fallback 安全 |
+| (b-2) **暗転重なり** (S3) | ✅ | 遷移中に暗くなる画素 = ゲーム領域 (finding #4 を直接活用) |
+| (d) **scorebar 帯アンカー** (S2) | ✅ | Rescue の y 走査を全 frame に拡張。FL 固有・精密だが試合中のみ |
+| (e) **複合** | ✅ | 推奨 (S1 coarse + S2/S3 precise) |
+
+## 3. アーキテクチャ
+
+### 3.1 2-tier 領域モデル
+
+「per-segment 再検出」かつ「Pass 1 が第一級利用者」という制約から領域を 2 層で扱う。
+
+| Tier | 役割 | 利用者 | 性質 |
+| --- | --- | --- | --- |
+| **Tier A — coarse 領域** | Pass 1 が「領域内輝度」で暗転検出できる最小限の領域 | Pass 1 暗転検知 | レイアウト変化に保守的 (常に game な中央コア)。OBS では frame 全体に解決 |
+| **Tier B — precise 領域 (per-segment)** | 各候補セグメント近傍の試合中フレームから再検出する精密矩形 | scorebar #480 / minimap #481 | 時刻範囲に紐づくタイムライン |
+
+### 3.2 bootstrapping 順序 + data flow
+
+「領域がないと暗転が取れない / 暗転がないとセグメントが分からない」を粗→精の段階適用で解く。
+
+```text
+video
+  │
+  ▼
+[Tier A: coarse 領域検出]   ← overlay 有無を判定。OBS → frame 全体 / VTuber → 中央 inset
+  │
+  ▼
+[Pass 1 暗転検知]            ← coarse 領域内の輝度で閾値判定 (full-frame ではなく)
+  │
+  ▼
+候補セグメント / 境界
+  │
+  ▼
+[Tier B: per-segment 精密領域 再検出]
+  │
+  ├──────────────┬───────────────┐
+  ▼              ▼               ▼
+Pass1 微調整    scorebar #480    minimap #481   ← 領域 contract の利用者
+(任意)
+```
+
+### 3.3 検出器は spec で固定しない (実験選定)
+
+Tier A/B の検出シグナルは spec で 1 案に確定せず、§6 の harness で候補 (S1 分散 / S2 scorebar 帯 / S3 暗転重なり / 複合) を benchmark + OBS で比較して選定する (決定ログ §11)。
+
+### 3.4 fallback と回帰安全 (最重要制約)
+
+- 低信頼 → **full-frame** (領域 = frame 全体)。
+- **OBS では Tier A が必ず full-frame に解決し、Pass 1 輝度が現行と数値一致 = v0.3.0 baseline を bit-exact 維持**しなければならない。
+- 誤って inset 判定すると baseline が壊れるため、Tier A は「inset 宣言」に強い保守バイアス (confidence gate) をかけ、harness の M4 で「OBS = 領域全体 & detect 出力 bit-exact」を hard gate として assert する。
+
+## 4. 出力 contract (データモデル)
+
+矩形は**解像度非依存の正規化座標** `[0,1]` で表現する。
+
+```text
+CaptureRegion  = { x, y, w, h: float[0,1], confidence: float[0,1], source: "tierB"|"tierA"|"fallback" }
+RegionTimeline = {
+    coarse:   CaptureRegion,                                       # Tier A (Pass 1 用)
+    segments: [ { time_range: [t0, t1], region: CaptureRegion } ]  # Tier B (#480/#481 用)
+}
+```
+
+- **本番 metadata.json への載せ方は本 issue では「契約スケッチ」止まり**。最終スキーマは Pass1 wiring / #480 / #481 と共有の関心事なので、それらと整合させて確定する (上位 spec §3 「metadata.json 拡張」を分担)。
+- 実験・spike では metadata を確定させず、サイドカー JSON (`tests/baselines/v0.3.0/vtuber-primary-regions.json`) に領域を吐いて proxy メトリクスに使う。
+
+## 5. 検出 candidate signals (実験対象)
+
+| ID | シグナル | 概要 | 適用 Tier | 弱点 |
+| --- | --- | --- | --- | --- |
+| **S1** | 時間分散 | N 枚サンプルの画素分散マップ → 高分散の最大連結矩形 | A (coarse) | webcam/chat の動きが混入 |
+| **S2** | scorebar 帯アンカー | `_find_scorebar_horizontal_range` を全 y 走査に拡張 → game 上端+幅+スケール。GC 紋章 3 点 AND (既存検証済) で FL 固有性を担保 | B (precise) | 試合中のみ・上端+幅のみ (全矩形でない) |
+| **S3** | 暗転重なり | 遷移中に暗くなる画素の重なり = game 領域 (finding #4) | A/B | coarse bootstrap が必要 (chicken-egg) |
+| **複合** | S1+S2 / S1+S3 等 | coarse は S1/S3、precise は S2 で上端・スケールを精緻化 | A+B | 実装量 |
+
+- S2 は既存 `_has_scorebar_v2` の機構 (GC 紋章 3 点 AND) を**領域検出シグナルとして**流用する。#480 の「scorebar で暗転を分類する」用途とは目的が別 (重複しない)。
+
+## 6. 実験 harness + メトリクス + 選定手順
+
+### 6.1 harness
+
+- 置き場所: `scripts/vtuber_region_experiment.py` (`scripts/compare-baseline.py` と同列の保守スクリプト。入力形式が増えたとき再実行できるよう残す)。
+- やること: 候補 (S1/S2/S3/複合) を benchmark + OBS baseline に適用し、下記メトリクスを計測して比較表を出力 → 勝者選定。§2.2 の輝度プローブもここに取り込む。
+
+### 6.2 メトリクス
+
+| # | 指標 | 内容 | 暫定基準 (実験で調整) |
+| --- | --- | --- | --- |
+| M1 | 領域精度 | 検出矩形 vs 正解矩形の IoU、および**上端 px 誤差** (scorebar 用に最重要) | IoU ≥ 0.9 / 上端誤差 ≤ ~15px |
+| M2 | コスト | detect への追加 wall-time | 現行 detect 比で許容範囲 |
+| M3 | e2e (±10s) | crop→Pass1→scorebar spike が 5 試合を検出し start/end が ground truth ±10s・index 1-5 一致 | Phase 2b 完了基準と同値 |
+| M4 | OBS 回帰 | OBS baseline で領域 = frame 全体 & detect 出力 bit-exact | 5 本すべて pass (**hard gate**) |
+
+### 6.3 選定手順 (実測値は実験後に本 spec へ追記)
+
+1. **M4 (OBS 回帰) pass を hard gate** — fail する候補は不採用。
+2. VTuber 領域精度 (M1) 最大。
+3. コスト (M2) 許容。
+4. e2e (M3) ±10s 達成。
+
+### 6.4 proxy ground truth (新規 annotation 成果物)
+
+- 既存 `vtuber-primary-ground-truth.json` は「試合の時刻」、新規 `vtuber-primary-regions.json` は「ゲーム矩形」で別物・補完関係。
+- 作り方: 抽出フレームを目視して各レイアウト (本ベンチは 2 種以上) の正解矩形を**初回推定 → user が確認・補正** → 確定。1 レイアウトにつき試合中フレーム数点 (計 5〜10 矩形) で十分。
+
+## 7. 検証 / exit 基準 (本 issue)
+
+1. **M1**: 両レイアウトの正解矩形に対し IoU 基準クリア。
+2. **M4**: OBS baseline 5 本で領域 = 全体 + bit-exact 再現 (**最重要・hard gate**)。
+3. **M3 spike**: crop→Pass1→scorebar で 5 試合 ±10s 検出を**実現可能性として実証** (本番 Pass1 wiring・#480・#481 は下流)。
+
+## 8. スコープ境界と issue 分解
+
+### 8.1 やる / やらない
+
+- **やる**: Tier A/B 検出アルゴリズム (候補実装 + 実験選定) / 領域出力 contract (in-memory 型 + サイドカー JSON) / harness + メトリクス M1–M4 / proxy 検証 (annotation 含む) + e2e spike。
+- **やらない (下流 issue)**: 本番 Pass 1 領域輝度 wiring / scorebar ROI 適応本体 (#480) / minimap 切抜き本体 (#481) / 本番 metadata.json スキーマ確定。
+
+### 8.2 issue 分解 (#753 配下、Phase 2a 起点)
+
+```text
+#753 (parent: VTuber + minimap)
+ ├─ [NEW] L3: game capture 領域検出アルゴリズム      ← 本 issue (Phase 2a)。下記を block
+ ├─ [NEW] L3: Pass 1 暗転検知の領域輝度適応 (本番 wiring)  ← finding #4 由来、当初スコープ外
+ ├─ #480  L3: scorebar ROI 適応化                  ← precise 領域を消費
+ ├─ #481  L3: minimap 切抜き                       ← precise 領域を消費
+ └─ (共有) metadata.json 領域フィールド確定          ← 上記 consumer と整合
+```
+
+- **Iron Law 2/3 注意**: 新規 child issue 作成は本ブレストでは**行わない**。3 件以上の issue 操作になり得るため、起票は別途 user 確認を取ってから (writing-plans 後など)。本 spec は分解案の記録に留める。
+
+## 9. リスクと緩和
+
+| # | リスク | 緩和 |
+| --- | --- | --- |
+| R1 | OBS を誤って inset 判定 → baseline 破壊 | Tier A に強保守バイアス + M4 で全体一致 & bit-exact を hard gate |
+| R2 | S2 がシアン帯等の高彩度 overlay を誤検出 | FL 固有の GC 紋章 3 点 AND (検証済機構) を流用、単純帯は通さない |
+| R3 | S1 分散に webcam/chat の動きが混入 | 最大連結成分 + FL アンカー (複合) で純化 |
+| R4 | 試合中のシーン切替で領域が割れる | 再検出粒度を調整、セグメント内は安定領域を採用 |
+| R5 | annotation の主観 (ゲーム端の取り方) | user 確認 + 許容誤差 (上端重視の px tolerance) |
+| R6 | VTuber ベンチが gyawa 1 本のみ → 過学習 | レイアウト非依存シグナルで一般化、選定は 1 ソース検証と明記。追加 VTuber ソースは後続 |
+| R7 | 将来の外部動画は guard 必須 | 新ベンチ追加時は `allaganeye-guard verify` 通過を前提に |
+| R8 | Tier B per-segment のプローブ増でコスト増 | 既存プローブ基盤を再利用し M2 で上限監視 |
+
+## 10. Open questions (writing-plans / 実装で解決)
+
+1. **検出シグナルの最終選定**: §6 harness の実測後に確定 (本 spec へ追記)。
+2. **再検出粒度**: per-blackout / per-segment / 固定時間窓 のいずれか (M2 コストと R4 のトレードオフで決定)。
+3. **本番 metadata.json スキーマ**: consumer (Pass1 wiring / #480 / #481) と整合して別途確定。
+4. **annotation tolerance の具体値**: M1 の IoU / 上端 px 閾値を実データで較正。
+
+## 11. 決定ログ (本ブレストの選択)
+
+| 論点 | 決定 |
+| --- | --- |
+| 領域の時間モデル | **per-segment / 再検出** (static global 矩形ではない) |
+| 本 issue の検証 | **proxy metric (IoU/px) + thin e2e spike** (full wiring でも harness-only でもない) |
+| Pass 1 の扱い | **第一級利用者として設計に含める + e2e spike で ±10s 実証** (別 issue 分離でも #480 統合でもない)。本番 wiring は別 child issue |
+| 検出アルゴリズム | **spec で固定せず harness で実験選定** |
+| guard | gyawa benchmark は trusted 扱い (user 確認 2026-05-26) |
+
+## 12. 参照
+
+- parent: [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753) / 関連: #480 (scorebar ROI 適応化), #481 (minimap 切抜き)
+- 上位 spec: [2026-05-18-v030-l3-redefinition-design.md](2026-05-18-v030-l3-redefinition-design.md) §3 / §8
+- 現状コード: `allaganeye/video/scorebar.py`, `allaganeye/video/detector.py` (`_has_scorebar_v2` detector.py:1190, `_find_scorebar_horizontal_range` detector.py:1073, `_EMBLEM_POSITIONS` detector.py:928)
+- baseline: `tests/baselines/v0.3.0/` (README.md / vtuber-primary-ground-truth.json) / 比較: `scripts/compare-baseline.py`
+- testing: [docs/testing-guide.md](../../testing-guide.md) §baseline drift の判定

--- a/scripts/vtuber_region_experiment.py
+++ b/scripts/vtuber_region_experiment.py
@@ -261,20 +261,26 @@ def _eval_obs_regression(
         bright = _sample_gray_frames(video, _mid_match_timestamps(matches))
         dark = _sample_gray_frames(video, _boundary_dark_timestamps(matches))
 
-        s1 = detect_region_variance(bright)
-        ok1 = s1 == FULL_FRAME
-        status["S1"].append(ok1)
-        detail["S1"].append(f"{label}={'full' if ok1 else _fmt(s1)}")
+        # S1/S3 は frame が 2 枚未満だと自明に FULL_FRAME へ縮退するため、probe
+        # 失敗 (frame 不足) を pass と数えると hard gate が無根拠に PASS してしまう。
+        # noframe (評価対象外) として status には積まず detail にのみ残す。
+        if len(bright) < 2:
+            detail["S1"].append(f"{label}=noframe")
+            detail["S3"].append(f"{label}=noframe")
+        else:
+            s1 = detect_region_variance(bright)
+            ok1 = s1 == FULL_FRAME
+            status["S1"].append(ok1)
+            detail["S1"].append(f"{label}={'full' if ok1 else _fmt(s1)}")
 
-        s3 = detect_region_blackout_overlap(bright + dark)
-        ok3 = s3 == FULL_FRAME
-        status["S3"].append(ok3)
-        detail["S3"].append(f"{label}={'full' if ok3 else _fmt(s3)}")
+            s3 = detect_region_blackout_overlap(bright + dark)
+            ok3 = s3 == FULL_FRAME
+            status["S3"].append(ok3)
+            detail["S3"].append(f"{label}={'full' if ok3 else _fmt(s3)}")
 
         mid = _mid_match_timestamps(matches)
         raw = _probe_frame_rgb_hires(video, mid[0]) if mid else None
         if raw is None:
-            status["S2"].append(True)
             detail["S2"].append(f"{label}=noframe")
         else:
             frame = np.frombuffer(raw, dtype=np.uint8).reshape(
@@ -286,7 +292,8 @@ def _eval_obs_regression(
             detail["S2"].append(
                 f"{label}={'none' if s2 is None else ('full' if s2 == FULL_FRAME else _fmt(s2))}"
             )
-    return {c: (all(v) if v else True, detail[c]) for c, v in status.items()}
+    # 評価できた video が 1 本も無ければ PASS にしない (no evidence != pass)。
+    return {c: (bool(v) and all(v), detail[c]) for c, v in status.items()}
 
 
 def _fmt(r) -> str:

--- a/scripts/vtuber_region_experiment.py
+++ b/scripts/vtuber_region_experiment.py
@@ -1,0 +1,63 @@
+"""VTuber game capture 領域検出 候補の実験 harness (#753, spec §6)。
+
+候補 (S1/S2/S3) を gyawa benchmark + OBS baseline に適用し、proxy 矩形
+(tests/baselines/v0.3.0/vtuber-primary-regions.json) に対する M1 (IoU /
+上端 px 誤差)、M2 (cost)、M4 (OBS で FULL_FRAME か) を比較表で出力する。
+
+Usage:
+    python scripts/vtuber_region_experiment.py --benchmark <mp4> --obs <mkv>...
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def pick_winner(rows: list[dict]) -> dict | None:
+    """OBS hard gate (M4) を通過した候補のうち mean_iou 最大を返す。"""
+    eligible = [r for r in rows if r.get("obs_full_frame", True)]
+    if not eligible:
+        return None
+    return max(eligible, key=lambda r: r["mean_iou"])
+
+
+def format_comparison_table(rows: list[dict]) -> str:
+    header = f"{'candidate':<10}{'mean_iou':>10}{'top_err_px':>12}{'cost_s':>10}"
+    lines = [header, "-" * len(header)]
+    for r in rows:
+        lines.append(
+            f"{r['candidate']:<10}{r.get('mean_iou', 0):>10.3f}"
+            f"{r.get('mean_top_err_px', 0):>12.1f}{r.get('cost_s', 0):>10.1f}"
+        )
+    return "\n".join(lines)
+
+
+def _run_on_benchmark(args: argparse.Namespace) -> list[dict]:
+    """実走部 (machine-unverifiable, real video 要)。Task D.1 で実装・手動実行。
+
+    benchmark の annotation timestamp 近傍フレームを抽出し S1/S2/S3 を適用、
+    iou()/top_edge_error_px() で M1、時間で M2、OBS baseline で M4 を集計する。
+    """
+    raise NotImplementedError("Task D.1 で実走部を実装・手動実行")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark", type=Path, required=True)
+    parser.add_argument("--obs", type=Path, nargs="*", default=[])
+    parser.add_argument(
+        "--regions",
+        type=Path,
+        default=Path("tests/baselines/v0.3.0/vtuber-primary-regions.json"),
+    )
+    args = parser.parse_args(argv)
+    rows = _run_on_benchmark(args)
+    print(format_comparison_table(rows))
+    winner = pick_winner(rows)
+    print(f"\nWINNER (M4 gate + max IoU): {winner['candidate'] if winner else 'NONE'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vtuber_region_experiment.py
+++ b/scripts/vtuber_region_experiment.py
@@ -1,17 +1,44 @@
-"""VTuber game capture 領域検出 候補の実験 harness (#753, spec §6)。
+"""VTuber game capture 領域検出 候補の実験 harness (#753, spec section 6)。
 
 候補 (S1/S2/S3) を gyawa benchmark + OBS baseline に適用し、proxy 矩形
 (tests/baselines/v0.3.0/vtuber-primary-regions.json) に対する M1 (IoU /
-上端 px 誤差)、M2 (cost)、M4 (OBS で FULL_FRAME か) を比較表で出力する。
+上端 px 誤差)、M2 (cost)、M4 (OBS で領域=全体 or 安全に decline) を比較表で
+出力する。
+
+Tier ごとに評価方法が異なる (spec section 3.1):
+- S1/S3 = Tier A coarse: 動画全域から **1 領域**を推定し静的正解矩形と比較。
+- S2     = Tier B precise: annotation timestamp ごとの **単フレーム**で推定。
+
+M4 (OBS 回帰) の合否 (spec section 6.2):
+- S1/S3 は Pass 1 coarse に直接使うため OBS では FULL_FRAME 必須。
+- S2 は Tier B precise (coarse Pass 1 には使わない)。#806 の max-width gate で
+  OBS の全幅 scorebar (>1440px) は None を返し decline する。誤った inset を
+  主張しなければ regression-safe なので None / FULL_FRAME を pass とみなす。
+- なお本 issue は detector.py 本体を変更しないため、production detect 出力は
+  構造的に bit-exact (M4 の bit-exact 部分は自明に満たす)。本 harness が測るのは
+  「将来 wiring したとき OBS で安全に縮退するか」という前方互換性。
 
 Usage:
-    python scripts/vtuber_region_experiment.py --benchmark <mp4> --obs <mkv>...
+    python scripts/vtuber_region_experiment.py --benchmark <gyawa.mp4> \
+        --obs-dir <ALLAGANEYE_SAMPLE_VIDEO_DIR>
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+
+import numpy as np
+
+from allaganeye.ffmpeg_path import find_ffmpeg
+
+_GRAY_W = 320
+_GRAY_H = 180
+_GRAY_SIZE = _GRAY_W * _GRAY_H
 
 
 def pick_winner(rows: list[dict]) -> dict | None:
@@ -23,39 +50,329 @@ def pick_winner(rows: list[dict]) -> dict | None:
 
 
 def format_comparison_table(rows: list[dict]) -> str:
-    header = f"{'candidate':<10}{'mean_iou':>10}{'top_err_px':>12}{'cost_s':>10}"
+    header = (
+        f"{'candidate':<10}{'tier':>6}{'mean_iou':>10}{'top_err_px':>12}"
+        f"{'cost_s':>10}{'obs_ok':>8}"
+    )
     lines = [header, "-" * len(header)]
     for r in rows:
+        obs = "PASS" if r.get("obs_full_frame", True) else "FAIL"
         lines.append(
-            f"{r['candidate']:<10}{r.get('mean_iou', 0):>10.3f}"
+            f"{r['candidate']:<10}{r.get('tier', '-'):>6}{r.get('mean_iou', 0):>10.3f}"
             f"{r.get('mean_top_err_px', 0):>12.1f}{r.get('cost_s', 0):>10.1f}"
+            f"{obs:>8}"
         )
     return "\n".join(lines)
 
 
-def _run_on_benchmark(args: argparse.Namespace) -> list[dict]:
-    """実走部 (machine-unverifiable, real video 要)。Task D.1 で実装・手動実行。
+def region_metrics(detected, truth, frame_h: int) -> dict:
+    """検出矩形 vs 正解矩形の M1 指標 (IoU / 上端 px 誤差)。
 
-    benchmark の annotation timestamp 近傍フレームを抽出し S1/S2/S3 を適用、
-    iou()/top_edge_error_px() で M1、時間で M2、OBS baseline で M4 を集計する。
+    *detected* が None (検出失敗) のときは最悪値 (iou=0, top_err=frame_h)。
     """
-    raise NotImplementedError("Task D.1 で実走部を実装・手動実行")
+    from allaganeye.video.capture_region import iou, top_edge_error_px
+
+    if detected is None:
+        return {"iou": 0.0, "top_err_px": float(frame_h)}
+    return {
+        "iou": iou(detected, truth),
+        "top_err_px": top_edge_error_px(detected, truth, frame_h),
+    }
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg sampling (machine-unverifiable: real video 要)
+# ---------------------------------------------------------------------------
+
+
+def _probe_gray_frame(video_path: Path, timestamp: float) -> np.ndarray | None:
+    """320x180 グレースケール単フレームを ndarray で返す (_probe_single_frame 同型)。"""
+    cmd = [
+        find_ffmpeg(),
+        "-threads",
+        "1",
+        "-ss",
+        str(timestamp),
+        "-i",
+        str(video_path),
+        "-frames:v",
+        "1",
+        "-s",
+        f"{_GRAY_W}x{_GRAY_H}",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "gray",
+        "pipe:1",
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0 or len(result.stdout) < _GRAY_SIZE:
+        return None
+    return np.frombuffer(result.stdout[:_GRAY_SIZE], dtype=np.uint8).reshape(
+        _GRAY_H, _GRAY_W
+    )
+
+
+def _sample_gray_frames(
+    video_path: Path, timestamps: list[float], workers: int = 12
+) -> list[np.ndarray]:
+    """複数タイムスタンプの gray frame を並列取得 (None は除外)。"""
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        results = list(ex.map(lambda t: _probe_gray_frame(video_path, t), timestamps))
+    return [f for f in results if f is not None]
+
+
+def _mid_match_timestamps(matches: list[dict]) -> list[float]:
+    """各試合の 25/50/75% 地点 (試合中=高輝度・高動き)。"""
+    out: list[float] = []
+    for m in matches:
+        s, e = float(m["start_time"]), float(m["end_time"])
+        dur = e - s
+        out += [s + 0.25 * dur, s + 0.5 * dur, s + 0.75 * dur]
+    return out
+
+
+def _boundary_dark_timestamps(matches: list[dict]) -> list[float]:
+    """各試合終了直後 (+2/+4s) と先頭試合開始直前 (-3s) の暗転フレーム。"""
+    out: list[float] = []
+    for m in matches:
+        e = float(m["end_time"])
+        out += [e + 2.0, e + 4.0]
+    out.append(max(0.0, float(matches[0]["start_time"]) - 3.0))
+    return out
+
+
+def _eval_tierA_on_benchmark(
+    video: Path, matches: list[dict], truth, frame_h: int
+) -> tuple[dict, dict]:
+    """S1 (variance) / S3 (blackout-overlap) を benchmark で 1 領域評価。"""
+    from allaganeye.video.capture_region import (
+        detect_region_blackout_overlap,
+        detect_region_variance,
+    )
+
+    mid_ts = _mid_match_timestamps(matches)
+    dark_ts = _boundary_dark_timestamps(matches)
+    bright = _sample_gray_frames(video, mid_ts)
+    dark = _sample_gray_frames(video, dark_ts)
+
+    t0 = time.time()
+    s1 = detect_region_variance(bright)
+    s1_cost = time.time() - t0
+    m1 = region_metrics(s1, truth, frame_h)
+    s1_row = {
+        "candidate": "S1",
+        "tier": "A",
+        "mean_iou": m1["iou"],
+        "mean_top_err_px": m1["top_err_px"],
+        "cost_s": s1_cost,
+    }
+
+    t0 = time.time()
+    s3 = detect_region_blackout_overlap(bright + dark)
+    s3_cost = time.time() - t0
+    m3 = region_metrics(s3, truth, frame_h)
+    s3_row = {
+        "candidate": "S3",
+        "tier": "A",
+        "mean_iou": m3["iou"],
+        "mean_top_err_px": m3["top_err_px"],
+        "cost_s": s3_cost,
+    }
+    return s1_row, s3_row
+
+
+def _eval_tierB_on_benchmark(video: Path, truths: list[tuple], frame_h: int) -> dict:
+    """S2 (scorebar-band) を annotation timestamp ごとに単フレーム評価。"""
+    from allaganeye.video.capture_region import detect_region_scorebar_band
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+        _probe_frame_rgb_hires,
+    )
+
+    ious: list[float] = []
+    errs: list[float] = []
+    hit_top_errs: list[float] = []  # 上端誤差は検出できた frame のみ (S2 の主指標)
+    t0 = time.time()
+    for ts, truth in truths:
+        raw = _probe_frame_rgb_hires(video, float(ts))
+        if raw is None:
+            ious.append(0.0)
+            errs.append(float(frame_h))
+            continue
+        frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+            _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+        )
+        det = detect_region_scorebar_band(frame)
+        m = region_metrics(det, truth, frame_h)
+        ious.append(m["iou"])
+        errs.append(m["top_err_px"])
+        if det is not None:
+            hit_top_errs.append(m["top_err_px"])
+    cost = time.time() - t0
+    n = len(truths)
+    return {
+        "candidate": "S2",
+        "tier": "B",
+        "mean_iou": float(np.mean(ious)) if ious else 0.0,
+        "mean_top_err_px": float(np.mean(errs)) if errs else float(frame_h),
+        "cost_s": cost,
+        "hit_rate": len(hit_top_errs) / n if n else 0.0,
+        "top_err_hits_px": float(np.mean(hit_top_errs)) if hit_top_errs else None,
+    }
+
+
+def _eval_obs_regression(
+    obs_dir: Path, gt_dir: Path
+) -> dict[str, tuple[bool, list[str]]]:
+    """OBS baseline 各本で S1/S2/S3 が安全に縮退するか (M4)。
+
+    Returns {candidate: (all_pass, [detail per video])}。
+    S1/S3 は FULL_FRAME 必須、S2 は None / FULL_FRAME を安全とみなす。
+    """
+    from allaganeye.video.capture_region import (
+        FULL_FRAME,
+        detect_region_blackout_overlap,
+        detect_region_scorebar_band,
+        detect_region_variance,
+    )
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+        _probe_frame_rgb_hires,
+    )
+
+    status: dict[str, list[bool]] = {"S1": [], "S2": [], "S3": []}
+    detail: dict[str, list[str]] = {"S1": [], "S2": [], "S3": []}
+    gt_files = sorted(gt_dir.glob("obs-*.json"))
+    for gt_file in gt_files:
+        gt = json.loads(gt_file.read_text(encoding="utf-8"))
+        video = obs_dir / gt["source_file"]
+        label = gt.get("source_dir_label", gt_file.stem)
+        if not video.exists():
+            for c in status:
+                detail[c].append(f"{label}=SKIP(missing)")
+            continue
+        matches = gt["matches"]
+        bright = _sample_gray_frames(video, _mid_match_timestamps(matches))
+        dark = _sample_gray_frames(video, _boundary_dark_timestamps(matches))
+
+        s1 = detect_region_variance(bright)
+        ok1 = s1 == FULL_FRAME
+        status["S1"].append(ok1)
+        detail["S1"].append(f"{label}={'full' if ok1 else _fmt(s1)}")
+
+        s3 = detect_region_blackout_overlap(bright + dark)
+        ok3 = s3 == FULL_FRAME
+        status["S3"].append(ok3)
+        detail["S3"].append(f"{label}={'full' if ok3 else _fmt(s3)}")
+
+        mid = _mid_match_timestamps(matches)
+        raw = _probe_frame_rgb_hires(video, mid[0]) if mid else None
+        if raw is None:
+            status["S2"].append(True)
+            detail["S2"].append(f"{label}=noframe")
+        else:
+            frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+                _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+            )
+            s2 = detect_region_scorebar_band(frame)
+            ok2 = s2 is None or s2 == FULL_FRAME
+            status["S2"].append(ok2)
+            detail["S2"].append(
+                f"{label}={'none' if s2 is None else ('full' if s2 == FULL_FRAME else _fmt(s2))}"
+            )
+    return {c: (all(v) if v else True, detail[c]) for c, v in status.items()}
+
+
+def _fmt(r) -> str:
+    return f"({r.x:.2f},{r.y:.2f},{r.w:.2f},{r.h:.2f})"
+
+
+def _run_on_benchmark(args: argparse.Namespace) -> list[dict]:
+    """machine-unverifiable: real video 要。M1/M2/M4 を集計して rows を返す。"""
+    from allaganeye.video.capture_region import CaptureRegion
+
+    regions_data = json.loads(args.regions.read_text(encoding="utf-8"))
+    frame_h = int(regions_data.get("frame_height", 1080))
+    truths = [
+        (r["timestamp"], CaptureRegion(r["x"], r["y"], r["w"], r["h"]))
+        for r in regions_data["regions"]
+    ]
+    truth0 = truths[0][1]
+
+    gt = json.loads(args.benchmark_ground_truth.read_text(encoding="utf-8"))
+    matches = gt["matches"]
+
+    print(f"[M1/M2] benchmark={args.benchmark.name} ({len(truths)} annotated regions)")
+    s1_row, s3_row = _eval_tierA_on_benchmark(args.benchmark, matches, truth0, frame_h)
+    s2_row = _eval_tierB_on_benchmark(args.benchmark, truths, frame_h)
+
+    obs_status: dict[str, tuple[bool, list[str]]] = {}
+    if args.obs_dir is not None:
+        print(f"[M4] OBS regression from {args.obs_dir}")
+        obs_status = _eval_obs_regression(args.obs_dir, args.obs_ground_truth_dir)
+
+    rows = [s1_row, s2_row, s3_row]
+    for row in rows:
+        cand = row["candidate"]
+        if cand in obs_status:
+            row["obs_full_frame"] = obs_status[cand][0]
+            row["obs_detail"] = obs_status[cand][1]
+        else:
+            row["obs_full_frame"] = True  # M4 未実行時は gate を素通り
+    return rows
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--benchmark", type=Path, required=True)
-    parser.add_argument("--obs", type=Path, nargs="*", default=[])
+    parser.add_argument("--obs-dir", type=Path, default=None)
     parser.add_argument(
         "--regions",
         type=Path,
         default=Path("tests/baselines/v0.3.0/vtuber-primary-regions.json"),
     )
+    parser.add_argument(
+        "--benchmark-ground-truth",
+        type=Path,
+        default=Path("tests/baselines/v0.3.0/vtuber-primary-ground-truth.json"),
+    )
+    parser.add_argument(
+        "--obs-ground-truth-dir",
+        type=Path,
+        default=Path("tests/baselines/v0.3.0/ground-truth"),
+    )
     args = parser.parse_args(argv)
     rows = _run_on_benchmark(args)
+    print()
     print(format_comparison_table(rows))
-    winner = pick_winner(rows)
-    print(f"\nWINNER (M4 gate + max IoU): {winner['candidate'] if winner else 'NONE'}")
+    for row in rows:
+        if "obs_detail" in row:
+            print(f"  {row['candidate']} OBS: {', '.join(row['obs_detail'])}")
+
+    # Tier A coarse (full game rect) の勝者は IoU 最大 + M4 gate で選ぶ。
+    coarse_rows = [r for r in rows if r.get("tier") == "A"]
+    coarse = pick_winner(coarse_rows) if coarse_rows else pick_winner(rows)
+    print(
+        f"\nTier A coarse winner (M4 gate + max IoU): "
+        f"{coarse['candidate'] if coarse else 'NONE'}"
+    )
+    # Tier B precise (S2) は full-rect IoU ではなく上端 px 誤差で評価する
+    # (scorebar ROI #480 が要求するのは精密な上端/y-band)。
+    s2 = next((r for r in rows if r["candidate"] == "S2"), None)
+    if s2 is not None:
+        hit = s2.get("top_err_hits_px")
+        hit_s = "n/a" if hit is None else f"{hit:.1f}px"
+        print(
+            f"Tier B precise (S2) top-edge on hits: {hit_s} "
+            f"(hit_rate={s2.get('hit_rate', 0):.2f}); "
+            f"full-rect IoU low by design (FL scorebar width != game width)"
+        )
     return 0
 
 

--- a/scripts/vtuber_region_spike.py
+++ b/scripts/vtuber_region_spike.py
@@ -1,21 +1,36 @@
-"""e2e 実現可能性 spike: crop→Pass1→scorebar の ±10s 実証 (#753, spec §7 M3)。
+"""e2e 実現可能性 spike: crop->Pass1->scorebar の +-10s 実証 (#753, spec section 7 M3)。
 
-選定 (または annotation) 領域で frame を crop し、領域内輝度で Pass 1 暗転
-検知 → 試合 start/end を抽出し、vtuber-primary-ground-truth.json と ±10s で
-照合する。本番 Pass1 wiring ではなく feasibility 確認 (machine-unverifiable)。
+finding #4 (spec section 2.2): VTuber 動画では overlay により frame 全体の平均
+輝度が暗転中も ~52 に張り付き、Pass 1 の blackout 判定 (threshold 15) が試合
+境界を取りこぼす。本 spike は game 領域で crop した輝度なら境界が復活することを
+実証する: 全 frame 輝度 vs 領域 crop 輝度で blackout 遷移を検出し、それぞれ
+vtuber-primary-ground-truth.json の 5 試合 start と +-10s で照合する。
+
+本番 Pass1 wiring ではなく feasibility 確認 (machine-unverifiable, real video 要)。
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+
+import numpy as np
+
+from allaganeye.ffmpeg_path import find_ffmpeg
+
+_GRAY_W = 320
+_GRAY_H = 180
+_GRAY_SIZE = _GRAY_W * _GRAY_H
 
 
 def match_within_tolerance(
     detected: list[float], ground_truth: list[float], tol: float = 10.0
 ) -> tuple[int, list[float]]:
-    """各 ground_truth 時刻に ±tol 内の detected があれば matched。
+    """各 ground_truth 時刻に +-tol 内の detected があれば matched。
 
     Returns (matched_count, [未検出の gt 時刻])。
     """
@@ -29,13 +44,149 @@ def match_within_tolerance(
     return matched, misses
 
 
-def _run_spike(args: argparse.Namespace) -> list[float]:
-    """実走部 (machine-unverifiable)。Task D.1 で実装・手動実行。
+def crop_region_mean(
+    frame: np.ndarray, region: tuple[float, float, float, float]
+) -> float:
+    """正規化矩形 *region* (x,y,w,h) で frame を crop し平均輝度を返す。
 
-    benchmark を sampling → region で crop → 輝度 → 暗転 → segment 抽出。
-    Pass 1 本体は再利用せず最小再実装 (feasibility)。
+    crop が空になる場合は frame 全体の平均で fallback。
     """
-    raise NotImplementedError("Task D.1 で実走部を実装・手動実行")
+    h, w = frame.shape[:2]
+    x, y, ww, hh = region
+    x0 = max(0, min(round(x * w), w - 1))
+    y0 = max(0, min(round(y * h), h - 1))
+    x1 = max(x0 + 1, min(round((x + ww) * w), w))
+    y1 = max(y0 + 1, min(round((y + hh) * h), h))
+    return float(frame[y0:y1, x0:x1].mean())
+
+
+def blackout_boundary_candidates(
+    samples: list[tuple[float, float]], threshold: float
+) -> tuple[list[float], list[float]]:
+    """(timestamp, brightness) 列から明暗遷移時刻を返す。
+
+    Returns (recover_times, drop_times):
+    - recover = 暗->明 (brightness が threshold 以下から超へ) = 試合開始の候補。
+    - drop    = 明->暗 (threshold 超から以下へ)             = 試合終了の候補。
+    *samples* は時刻昇順を仮定。
+    """
+    recovers: list[float] = []
+    drops: list[float] = []
+    prev_dark: bool | None = None
+    for t, b in samples:
+        dark = b <= threshold
+        if prev_dark is not None:
+            if dark and not prev_dark:
+                drops.append(t)
+            elif not dark and prev_dark:
+                recovers.append(t)
+        prev_dark = dark
+    return recovers, drops
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg sampling (machine-unverifiable: real video 要)
+# ---------------------------------------------------------------------------
+
+
+def _probe_gray_frame(video_path: Path, timestamp: float) -> np.ndarray | None:
+    """320x180 グレースケール単フレームを ndarray で返す。"""
+    cmd = [
+        find_ffmpeg(),
+        "-threads",
+        "1",
+        "-ss",
+        str(timestamp),
+        "-i",
+        str(video_path),
+        "-frames:v",
+        "1",
+        "-s",
+        f"{_GRAY_W}x{_GRAY_H}",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "gray",
+        "pipe:1",
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0 or len(result.stdout) < _GRAY_SIZE:
+        return None
+    return np.frombuffer(result.stdout[:_GRAY_SIZE], dtype=np.uint8).reshape(
+        _GRAY_H, _GRAY_W
+    )
+
+
+def _run_spike(args: argparse.Namespace) -> list[float]:
+    """benchmark を sampling -> 全 frame / 領域 crop の両輝度で blackout 検出。
+
+    crop 領域は vtuber-primary-regions.json の矩形 (本ベンチは A=B 静的)。
+    full-frame では試合境界が masked され、crop では復活することを実証する。
+    Returns crop 由来の recover 時刻 (= 検出した試合 start 候補)。
+    """
+    regions_data = json.loads(args.regions.read_text(encoding="utf-8"))
+    r0 = regions_data["regions"][0]
+    region = (r0["x"], r0["y"], r0["w"], r0["h"])
+    print(f"[spike] crop region (normalized) = {region}")
+
+    gt = json.loads(args.ground_truth.read_text(encoding="utf-8"))
+    matches = gt["matches"]
+    gt_starts = [float(m["start_time"]) for m in matches]
+    gt_ends = [float(m["end_time"]) for m in matches]
+    cap = args.max_time if args.max_time else max(gt_ends) + 90.0
+
+    timestamps = [float(t) for t in np.arange(0.0, cap, args.interval)]
+    print(
+        f"[spike] sampling {len(timestamps)} frames over 0..{cap:.0f}s "
+        f"@ {args.interval}s (threshold={args.threshold})"
+    )
+    t_start = time.time()
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        frames = list(
+            ex.map(lambda t: _probe_gray_frame(args.benchmark, t), timestamps)
+        )
+    elapsed = time.time() - t_start
+    print(f"[spike] decode wall-time = {elapsed:.1f}s")
+
+    full_samples: list[tuple[float, float]] = []
+    crop_samples: list[tuple[float, float]] = []
+    for t, f in zip(timestamps, frames, strict=True):
+        if f is None:
+            continue
+        full_samples.append((t, float(f.mean())))
+        crop_samples.append((t, crop_region_mean(f, region)))
+
+    full_recovers, _ = blackout_boundary_candidates(full_samples, args.threshold)
+    crop_recovers, crop_drops = blackout_boundary_candidates(
+        crop_samples, args.threshold
+    )
+
+    full_matched, full_misses = match_within_tolerance(
+        full_recovers, gt_starts, args.tol
+    )
+    crop_matched, crop_misses = match_within_tolerance(
+        crop_recovers, gt_starts, args.tol
+    )
+    crop_end_matched, _ = match_within_tolerance(crop_drops, gt_ends, args.tol)
+
+    n = len(gt_starts)
+    print()
+    print("=== M3 spike result (crop unlocks Pass 1) ===")
+    print(
+        f"  full-frame brightness : start {full_matched}/{n} within +-{args.tol}s "
+        f"(misses={full_misses})"
+    )
+    print(
+        f"  region-crop brightness: start {crop_matched}/{n} within +-{args.tol}s "
+        f"(misses={crop_misses})"
+    )
+    print(
+        f"  region-crop brightness: end   {crop_end_matched}/{n} within +-{args.tol}s"
+    )
+    return crop_recovers
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -46,13 +197,23 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=Path("tests/baselines/v0.3.0/vtuber-primary-ground-truth.json"),
     )
+    parser.add_argument(
+        "--regions",
+        type=Path,
+        default=Path("tests/baselines/v0.3.0/vtuber-primary-regions.json"),
+    )
     parser.add_argument("--tol", type=float, default=10.0)
+    parser.add_argument("--interval", type=float, default=2.5)
+    parser.add_argument("--threshold", type=float, default=15.0)
+    parser.add_argument("--max-time", type=float, default=0.0)
+    parser.add_argument("--workers", type=int, default=16)
     args = parser.parse_args(argv)
+
     gt_data = json.loads(args.ground_truth.read_text(encoding="utf-8"))
-    starts = [m["start_time"] for m in gt_data["matches"]]
+    starts = [float(m["start_time"]) for m in gt_data["matches"]]
     detected = _run_spike(args)
     matched, misses = match_within_tolerance(detected, starts, args.tol)
-    print(f"matched {matched}/{len(starts)} within +-{args.tol}s; misses={misses}")
+    print(f"\nmatched {matched}/{len(starts)} within +-{args.tol}s; misses={misses}")
     return 0 if matched == len(starts) else 1
 
 

--- a/scripts/vtuber_region_spike.py
+++ b/scripts/vtuber_region_spike.py
@@ -1,0 +1,60 @@
+"""e2e 実現可能性 spike: crop→Pass1→scorebar の ±10s 実証 (#753, spec §7 M3)。
+
+選定 (または annotation) 領域で frame を crop し、領域内輝度で Pass 1 暗転
+検知 → 試合 start/end を抽出し、vtuber-primary-ground-truth.json と ±10s で
+照合する。本番 Pass1 wiring ではなく feasibility 確認 (machine-unverifiable)。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def match_within_tolerance(
+    detected: list[float], ground_truth: list[float], tol: float = 10.0
+) -> tuple[int, list[float]]:
+    """各 ground_truth 時刻に ±tol 内の detected があれば matched。
+
+    Returns (matched_count, [未検出の gt 時刻])。
+    """
+    matched = 0
+    misses: list[float] = []
+    for g in ground_truth:
+        if any(abs(d - g) <= tol for d in detected):
+            matched += 1
+        else:
+            misses.append(g)
+    return matched, misses
+
+
+def _run_spike(args: argparse.Namespace) -> list[float]:
+    """実走部 (machine-unverifiable)。Task D.1 で実装・手動実行。
+
+    benchmark を sampling → region で crop → 輝度 → 暗転 → segment 抽出。
+    Pass 1 本体は再利用せず最小再実装 (feasibility)。
+    """
+    raise NotImplementedError("Task D.1 で実走部を実装・手動実行")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark", type=Path, required=True)
+    parser.add_argument(
+        "--ground-truth",
+        type=Path,
+        default=Path("tests/baselines/v0.3.0/vtuber-primary-ground-truth.json"),
+    )
+    parser.add_argument("--tol", type=float, default=10.0)
+    args = parser.parse_args(argv)
+    gt_data = json.loads(args.ground_truth.read_text(encoding="utf-8"))
+    starts = [m["start_time"] for m in gt_data["matches"]]
+    detected = _run_spike(args)
+    matched, misses = match_within_tolerance(detected, starts, args.tol)
+    print(f"matched {matched}/{len(starts)} within +-{args.tol}s; misses={misses}")
+    return 0 if matched == len(starts) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/baselines/v0.3.0/vtuber-primary-regions.json
+++ b/tests/baselines/v0.3.0/vtuber-primary-regions.json
@@ -1,0 +1,14 @@
+{
+  "source_file": "2772549129-151803977-da21c691-9ed6-4068-9a8b-4726a8a519a8.mp4",
+  "frame_width": 1920,
+  "frame_height": 1080,
+  "annotation_provider": "agent visual estimate, user (Idios) verified 2026-05-26",
+  "annotated_at": "2026-05-26",
+  "layout_note": "Layouts A (match 1, Valentine card) and B (matches 3/5, Halloween card) share the SAME game capture region; only decoration card overlays differ. The game capture is STATIC across this VOD. Top edge = bottom of the cyan streaming banner; right edge = frame right edge (the X/Y info panel + minimap + decoration cards are in-game HUD or overlays on top of the game); bottom edge = above the white follower-progress bar; left edge = right of the chat/avatar strip. Per-segment re-detect remains a general capability for other streams/VODs that DO change layout.",
+  "regions": [
+    {"timestamp": 1900, "layout": "A", "x": 0.1302, "y": 0.0898, "w": 0.8698, "h": 0.8667, "px": {"x": 250, "y": 97, "w": 1670, "h": 936}},
+    {"timestamp": 2361, "layout": "A", "x": 0.1302, "y": 0.0898, "w": 0.8698, "h": 0.8667, "px": {"x": 250, "y": 97, "w": 1670, "h": 936}},
+    {"timestamp": 4700, "layout": "B", "x": 0.1302, "y": 0.0898, "w": 0.8698, "h": 0.8667, "px": {"x": 250, "y": 97, "w": 1670, "h": 936}},
+    {"timestamp": 6900, "layout": "B", "x": 0.1302, "y": 0.0898, "w": 0.8698, "h": 0.8667, "px": {"x": 250, "y": 97, "w": 1670, "h": 936}}
+  ]
+}

--- a/tests/scripts/test_vtuber_region_experiment.py
+++ b/tests/scripts/test_vtuber_region_experiment.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "vtuber_region_experiment",
+    Path(__file__).resolve().parents[2] / "scripts" / "vtuber_region_experiment.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+mod = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mod)  # type: ignore[union-attr]
+
+
+def test_format_comparison_table_marks_best_iou():
+    rows = [
+        {"candidate": "S1", "mean_iou": 0.81, "mean_top_err_px": 30.0, "cost_s": 5.0},
+        {"candidate": "S2", "mean_iou": 0.94, "mean_top_err_px": 8.0, "cost_s": 9.0},
+    ]
+    out = mod.format_comparison_table(rows)
+    assert "S2" in out and "0.94" in out
+    assert mod.pick_winner(rows)["candidate"] == "S2"
+
+
+def test_pick_winner_requires_obs_passing():
+    rows = [
+        {
+            "candidate": "S1",
+            "mean_iou": 0.99,
+            "mean_top_err_px": 2.0,
+            "obs_full_frame": False,
+        },
+        {
+            "candidate": "S2",
+            "mean_iou": 0.90,
+            "mean_top_err_px": 9.0,
+            "obs_full_frame": True,
+        },
+    ]
+    assert mod.pick_winner(rows)["candidate"] == "S2"

--- a/tests/scripts/test_vtuber_region_experiment.py
+++ b/tests/scripts/test_vtuber_region_experiment.py
@@ -36,3 +36,19 @@ def test_pick_winner_requires_obs_passing():
         },
     ]
     assert mod.pick_winner(rows)["candidate"] == "S2"
+
+
+def test_region_metrics_identical_is_perfect():
+    from allaganeye.video.capture_region import CaptureRegion
+
+    r = CaptureRegion(0.13, 0.09, 0.87, 0.87)
+    m = mod.region_metrics(r, r, 1080)
+    assert m["iou"] == 1.0 and m["top_err_px"] == 0.0
+
+
+def test_region_metrics_none_detection_is_worst_case():
+    from allaganeye.video.capture_region import CaptureRegion
+
+    truth = CaptureRegion(0.13, 0.09, 0.87, 0.87)
+    m = mod.region_metrics(None, truth, 1080)
+    assert m["iou"] == 0.0 and m["top_err_px"] == 1080.0

--- a/tests/scripts/test_vtuber_region_spike.py
+++ b/tests/scripts/test_vtuber_region_spike.py
@@ -22,3 +22,26 @@ def test_match_within_tolerance_reports_miss():
     detected = [1435]
     matched, misses = mod.match_within_tolerance(detected, gt, tol=10)
     assert matched == 1 and misses == [2624]
+
+
+def test_crop_region_mean_isolates_dark_inset():
+    import numpy as np
+
+    f = np.full((180, 320), 200, dtype=np.uint8)
+    f[int(0.20 * 180) : int(0.70 * 180), int(0.30 * 320) : int(0.70 * 320)] = 5
+    full = mod.crop_region_mean(f, (0.0, 0.0, 1.0, 1.0))
+    inset = mod.crop_region_mean(f, (0.30, 0.20, 0.40, 0.50))
+    assert inset < 20.0 and full > inset
+
+
+def test_blackout_boundary_candidates_detects_transitions():
+    # bright .. bright | dark dark | bright bright  -> drop@4, recover@8
+    samples = [(0, 200), (2, 200), (4, 5), (6, 5), (8, 200), (10, 200)]
+    recovers, drops = mod.blackout_boundary_candidates(samples, threshold=15.0)
+    assert drops == [4] and recovers == [8]
+
+
+def test_blackout_boundary_candidates_no_blackout_is_empty():
+    samples = [(0, 200), (2, 180), (4, 190)]
+    recovers, drops = mod.blackout_boundary_candidates(samples, threshold=15.0)
+    assert recovers == [] and drops == []

--- a/tests/scripts/test_vtuber_region_spike.py
+++ b/tests/scripts/test_vtuber_region_spike.py
@@ -1,0 +1,24 @@
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "vtuber_region_spike",
+    Path(__file__).resolve().parents[2] / "scripts" / "vtuber_region_spike.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+mod = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mod)  # type: ignore[union-attr]
+
+
+def test_match_within_tolerance_all_hit():
+    gt = [1433, 2624, 4253, 5684, 6609]
+    detected = [1435, 2620, 4258, 5680, 6612]
+    matched, misses = mod.match_within_tolerance(detected, gt, tol=10)
+    assert matched == 5 and misses == []
+
+
+def test_match_within_tolerance_reports_miss():
+    gt = [1433, 2624]
+    detected = [1435]
+    matched, misses = mod.match_within_tolerance(detected, gt, tol=10)
+    assert matched == 1 and misses == [2624]

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -202,3 +202,12 @@ def test_scorebar_band_uniform_cyan_banner_rejected():
     f = np.full((H, W, 3), 40, dtype=np.uint8)
     f[0:55, :] = (60, 200, 200)  # 単色 cyan 帯 (紋章なし)
     assert detect_region_scorebar_band(f) is None
+
+
+def test_all_grayscale_detectors_snap_full_on_obs_like_input():
+    rng = np.random.default_rng(2)
+    motion = [rng.integers(0, 256, (180, 320), dtype=np.uint8) for _ in range(8)]
+    assert detect_region_variance(motion) == FULL_FRAME
+    bright = np.full((180, 320), 120, dtype=np.uint8)
+    dark = np.full((180, 320), 2, dtype=np.uint8)
+    assert detect_region_blackout_overlap([bright, bright, dark]) == FULL_FRAME

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -5,6 +5,7 @@ from allaganeye.video.capture_region import (
     CaptureRegion,
     RegionTimeline,
     _maybe_snap_full_frame,
+    detect_region_blackout_overlap,
     detect_region_variance,
     iou,
     top_edge_error_px,
@@ -106,3 +107,30 @@ def test_variance_full_frame_motion_snaps_full():
 def test_variance_static_frames_fall_back_full():
     frames = [np.full((180, 320), 50, dtype=np.uint8) for _ in range(12)]
     assert detect_region_variance(frames) == FULL_FRAME
+
+
+# ---------------------------------------------------------------------------
+# Task B.3: S3 detect_region_blackout_overlap
+# ---------------------------------------------------------------------------
+
+
+def test_blackout_overlap_finds_region_that_goes_dark():
+    h, w = 180, 320
+    inset = (0.30, 0.20, 0.40, 0.50)
+    x0, y0 = int(inset[0] * w), int(inset[1] * h)
+    ww, hh = int(inset[2] * w), int(inset[3] * h)
+    bright = np.full((h, w), 120, dtype=np.uint8)
+    dark_inset = bright.copy()
+    dark_inset[y0 : y0 + hh, x0 : x0 + ww] = 2
+    frames = [bright, bright, dark_inset, dark_inset]
+    r = detect_region_blackout_overlap(frames)
+    assert r.source == "tierA"
+    assert inset[0] <= r.x + r.w / 2 <= inset[0] + inset[2]
+    assert inset[1] <= r.y + r.h / 2 <= inset[1] + inset[3]
+
+
+def test_blackout_overlap_obs_full_frame_blackout_snaps_full():
+    h, w = 180, 320
+    bright = np.full((h, w), 120, dtype=np.uint8)
+    dark = np.full((h, w), 2, dtype=np.uint8)
+    assert detect_region_blackout_overlap([bright, bright, dark]) == FULL_FRAME

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -187,9 +187,12 @@ def test_scorebar_band_at_offset_y_returns_inset_top():
     assert abs(r.y - 120 / 1080) < 0.012
 
 
-def test_scorebar_band_full_width_top_snaps_full():
+def test_scorebar_band_overwide_returns_none():
+    # scorebar 幅 1690px > detector._SCOREBAR_SCAN_MAX_WIDTH_PX (1440, #806) のため
+    # _find_scorebar_horizontal_range が None を返し S2 も None。OBS の全体縮退は
+    # coarse 検出器 (S1/S3) の責務であり S2 (Tier-B precise) は OBS を snap しない。
     f = _hires_with_scorebar_at(y_top=2, x_left=120, x_right=1810)
-    assert detect_region_scorebar_band(f) == FULL_FRAME
+    assert detect_region_scorebar_band(f) is None
 
 
 def test_scorebar_band_uniform_cyan_banner_rejected():

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -1,0 +1,28 @@
+from allaganeye.video.capture_region import CaptureRegion, RegionTimeline, FULL_FRAME
+
+
+def test_full_frame_is_unit_square():
+    assert (FULL_FRAME.x, FULL_FRAME.y, FULL_FRAME.w, FULL_FRAME.h) == (
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+    )
+
+
+def test_clamp_bounds_region_into_unit_square():
+    r = CaptureRegion(-0.1, 0.2, 1.5, 0.5).clamp()
+    assert r.x == 0.0 and r.y == 0.2
+    assert r.x + r.w <= 1.0 + 1e-9 and r.y + r.h <= 1.0 + 1e-9
+
+
+def test_round_trip_dict():
+    r = CaptureRegion(0.1, 0.2, 0.3, 0.4, confidence=0.8, source="tierB")
+    assert CaptureRegion.from_dict(r.to_dict()) == r
+
+
+def test_region_timeline_to_dict_shape():
+    tl = RegionTimeline(coarse=FULL_FRAME, segments=[((10.0, 20.0), FULL_FRAME)])
+    d = tl.to_dict()
+    assert d["coarse"]["w"] == 1.0
+    assert d["segments"][0]["time_range"] == [10.0, 20.0]

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -6,6 +6,7 @@ from allaganeye.video.capture_region import (
     RegionTimeline,
     _maybe_snap_full_frame,
     detect_region_blackout_overlap,
+    detect_region_scorebar_band,
     detect_region_variance,
     iou,
     top_edge_error_px,
@@ -148,3 +149,56 @@ def test_variance_tiny_speck_below_min_area_falls_back_full():
         f[0:8, 0:8] = rng.integers(0, 256, (8, 8), dtype=np.uint8)  # ~0.1% area
         frames.append(f)
     assert detect_region_variance(frames) == FULL_FRAME
+
+
+# ---------------------------------------------------------------------------
+# Task B.2: S2 detect_region_scorebar_band
+# ---------------------------------------------------------------------------
+
+
+def _hires_with_scorebar_at(y_top: int, x_left: int, x_right: int):
+    """1920x1080 RGB: y_top 行に saturated 帯 + 3 紋章 (striped) を描く。
+
+    紋章位置は detector._EMBLEM_RELATIVE_POSITIONS を帯 span に投影。
+    """
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_WIDTH,
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _EMBLEM_RELATIVE_POSITIONS,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    bar_w = x_right - x_left
+    f[y_top : y_top + 45, x_left : x_right + 1] = (50, 50, 200)
+    for _name, cx_rel, hw_rel, ey1, ey2 in _EMBLEM_RELATIVE_POSITIONS:
+        cx = int(x_left + cx_rel * bar_w)
+        hw = max(2, int(hw_rel * bar_w))
+        region = f[y_top + ey1 : y_top + ey2, cx - hw : cx + hw]
+        for col in range(region.shape[1]):
+            region[:, col] = (200, 30, 30) if (col // 2) % 2 == 0 else (0, 0, 0)
+    return f
+
+
+def test_scorebar_band_at_offset_y_returns_inset_top():
+    f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
+    r = detect_region_scorebar_band(f)
+    assert r is not None and r.source == "tierB"
+    assert abs(r.y - 120 / 1080) < 0.03
+
+
+def test_scorebar_band_full_width_top_snaps_full():
+    f = _hires_with_scorebar_at(y_top=2, x_left=120, x_right=1810)
+    assert detect_region_scorebar_band(f) == FULL_FRAME
+
+
+def test_scorebar_band_uniform_cyan_banner_rejected():
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_WIDTH,
+        _SCOREBAR_V2_PROBE_HEIGHT,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    f[0:55, :] = (60, 200, 200)  # 単色 cyan 帯 (紋章なし)
+    assert detect_region_scorebar_band(f) is None

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -96,6 +96,8 @@ def test_variance_finds_moving_inset():
     assert r.source == "tierA"
     assert inset[0] <= r.x + r.w / 2 <= inset[0] + inset[2]
     assert inset[1] <= r.y + r.h / 2 <= inset[1] + inset[3]
+    expected = CaptureRegion(inset[0], inset[1], inset[2], inset[3])
+    assert iou(r, expected) >= 0.8
 
 
 def test_variance_full_frame_motion_snaps_full():
@@ -127,6 +129,8 @@ def test_blackout_overlap_finds_region_that_goes_dark():
     assert r.source == "tierA"
     assert inset[0] <= r.x + r.w / 2 <= inset[0] + inset[2]
     assert inset[1] <= r.y + r.h / 2 <= inset[1] + inset[3]
+    expected = CaptureRegion(inset[0], inset[1], inset[2], inset[3])
+    assert iou(r, expected) >= 0.8
 
 
 def test_blackout_overlap_obs_full_frame_blackout_snaps_full():
@@ -134,3 +138,13 @@ def test_blackout_overlap_obs_full_frame_blackout_snaps_full():
     bright = np.full((h, w), 120, dtype=np.uint8)
     dark = np.full((h, w), 2, dtype=np.uint8)
     assert detect_region_blackout_overlap([bright, bright, dark]) == FULL_FRAME
+
+
+def test_variance_tiny_speck_below_min_area_falls_back_full():
+    rng = np.random.default_rng(7)
+    frames = []
+    for _ in range(8):
+        f = np.full((180, 320), 50, dtype=np.uint8)
+        f[0:8, 0:8] = rng.integers(0, 256, (8, 8), dtype=np.uint8)  # ~0.1% area
+        frames.append(f)
+    assert detect_region_variance(frames) == FULL_FRAME

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -1,8 +1,11 @@
+import numpy as np
+
 from allaganeye.video.capture_region import (
-    CaptureRegion,
     FULL_FRAME,
+    CaptureRegion,
     RegionTimeline,
     _maybe_snap_full_frame,
+    detect_region_variance,
     iou,
     top_edge_error_px,
 )
@@ -60,3 +63,46 @@ def test_snap_full_frame_when_region_covers_most_of_frame():
 def test_snap_keeps_small_inset_unchanged():
     inset = CaptureRegion(0.2, 0.1, 0.5, 0.5, source="tierA")
     assert _maybe_snap_full_frame(inset) is inset
+
+
+# ---------------------------------------------------------------------------
+# Task B.1: S1 detect_region_variance
+# ---------------------------------------------------------------------------
+
+
+def _stack_static_bg_with_moving_inset(
+    n=12, h=180, w=320, inset=(0.30, 0.20, 0.40, 0.50)
+):
+    """静止 bg (一定値) + inset 内だけフレームごとに乱数 = 高分散."""
+    rng = np.random.default_rng(0)
+    x0, y0, ww, hh = (
+        int(inset[0] * w),
+        int(inset[1] * h),
+        int(inset[2] * w),
+        int(inset[3] * h),
+    )
+    frames = []
+    for _ in range(n):
+        f = np.full((h, w), 50, dtype=np.uint8)
+        f[y0 : y0 + hh, x0 : x0 + ww] = rng.integers(0, 256, (hh, ww), dtype=np.uint8)
+        frames.append(f)
+    return frames, inset
+
+
+def test_variance_finds_moving_inset():
+    frames, inset = _stack_static_bg_with_moving_inset()
+    r = detect_region_variance(frames)
+    assert r.source == "tierA"
+    assert inset[0] <= r.x + r.w / 2 <= inset[0] + inset[2]
+    assert inset[1] <= r.y + r.h / 2 <= inset[1] + inset[3]
+
+
+def test_variance_full_frame_motion_snaps_full():
+    rng = np.random.default_rng(1)
+    frames = [rng.integers(0, 256, (180, 320), dtype=np.uint8) for _ in range(12)]
+    assert detect_region_variance(frames) == FULL_FRAME
+
+
+def test_variance_static_frames_fall_back_full():
+    frames = [np.full((180, 320), 50, dtype=np.uint8) for _ in range(12)]
+    assert detect_region_variance(frames) == FULL_FRAME

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -184,7 +184,7 @@ def test_scorebar_band_at_offset_y_returns_inset_top():
     f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
     r = detect_region_scorebar_band(f)
     assert r is not None and r.source == "tierB"
-    assert abs(r.y - 120 / 1080) < 0.03
+    assert abs(r.y - 120 / 1080) < 0.012
 
 
 def test_scorebar_band_full_width_top_snaps_full():

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -1,4 +1,11 @@
-from allaganeye.video.capture_region import CaptureRegion, RegionTimeline, FULL_FRAME
+from allaganeye.video.capture_region import (
+    CaptureRegion,
+    FULL_FRAME,
+    RegionTimeline,
+    _maybe_snap_full_frame,
+    iou,
+    top_edge_error_px,
+)
 
 
 def test_full_frame_is_unit_square():
@@ -26,3 +33,30 @@ def test_region_timeline_to_dict_shape():
     d = tl.to_dict()
     assert d["coarse"]["w"] == 1.0
     assert d["segments"][0]["time_range"] == [10.0, 20.0]
+
+
+def test_iou_identical_is_one():
+    r = CaptureRegion(0.1, 0.1, 0.5, 0.5)
+    assert iou(r, r) == 1.0
+
+
+def test_iou_disjoint_is_zero():
+    a = CaptureRegion(0.0, 0.0, 0.2, 0.2)
+    b = CaptureRegion(0.5, 0.5, 0.2, 0.2)
+    assert iou(a, b) == 0.0
+
+
+def test_top_edge_error_px_scales_by_height():
+    a = CaptureRegion(0.0, 0.10, 1.0, 0.5)
+    b = CaptureRegion(0.0, 0.12, 1.0, 0.5)
+    assert round(top_edge_error_px(a, b, 1080)) == round(0.02 * 1080)
+
+
+def test_snap_full_frame_when_region_covers_most_of_frame():
+    near_full = CaptureRegion(0.01, 0.01, 0.97, 0.97, source="tierA")
+    assert _maybe_snap_full_frame(near_full) == FULL_FRAME
+
+
+def test_snap_keeps_small_inset_unchanged():
+    inset = CaptureRegion(0.2, 0.1, 0.5, 0.5, source="tierA")
+    assert _maybe_snap_full_frame(inset) is inset


### PR DESCRIPTION
## Summary

#753 Phase 2a: VTuber 配信動画の game capture 矩形を検出するアルゴリズム候補 (S1/S2/S3) を実装し、実験 harness で gyawa benchmark に対し比較選定した。本番 detector への wiring・scorebar #480・minimap #481 は下流のため、本 PR では `detector.py` 本体は **不変更** (production detect 出力 bit-exact)。

- 新規 `allaganeye/video/capture_region.py`: 正規化矩形 contract (`CaptureRegion` / `RegionTimeline`) + 幾何 (IoU / 上端 px 誤差 / full-frame snap) + 候補検出器 **S1 時間分散 / S2 scorebar 帯 / S3 暗転重なり**。OBS 相当では全器が `FULL_FRAME` に縮退。
- 実験 harness `scripts/vtuber_region_experiment.py` (M1/M2/M4) + e2e spike `scripts/vtuber_region_spike.py` (M3) + proxy 正解矩形 `tests/baselines/v0.3.0/vtuber-primary-regions.json` (user 確認済 2026-05-26)。
- design spec + implementation plan (`docs/superpowers/`)。

## 実測選定結果 (gyawa benchmark + OBS baseline 5 本、実機 ffmpeg 8.1)

| 候補 | tier | M1 IoU | 上端誤差 | M4 OBS |
| --- | --- | --- | --- | --- |
| **S3 暗転重なり (採用)** | A coarse | **0.851** | **11px** | FULL_FRAME x5 PASS |
| S1 時間分散 (近接候補・残置) | A coarse | 0.846 | 11px | FULL_FRAME x5 PASS |
| **S2 scorebar 帯 (採用・上端のみ)** | B precise | 0.188 (注) | 上端 15.7px (hit 3/4) | inset 誤検出 = coarse 不適 |

- **M3 spike**: full-frame Pass1 = `start 0/5` (overlay により暗転が平均輝度 ~52 で mask = finding #4 を実測再現) -> 領域 crop Pass1 = `start 4/5 + end 5/5` (threshold 30)。**領域 crop が Pass1 を解錠する**ことを実証。
- 追加 finding: 領域 crop の暗転 floor は ~17-20 (FF14 load 画面は純黒でない) のため、領域 crop には OBS の `blackout_threshold=15` より高い ~30 が必要 (Pass1 wiring child issue へ申し送り)。
- 注: S2 の full-rect IoU が低いのは設計上の帰結 (FL scorebar は game 全幅でなく中央 ~835px の HUD)。S2 は上端 y-band のみ消費し横 extent は Tier A から取得。単一 scorebar frame では OBS/VTuber を区別できず OBS で inset 誤検出するため **coarse 不可 = Tier B 限定が hard constraint**。

## Self-Test Report

machine-verified:

- [x] `ruff check .` / `ruff format --check .` クリーン
- [x] `pyright` (変更ファイル) 0 errors / 0 warnings
- [x] `pytest` (非 slow) = 1279 passed / 13 skipped
- [x] markdownlint 0 errors (CI と同 version)
- [x] `detector.py` / `scorebar.py` / `gpu_detector.py` / `cli.py` 不変更 (diff で確認) = production detect 出力 bit-exact (M4 bit-exact 部は構造的に成立)

machine-unverifiable (real video / 長尺 / GPU 環境要、本 session で Idios 機にて実走済み):

- gyawa benchmark (2h43m, 7.5GB) で M1/M2 を計測 (S3 IoU 0.851 / S2 上端 15.7px)
- OBS baseline 5 本で M4 縮退を確認 (S1/S3 -> FULL_FRAME x5)
- e2e spike で M3 ±10s を確認 (full-frame 0/5 -> 領域 crop start 4/5 + end 5/5)
- 再現コマンドは spec section 6.3.1 に記載

## 下流 child issue 起票案 (本 PR では未起票 = Iron Law 2、user 確認後に別途)

1. **[L3] Pass 1 暗転検知の game 領域輝度適応 (VTuber 本番 wiring)**: coarse 領域 (S3) で crop した輝度で Pass1。受入案: OBS bit-exact / gyawa 5 試合 ±10s / 領域 crop 閾値 ~30 可変 (OBS path は 15 維持) / 試合 start = fade-in recover 定義。
2. **[L3] metadata.json に game capture 領域フィールドを確定**: `RegionTimeline` 形式 (正規化 x/y/w/h + source + confidence) を記録。OBS は (0,0,1,1)。

(#480 scorebar / #481 minimap は既存 issue = consumer のため新規起票不要)

## adversarial review (Codex fallback notice)

Iron Law 6 Pre-flight Step 5 の `/codex:adversarial-review` は `disable-model-invocation` のため自動起動不可。**C6 fallback** として superpowers `requesting-code-review` subagent で adversarial pass を実施 (Codex 本体は未実行)。結果: **blocking 0 / nit 4**、うち 3 件を本 PR 内で対応済 (S2 `band_h` の定数 drift 防止 / 実験 harness M4 の silent false-pass 防止 / spec 再現コマンド明記)。必要なら merge 前に Idios が `/codex:adversarial-review` を手動実行可能。

Refs #753

session: l3-vtuber-capture-region
