### PR TITLE
fix(ci): pin typer<0.25 / click<8.4 (typer._click namespace drift)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,13 @@ description = "FF14 Frontline video auto-highlight extraction tool"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
-    "typer>=0.9",
+    # click 8.4 / typer 0.25+ は click 例外を typer._click 名前空間へ分離し、
+    # cli.py の単一ダッシュ hint (NoSuchOption 捕捉) と debug_brightness の
+    # typer.Exit 捕捉を破壊する (CI 2026-05-27、develop-0.3.0 全体が赤化)。
+    # 既知 good ライン (typer 0.24.x / click 8.3.x) に pin して回帰を防ぐ。
+    # click は cli.py / tests が直接 import するため明示依存として宣言。
+    "typer>=0.9,<0.25",
+    "click>=8.0,<8.4",
     "numpy>=1.24",
     "scipy>=1.11",
     "opencv-python-headless>=4.8",


### PR DESCRIPTION
## Summary

`click 8.4.1` / `typer 0.26.1` (2026-05-26 以降リリース) が click の例外クラスを `typer._click` 名前空間へ分離したため、`develop-0.3.0` 既存の CLI テストが CI で fail するようになった。**機能変更とは無関係の依存ドリフトで、develop-0.3.0 自体が現状赤**（直近 green は 2026-05-26）。

壊れていたテスト (`typer._click.exceptions.*` に変化):

- `tests/test_cli.py`: 単一ダッシュ option hint 系 4 件 (`NoSuchOption` 捕捉)
- `tests/test_debug_brightness.py::test_start_ge_end_exits` (`click.exceptions.Exit` 捕捉)

## Fix

`pyproject.toml` の依存を既知 good ライン (typer 0.24.x / click 8.3.x) に pin:

- `typer>=0.9` -> `typer>=0.9,<0.25`
- `click>=8.0,<8.4` を明示依存として追加 (`cli.py` / tests が直接 import するため宣言が正しい。`typer<0.25` 単独では click 8.4.1 が入り不十分なことを dry-run で確認)

## Self-Test Report

machine-verified:

- [x] dry-run 解決: `typer>=0.9,<0.25` + `click>=8.0,<8.4` -> typer 0.24.2 + click 8.3.3
- [x] 上記 pin 解決版で `tests/test_cli.py` + `tests/test_debug_brightness.py` = 122 passed
- [x] develop-0.3.0 + pin 全 suite (非 slow) = 1251 passed / 13 skipped
- [x] pin なし (`typer>=0.9`) では typer 0.26.1 + click 8.4.1 が入り 5 件 fail (CI で再現)

## Note

- 恒久対応 (新 typer/click への前方互換化: hint 機構と test を `typer._click` 名前空間対応に) は follow-up 候補。本 PR は CI 復旧の最小 pin。
- PR #807 (#753 Phase 2a) はこの PR の merge 後に rebase して green 化する予定。

session: l3-vtuber-capture-region
