### PR TITLE
feat(l3): robust scorebar localization (P1, re-plan #753)

### DIFF
--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -195,9 +195,6 @@ _LOCALIZE_TARGET_RATIO = 2.0
 """confidence が 1.0 に達する emblem margin 倍率 (最弱 emblem の sat/edge が
 閾値の TARGET 倍で満点)。clear な in-match frame で ~1.0 に出るよう選定。"""
 
-_GAME_ASPECT = 16.0 / 9.0
-"""FF14 game capture のアスペクト比 (帯幅から game 高さを逆算)。"""
-
 
 def _scorebar_saturated_runs(band: np.ndarray, cv2) -> list[tuple[int, int]]:
     """band (Hb,W,3 uint8 RGB) の saturated column run を width-gate して全件返す。
@@ -369,70 +366,6 @@ def localize_scorebar(
         y_bottom=y + band_h,
         confidence=confidence,
     )
-
-
-def detect_region_scorebar_band(
-    frame: np.ndarray,
-    *,
-    stride: int = _BAND_SCAN_STRIDE,
-) -> CaptureRegion | None:
-    """S2: FL scorebar 帯を全 y で探し、game 矩形を逆算 (Tier B precise)。
-
-    *frame* は 1920x1080 RGB (H,W,3) uint8。検出帯を GC 紋章 3 点 AND で
-    FL と検証してから返す。FL 帯が見つからなければ None (試合外フレーム
-    や opencv 未導入)。OBS の全体縮退は coarse 検出器 (S1/S3) の責務であり、
-    scorebar 幅 > detector._SCOREBAR_SCAN_MAX_WIDTH_PX (1440, #806) の広帯は None。
-    """
-    try:
-        import cv2
-    except ImportError:
-        return None
-    from allaganeye.video.detector import (
-        _SCOREBAR_V2_PROBE_WIDTH,
-        _SCOREBAR_V2_PROBE_HEIGHT,
-        _SCOREBAR_SCAN_Y_START,
-        _SCOREBAR_SCAN_Y_END,
-        _EMBLEM_RELATIVE_POSITIONS,
-        _emblem_and_check,
-        _find_scorebar_horizontal_range,
-    )
-
-    H = _SCOREBAR_V2_PROBE_HEIGHT
-    W = _SCOREBAR_V2_PROBE_WIDTH
-    if frame.shape[:2] != (H, W):
-        return None
-    # _find_scorebar_horizontal_range は内部で y=_SCOREBAR_SCAN_Y_START.._END を
-    # 走査するため、その窓高に合わせて band を切り出す (定数 drift 防止)。
-    band_h = _SCOREBAR_SCAN_Y_END - _SCOREBAR_SCAN_Y_START
-    y_max = int(H * _BAND_Y_MAX_FRAC)
-    shifted = np.zeros_like(frame)
-    for y in range(0, y_max, stride):
-        shifted[band_h:] = 0
-        shifted[0:band_h] = frame[y : y + band_h]
-        span = _find_scorebar_horizontal_range(shifted.tobytes())
-        if span is None:
-            continue
-        x_left, x_right = span
-        bar_w = x_right - x_left
-        positions = [
-            (
-                name,
-                int(x_left + cx_rel * bar_w - hw_rel * bar_w),
-                y + ey1,
-                int(x_left + cx_rel * bar_w + hw_rel * bar_w),
-                y + ey2,
-            )
-            for name, cx_rel, hw_rel, ey1, ey2 in _EMBLEM_RELATIVE_POSITIONS
-        ]
-        if not _emblem_and_check(frame, positions, f"band y={y}", cv2):
-            continue
-        gw = bar_w / W
-        gx = x_left / W
-        gy = y / H
-        gh = (bar_w / _GAME_ASPECT) / H
-        region = CaptureRegion(gx, gy, gw, gh, confidence=0.9, source="tierB").clamp()
-        return region
-    return None
 
 
 def detect_region_blackout_overlap(

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -256,6 +256,52 @@ def _scorebar_saturated_runs(band: np.ndarray, cv2) -> list[tuple[int, int]]:
     return runs
 
 
+def _emblem_and_margin(
+    frame: np.ndarray,
+    positions: list[tuple[str, int, int, int, int]],
+    cv2,
+) -> float | None:
+    """3点 emblem AND。全通過なら最弱 margin (min ratio>1.0)、不通過なら None。
+
+    `detector._emblem_and_check` と同一の sat (bright pixel) / Sobel edge 計算を
+    用いる (OBS parity は plan Task 7 で担保)。各 position は (name,x1,y1,x2,y2)。
+    """
+    from allaganeye.video.detector import (
+        _EMBLEM_EDGE_THRESHOLD,
+        _EMBLEM_SAT_THRESHOLD,
+    )
+
+    min_ratio: float | None = None
+    for _name, x1, y1, x2, y2 in positions:
+        region = frame[y1:y2, x1:x2, :]
+        if region.size == 0:
+            return None
+        bgr = cv2.cvtColor(region, cv2.COLOR_RGB2BGR)
+        hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+        gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+
+        val = hsv[:, :, 2].astype(np.float32)
+        sat = hsv[:, :, 1].astype(np.float32)
+        bright_mask = val > 30
+        if bright_mask.sum() > 5:
+            mean_sat = float(sat[bright_mask].mean())
+        else:
+            mean_sat = 0.0
+
+        sobel_x = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
+        sobel_y = cv2.Sobel(gray, cv2.CV_64F, 0, 1, ksize=3)
+        edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
+
+        if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
+            return None
+        ratio = min(
+            mean_sat / _EMBLEM_SAT_THRESHOLD,
+            edge_density / _EMBLEM_EDGE_THRESHOLD,
+        )
+        min_ratio = ratio if min_ratio is None else min(min_ratio, ratio)
+    return min_ratio
+
+
 def detect_region_scorebar_band(
     frame: np.ndarray,
     *,

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -199,6 +199,63 @@ _GAME_ASPECT = 16.0 / 9.0
 """FF14 game capture のアスペクト比 (帯幅から game 高さを逆算)。"""
 
 
+def _scorebar_saturated_runs(band: np.ndarray, cv2) -> list[tuple[int, int]]:
+    """band (Hb,W,3 uint8 RGB) の saturated column run を width-gate して全件返す。
+
+    `detector._find_scorebar_horizontal_range` の per-pixel mask + col-ratio +
+    gap-merge を共有しつつ、center-straddling 選択 (#803) を撤廃する。返す run は
+    `_SCOREBAR_SCAN_MIN_WIDTH_PX`..`_SCOREBAR_SCAN_MAX_WIDTH_PX` の幅のもののみ。
+    """
+    from allaganeye.video.detector import (
+        _SCOREBAR_SCAN_COL_RATIO,
+        _SCOREBAR_SCAN_MAX_GAP_PX,
+        _SCOREBAR_SCAN_MAX_WIDTH_PX,
+        _SCOREBAR_SCAN_MIN_WIDTH_PX,
+        _SCOREBAR_SCAN_SAT_THRESHOLD,
+        _SCOREBAR_SCAN_VAL_THRESHOLD,
+    )
+
+    bgr = cv2.cvtColor(band, cv2.COLOR_RGB2BGR)
+    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    sat = hsv[:, :, 1].astype(np.float32)
+    val = hsv[:, :, 2].astype(np.float32)
+    pixel_mask = (sat > _SCOREBAR_SCAN_SAT_THRESHOLD) & (
+        val > _SCOREBAR_SCAN_VAL_THRESHOLD
+    )
+    col_saturated = pixel_mask.mean(axis=0) >= _SCOREBAR_SCAN_COL_RATIO
+
+    width = band.shape[1]
+    raw_runs: list[tuple[int, int]] = []
+    i = 0
+    while i < width:
+        if col_saturated[i]:
+            j = i
+            while j < width and col_saturated[j]:
+                j += 1
+            raw_runs.append((i, j - 1))
+            i = j
+        else:
+            i += 1
+
+    if not raw_runs:
+        return []
+
+    merged: list[tuple[int, int]] = [raw_runs[0]]
+    for start, end in raw_runs[1:]:
+        prev_start, prev_end = merged[-1]
+        if start - prev_end - 1 <= _SCOREBAR_SCAN_MAX_GAP_PX:
+            merged[-1] = (prev_start, end)
+        else:
+            merged.append((start, end))
+
+    runs: list[tuple[int, int]] = []
+    for start, end in merged:
+        span_width = end - start + 1
+        if _SCOREBAR_SCAN_MIN_WIDTH_PX <= span_width <= _SCOREBAR_SCAN_MAX_WIDTH_PX:
+            runs.append((start, end))
+    return runs
+
+
 def detect_region_scorebar_band(
     frame: np.ndarray,
     *,

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -302,6 +302,75 @@ def _emblem_and_margin(
     return min_ratio
 
 
+def localize_scorebar(
+    frame: np.ndarray,
+    *,
+    stride: int = _BAND_SCAN_STRIDE,
+    target_ratio: float = _LOCALIZE_TARGET_RATIO,
+) -> ScorebarLocalization | None:
+    """1920x1080 RGB frame から FL scorebar を位置独立に局在化する (P1, #753).
+
+    y を stride 全走査し、各 band で width-gated 全 run に emblem 3点 AND をかけ、
+    通過候補のうち emblem margin が最大の (run, y) を返す (best-hit)。best-hit に
+    より y_top 精度が ±stride/2 に上がり confidence が最良整合の margin になる。
+    試合外 / cv2 不在 / 形状不一致は None。OBS 分類 path からは呼ばれない
+    (Additive、§7)。
+    """
+    try:
+        import cv2
+    except ImportError:
+        return None
+
+    from allaganeye.video.detector import (
+        _EMBLEM_RELATIVE_POSITIONS,
+        _SCOREBAR_SCAN_Y_END,
+        _SCOREBAR_SCAN_Y_START,
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    W = _SCOREBAR_V2_PROBE_WIDTH
+    H = _SCOREBAR_V2_PROBE_HEIGHT
+    if frame.shape[:2] != (H, W):
+        return None
+
+    band_h = _SCOREBAR_SCAN_Y_END - _SCOREBAR_SCAN_Y_START
+    y_max = int(H * _BAND_Y_MAX_FRAC)
+    best: tuple[float, int, int, int] | None = None  # (margin, x_left, x_right, y)
+    for y in range(0, y_max, stride):
+        band = frame[y : y + band_h]
+        for x_left, x_right in _scorebar_saturated_runs(band, cv2):
+            bar_w = x_right - x_left
+            positions: list[tuple[str, int, int, int, int]] = []
+            valid = True
+            for name, cx_rel, hw_rel, ey1, ey2 in _EMBLEM_RELATIVE_POSITIONS:
+                px1 = int(x_left + cx_rel * bar_w - hw_rel * bar_w)
+                px2 = int(x_left + cx_rel * bar_w + hw_rel * bar_w)
+                py1 = y + ey1
+                py2 = y + ey2
+                if px1 < 0 or px2 > W or py1 < 0 or py2 > H or px2 <= px1:
+                    valid = False
+                    break
+                positions.append((name, px1, py1, px2, py2))
+            if not valid:
+                continue
+            margin = _emblem_and_margin(frame, positions, cv2)
+            if margin is not None and (best is None or margin > best[0]):
+                best = (margin, x_left, x_right, y)
+
+    if best is None:
+        return None
+    margin, x_left, x_right, y = best
+    confidence = max(0.0, min(1.0, (margin - 1.0) / (target_ratio - 1.0)))
+    return ScorebarLocalization(
+        x_left=x_left,
+        x_right=x_right,
+        y_top=y,
+        y_bottom=y + band_h,
+        confidence=confidence,
+    )
+
+
 def detect_region_scorebar_band(
     frame: np.ndarray,
     *,

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -313,6 +313,8 @@ def localize_scorebar(
     試合外 / cv2 不在 / 形状不一致は None。OBS 分類 path からは呼ばれない
     (Additive、spec section 7)。
     """
+    if target_ratio <= 1.0:
+        raise ValueError("target_ratio must be > 1.0 (confidence denominator)")
     try:
         import cv2
     except ImportError:

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -54,6 +54,20 @@ class CaptureRegion:
         )
 
 
+@dataclass(frozen=True)
+class ScorebarLocalization:
+    """FL scorebar 帯を 1920x1080 probe frame 内で局在化した結果 (P1, re-plan #753).
+
+    座標はすべて probe px (inclusive)。consumer (P2) が /1920,/1080 で正規化する。
+    """
+
+    x_left: int
+    x_right: int
+    y_top: int
+    y_bottom: int
+    confidence: float
+
+
 FULL_FRAME = CaptureRegion(0.0, 0.0, 1.0, 1.0, confidence=1.0, source="fallback")
 
 
@@ -176,6 +190,10 @@ _BAND_SCAN_STRIDE = 6
 
 _BAND_Y_MAX_FRAC = 0.55
 """scorebar を探す y の上限 (frame 高さ比)。game は frame 上〜中央寄り。"""
+
+_LOCALIZE_TARGET_RATIO = 2.0
+"""confidence が 1.0 に達する emblem margin 倍率 (最弱 emblem の sat/edge が
+閾値の TARGET 倍で満点)。clear な in-match frame で ~1.0 に出るよう選定。"""
 
 _GAME_ASPECT = 16.0 / 9.0
 """FF14 game capture のアスペクト比 (帯幅から game 高さを逆算)。"""

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -309,9 +309,9 @@ def localize_scorebar(
 
     y を stride 全走査し、各 band で width-gated 全 run に emblem 3点 AND をかけ、
     通過候補のうち emblem margin が最大の (run, y) を返す (best-hit)。best-hit に
-    より y_top 精度が ±stride/2 に上がり confidence が最良整合の margin になる。
+    より y_top 精度が +-stride/2 に上がり confidence が最良整合の margin になる。
     試合外 / cv2 不在 / 形状不一致は None。OBS 分類 path からは呼ばれない
-    (Additive、§7)。
+    (Additive、spec section 7)。
     """
     try:
         import cv2

--- a/docs/superpowers/plans/2026-05-29-p1-robust-scorebar-localization.md
+++ b/docs/superpowers/plans/2026-05-29-p1-robust-scorebar-localization.md
@@ -642,7 +642,7 @@ Expected: `allaganeye/video/capture_region.py` の定義行のみ (他の produc
 
 - [ ] **Step 2: S2 関数を削除**
 
-`allaganeye/video/capture_region.py` から `def detect_region_scorebar_band(...)` 関数全体 (docstring 含む、`return None` まで) を削除する。`_BAND_SCAN_STRIDE` / `_BAND_Y_MAX_FRAC` / `_GAME_ASPECT` 定数は `localize_scorebar` (前者2つ) や P2 (後者) で使うため **残す**。
+`allaganeye/video/capture_region.py` から `def detect_region_scorebar_band(...)` 関数全体 (docstring 含む、`return None` まで) を削除する。`_BAND_SCAN_STRIDE` / `_BAND_Y_MAX_FRAC` は `localize_scorebar` で使うため **残す**。`_GAME_ASPECT` は S2 削除後 dead になる (使用箇所が S2 のみ) ため本 Task で **併せて削除** する (P2 で game rect 逆算時に `16/9` を再導入、spec §10)。
 
 - [ ] **Step 3: S2 テストと import を削除**
 

--- a/docs/superpowers/plans/2026-05-29-p1-robust-scorebar-localization.md
+++ b/docs/superpowers/plans/2026-05-29-p1-robust-scorebar-localization.md
@@ -1,0 +1,784 @@
+# P1: robust scorebar 局在化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 任意の 1920x1080 単フレームから FL scorebar を位置独立 (game inset の x/y 位置・HUD スケール非依存) に局在化し span/位置/confidence を返す純粋関数 `localize_scorebar` を追加する (re-plan #753 の P1)。
+
+**Architecture:** Additive (D1)。新規 `localize_scorebar` + helper を `allaganeye/video/capture_region.py` に追加し、wired・OBS 検証済の `detector.py` primitive (`_has_scorebar_v2` / `_find_scorebar_horizontal_range` / `_emblem_and_check`) は一切変更しない。アルゴリズムは方式1 (all-y band scan × width-gated 全 run × emblem 3点 AND gate、#803 center-straddling を撤廃)。unwired な S2 (`detect_region_scorebar_band`) は本 PR で退役。
+
+**Tech Stack:** Python 3 / numpy / opencv-python-headless (cv2) / pytest。TDD hard-gate (Red→Green→Refactor)。
+
+**Spec:** [2026-05-29-p1-robust-scorebar-localization-design.md](../specs/2026-05-29-p1-robust-scorebar-localization-design.md)
+
+**作業 worktree/branch:** `claude/l3-vtuber-replan` (`.claude/worktrees/l3-vtuber-replan`)
+
+**実装方針メモ (spec §5.2/§5.3 の案 A/案 B 決定):** 本計画は **案 A (zero-touch)** を採る。P1 は自前の `_scorebar_saturated_runs` / `_emblem_and_margin` を持ち、`detector.py` の wired 関数を編集しない。emblem sat/edge 計算は `_emblem_and_check` と意図的に同一ロジックを複製し、Task 7 の OBS parity test が drift を検出する。案 B (共有 extract) は P1 land 後の任意 cleanup とする。
+
+---
+
+## File Structure
+
+| ファイル | 変更 | 責務 |
+| --- | --- | --- |
+| `allaganeye/video/capture_region.py` | Modify | `ScorebarLocalization` dataclass + `localize_scorebar` + `_scorebar_saturated_runs` + `_emblem_and_margin` + `_LOCALIZE_TARGET_RATIO` を追加。`detect_region_scorebar_band` (S2) を削除 |
+| `tests/test_capture_region.py` | Modify | localize 系テストを追加。S2 (`detect_region_scorebar_band`) のテスト・import を削除 |
+
+`detector.py` / `scorebar.py` は **変更しない** (D1)。
+
+---
+
+## Task 1: `ScorebarLocalization` dataclass + 定数
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py` (CaptureRegion dataclass の直後、`FULL_FRAME` 定義の前あたり)
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/test_capture_region.py` の import 行を更新し (まだ `detect_region_scorebar_band` は残す。削除は Task 6)、`ScorebarLocalization` を import に追加:
+
+```python
+from allaganeye.video.capture_region import (
+    FULL_FRAME,
+    CaptureRegion,
+    RegionTimeline,
+    ScorebarLocalization,
+    _maybe_snap_full_frame,
+    detect_region_blackout_overlap,
+    detect_region_scorebar_band,
+    detect_region_variance,
+    iou,
+    top_edge_error_px,
+)
+```
+
+ファイル末尾に追加:
+
+```python
+# ---------------------------------------------------------------------------
+# P1: localize_scorebar (re-plan #753)
+# ---------------------------------------------------------------------------
+
+
+def test_scorebar_localization_is_frozen_with_fields():
+    loc = ScorebarLocalization(
+        x_left=100, x_right=700, y_top=300, y_bottom=345, confidence=0.9
+    )
+    assert (loc.x_left, loc.x_right, loc.y_top, loc.y_bottom) == (100, 700, 300, 345)
+    assert loc.confidence == 0.9
+    import dataclasses
+
+    with __import__("pytest").raises(dataclasses.FrozenInstanceError):
+        loc.x_left = 0  # type: ignore[misc]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_capture_region.py::test_scorebar_localization_is_frozen_with_fields -v`
+Expected: FAIL — `ImportError: cannot import name 'ScorebarLocalization'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`allaganeye/video/capture_region.py` の `CaptureRegion` クラス定義の直後 (`FULL_FRAME = ...` の前) に追加:
+
+```python
+@dataclass(frozen=True)
+class ScorebarLocalization:
+    """FL scorebar 帯を 1920x1080 probe frame 内で局在化した結果 (P1, re-plan #753).
+
+    座標はすべて probe px (inclusive)。consumer (P2) が /1920,/1080 で正規化する。
+    """
+
+    x_left: int
+    x_right: int
+    y_top: int
+    y_bottom: int
+    confidence: float
+```
+
+同ファイルの定数群 (`_BAND_Y_MAX_FRAC` 付近) に追加:
+
+```python
+_LOCALIZE_TARGET_RATIO = 2.0
+"""confidence が 1.0 に達する emblem margin 倍率 (最弱 emblem の sat/edge が
+閾値の TARGET 倍で満点)。clear な in-match frame で ~1.0 に出るよう選定。"""
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_capture_region.py::test_scorebar_localization_is_frozen_with_fields -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "feat(l3): add ScorebarLocalization dataclass (P1, re-plan #753)"
+```
+
+---
+
+## Task 2: `_scorebar_saturated_runs` (width-gated 全 run、center 前提なし)
+
+`_find_scorebar_horizontal_range` の (a)〜(c) ロジックを複製し、(d) center-straddling 選択を撤廃して **width-gate を通過した全 run** を返す。これが #803 center 前提の撤廃点。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_capture_region.py` の import に `_scorebar_saturated_runs` を追加 (capture_region から):
+
+```python
+from allaganeye.video.capture_region import (
+    FULL_FRAME,
+    CaptureRegion,
+    RegionTimeline,
+    ScorebarLocalization,
+    _maybe_snap_full_frame,
+    _scorebar_saturated_runs,
+    detect_region_blackout_overlap,
+    detect_region_scorebar_band,
+    detect_region_variance,
+    iou,
+    top_edge_error_px,
+)
+```
+
+ファイル末尾に追加:
+
+```python
+def _sat_band(width_runs, h=45, w=1920):
+    """指定 (x_left, x_right) 範囲を saturated blue で塗った band (h,w,3) を返す。"""
+    band = np.full((h, w, 3), 40, dtype=np.uint8)
+    for x_left, x_right in width_runs:
+        band[:, x_left : x_right + 1] = (50, 50, 200)
+    return band
+
+
+def test_saturated_runs_finds_centered_run():
+    import cv2
+
+    band = _sat_band([(500, 1400)])
+    runs = _scorebar_saturated_runs(band, cv2)
+    assert len(runs) == 1
+    x_left, x_right = runs[0]
+    assert abs(x_left - 500) <= 2 and abs(x_right - 1400) <= 2
+
+
+def test_saturated_runs_finds_off_center_run():
+    # 中心 (x=960) をまたがない左寄り帯。_find_scorebar_horizontal_range は
+    # center-straddling で None を返すが、P1 はこれを拾えねばならない (#803 撤廃)。
+    import cv2
+
+    band = _sat_band([(100, 700)])
+    runs = _scorebar_saturated_runs(band, cv2)
+    assert len(runs) == 1
+    x_left, x_right = runs[0]
+    assert abs(x_left - 100) <= 2 and abs(x_right - 700) <= 2
+
+
+def test_saturated_runs_drops_narrow_and_overwide():
+    import cv2
+
+    # narrow (<500px) と overwide (>1440px) はどちらも width gate で除外。
+    band = _sat_band([(0, 300), (700, 1300)])  # 301px run, 601px run
+    runs = _scorebar_saturated_runs(band, cv2)
+    assert len(runs) == 1
+    assert abs(runs[0][0] - 700) <= 2 and abs(runs[0][1] - 1300) <= 2
+
+    overwide = _sat_band([(100, 1800)])  # 1701px
+    assert _scorebar_saturated_runs(overwide, cv2) == []
+
+
+def test_saturated_runs_blank_returns_empty():
+    import cv2
+
+    band = np.full((45, 1920, 3), 40, dtype=np.uint8)
+    assert _scorebar_saturated_runs(band, cv2) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_capture_region.py -k saturated_runs -v`
+Expected: FAIL — `ImportError: cannot import name '_scorebar_saturated_runs'`
+
+- [ ] **Step 3: Write implementation**
+
+`allaganeye/video/capture_region.py` の `detect_region_scorebar_band` の **直前** に追加:
+
+```python
+def _scorebar_saturated_runs(band: np.ndarray, cv2) -> list[tuple[int, int]]:
+    """band (Hb,W,3 uint8 RGB) の saturated column run を width-gate して全件返す。
+
+    `detector._find_scorebar_horizontal_range` の per-pixel mask + col-ratio +
+    gap-merge を共有しつつ、center-straddling 選択 (#803) を撤廃する。返す run は
+    `_SCOREBAR_SCAN_MIN_WIDTH_PX`..`_SCOREBAR_SCAN_MAX_WIDTH_PX` の幅のもののみ。
+    """
+    from allaganeye.video.detector import (
+        _SCOREBAR_SCAN_COL_RATIO,
+        _SCOREBAR_SCAN_MAX_GAP_PX,
+        _SCOREBAR_SCAN_MAX_WIDTH_PX,
+        _SCOREBAR_SCAN_MIN_WIDTH_PX,
+        _SCOREBAR_SCAN_SAT_THRESHOLD,
+        _SCOREBAR_SCAN_VAL_THRESHOLD,
+    )
+
+    bgr = cv2.cvtColor(band, cv2.COLOR_RGB2BGR)
+    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    sat = hsv[:, :, 1].astype(np.float32)
+    val = hsv[:, :, 2].astype(np.float32)
+    pixel_mask = (sat > _SCOREBAR_SCAN_SAT_THRESHOLD) & (
+        val > _SCOREBAR_SCAN_VAL_THRESHOLD
+    )
+    col_saturated = pixel_mask.mean(axis=0) >= _SCOREBAR_SCAN_COL_RATIO
+
+    width = band.shape[1]
+    raw_runs: list[tuple[int, int]] = []
+    i = 0
+    while i < width:
+        if col_saturated[i]:
+            j = i
+            while j < width and col_saturated[j]:
+                j += 1
+            raw_runs.append((i, j - 1))
+            i = j
+        else:
+            i += 1
+
+    if not raw_runs:
+        return []
+
+    merged: list[tuple[int, int]] = [raw_runs[0]]
+    for start, end in raw_runs[1:]:
+        prev_start, prev_end = merged[-1]
+        if start - prev_end - 1 <= _SCOREBAR_SCAN_MAX_GAP_PX:
+            merged[-1] = (prev_start, end)
+        else:
+            merged.append((start, end))
+
+    runs: list[tuple[int, int]] = []
+    for start, end in merged:
+        span_width = end - start + 1
+        if _SCOREBAR_SCAN_MIN_WIDTH_PX <= span_width <= _SCOREBAR_SCAN_MAX_WIDTH_PX:
+            runs.append((start, end))
+    return runs
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_capture_region.py -k saturated_runs -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "feat(l3): add _scorebar_saturated_runs (all width-gated runs, no center gate)"
+```
+
+---
+
+## Task 3: `_emblem_and_margin` (3点 AND の margin 版)
+
+`_emblem_and_check` と **同一の sat/edge 計算** を行い、3点すべて通過なら最弱 margin (min ratio、>1.0)、1点でも不通過なら `None` を返す。OBS parity は Task 7 で担保。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+import に `_emblem_and_margin` を追加し、ファイル末尾に追加:
+
+```python
+def _frame_with_emblem_box(fill, x1=600, y1=2, x2=665, y2=40):
+    """1920x1080 frame の 1 box を指定 fill で塗る。stripe=高 sat/edge を作る用。"""
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    region = f[y1:y2, x1:x2]
+    if fill == "stripe":
+        for col in range(region.shape[1]):
+            region[:, col] = (200, 30, 30) if (col // 2) % 2 == 0 else (0, 0, 0)
+    else:
+        region[:] = fill
+    return f, [("e", x1, y1, x2, y2)]
+
+
+def test_emblem_and_margin_strong_emblem_returns_ratio_above_one():
+    import cv2
+
+    f, positions = _frame_with_emblem_box("stripe")
+    margin = _emblem_and_margin(f, positions, cv2)
+    assert margin is not None and margin > 1.0
+
+
+def test_emblem_and_margin_flat_region_returns_none():
+    import cv2
+
+    # 単色 (低 edge) は edge 閾値を割るので None。
+    f, positions = _frame_with_emblem_box((50, 50, 200))
+    assert _emblem_and_margin(f, positions, cv2) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_capture_region.py -k emblem_and_margin -v`
+Expected: FAIL — `ImportError: cannot import name '_emblem_and_margin'`
+
+- [ ] **Step 3: Write implementation**
+
+`_scorebar_saturated_runs` の直後に追加:
+
+```python
+def _emblem_and_margin(
+    frame: np.ndarray,
+    positions: list[tuple[str, int, int, int, int]],
+    cv2,
+) -> float | None:
+    """3点 emblem AND。全通過なら最弱 margin (min ratio>1.0)、不通過なら None。
+
+    `detector._emblem_and_check` と同一の sat (bright pixel) / Sobel edge 計算を
+    用いる (OBS parity は plan Task 7 で担保)。各 position は (name,x1,y1,x2,y2)。
+    """
+    from allaganeye.video.detector import (
+        _EMBLEM_EDGE_THRESHOLD,
+        _EMBLEM_SAT_THRESHOLD,
+    )
+
+    min_ratio: float | None = None
+    for _name, x1, y1, x2, y2 in positions:
+        region = frame[y1:y2, x1:x2, :]
+        if region.size == 0:
+            return None
+        bgr = cv2.cvtColor(region, cv2.COLOR_RGB2BGR)
+        hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+        gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+
+        val = hsv[:, :, 2].astype(np.float32)
+        sat = hsv[:, :, 1].astype(np.float32)
+        bright_mask = val > 30
+        if bright_mask.sum() > 5:
+            mean_sat = float(sat[bright_mask].mean())
+        else:
+            mean_sat = 0.0
+
+        sobel_x = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
+        sobel_y = cv2.Sobel(gray, cv2.CV_64F, 0, 1, ksize=3)
+        edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
+
+        if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
+            return None
+        ratio = min(
+            mean_sat / _EMBLEM_SAT_THRESHOLD,
+            edge_density / _EMBLEM_EDGE_THRESHOLD,
+        )
+        min_ratio = ratio if min_ratio is None else min(min_ratio, ratio)
+    return min_ratio
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_capture_region.py -k emblem_and_margin -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "feat(l3): add _emblem_and_margin (margin variant of emblem 3-point AND)"
+```
+
+---
+
+## Task 4: `localize_scorebar` (all-y × all-run scan)
+
+方式1 本体。位置独立 (off-center 復元) を駆動テストにする。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+import に `localize_scorebar` を追加し、ファイル末尾に追加 (`_hires_with_scorebar_at` は既存の S2 テスト helper を再利用):
+
+```python
+def test_localize_centered_in_match_returns_localization():
+    f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
+    loc = localize_scorebar(f)
+    assert loc is not None
+    assert abs(loc.x_left - 500) <= 4 and abs(loc.x_right - 1400) <= 4
+    assert abs(loc.y_top - 120) <= 6  # stride 既定 6
+    assert loc.y_bottom == loc.y_top + 45
+    assert 0.0 < loc.confidence <= 1.0
+
+
+def test_localize_off_center_inset_position_independent():
+    # 中心 (x=960) をまたがない左寄り inset。退役した S2 (_find_scorebar_horizontal_range
+    # center-straddling) では検出不能だった位置独立ケース (P1 の存在意義)。
+    f = _hires_with_scorebar_at(y_top=300, x_left=100, x_right=700)
+    loc = localize_scorebar(f)
+    assert loc is not None
+    assert abs(loc.x_left - 100) <= 4 and abs(loc.x_right - 700) <= 4
+    assert abs(loc.y_top - 300) <= 6
+
+
+def test_localize_blank_frame_returns_none():
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    f = np.full(
+        (_SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3), 40, dtype=np.uint8
+    )
+    assert localize_scorebar(f) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_capture_region.py -k localize -v`
+Expected: FAIL — `ImportError: cannot import name 'localize_scorebar'`
+
+- [ ] **Step 3: Write implementation**
+
+`_emblem_and_margin` の直後に追加:
+
+```python
+def localize_scorebar(
+    frame: np.ndarray,
+    *,
+    stride: int = _BAND_SCAN_STRIDE,
+    target_ratio: float = _LOCALIZE_TARGET_RATIO,
+) -> ScorebarLocalization | None:
+    """1920x1080 RGB frame から FL scorebar を位置独立に局在化する (P1, #753).
+
+    y を stride 全走査し、各 band で width-gated 全 run に emblem 3点 AND をかけ、
+    通過候補のうち emblem margin が最大の (run, y) を返す (best-hit)。best-hit に
+    より y_top 精度が ±stride/2 に上がり confidence が最良整合の margin になる。
+    試合外 / cv2 不在 / 形状不一致は None。OBS 分類 path からは呼ばれない
+    (Additive、§7)。
+    """
+    try:
+        import cv2
+    except ImportError:
+        return None
+
+    from allaganeye.video.detector import (
+        _EMBLEM_RELATIVE_POSITIONS,
+        _SCOREBAR_SCAN_Y_END,
+        _SCOREBAR_SCAN_Y_START,
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    W = _SCOREBAR_V2_PROBE_WIDTH
+    H = _SCOREBAR_V2_PROBE_HEIGHT
+    if frame.shape[:2] != (H, W):
+        return None
+
+    band_h = _SCOREBAR_SCAN_Y_END - _SCOREBAR_SCAN_Y_START
+    y_max = int(H * _BAND_Y_MAX_FRAC)
+    best: tuple[float, int, int, int] | None = None  # (margin, x_left, x_right, y)
+    for y in range(0, y_max, stride):
+        band = frame[y : y + band_h]
+        for x_left, x_right in _scorebar_saturated_runs(band, cv2):
+            bar_w = x_right - x_left
+            positions: list[tuple[str, int, int, int, int]] = []
+            valid = True
+            for name, cx_rel, hw_rel, ey1, ey2 in _EMBLEM_RELATIVE_POSITIONS:
+                px1 = int(x_left + cx_rel * bar_w - hw_rel * bar_w)
+                px2 = int(x_left + cx_rel * bar_w + hw_rel * bar_w)
+                py1 = y + ey1
+                py2 = y + ey2
+                if px1 < 0 or px2 > W or py1 < 0 or py2 > H or px2 <= px1:
+                    valid = False
+                    break
+                positions.append((name, px1, py1, px2, py2))
+            if not valid:
+                continue
+            margin = _emblem_and_margin(frame, positions, cv2)
+            if margin is not None and (best is None or margin > best[0]):
+                best = (margin, x_left, x_right, y)
+
+    if best is None:
+        return None
+    margin, x_left, x_right, y = best
+    confidence = max(0.0, min(1.0, (margin - 1.0) / (target_ratio - 1.0)))
+    return ScorebarLocalization(
+        x_left=x_left,
+        x_right=x_right,
+        y_top=y,
+        y_bottom=y + band_h,
+        confidence=confidence,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_capture_region.py -k localize -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "feat(l3): add localize_scorebar all-y x all-run scan (P1, re-plan #753)"
+```
+
+---
+
+## Task 5: localize_scorebar robustness / negative / 異常系 coverage
+
+§8.1 scale / §8.2 negative / §8.5 異常系 を網羅する。Task 4 の実装で全 pass するはず。fail したら実装を修正する (bounds guard / width gate)。
+
+**Files:**
+
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write the tests**
+
+ファイル末尾に追加:
+
+```python
+def test_localize_scale_variation_recovers_span():
+    # HUD スケール差を span 幅で模擬。narrow と wide の両方で復元できること。
+    for x_left, x_right in [(700, 1220), (300, 1620)]:
+        f = _hires_with_scorebar_at(y_top=60, x_left=x_left, x_right=x_right)
+        loc = localize_scorebar(f)
+        assert loc is not None, (x_left, x_right)
+        assert abs(loc.x_left - x_left) <= 4 and abs(loc.x_right - x_right) <= 4
+
+
+def test_localize_off_center_band_without_emblems_returns_none():
+    # 中心をまたがない右寄りの単色帯 (emblem なし)。all-run 化しても emblem-AND
+    # が落とすので None。#803 (post-match 広帯) 防御が center 前提なしで成立する確証。
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    f[0:45, 1400:1919] = (50, 50, 200)  # 519px 右寄り帯、紋章なし
+    assert localize_scorebar(f) is None
+
+
+def test_localize_overwide_band_returns_none():
+    f = _hires_with_scorebar_at(y_top=2, x_left=120, x_right=1810)
+    assert localize_scorebar(f) is None
+
+
+def test_localize_uniform_cyan_banner_returns_none():
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    f[0:55, :] = (60, 200, 200)  # 全幅単色 cyan (>max width かつ紋章なし)
+    assert localize_scorebar(f) is None
+
+
+def test_localize_wrong_shape_returns_none():
+    f = np.full((100, 100, 3), 40, dtype=np.uint8)
+    assert localize_scorebar(f) is None
+
+
+def test_localize_returns_none_without_cv2(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "cv2":
+            raise ImportError("simulated missing cv2")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
+    assert localize_scorebar(f) is None
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pytest tests/test_capture_region.py -k localize -v`
+Expected: PASS (全 localize テストが pass)。fail した場合は `localize_scorebar` の bounds guard / width gate を見直して修正し、再実行。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_capture_region.py
+git commit -m "test(l3): localize_scorebar scale/negative/error coverage (#803 guard, cv2-absent)"
+```
+
+---
+
+## Task 6: S2 (`detect_region_scorebar_band`) 退役
+
+unwired・superseded な S2 を削除し、そのテストを除去する (D3)。`localize_scorebar` が後継。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py` (関数削除)
+- Modify: `tests/test_capture_region.py` (import + 3 テスト削除)
+
+- [ ] **Step 1: 参照が production に無いことを確認**
+
+Run: `git grep -n "detect_region_scorebar_band" -- allaganeye`
+Expected: `allaganeye/video/capture_region.py` の定義行のみ (他の production 参照なし)。もし他に参照があれば STOP して原因調査 (本計画の前提が崩れる)。
+
+- [ ] **Step 2: S2 関数を削除**
+
+`allaganeye/video/capture_region.py` から `def detect_region_scorebar_band(...)` 関数全体 (docstring 含む、`return None` まで) を削除する。`_BAND_SCAN_STRIDE` / `_BAND_Y_MAX_FRAC` / `_GAME_ASPECT` 定数は `localize_scorebar` (前者2つ) や P2 (後者) で使うため **残す**。
+
+- [ ] **Step 3: S2 テストと import を削除**
+
+`tests/test_capture_region.py` から:
+
+- import 文の `detect_region_scorebar_band,` 行を削除
+- 以下 3 テストを削除: `test_scorebar_band_at_offset_y_returns_inset_top` / `test_scorebar_band_overwide_returns_none` / `test_scorebar_band_uniform_cyan_banner_rejected`
+
+`_hires_with_scorebar_at` helper は localize テストが使うため **残す**。
+
+- [ ] **Step 4: 全テスト + 参照確認**
+
+Run: `pytest tests/test_capture_region.py -v`
+Expected: PASS (S2 テストが消え、localize テスト群が残って全 pass)
+
+Run: `git grep -n "detect_region_scorebar_band"`
+Expected: 出力なし (定義・テスト・import すべて消えた)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "refactor(l3): retire unwired S2 detect_region_scorebar_band (superseded by localize_scorebar)"
+```
+
+---
+
+## Task 7: OBS parity test (F4-b、案 A の drift guard)
+
+`localize_scorebar` と wired な `_has_scorebar_v2` が同一フレームで合致することを確認し、emblem 計算の意図的複製 (案 A) が drift していないことを担保する。
+
+**Files:**
+
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write the tests**
+
+ファイル末尾に追加:
+
+```python
+def test_localize_agrees_with_has_scorebar_v2_in_match():
+    # 絶対 emblem 位置に重なる span を描くと _has_scorebar_v2 Primary が True。
+    # localize_scorebar も relative 位置で検出 -> 両者が in-match で合致 (OBS parity)。
+    from allaganeye.video.detector import _has_scorebar_v2
+
+    f = _hires_with_scorebar_at(y_top=0, x_left=600, x_right=1318)
+    assert localize_scorebar(f) is not None
+    assert _has_scorebar_v2(f.tobytes()) is True
+
+
+def test_localize_agrees_with_has_scorebar_v2_non_match():
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+        _has_scorebar_v2,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    assert localize_scorebar(f) is None
+    assert _has_scorebar_v2(f.tobytes()) is False
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pytest tests/test_capture_region.py -k agrees_with_has_scorebar_v2 -v`
+Expected: PASS (2 passed)。fail する場合は `_emblem_and_margin` の sat/edge 計算が `_emblem_and_check` と乖離している可能性 → 計算を一致させる。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_capture_region.py
+git commit -m "test(l3): OBS parity between localize_scorebar and _has_scorebar_v2 (F4-b)"
+```
+
+---
+
+## Task 8: 全自動チェック + 実機検証 handoff
+
+**Files:** なし (検証のみ)
+
+- [ ] **Step 1: Python 自動チェックを全 pass させる (Iron Law 6)**
+
+Run (worktree root で):
+
+```bash
+ruff check .
+ruff format --check .
+pyright
+pytest
+```
+
+Expected: すべて pass (`pytest` は slow 除外で全 green)。失敗は本 PR 内で修正してから次へ。
+
+- [ ] **Step 2: 実機 sanity (gyawa、§8.3) — 手動**
+
+サンプル VOD (gyawa) の in-match 時刻で `localize_scorebar` が非 None、lobby/transition で None になることを手動確認する。`ALLAGANEYE_SAMPLE_VIDEO_DIR` 設定済み前提で、以下を python で実行 (`<gyawa.mkv>` と `<in_match_sec>` / `<lobby_sec>` は実 VOD から指定):
+
+```bash
+python -c "import numpy as np; from allaganeye.video.detector import _probe_frame_rgb_hires, _SCOREBAR_V2_PROBE_WIDTH as W, _SCOREBAR_V2_PROBE_HEIGHT as H; from allaganeye.video.capture_region import localize_scorebar; from pathlib import Path; p=Path(r'<gyawa.mkv>'); b=_probe_frame_rgb_hires(p, <in_match_sec>); f=np.frombuffer(b,np.uint8).reshape(H,W,3); print('in-match:', localize_scorebar(f))"
+```
+
+Expected: in-match 時刻で `ScorebarLocalization(...)` が出力され、span/y が game inset 上端と整合。lobby 時刻 (`<lobby_sec>`) で `None`。結果を PR 本文に記録 (machine-unverifiable bullet)。
+
+- [ ] **Step 3: 実機検証依頼の用意 (Iron Law 6)**
+
+`localize_scorebar` は detector 隣接の新ロジックのため、PR 作成時に Idios へ実機検証 (gyawa VOD での localization 目視確認) を `AskUserQuestion` で依頼する。Step 2 の結果を添える。
+
+- [ ] **Step 4: D4 マージ gate の明示**
+
+PR 本文に「**multi-source 検証 (受け入れ条件 6) 未達のためマージ保留**。追加 VTuber source 入手・`allaganeye-guard verify` 通過・localization 確認まで land しない」と明記する (spec §3 D4 / §8.6-6)。chain は方針 (i): 実装・レビューは進め、マージのみ保留。
+
+---
+
+## Self-Review (この計画 vs spec)
+
+**1. Spec coverage:**
+
+| spec | 対応タスク |
+| --- | --- |
+| §4 API (`ScorebarLocalization` / `localize_scorebar`) | Task 1, 4 |
+| §5.2 saturated_runs (#803 撤廃) | Task 2 |
+| §5.3 emblem_and_margin | Task 3 |
+| §5.1/§5.4 scan 本体 | Task 4 |
+| §6 confidence (best-hit margin) | Task 4 (`target_ratio` / clamp / best-hit / range assert `0<conf<=1`) |
+| §7.2 None 契約 / §7.3 小 inset | Task 4, 5 |
+| §8.1 合成 position/scale | Task 4, 5 |
+| §8.2 negative (#803 含む) | Task 5 |
+| §8.4 OBS parity (F4-b) | Task 7 (F4-a は既存 baseline 回帰で自明) |
+| §8.5 異常系 | Task 5 |
+| §8.6-4 S2 退役 | Task 6 |
+| §8.6-5 全チェック | Task 8 |
+| §8.6-6 multi-source マージ gate (D4) | Task 8 (手動 gate、コード化対象外) |
+
+**2. Placeholder scan:** Task 8 Step 2 の `<gyawa.mkv>` / `<in_match_sec>` は実 VOD 依存の手動検証値で、自動テストではない (data-gated)。自動テスト (Task 1-7) に placeholder はなく完全なコードを記載済み。
+
+**3. Type consistency:** `ScorebarLocalization(x_left,x_right,y_top,y_bottom,confidence)` は Task 1 定義と Task 4 生成・全テストで一致。`_scorebar_saturated_runs(band, cv2)->list[(int,int)]` / `_emblem_and_margin(frame,positions,cv2)->float|None` のシグネチャは Task 2/3 定義と Task 4 呼び出しで一致。
+
+**結論:** spec の全項目に対応タスクあり。自動化可能な §8.1-8.5/§8.6-1〜5 は Task 1-7 で TDD 実装、手動/data-gated な §8.3 実機・§8.6-6 multi-source は Task 8 で gate 化。

--- a/docs/superpowers/specs/2026-05-28-vtuber-region-boundary-replan-design.md
+++ b/docs/superpowers/specs/2026-05-28-vtuber-region-boundary-replan-design.md
@@ -1,0 +1,96 @@
+# L3: VTuber 領域・境界検出 再アーキテクチャ (re-plan) 設計 (2026-05-28)
+
+> **Status**: brainstorming 完了 (分解レベル) / 各サブプロジェクトは個別に spec → plan
+> **Parent**: [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753)
+> **Supersedes (approach)**: #809 の領域 auto-detection 手法 (S3 uniform-sampling + near-black dark_thresh)。#809 の wiring コードは P3 で再利用
+> **基づく**: Codex rescue (2026-05-28) の知見 + #809 Wave F 実機検証
+> **関連 spec**: [2026-05-26-vtuber-capture-region-detection-design.md](2026-05-26-vtuber-capture-region-detection-design.md) (Phase 2a) / [2026-05-27-vtuber-pass1-region-wiring-design.md](2026-05-27-vtuber-pass1-region-wiring-design.md) (#809) / [2026-05-18-v030-l3-redefinition-design.md](2026-05-18-v030-l3-redefinition-design.md) (上位 L3)
+
+## 1. 背景: #809 Wave F で判明したこと
+
+本 issue #809 (VTuber Pass1 領域輝度 wiring) を実装し gyawa 2h43m VOD で実機検証した結果:
+
+- ✅ **wiring は健全**: 検出領域で crop した輝度を Pass1/Pass2/GPU に通す経路 + OBS は FULL_FRAME 縮退で detect 出力 bit-exact (5 baseline FULL_FRAME + OBS+GPU detect が baseline と MATCH)。
+- ✅ **crop が Pass1 を解錠** (finding #4 実証): spike で full-frame recover 0/5 → 領域 crop recover 4/5 start + drop 5/5 end。
+- ⚠️ **領域 auto-detection が脆い**: 全 VOD 一様 sampling → S3 (per-pixel max/min) は overlay/avatar の時間変動も拾い full-width 誤検出。near-black `dark_thresh=3` で gyawa は IoU 0.976 に改善したが **sampling 密度依存 + gyawa 1-source 過学習** (R6)。黒画面の深さは encoder/overlay 輝度依存で multi-source 不安定。
+- ⚠️ **production の clean な試合分割は未達**: `detect_match_boundaries` を VTuber crop に回すと 8 境界が出て GT の ~4/10。原因は (a) OBS 調整の `_expand_regions_with_transitions` (閾値 55, lobby ~51 向け) が VTuber crop の lobby 輝度 50-86 を過剰 merge し実境界を失う、(b) scorebar 分類が OBS 絶対座標前提で VTuber inset 内の scorebar を誤分類 (#480 未対応)。
+
+## 2. アーキテクチャの転換: scorebar を上流 anchor に
+
+Codex rescue の核心: **FL scorebar の HUD 幾何はコンテンツ固定**で encoder/overlay に依存しない。よって領域検出の anchor と境界分類の両方に使える共有基盤になる。これは依存順序を**反転**させる。
+
+| | 旧 (#807/#809) | 新 (本再計画) |
+| --- | --- | --- |
+| scorebar | 領域検出の**下流** (#480 が領域を消費) | **上流 anchor** (領域も分類も scorebar 局在化を消費) |
+| 領域検出 | S3 uniform-sampling + near-black dark (黒深度依存・脆い) | scorebar 幾何 anchor + S3 extent の **consensus** (幾何固定・頑健) |
+| 鶏卵 (領域↔暗転) | S3 が暗転フレームを必要 (uniform sampling で代替→汚染) | scorebar は試合中フレームで局在化 → 暗転時刻不要で解消 |
+
+## 3. サブプロジェクト分解と依存順
+
+| # | サブプロジェクト | 内容 | 依存 | issue 対応 |
+| --- | --- | --- | --- | --- |
+| **P1** | **robust scorebar 局在化 (anchor)** | 任意フレームで FL scorebar を HUD signature (GC 紋章 3 点 AND + span) で位置特定。game inset 位置非依存・OBS/VTuber 統一・confidence 付き。Phase 2a の S2 (`detect_region_scorebar_band`) / 絶対座標 `_has_scorebar_v2` を一般化 | — | #480 内包 or 新規 (Iron Law 2 で起票時確定。案: #480 を localization+classification に再定義) |
+| **P2** | **scorebar-anchored 領域検出** | scorebar 幾何 + S3 extent の consensus + 幾何/aspect/area サニティ + confidence gate → game 矩形。低信頼/不一致は FULL_FRAME。`detect_coarse_region` の dark_thresh=3 を置換 | P1 | #809 detect_coarse_region 再設計 |
+| **P3** | **領域 crop 輝度 wiring** | crop→Pass1/Pass2/GPU + `effective_threshold` + OBS bit-exact。#809 の検証済みコードを再利用 | P2 | #809 wiring コード再利用 |
+| **P4** | **region-aware 境界分類 (#480)** | 局在化した scorebar (P1) で inset 内 scorebar を読み `match_boundary`/`in_match`/`non_fl` 分類。clean end-to-end の鍵 | P1, P2 | #480 |
+| **P5** | **adaptive transition expansion** | inset 検出時は crop 輝度分布から transition 閾値を動的導出。FULL_FRAME は現行 55 維持 | P3 | 新規 |
+| **P6** | **metadata 領域フィールド** | coarse region (+ per-segment) を metadata.json 永続化 | P2 | #810 (既存) |
+
+依存順: **P1 → P2 → {P3, P4} → P5**、P6 は P2 後に並行。#481 (minimap) は別レイヤーで P1/P2 の領域を消費。
+
+## 4. #809 の処遇
+
+- **#809 branch (`claude/l3-809-pass1-region-wiring`, 22 commits) は park** (PR せず)。
+- **再利用**: P3 wiring コード (capture_region.py の `is_full_frame`/`region_mean`、detector.py の crop 分岐 + `effective_threshold` + GPU crop、bit-exact 機構) は新計画下で cherry-pick / 再適用。
+- **置換**: `detect_coarse_region` (uniform-sampling + dark_thresh=3) は P2 の consensus 検出器で置換。`_REGION_DARK_THRESH` は廃止。
+- #809 の spec (2026-05-27) は「approach は本再計画で supersede、wiring は再利用」と注記する。
+
+## 5. 検証前提 (multi-source data 未確定)
+
+- multi-source VTuber source の入手は**現時点で未確定** (別途確認)。
+- よって本再計画は「**設計・実装はするが robustness 検証はデータ待ち**」を前提とする: P1/P2/P5 は当面 gyawa 1-source + 合成テストで検証し、multi-source robustness は追加ソース (guard verify 通過) 入手後の data-gated follow-up とする。
+- **OBS bit-exact は全 P で hard gate 維持** (FULL_FRAME 縮退で v0.3.0 baseline と bit-exact)。新 VTuber ロジックは「non-full-frame かつ high-confidence」gate の内側に閉じ込め、OBS 回帰を構造的に防ぐ。
+
+## 6. サブプロジェクト・スケッチ (各 P は個別 spec で詳細化)
+
+- **P1 (最初に spec 化)**: 入力=単フレーム (RGB)。出力=scorebar span/位置/confidence または None。OBS (全幅 HUD) と VTuber (inset 内 HUD) を統一的に扱う。GC 紋章 3 点 AND の HUD スケール耐性、全 y 走査コスト、confidence スコアリング、試合外フレームでの None 返却が論点。Phase 2a の S2 が原型。
+- **P2**: P1 を試合中らしい複数フレームで実行 → scorebar 幾何の median/consensus → game 上端・幅。S3 extent で下端・左右を補完。幾何サニティ (aspect/area) + confidence gate。OBS は FULL_FRAME。
+- **P3**: #809 wiring を P2 の region で駆動。bit-exact 機構そのまま。
+- **P4 (#480)**: P1 の局在化 scorebar を inset 座標で読み分類。`filter_blackouts_with_scorebar` に CaptureRegion を渡す。
+- **P5**: crop Pass1 brightness の percentile クラスタから transition 閾値推定。
+- **P6 (#810)**: `RegionTimeline.to_dict` を metadata.json schema に。
+
+## 7. リスク
+
+| # | リスク | 緩和 |
+| --- | --- | --- |
+| R1 | OBS bit-exact 回帰 | FULL_FRAME 縮退 + confidence gate + 全 P で baseline 回帰テスト hard gate |
+| R2 | gyawa 1-source 過学習 (multi-source 未確定) | 幾何ベース (scorebar) で原理的頑健化 + multi-source 検証を data-gated follow-up に明示 |
+| R3 | P1 が試合中フレームを十分得られない (短い VOD / 試合少) | 疎 sampling + 複数フレーム consensus + 取得失敗時 FULL_FRAME fallback |
+| R4 | scorebar が overlay 装飾 (シアン帯等) と誤検出 | GC 紋章 3 点 AND (Phase 2a 検証済機構) を流用 |
+| R5 | 大きめスコープでの統合コスト | P1→P2→… の段階導入、各 P 独立 spec/plan/PR |
+
+## 8. 決定ログ (本再計画ブレスト)
+
+| 論点 | 決定 |
+| --- | --- |
+| アーキテクチャ | **scorebar 局在化を上流 anchor に**転換 (領域・分類の共有基盤) |
+| #809 | **branch park** (PR せず)、wiring コードは P3 で再利用、detect_coarse_region は P2 で置換 |
+| 分解 | P1 scorebar 局在化 → P2 領域検出 → {P3 wiring, P4 分類#480} → P5 transition、P6 metadata 並行 |
+| 最初の spec 対象 | **P1 robust scorebar 局在化** |
+| multi-source 検証 | データ未確定 → 設計・実装は進め、robustness 検証は data-gated follow-up。gyawa 1-source + 合成で当面検証 |
+| OBS bit-exact | 全 P で hard gate 維持 |
+
+## 9. 次のステップ
+
+1. 本 overview を user レビュー。
+2. **P1 (robust scorebar 局在化) を個別 brainstorming → spec → writing-plans → 実装**。
+3. 以降 P2→… を順に。issue 再構成 (P1 を #480 に内包、P5 新規起票等) は Iron Law 2 で user 承認後に実施。
+
+## 10. 参照
+
+- #809 spec: [2026-05-27-vtuber-pass1-region-wiring-design.md](2026-05-27-vtuber-pass1-region-wiring-design.md) (§10 Wave F 実測)
+- Phase 2a spec: [2026-05-26-vtuber-capture-region-detection-design.md](2026-05-26-vtuber-capture-region-detection-design.md) (§6.3.1 実測選定: S2 上端 15.7px / S3 IoU 0.851)
+- 現行コード: `allaganeye/video/capture_region.py` (`detect_region_scorebar_band`=S2, `detect_region_blackout_overlap`=S3), `allaganeye/video/detector.py` (`_has_scorebar_v2` 絶対座標, `_find_scorebar_horizontal_range`, `_expand_regions_with_transitions`), `allaganeye/video/scorebar.py` (`filter_blackouts_with_scorebar`)
+- 既存 issue: #480 (scorebar ROI 適応。本再計画で P1+P4 に再定義する案), #481 (minimap), #810 (metadata 領域フィールド)
+- Codex rescue (2026-05-28): consensus 検出器 / region-aware scorebar / adaptive transition / BLOCKED (multi-source 必要)

--- a/docs/superpowers/specs/2026-05-29-p1-robust-scorebar-localization-design.md
+++ b/docs/superpowers/specs/2026-05-29-p1-robust-scorebar-localization-design.md
@@ -1,0 +1,221 @@
+# P1: robust scorebar 局在化 (anchor) 設計 (2026-05-29)
+
+> **Status**: brainstorming 完了 / writing-plans へ
+> **Parent (re-plan)**: [2026-05-28-vtuber-region-boundary-replan-design.md](2026-05-28-vtuber-region-boundary-replan-design.md) §3 P1 / §6 P1 スケッチ
+> **上位 issue**: [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753)
+> **基づく**: Phase 2a ([2026-05-26-vtuber-capture-region-detection-design.md](2026-05-26-vtuber-capture-region-detection-design.md)) の S2 / `_has_scorebar_v2`、#809 Wave F 実機検証
+> **issue 対応**: 起票方針は Iron Law 2 で user 承認後に確定 (§11)。案: #480 を localization(P1)+classification(P4) に再定義し P1 を内包
+
+## 1. 目的
+
+任意の単フレームから FL scorebar を **位置独立** (game inset の x/y 位置・HUD スケールに非依存) に局在化し、span・位置・confidence を返す純粋関数 `localize_scorebar` を提供する。これは再アーキテクチャ (replan) の **上流 anchor** であり、P2 (領域検出) と P4 (#480 境界分類) の共有基盤になる。
+
+replan の核心: **FL scorebar の HUD 幾何はコンテンツ固定**で encoder/overlay/inset 位置に依存しない。よって「黒画面の深さ」(脆い・1-source 過学習) ではなく scorebar 幾何を anchor にすることで原理的に頑健化する。
+
+## 2. スコープと成果物
+
+### 2.1 P1 の成果物
+
+- `ScorebarLocalization` dataclass (§4)
+- `localize_scorebar(frame: np.ndarray) -> ScorebarLocalization | None` (`allaganeye/video/capture_region.py`)
+- 補助 helper (saturated-run 列挙 / emblem margin、§5)
+- 上記のユニット/合成/実フレーム テスト (§8)
+
+### 2.2 P1 がやらないこと (境界)
+
+| 項目 | 担当 |
+| --- | --- |
+| game 矩形の逆算 (span → game rect) | **P2** (現 S2 の `gw/gh` 逆算ロジックは P2 へ移設) |
+| 複数フレーム consensus / median | **P2** |
+| 暗転分類 (`match_boundary`/`in_match`/`non_fl`) | **P4 (#480)** |
+| coarse region の metadata 永続化 | **P6 (#810)** |
+| detect pipeline への wiring | **P2 / P3 / P4** |
+
+P1 は **単フレーム localization のみ**。robustness (外れ値除去) は P2 の多フレーム consensus が担う。
+
+### 2.3 不変条件 (判定挙動を変えないもの)
+
+`_has_scorebar_v2` / `_probe_scorebar_context` / `_drop_post_match_trailing` / `_find_scorebar_horizontal_range` の **判定挙動 (bool/span の結果) は不変**。P1 は Additive (新規関数) で追加し、OBS 分類 path には P1 を一切結線しない (§7)。
+
+注: §5.2/§5.3 で共有 helper を extract する選択肢を採る場合も、それは **挙動完全保存 (behavior-preserving) な内部抽出**に限り、上記関数の判定結果は 1 bit も変えない (§8.4 F4 parity test で担保)。「touch しない」の核心は OBS 判定の不変であり、内部構造の保存的抽出は許容範囲。D1 (Additive) の趣旨を最優先して zero-touch を選ぶこともできる (§5.2)。
+
+## 3. 決定事項 (brainstorming 2026-05-29)
+
+| # | 論点 | 決定 | 理由 |
+| --- | --- | --- | --- |
+| D1 | 実装構成 | **Additive (新規 `localize_scorebar`)**。`_has_scorebar_v2` は不変 | wired・OBS bit-exact 検証済 primitive を touch せず、OBS 回帰を構造的に防止。replan の「新ロジックを gate 内に封じる」哲学に合致 |
+| D2 | 局在化アルゴリズム | **方式1: all-runs × all-y band scan + emblem-AND gate** | 検証済み emblem-AND (zero-FP) を最終 discriminator にする素直な一般化。x/y 位置独立。#803 center-straddling 前提を構造的に解消 |
+| D3 | S2 (`detect_region_scorebar_band`) | **P1 で退役** (`localize_scorebar` に一般化、テストは localize 系へ移行) | unwired・superseded。dead/重複コードを残さず clean。overview の「S2 を一般化」に沿う |
+| D4 | multi-source 検証 | **P1 のマージ gate (受け入れ条件)**。実装+gyawa+合成は今進め、追加 source 入手・guard verify・検証完了まで **P1 マージは保留** | 追加 VTuber source 入手見込みあり。gyawa 1-source 過学習リスク (R2) を実データで潰してから land する |
+
+> **D4 の replan との差分**: replan §5/§8 は multi-source を「data-gated *follow-up*」としていたが、本 P1 では user 判断により **マージ gate** に強化する。これは P1 (および依存する P2→P4→P5 chain) の land を multi-source データ入手まで保留することを意味する (§8.4 / §10 で chain 影響を明記)。
+
+## 4. API / データ構造
+
+```python
+@dataclass(frozen=True)
+class ScorebarLocalization:
+    x_left: int        # 1920x1080 probe 上の px、inclusive
+    x_right: int       # px、inclusive
+    y_top: int         # scorebar 帯の上端 px (P2 はこれを game 上端 anchor に使う)
+    y_bottom: int      # y_top + band_h
+    confidence: float  # [0,1]、emblem margin 由来 (§6)
+```
+
+- **入力**: `np.ndarray (1080, 1920, 3) uint8` (RGB)。caller は `_probe_frame_rgb_hires` で取得。
+- **座標系**: probe px (emblem 機構と同一基準で精度確保)。正規化 ([0,1]) は consumer (P2) が `/1920, /1080` で実施。
+- **戻り値**: 局在化成功で `ScorebarLocalization`、非試合/検出不能/cv2 不在/形状不一致で `None` (§7)。
+
+## 5. アルゴリズム (方式1)
+
+### 5.1 擬似コード
+
+```text
+localize_scorebar(frame):                       # frame: (1080,1920,3) uint8
+    if cv2 unavailable: return None
+    if frame.shape != (1080,1920,3): return None
+    band_h = _SCOREBAR_SCAN_Y_END - _SCOREBAR_SCAN_Y_START   # = 45
+    y_max  = int(1080 * _BAND_Y_MAX_FRAC)                     # ≈ 594
+    for y in range(0, y_max, stride):            # stride 既定 = _BAND_SCAN_STRIDE (6) → ~99 steps
+        band = frame[y : y + band_h]             # (45,1920,3)
+        for (x_left, x_right) in saturated_runs(band):   # width-gated 全 run、center 前提なし
+            positions = emblem_positions(x_left, x_right, y)   # _EMBLEM_RELATIVE_POSITIONS
+            margin = emblem_and_margin(frame, positions)       # 3点 AND 通過なら最弱 margin、不通過 None
+            if margin is not None:
+                return ScorebarLocalization(x_left, x_right, y, y + band_h, conf(margin))
+    return None
+```
+
+### 5.2 saturated_runs (#803 center-straddling の撤廃)
+
+既存 `_find_scorebar_horizontal_range` は (a) sat/val 閾値で per-pixel mask → (b) col-ratio で saturated column 判定 → (c) gap-merge で run 構築 → (d) **screen center を straddle する run のみ採用** → (e) width gate、という流れ。
+
+P1 の `saturated_runs(band)` は **(a)〜(c) を共有**し、(d) を撤廃して **width-gated 全 run のリスト**を返す:
+
+- 撤廃理由: VTuber inset は frame 中心に無いため center-straddling 前提が破綻する。
+- #803 (post-match 広帯の誤検出) の代替防御: 全 run に emblem-AND をかける。post-match の彩度帯は emblem-AND (zero-FP 検証済) で落ちるので、center 前提なしでも誤検出しない。
+- width gate (`_SCOREBAR_SCAN_MIN_WIDTH_PX`=500 .. `_SCOREBAR_SCAN_MAX_WIDTH_PX`=1440) は既定維持。
+
+**実装手段** (plan/TDD で確定、いずれも OBS 判定不変):
+
+- **案 A (zero-touch、D1 趣旨最優先)**: P1 側で run 構築 (a)〜(c) を ~15 行持つ。`_find_scorebar_horizontal_range` を一切編集しない。
+- **案 B (共有 extract)**: (a)〜(c) を behavior-preserving な pure helper `_scorebar_saturated_runs(band)` に抽出し、`_find_scorebar_horizontal_range` (center+width filter を後段適用) と P1 (width filter のみ + 全 run) が共用。重複ゼロだが wired 関数の内部を保存的に書き換える。§8.4 F4 parity test で挙動保存を担保。
+
+D1 (Additive) を OBS 安全のため選んだ経緯から既定は案 A 寄り。重複を嫌う場合に案 B を選択 (parity test で安全)。どちらでも **OBS 判定は 1 bit も変わらない**。
+
+### 5.3 emblem_positions / emblem_and_margin
+
+- `emblem_positions(x_left, x_right, y)`: `_EMBLEM_RELATIVE_POSITIONS` の `(name, cx_rel, hw_rel, ey1, ey2)` から、span 幅 `bar_w = x_right - x_left` を基準に各 emblem の絶対矩形を算出 (現 S2 / `_has_scorebar_v2` Path2 と同一式)。y オフセットを加算して band 内座標を frame 座標へ戻す。
+- `emblem_and_margin(frame, positions)`: 各 emblem で `mean_sat` (bright pixel) と `edge_density` (Sobel) を計算し、`_EMBLEM_SAT_THRESHOLD`(70) / `_EMBLEM_EDGE_THRESHOLD`(40) と比較。3点すべて両閾値超なら最弱 margin を返し、1点でも不通過なら `None`。bool だけ返す既存 `_emblem_and_check` の margin 版。
+  - **実装手段** (plan/TDD で確定、§5.2 と同じ案 A/案 B の trade-off): 案 A = P1 側に margin 計算を持つ (`_emblem_and_check` 不変)。案 B = `_emblem_and_margin` を新設し `_emblem_and_check` をその bool ラッパに保存的 refactor (OBS parity で担保)。いずれも `_has_scorebar_v2` の判定不変。
+
+### 5.4 探索順序とコスト
+
+- y 昇順 first-hit short-circuit: in-match は scorebar が inset 上端 (小 y) にあるため早期 hit。
+- 最悪 (非試合・hit なし): ~99 y-step × (band の HSV 変換 + run 構築)。emblem-AND は width-gated run (非試合では 0〜1 本) のみに走るため、支配コストは per-y の HSV 変換 (cheap numpy)。
+- `stride` は引数で可変 (既定 6)。P2 多フレーム利用時に実測コストが問題化したら upper-frame 一括 HSV + sliding window へ最適化 (YAGNI、後付け)。
+
+## 6. confidence
+
+emblem-AND の **最弱リンク margin** から連続値を算出する:
+
+```text
+ratio_sat_i  = mean_sat_i  / _EMBLEM_SAT_THRESHOLD     # i ∈ {left, center, right}
+ratio_edge_i = edge_i      / _EMBLEM_EDGE_THRESHOLD
+m            = min over i of min(ratio_sat_i, ratio_edge_i)   # AND 通過時 m > 1.0
+confidence   = clamp((m - 1.0) / (TARGET_RATIO - 1.0), 0.0, 1.0)
+```
+
+- AND 通過 = 全 ratio > 1.0。margin が大きいほど 1.0 に近づく。
+- `TARGET_RATIO` (満点に達する margin 倍率) は gyawa/OBS の clear な in-match frame で confidence が 1.0 近傍に出るよう calibrate (既定候補は実装時に決定)。
+- 用途: P2 が「inset を信頼して採用するか FULL_FRAME に縮退するか」の gate に使う。P4 は localization の **有無** (None か否か) を主に使う。
+
+## 7. OBS bit-exact / None 契約 / 小 inset 制約
+
+### 7.1 OBS bit-exact (全 P hard gate の P1 分担)
+
+- P1 は OBS 分類 path (`_probe_scorebar_context` → `_has_scorebar_v2`) と `_drop_post_match_trailing` から **consume されない** (P2 以降が non-full-frame & high-confidence gate 内でのみ P1 を呼ぶ)。
+- よって P1 PR 時点で OBS の detect/split 出力は v0.3.0 baseline と **bit-exact** (構造的に自明)。§8.4 F4 の parity/baseline test で担保。
+
+### 7.2 None 契約
+
+`None` を返す条件 (S2 契約を継承):
+
+- cv2 (opencv) 未インストール
+- frame 形状が 1920x1080 でない
+- 全 y・全 run で emblem-AND が不通過 (lobby / loading / transition / post-match interior / 純黒画面)
+
+### 7.3 小 inset 制約 (既知・data-gated)
+
+`_SCOREBAR_SCAN_MIN_WIDTH_PX`(500) は frame 相対の絶対 px。inset が小さく scorebar 幅 < 500px だと run が width gate で落ち `None` → P2 は **FULL_FRAME に safe 縮退** (誤検出ではなく検出機会の損失)。min-width の相対化 (inset 推定幅基準) は multi-source データ入手後の調整候補。gyawa は大 inset で本制約に非該当。
+
+## 8. テスト戦略 / 受け入れ条件
+
+### 8.1 合成 位置・スケール復元 (主たる robustness 検証、データ非依存)
+
+既知の scorebar swatch (3 emblem 風の high-sat/high-edge パッチを `_EMBLEM_RELATIVE_POSITIONS` 比で配置) を、合成 1920x1080 frame の **様々な (x_offset, y_offset, scale)** に貼り付け、`localize_scorebar` が `(x_left, x_right, y_top)` を許容誤差内で復元し confidence が高いことを assert。**P1 の存在意義 = 位置独立性を直接検証**する。
+
+### 8.2 Negative
+
+- 無地 / 低彩度 frame → `None`
+- 端寄り edge-only 帯 (#803 の右チャット panel / 左 widget 相当) → `None`
+- post-match 風の広彩度帯 (emblem なし) → `None`
+
+### 8.3 gyawa 実フレーム (slow, sample-gated, 1-source)
+
+- in-match frame → 妥当な span/y で局在化
+- lobby / transition frame → `None`
+
+### 8.4 OBS parity (bit-exact hard gate)
+
+- **F4-a**: 5 OBS baseline の detect 出力が不変 (nothing wired のため自明に pass する回帰 guard)
+- **F4-b**: OBS in-match frame で `localize_scorebar` ≠ None かつ `_has_scorebar_v2` = True と整合 / OBS non-match frame で両者整合し `None`
+- helper extract (§5.2/§5.3) を採る場合、この parity test が「extract が OBS 判定を変えていない」ことの担保になる
+
+### 8.5 異常系
+
+- cv2 不在 → `None`
+- 形状不一致 → `None`
+
+### 8.6 受け入れ条件 (issue 化時の `## 受け入れ条件` 原型)
+
+1. `localize_scorebar` / `ScorebarLocalization` が §4 の API で実装され、§8.1 合成 position/scale test が pass する (位置独立性)
+2. §8.2 negative・§8.5 異常系・§8.3 gyawa 実フレームが pass する
+3. §8.4 OBS parity / baseline bit-exact が pass する (OBS hard gate)
+4. S2 (`detect_region_scorebar_band`) が退役し、テストが localize 系へ移行している (D3)
+5. `ruff check . && ruff format --check . && pyright && pytest` が全 pass (Iron Law 6)
+6. **(マージ gate, D4)** 追加 VTuber source を 1 つ以上入手・`allaganeye-guard verify` 通過後、その実フレームで §8.3 相当の localization が pass する。**本項目が満たされるまで P1 はマージしない**
+
+> 1〜5 は実装完了で達成可能。6 はデータ入手待ちの保留項目 (§10 chain 影響参照)。
+
+## 9. リスク
+
+| # | リスク | 緩和 |
+| --- | --- | --- |
+| R1 | all-runs 化で #803 級 FP 再発 | emblem-AND (zero-FP 検証済) を最終 gate に維持。#803 相当を §8.2 negative test 化 |
+| R2 | gyawa 1-source 過学習 | 幾何ベース anchor + §8.1 合成 position/scale で位置独立を検証。multi-source を D4 でマージ gate に格上げし実データで確証 |
+| R3 | y-scan コスト (P2 多フレーム時) | stride / short-circuit。必要時のみ upper-frame 一括 HSV + sliding window (YAGNI) |
+| R4 | helper extract が OBS 判定を変える | extract は behavior-preserving、§8.4 F4 で担保。回避時は複製 (zero-touch) |
+| R5 | 小 inset で scorebar < min-width → 未検出 | FULL_FRAME safe 縮退 (誤検出ではない)。min-width 相対化は data-gated follow-up (§7.3) |
+
+## 10. P2 以降への引き継ぎと chain 影響
+
+- **P2** は sample した複数 in-match frame に `localize_scorebar` を適用し、`x_left/x_right/y_top` の median/consensus → game 上端・幅を逆算 (現 S2 の `gw=bar_w/W`, `gh=(bar_w/_GAME_ASPECT)/H` 式)。S3 extent で下端・左右補完。幾何サニティ + confidence gate。OBS は FULL_FRAME。
+- **P4 (#480)** は `localize_scorebar` の inset 内 span/位置で scorebar を読み、暗転を分類。
+- **chain 影響 (D4 由来)**: P1 → P2 → {P3, P4} → P5 の依存上、P1 のマージを multi-source データまで保留すると後続も保留になる。回避したい場合の選択肢 (user review で確認):
+  - (i) P1 を branch 上で実装・レビュー完了させ、**マージのみ**データ待ち保留 (P2 は P1 branch 上で先行着手可)
+  - (ii) chain 全体をデータ入手まで保留
+  - 既定の解釈は (i) (実装は進め land を保留)
+
+## 11. 未確定 (Iron Law 2 で user 承認後に確定)
+
+- **issue 起票**: P1 を #480 に内包 (案: #480 を localization+classification に再定義) するか新規起票するか。#809 の close 方針 (park した branch の扱い)。これらは issue 編集/起票を伴うため §3 D1-D4 確定後、起票時に AskUserQuestion で確認。
+- **追加 source の具体 (D4)**: 入手時期・source 種別が判明したら §8.3/§8.6-6 を更新。
+
+## 12. 参照
+
+- replan overview: [2026-05-28-vtuber-region-boundary-replan-design.md](2026-05-28-vtuber-region-boundary-replan-design.md)
+- Phase 2a: [2026-05-26-vtuber-capture-region-detection-design.md](2026-05-26-vtuber-capture-region-detection-design.md) (§6.3.1 S2 上端 15.7px / S3 IoU)
+- #809 wiring (park): [2026-05-27-vtuber-pass1-region-wiring-design.md](2026-05-27-vtuber-pass1-region-wiring-design.md)
+- 現行コード: `allaganeye/video/capture_region.py` (`detect_region_scorebar_band`=S2 → 退役対象), `allaganeye/video/detector.py` (`_has_scorebar_v2` / `_find_scorebar_horizontal_range` / `_emblem_and_check` / `_EMBLEM_RELATIVE_POSITIONS` / `_SCOREBAR_SCAN_*`), `allaganeye/video/scorebar.py` (`_probe_scorebar_context`)
+- 既存 issue: #480 (scorebar ROI 適応、P1+P4 再定義案), #810 (metadata 領域), #753 (上位)

--- a/docs/superpowers/specs/2026-05-29-p1-robust-scorebar-localization-design.md
+++ b/docs/superpowers/specs/2026-05-29-p1-robust-scorebar-localization-design.md
@@ -188,9 +188,35 @@ confidence   = clamp((m - 1.0) / (TARGET_RATIO - 1.0), 0.0, 1.0)
 3. §8.4 OBS parity / baseline bit-exact が pass する (OBS hard gate)
 4. S2 (`detect_region_scorebar_band`) が退役し、テストが localize 系へ移行している (D3)
 5. `ruff check . && ruff format --check . && pyright && pytest` が全 pass (Iron Law 6)
-6. **(マージ gate, D4)** 追加 VTuber source を 1 つ以上入手・`allaganeye-guard verify` 通過後、その実フレームで §8.3 相当の localization が pass する。**本項目が満たされるまで P1 はマージしない**
+6. **(マージ gate, D4)** 追加 VTuber source を 1 つ以上入手・`allaganeye-guard verify` 通過後、その実フレームで §8.3 相当の localization が pass する。**本項目が満たされるまで P1 はマージしない** → **✅ 2026-05-29 検証済 (§8.7、guard は FP override 経由)。**
 
-> 1〜5 は実装完了で達成可能。6 はデータ入手待ちの保留項目 (§10 chain 影響参照)。
+> 1〜5 は実装完了で達成。6 は §8.7 の multi-source 実機検証で達成 (guard verify は FP のため owner override、§8.7 参照)。
+
+### 8.7 multi-source 実機検証結果 (2026-05-29、D4 達成)
+
+`E:\allaganeye-samples` の **5 本の実 VTuber FF14 FL VOD** (Twitch DL、8〜22GB) で `localize_scorebar` を時刻 grid (120s..3h/5min) probe 検証。
+
+**guard verify**: 5 本すべて `allaganeye-guard verify` (v0.4.0) **FAIL**。原因はいずれも false positive と実証:
+
+- `exploit_framework_marker` (2本): 6byte 署名 `FC E8 82 00 00 00` が moov sample-table / H.264 データ中に 1 回偶発衝突 (shellcode ではない)。rule (`ffmpeg_cve.yar`) は短い context-free 署名で大容量データに FP しやすい。
+- `Non-media data exceeds scan buffer limit (10MB)` (5本): moov atom が 28〜64MB (>guard の 10MB scan buffer)。長尺 VOD は必ず該当。
+- → owner (Idios) が FP と判断し override で processing 認可。**guard FP + cp932 CLI crash (絵文字ファイル名) は guard repo の別 issue で追跡**。
+
+**localize 結果** (confidence >=0.5 の高信頼 hit クラスタ、probe px):
+
+| source | x_left | x_right | y_top | span | conf med | n |
+| --- | --- | --- | --- | --- | --- | --- |
+| シルロリ | 633 (sd4.5) | 1287 (sd2.2) | 24 (sd3.1) | 654 | 1.00 | 18 |
+| メテオ | 646 (sd8) | 1273 (sd7) | 42 (sd5) | 627 | 0.92 | 14 |
+| Shinryu | 554 (sd10) | 1131 (sd44) | 63 (sd20) | 577 | 0.95 | 16 |
+| 湿気 | 446 | 1477 | 90 (sd14) | 1033 | 1.00 | 21 |
+| きゅま | 532 | 1149 | 3 | 617 (sd34) | 0.57 | 10 |
+
+**結論**:
+
+1. **位置独立を実データで実証** (R2 解消): 5 source が異なる y_top (3〜90) / span (577〜1033) / x-center を持ち、localize が各々の scorebar を捕捉。gyawa 単一過学習ではない。
+2. **confidence が discriminator として機能**: 高信頼 hit はタイトにクラスタ (シルロリ sd≈3px)、低信頼は散乱。spec §6 の confidence-gate (P2 用) 設計を実証。
+3. **きゅま は P2 課題**: span 一貫 (617±34) だが高信頼でも位置分散大 (conf 0.57)。VOD 内で FL inset 位置が変動 (scene 切替) しており localize は追従できている。**VOD 内レイアウト変動は P2 の per-segment region (`RegionTimeline.segments`) で扱う**。P1 の欠陥ではない。
 
 ## 9. リスク
 

--- a/docs/superpowers/specs/2026-05-29-p1-robust-scorebar-localization-design.md
+++ b/docs/superpowers/specs/2026-05-29-p1-robust-scorebar-localization-design.md
@@ -49,6 +49,8 @@ P1 は **単フレーム localization のみ**。robustness (外れ値除去) �
 | D4 | multi-source 検証 | **P1 のマージ gate (受け入れ条件)**。実装+gyawa+合成は今進め、追加 source 入手・guard verify・検証完了まで **P1 マージは保留** | 追加 VTuber source 入手見込みあり。gyawa 1-source 過学習リスク (R2) を実データで潰してから land する |
 
 > **D4 の replan との差分**: replan §5/§8 は multi-source を「data-gated *follow-up*」としていたが、本 P1 では user 判断により **マージ gate** に強化する。これは P1 (および依存する P2→P4→P5 chain) の land を multi-source データ入手まで保留することを意味する (§8.4 / §10 で chain 影響を明記)。
+>
+> **D2 の plan 時改訂**: 方式1 の y 走査 hit 選択を当初の first-hit short-circuit から **best-hit (emblem margin 最大の候補を選択)** に変更した (plan 作成時に first-hit の confidence/y 精度問題が判明、2026-05-29 user 承認済)。詳細・理由は §5.4。
 
 ## 4. API / データ構造
 
@@ -76,14 +78,16 @@ localize_scorebar(frame):                       # frame: (1080,1920,3) uint8
     if frame.shape != (1080,1920,3): return None
     band_h = _SCOREBAR_SCAN_Y_END - _SCOREBAR_SCAN_Y_START   # = 45
     y_max  = int(1080 * _BAND_Y_MAX_FRAC)                     # ≈ 594
-    for y in range(0, y_max, stride):            # stride 既定 = _BAND_SCAN_STRIDE (6) → ~99 steps
+    best = None                                  # (margin, x_left, x_right, y)
+    for y in range(0, y_max, stride):            # stride 既定 = _BAND_SCAN_STRIDE (6) → ~99 steps (全走査)
         band = frame[y : y + band_h]             # (45,1920,3)
         for (x_left, x_right) in saturated_runs(band):   # width-gated 全 run、center 前提なし
             positions = emblem_positions(x_left, x_right, y)   # _EMBLEM_RELATIVE_POSITIONS
             margin = emblem_and_margin(frame, positions)       # 3点 AND 通過なら最弱 margin、不通過 None
-            if margin is not None:
-                return ScorebarLocalization(x_left, x_right, y, y + band_h, conf(margin))
-    return None
+            if margin is not None and (best is None or margin > best.margin):
+                best = (margin, x_left, x_right, y)            # best-hit: 最大 margin を保持
+    if best is None: return None
+    return ScorebarLocalization(best.x_left, best.x_right, best.y, best.y + band_h, conf(best.margin))
 ```
 
 ### 5.2 saturated_runs (#803 center-straddling の撤廃)
@@ -109,10 +113,10 @@ D1 (Additive) を OBS 安全のため選んだ経緯から既定は案 A 寄り�
 - `emblem_and_margin(frame, positions)`: 各 emblem で `mean_sat` (bright pixel) と `edge_density` (Sobel) を計算し、`_EMBLEM_SAT_THRESHOLD`(70) / `_EMBLEM_EDGE_THRESHOLD`(40) と比較。3点すべて両閾値超なら最弱 margin を返し、1点でも不通過なら `None`。bool だけ返す既存 `_emblem_and_check` の margin 版。
   - **実装手段** (plan/TDD で確定、§5.2 と同じ案 A/案 B の trade-off): 案 A = P1 側に margin 計算を持つ (`_emblem_and_check` 不変)。案 B = `_emblem_and_margin` を新設し `_emblem_and_check` をその bool ラッパに保存的 refactor (OBS parity で担保)。いずれも `_has_scorebar_v2` の判定不変。
 
-### 5.4 探索順序とコスト
+### 5.4 探索順序とコスト (best-hit、plan 作成時の改訂)
 
-- y 昇順 first-hit short-circuit: in-match は scorebar が inset 上端 (小 y) にあるため早期 hit。
-- 最悪 (非試合・hit なし): ~99 y-step × (band の HSV 変換 + run 構築)。emblem-AND は width-gated run (非試合では 0〜1 本) のみに走るため、支配コストは per-y の HSV 変換 (cheap numpy)。
+- **best-hit**: y を全走査し、emblem-AND 通過候補のうち **margin 最大の (run, y)** を返す。当初案の first-hit short-circuit は、scan band が scorebar 帯に**部分的に重なった時点** (true y_top 手前) で AND が通り、(a) y_top が ±stride 超ずれ、(b) 部分重なりで sat が薄まり confidence が clean in-match でも低く出る、という問題があったため改訂 (plan 作成時に判明、user 承認済)。best-hit は最大整合の y を選ぶため y_top 精度 ±stride/2、confidence は最良整合 margin になる。
+- コスト: short-circuit を持たず常に ~99 y-step 全走査 (band の HSV 変換 + run 構築)。emblem-AND は width-gated run (非試合では 0〜1 本) のみに走るため、支配コストは per-y の HSV 変換 (cheap numpy)。spec §5.1/§9 R3 が「最悪は全走査」を既に織り込み済み。
 - `stride` は引数で可変 (既定 6)。P2 多フレーム利用時に実測コストが問題化したら upper-frame 一括 HSV + sliding window へ最適化 (YAGNI、後付け)。
 
 ## 6. confidence
@@ -126,7 +130,7 @@ m            = min over i of min(ratio_sat_i, ratio_edge_i)   # AND 通過時 m 
 confidence   = clamp((m - 1.0) / (TARGET_RATIO - 1.0), 0.0, 1.0)
 ```
 
-- AND 通過 = 全 ratio > 1.0。margin が大きいほど 1.0 に近づく。
+- AND 通過 = 全 ratio > 1.0。margin が大きいほど 1.0 に近づく。`m` は best-hit (§5.4) で選ばれた **最大 margin 候補**のものなので、confidence は「最良整合 frame 位置での余裕」を表す。
 - `TARGET_RATIO` (満点に達する margin 倍率) は gyawa/OBS の clear な in-match frame で confidence が 1.0 近傍に出るよう calibrate (既定候補は実装時に決定)。
 - 用途: P2 が「inset を信頼して採用するか FULL_FRAME に縮退するか」の gate に使う。P4 は localization の **有無** (None か否か) を主に使う。
 

--- a/scripts/vtuber_region_experiment.py
+++ b/scripts/vtuber_region_experiment.py
@@ -1,19 +1,15 @@
 """VTuber game capture 領域検出 候補の実験 harness (#753, spec section 6)。
 
-候補 (S1/S2/S3) を gyawa benchmark + OBS baseline に適用し、proxy 矩形
+候補 (S1/S3) を gyawa benchmark + OBS baseline に適用し、proxy 矩形
 (tests/baselines/v0.3.0/vtuber-primary-regions.json) に対する M1 (IoU /
 上端 px 誤差)、M2 (cost)、M4 (OBS で領域=全体 or 安全に decline) を比較表で
 出力する。
 
-Tier ごとに評価方法が異なる (spec section 3.1):
 - S1/S3 = Tier A coarse: 動画全域から **1 領域**を推定し静的正解矩形と比較。
-- S2     = Tier B precise: annotation timestamp ごとの **単フレーム**で推定。
+- S2 (scorebar-band) は localize_scorebar に一般化され退役 (#753 P1 / re-plan)。
 
 M4 (OBS 回帰) の合否 (spec section 6.2):
 - S1/S3 は Pass 1 coarse に直接使うため OBS では FULL_FRAME 必須。
-- S2 は Tier B precise (coarse Pass 1 には使わない)。#806 の max-width gate で
-  OBS の全幅 scorebar (>1440px) は None を返し decline する。誤った inset を
-  主張しなければ regression-safe なので None / FULL_FRAME を pass とみなす。
 - なお本 issue は detector.py 本体を変更しないため、production detect 出力は
   構造的に bit-exact (M4 の bit-exact 部分は自明に満たす)。本 harness が測るのは
   「将来 wiring したとき OBS で安全に縮退するか」という前方互換性。
@@ -185,69 +181,22 @@ def _eval_tierA_on_benchmark(
     return s1_row, s3_row
 
 
-def _eval_tierB_on_benchmark(video: Path, truths: list[tuple], frame_h: int) -> dict:
-    """S2 (scorebar-band) を annotation timestamp ごとに単フレーム評価。"""
-    from allaganeye.video.capture_region import detect_region_scorebar_band
-    from allaganeye.video.detector import (
-        _SCOREBAR_V2_PROBE_HEIGHT,
-        _SCOREBAR_V2_PROBE_WIDTH,
-        _probe_frame_rgb_hires,
-    )
-
-    ious: list[float] = []
-    errs: list[float] = []
-    hit_top_errs: list[float] = []  # 上端誤差は検出できた frame のみ (S2 の主指標)
-    t0 = time.time()
-    for ts, truth in truths:
-        raw = _probe_frame_rgb_hires(video, float(ts))
-        if raw is None:
-            ious.append(0.0)
-            errs.append(float(frame_h))
-            continue
-        frame = np.frombuffer(raw, dtype=np.uint8).reshape(
-            _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
-        )
-        det = detect_region_scorebar_band(frame)
-        m = region_metrics(det, truth, frame_h)
-        ious.append(m["iou"])
-        errs.append(m["top_err_px"])
-        if det is not None:
-            hit_top_errs.append(m["top_err_px"])
-    cost = time.time() - t0
-    n = len(truths)
-    return {
-        "candidate": "S2",
-        "tier": "B",
-        "mean_iou": float(np.mean(ious)) if ious else 0.0,
-        "mean_top_err_px": float(np.mean(errs)) if errs else float(frame_h),
-        "cost_s": cost,
-        "hit_rate": len(hit_top_errs) / n if n else 0.0,
-        "top_err_hits_px": float(np.mean(hit_top_errs)) if hit_top_errs else None,
-    }
-
-
 def _eval_obs_regression(
     obs_dir: Path, gt_dir: Path
 ) -> dict[str, tuple[bool, list[str]]]:
-    """OBS baseline 各本で S1/S2/S3 が安全に縮退するか (M4)。
+    """OBS baseline 各本で S1/S3 が安全に縮退するか (M4)。
 
     Returns {candidate: (all_pass, [detail per video])}。
-    S1/S3 は FULL_FRAME 必須、S2 は None / FULL_FRAME を安全とみなす。
+    S1/S3 は FULL_FRAME 必須。
     """
     from allaganeye.video.capture_region import (
         FULL_FRAME,
         detect_region_blackout_overlap,
-        detect_region_scorebar_band,
         detect_region_variance,
     )
-    from allaganeye.video.detector import (
-        _SCOREBAR_V2_PROBE_HEIGHT,
-        _SCOREBAR_V2_PROBE_WIDTH,
-        _probe_frame_rgb_hires,
-    )
 
-    status: dict[str, list[bool]] = {"S1": [], "S2": [], "S3": []}
-    detail: dict[str, list[str]] = {"S1": [], "S2": [], "S3": []}
+    status: dict[str, list[bool]] = {"S1": [], "S3": []}
+    detail: dict[str, list[str]] = {"S1": [], "S3": []}
     gt_files = sorted(gt_dir.glob("obs-*.json"))
     for gt_file in gt_files:
         gt = json.loads(gt_file.read_text(encoding="utf-8"))
@@ -278,20 +227,6 @@ def _eval_obs_regression(
             status["S3"].append(ok3)
             detail["S3"].append(f"{label}={'full' if ok3 else _fmt(s3)}")
 
-        mid = _mid_match_timestamps(matches)
-        raw = _probe_frame_rgb_hires(video, mid[0]) if mid else None
-        if raw is None:
-            detail["S2"].append(f"{label}=noframe")
-        else:
-            frame = np.frombuffer(raw, dtype=np.uint8).reshape(
-                _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
-            )
-            s2 = detect_region_scorebar_band(frame)
-            ok2 = s2 is None or s2 == FULL_FRAME
-            status["S2"].append(ok2)
-            detail["S2"].append(
-                f"{label}={'none' if s2 is None else ('full' if s2 == FULL_FRAME else _fmt(s2))}"
-            )
     # 評価できた video が 1 本も無ければ PASS にしない (no evidence != pass)。
     return {c: (bool(v) and all(v), detail[c]) for c, v in status.items()}
 
@@ -317,14 +252,13 @@ def _run_on_benchmark(args: argparse.Namespace) -> list[dict]:
 
     print(f"[M1/M2] benchmark={args.benchmark.name} ({len(truths)} annotated regions)")
     s1_row, s3_row = _eval_tierA_on_benchmark(args.benchmark, matches, truth0, frame_h)
-    s2_row = _eval_tierB_on_benchmark(args.benchmark, truths, frame_h)
 
     obs_status: dict[str, tuple[bool, list[str]]] = {}
     if args.obs_dir is not None:
         print(f"[M4] OBS regression from {args.obs_dir}")
         obs_status = _eval_obs_regression(args.obs_dir, args.obs_ground_truth_dir)
 
-    rows = [s1_row, s2_row, s3_row]
+    rows = [s1_row, s3_row]
     for row in rows:
         cand = row["candidate"]
         if cand in obs_status:
@@ -369,17 +303,6 @@ def main(argv: list[str] | None = None) -> int:
         f"\nTier A coarse winner (M4 gate + max IoU): "
         f"{coarse['candidate'] if coarse else 'NONE'}"
     )
-    # Tier B precise (S2) は full-rect IoU ではなく上端 px 誤差で評価する
-    # (scorebar ROI #480 が要求するのは精密な上端/y-band)。
-    s2 = next((r for r in rows if r["candidate"] == "S2"), None)
-    if s2 is not None:
-        hit = s2.get("top_err_hits_px")
-        hit_s = "n/a" if hit is None else f"{hit:.1f}px"
-        print(
-            f"Tier B precise (S2) top-edge on hits: {hit_s} "
-            f"(hit_rate={s2.get('hit_rate', 0):.2f}); "
-            f"full-rect IoU low by design (FL scorebar width != game width)"
-        )
     return 0
 
 

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -5,6 +5,7 @@ from allaganeye.video.capture_region import (
     CaptureRegion,
     RegionTimeline,
     ScorebarLocalization,
+    _emblem_and_margin,
     _maybe_snap_full_frame,
     _scorebar_saturated_runs,
     detect_region_blackout_overlap,
@@ -283,3 +284,37 @@ def test_saturated_runs_blank_returns_empty():
 
     band = np.full((45, 1920, 3), 40, dtype=np.uint8)
     assert _scorebar_saturated_runs(band, cv2) == []
+
+
+def _frame_with_emblem_box(fill, x1=600, y1=2, x2=665, y2=40):
+    """1920x1080 frame の 1 box を指定 fill で塗る。stripe=高 sat/edge を作る用。"""
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    region = f[y1:y2, x1:x2]
+    if fill == "stripe":
+        for col in range(region.shape[1]):
+            region[:, col] = (200, 30, 30) if (col // 2) % 2 == 0 else (0, 0, 0)
+    else:
+        region[:] = fill
+    return f, [("e", x1, y1, x2, y2)]
+
+
+def test_emblem_and_margin_strong_emblem_returns_ratio_above_one():
+    import cv2
+
+    f, positions = _frame_with_emblem_box("stripe")
+    margin = _emblem_and_margin(f, positions, cv2)
+    assert margin is not None and margin > 1.0
+
+
+def test_emblem_and_margin_flat_region_returns_none():
+    import cv2
+
+    # 単色 (低 edge) は edge 閾値を割るので None。
+    f, positions = _frame_with_emblem_box((50, 50, 200))
+    assert _emblem_and_margin(f, positions, cv2) is None

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -4,6 +4,7 @@ from allaganeye.video.capture_region import (
     FULL_FRAME,
     CaptureRegion,
     RegionTimeline,
+    ScorebarLocalization,
     _maybe_snap_full_frame,
     detect_region_blackout_overlap,
     detect_region_scorebar_band,
@@ -214,3 +215,20 @@ def test_all_grayscale_detectors_snap_full_on_obs_like_input():
     bright = np.full((180, 320), 120, dtype=np.uint8)
     dark = np.full((180, 320), 2, dtype=np.uint8)
     assert detect_region_blackout_overlap([bright, bright, dark]) == FULL_FRAME
+
+
+# ---------------------------------------------------------------------------
+# P1: localize_scorebar (re-plan #753)
+# ---------------------------------------------------------------------------
+
+
+def test_scorebar_localization_is_frozen_with_fields():
+    loc = ScorebarLocalization(
+        x_left=100, x_right=700, y_top=300, y_bottom=345, confidence=0.9
+    )
+    assert (loc.x_left, loc.x_right, loc.y_top, loc.y_bottom) == (100, 700, 300, 345)
+    assert loc.confidence == 0.9
+    import dataclasses
+
+    with __import__("pytest").raises(dataclasses.FrozenInstanceError):
+        loc.x_left = 0  # type: ignore[misc]

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -303,6 +303,15 @@ def test_localize_centered_in_match_returns_localization():
     assert 0.0 < loc.confidence <= 1.0
 
 
+def test_localize_invalid_target_ratio_raises():
+    # target_ratio<=1.0 は confidence 分母が 0/負 になるため ValueError (public kwarg 前提条件)。
+    import pytest
+
+    f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
+    with pytest.raises(ValueError):
+        localize_scorebar(f, target_ratio=1.0)
+
+
 def test_localize_off_center_inset_position_independent():
     # 中心 (x=960) をまたがない左寄り inset。退役した S2 (_find_scorebar_horizontal_range
     # center-straddling) では検出不能だった位置独立ケース (P1 の存在意義)。

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -9,7 +9,6 @@ from allaganeye.video.capture_region import (
     _maybe_snap_full_frame,
     _scorebar_saturated_runs,
     detect_region_blackout_overlap,
-    detect_region_scorebar_band,
     detect_region_variance,
     iou,
     localize_scorebar,
@@ -156,7 +155,7 @@ def test_variance_tiny_speck_below_min_area_falls_back_full():
 
 
 # ---------------------------------------------------------------------------
-# Task B.2: S2 detect_region_scorebar_band
+# Shared hi-res scorebar frame builder (used by P1 localize tests)
 # ---------------------------------------------------------------------------
 
 
@@ -182,33 +181,6 @@ def _hires_with_scorebar_at(y_top: int, x_left: int, x_right: int):
         for col in range(region.shape[1]):
             region[:, col] = (200, 30, 30) if (col // 2) % 2 == 0 else (0, 0, 0)
     return f
-
-
-def test_scorebar_band_at_offset_y_returns_inset_top():
-    f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
-    r = detect_region_scorebar_band(f)
-    assert r is not None and r.source == "tierB"
-    assert abs(r.y - 120 / 1080) < 0.012
-
-
-def test_scorebar_band_overwide_returns_none():
-    # scorebar 幅 1690px > detector._SCOREBAR_SCAN_MAX_WIDTH_PX (1440, #806) のため
-    # _find_scorebar_horizontal_range が None を返し S2 も None。OBS の全体縮退は
-    # coarse 検出器 (S1/S3) の責務であり S2 (Tier-B precise) は OBS を snap しない。
-    f = _hires_with_scorebar_at(y_top=2, x_left=120, x_right=1810)
-    assert detect_region_scorebar_band(f) is None
-
-
-def test_scorebar_band_uniform_cyan_banner_rejected():
-    from allaganeye.video.detector import (
-        _SCOREBAR_V2_PROBE_WIDTH,
-        _SCOREBAR_V2_PROBE_HEIGHT,
-    )
-
-    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
-    f = np.full((H, W, 3), 40, dtype=np.uint8)
-    f[0:55, :] = (60, 200, 200)  # 単色 cyan 帯 (紋章なし)
-    assert detect_region_scorebar_band(f) is None
 
 
 def test_all_grayscale_detectors_snap_full_on_obs_like_input():

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -351,3 +351,63 @@ def test_localize_blank_frame_returns_none():
         (_SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3), 40, dtype=np.uint8
     )
     assert localize_scorebar(f) is None
+
+
+def test_localize_scale_variation_recovers_span():
+    # HUD スケール差を span 幅で模擬。narrow と wide の両方で復元できること。
+    for x_left, x_right in [(700, 1220), (300, 1620)]:
+        f = _hires_with_scorebar_at(y_top=60, x_left=x_left, x_right=x_right)
+        loc = localize_scorebar(f)
+        assert loc is not None, (x_left, x_right)
+        assert abs(loc.x_left - x_left) <= 4 and abs(loc.x_right - x_right) <= 4
+
+
+def test_localize_off_center_band_without_emblems_returns_none():
+    # 中心をまたがない右寄りの単色帯 (emblem なし)。all-run 化しても emblem-AND
+    # が落とすので None。#803 (post-match 広帯) 防御が center 前提なしで成立する確証。
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    f[0:45, 1400:1919] = (50, 50, 200)  # 519px 右寄り帯、紋章なし
+    assert localize_scorebar(f) is None
+
+
+def test_localize_overwide_band_returns_none():
+    f = _hires_with_scorebar_at(y_top=2, x_left=120, x_right=1810)
+    assert localize_scorebar(f) is None
+
+
+def test_localize_uniform_cyan_banner_returns_none():
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    f[0:55, :] = (60, 200, 200)  # 全幅単色 cyan (>max width かつ紋章なし)
+    assert localize_scorebar(f) is None
+
+
+def test_localize_wrong_shape_returns_none():
+    f = np.full((100, 100, 3), 40, dtype=np.uint8)
+    assert localize_scorebar(f) is None
+
+
+def test_localize_returns_none_without_cv2(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "cv2":
+            raise ImportError("simulated missing cv2")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
+    assert localize_scorebar(f) is None

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -12,6 +12,7 @@ from allaganeye.video.capture_region import (
     detect_region_scorebar_band,
     detect_region_variance,
     iou,
+    localize_scorebar,
     top_edge_error_px,
 )
 
@@ -318,3 +319,35 @@ def test_emblem_and_margin_flat_region_returns_none():
     # 単色 (低 edge) は edge 閾値を割るので None。
     f, positions = _frame_with_emblem_box((50, 50, 200))
     assert _emblem_and_margin(f, positions, cv2) is None
+
+
+def test_localize_centered_in_match_returns_localization():
+    f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
+    loc = localize_scorebar(f)
+    assert loc is not None
+    assert abs(loc.x_left - 500) <= 4 and abs(loc.x_right - 1400) <= 4
+    assert abs(loc.y_top - 120) <= 6  # stride 既定 6
+    assert loc.y_bottom == loc.y_top + 45
+    assert 0.0 < loc.confidence <= 1.0
+
+
+def test_localize_off_center_inset_position_independent():
+    # 中心 (x=960) をまたがない左寄り inset。退役した S2 (_find_scorebar_horizontal_range
+    # center-straddling) では検出不能だった位置独立ケース (P1 の存在意義)。
+    f = _hires_with_scorebar_at(y_top=300, x_left=100, x_right=700)
+    loc = localize_scorebar(f)
+    assert loc is not None
+    assert abs(loc.x_left - 100) <= 4 and abs(loc.x_right - 700) <= 4
+    assert abs(loc.y_top - 300) <= 6
+
+
+def test_localize_blank_frame_returns_none():
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+
+    f = np.full(
+        (_SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3), 40, dtype=np.uint8
+    )
+    assert localize_scorebar(f) is None

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -6,6 +6,7 @@ from allaganeye.video.capture_region import (
     RegionTimeline,
     ScorebarLocalization,
     _maybe_snap_full_frame,
+    _scorebar_saturated_runs,
     detect_region_blackout_overlap,
     detect_region_scorebar_band,
     detect_region_variance,
@@ -232,3 +233,53 @@ def test_scorebar_localization_is_frozen_with_fields():
 
     with __import__("pytest").raises(dataclasses.FrozenInstanceError):
         loc.x_left = 0  # type: ignore[misc]
+
+
+def _sat_band(width_runs, h=45, w=1920):
+    """指定 (x_left, x_right) 範囲を saturated blue で塗った band (h,w,3) を返す。"""
+    band = np.full((h, w, 3), 40, dtype=np.uint8)
+    for x_left, x_right in width_runs:
+        band[:, x_left : x_right + 1] = (50, 50, 200)
+    return band
+
+
+def test_saturated_runs_finds_centered_run():
+    import cv2
+
+    band = _sat_band([(500, 1400)])
+    runs = _scorebar_saturated_runs(band, cv2)
+    assert len(runs) == 1
+    x_left, x_right = runs[0]
+    assert abs(x_left - 500) <= 2 and abs(x_right - 1400) <= 2
+
+
+def test_saturated_runs_finds_off_center_run():
+    # 中心 (x=960) をまたがない左寄り帯。_find_scorebar_horizontal_range は
+    # center-straddling で None を返すが、P1 はこれを拾えねばならない (#803 撤廃)。
+    import cv2
+
+    band = _sat_band([(100, 700)])
+    runs = _scorebar_saturated_runs(band, cv2)
+    assert len(runs) == 1
+    x_left, x_right = runs[0]
+    assert abs(x_left - 100) <= 2 and abs(x_right - 700) <= 2
+
+
+def test_saturated_runs_drops_narrow_and_overwide():
+    import cv2
+
+    # narrow (<500px) と overwide (>1440px) はどちらも width gate で除外。
+    band = _sat_band([(0, 300), (700, 1300)])  # 301px run, 601px run
+    runs = _scorebar_saturated_runs(band, cv2)
+    assert len(runs) == 1
+    assert abs(runs[0][0] - 700) <= 2 and abs(runs[0][1] - 1300) <= 2
+
+    overwide = _sat_band([(100, 1800)])  # 1701px
+    assert _scorebar_saturated_runs(overwide, cv2) == []
+
+
+def test_saturated_runs_blank_returns_empty():
+    import cv2
+
+    band = np.full((45, 1920, 3), 40, dtype=np.uint8)
+    assert _scorebar_saturated_runs(band, cv2) == []

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -383,3 +383,26 @@ def test_localize_returns_none_without_cv2(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     f = _hires_with_scorebar_at(y_top=120, x_left=500, x_right=1400)
     assert localize_scorebar(f) is None
+
+
+def test_localize_agrees_with_has_scorebar_v2_in_match():
+    # 絶対 emblem 位置に重なる span を描くと _has_scorebar_v2 Primary が True。
+    # localize_scorebar も relative 位置で検出 -> 両者が in-match で合致 (OBS parity)。
+    from allaganeye.video.detector import _has_scorebar_v2
+
+    f = _hires_with_scorebar_at(y_top=0, x_left=600, x_right=1318)
+    assert localize_scorebar(f) is not None
+    assert _has_scorebar_v2(f.tobytes()) is True
+
+
+def test_localize_agrees_with_has_scorebar_v2_non_match():
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+        _has_scorebar_v2,
+    )
+
+    W, H = _SCOREBAR_V2_PROBE_WIDTH, _SCOREBAR_V2_PROBE_HEIGHT
+    f = np.full((H, W, 3), 40, dtype=np.uint8)
+    assert localize_scorebar(f) is None
+    assert _has_scorebar_v2(f.tobytes()) is False


### PR DESCRIPTION
## Summary

re-plan (#753) の P1: 任意フレームから FL scorebar を**位置独立**に局在化する純粋関数 `localize_scorebar` を追加 (上流 anchor)。後続 P2 (領域検出) / P4 (#480 分類) の共有基盤。

- 新規 `localize_scorebar` (best-hit all-y × all-run scan) + `ScorebarLocalization` dataclass + helper (`_scorebar_saturated_runs` / `_emblem_and_margin`) を `capture_region.py` に追加
- #803 の center-straddling 前提を撤廃 (width-gated 全 run × emblem 3点 AND gate) → VTuber inset の任意 x/y 位置に対応
- **Additive**: `detector.py` / `scorebar.py` は byte-unchanged → OBS detect/split は bit-exact
- unwired な S2 `detect_region_scorebar_band` (+ dead `_GAME_ASPECT`) を退役、実験 script も S1/S3 のみに整理

元 issue: **Refs #480** (P1 portion。#480 は re-plan で localization(P1)+classification(P4) の傘 issue に再定義。Phase 分割 close = P1+P4 完了後に手動 close、本 PR では close keyword 不使用)。
spec: `docs/superpowers/specs/2026-05-29-p1-robust-scorebar-localization-design.md`

## 決定事項 (spec §3)

D1 Additive / D2 方式1 (all-runs × all-y + emblem-AND) + best-hit (margin 最大選択) / D3 S2 退役 / D4 multi-source = マージ gate

## Self-Test Report

machine-verified:

- [x] `ruff check .` / `ruff format --check .` clean
- [x] `pyright` 0 errors
- [x] `pytest -m "not slow"` 1294 passed, 16 skipped
- [x] zero-touch 監査: `git diff <base>..HEAD -- allaganeye/video/detector.py allaganeye/video/scorebar.py` 空 (OBS bit-exact 構造保証)
- [x] 合成 position/scale 復元・negative (#803 guard)・error (cv2-absent/wrong-shape)・OBS parity (`localize_scorebar` <-> `_has_scorebar_v2`) test pass
- [x] 独立 code review (fresh opus subagent): Critical/Important ゼロ
- [x] Codex adversarial review (Iron Law 6 Step 5、`codex:rescue` 経由 ※ dedicated adversarial-review skill が本 session の plugin set に無いため代替): zero-touch / scope / Phase2a / localize 全 PASS。唯一の finding (docstring 日本語非ASCII) は false alarm (project は CJK コメント許容・ASCII guard green) として owner 判断で無視

machine-unverifiable (実機検証):

- multi-source 実機検証 (D4): 実 VTuber FF14 FL VOD **5 本** で `localize_scorebar` を時刻 grid probe 検証。位置独立を実証 (high-conf cluster の y_top 3〜90 / span 577〜1033 が source 別、最良 sd≈3px)。confidence が real/outlier discriminator として機能。R2 (gyawa 単一過学習) 解消。詳細 spec §8.7
- guard verify: 5 本とも `allaganeye-guard verify` FAIL だが全て false positive と実証 (6byte 署名 `FC E8 82 00 00 00` の moov/H.264 偶発衝突 + moov 28〜64MB > 10MB scan buffer) → owner override で processing 認可

## Notes / follow-up

- **D4 マージ gate 達成** (受け入れ条件 1〜6 すべて満たす)
- きゅま (邪竜眼) VOD は VOD 内で inset 位置が変動 → P2 の per-segment region (`RegionTimeline.segments`) の動機。P1 欠陥ではない
- guard が実 VTuber VOD を軒並み FP (短署名衝突 + 10MB buffer) + cp932 CLI crash (絵文字ファイル名) → guard repo の別 issue で追跡予定 (L3/L4 VTuber ワークフローの前提)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
