### PR TITLE
fix(test): v0.3.0 baseline の slow マーカー配線修正 + 規約 guard (Refs #812)

### DIFF
--- a/docs/audits/2026-06-10-full-audit.md
+++ b/docs/audits/2026-06-10-full-audit.md
@@ -1,0 +1,188 @@
+# 2026-06-10 全体監査レポート (Fable)
+
+## メタ情報
+
+- 実施日: 2026-06-10 / モデル: Claude Fable 5
+- 対象: branch `develop-0.3.0` (HEAD: ef26bd9)
+- 手法: 6 観点並列監査 (コア検知 / CLI・export・インフラ / GUI / テスト / ドキュメント / issue トラッカー) + 主セッションによる P1 全件のコード再検証
+- 対策設計: [`docs/superpowers/specs/2026-06-10-audit-remediation-design.md`](../superpowers/specs/2026-06-10-audit-remediation-design.md)
+- 表記: `[確実]` = コードを読んで論理的に確認済み / `[要検証]` = 実機・実動画でないと断定不可
+
+## 即時処置 (2026-06-10 実施済み)
+
+| 処置 | 内容 |
+| --- | --- |
+| park branch 保全 | `claude/l3-809-pass1-region-wiring` (22 commits) と `claude/l3-vtuber-replan` が origin 未 push だったため push (PR なし、保全のみ) |
+| red test 退避 | `tests/test_config.py` の未コミット diff (`region_blackout_threshold` テスト 2 件、config.py 側 field 未実装で必ず fail) を `git stash push -m "audit 2026-06-10: region_blackout_threshold red tests (park #809 leftover)"` で退避。bare `pytest` を green に復旧 |
+
+## P1: 重大 (すべて再検証済み・確実)
+
+### コード
+
+| ID | 問題 | 場所 |
+| --- | --- | --- |
+| P1-1 | GUI の detect「中断」がプロセスを kill しない。phase 遷移のみで Python + 最大 32 本の ffmpeg は走り続け、drop 画面から同一動画への二重 detect も起動できる (detect イベントに run 識別子がなく越境受信もありうる)。`kill_tracked_processes` の production 呼び出しは ExportScreen と ConfirmExitModal のみ | `gui/src/screens/DetectingScreen.tsx:314-321` |
+| P1-2 | OUT < IN の境界編集を無検証で apply でき、metadata.json が GUI 自身で読めなくなる。書き込みは素通し、次回 load は zod refine で reject → load エラーは非表示 (P2-13) のため「No metadata」の空画面になり GUI 内に復旧手段なし | `gui/src/screens/PreviewScreen.tsx`、`gui/src/state/metadataStore.ts:152-176`、`gui/src/types/metadata.schema.ts:29-31` |
+| P1-3 | v0.3.0 baseline regression がマーカー配線ミスで「回したつもりで回らない」。4 テストが `slow_detect` 単独付与で、addopts `-m 'not slow and not baseline_regen'` は除外せず (サンプル動画がある環境で bare pytest が数時間級 detect を実行)、逆に docs 推奨の `pytest -m slow` / `pytest -m "slow or baseline_regen"` では deselect される。conftest の GPU cooldown (`slow` のみ参照) も効かない | `tests/test_v030_baseline_regression.py:28,62,143,181`、`pyproject.toml:53`、`tests/conftest.py:136` |
+| P1-4 | #805 の trailing drop が metadata.json に一切の痕跡を残さない。記録は verbose 用 stats のみで `warnings[]` は常に空 (`detection/warnings.py` の scaffold 未配線)。消えた試合の start/end が残らず手動復旧も不可。`MetadataWarning` は forward-compat 設計済みのため warning code 追加だけで schema bump 不要 | `allaganeye/video/detector.py:1985-1992`、`allaganeye/detection/warnings.py:43-59` |
+
+### ドキュメント
+
+| ID | 問題 | 場所 |
+| --- | --- | --- |
+| P1-5 | export `--include`/`--exclude` を「0 始まり」と記載、実装は metadata の 1 始まり `index` と照合。doc どおり `--exclude 0` しても先頭 match は除外されず誤った match 集合が silent に書き出される | `docs/cli-spec.md:353-354` ↔ `allaganeye/commands/export.py:149` |
+| P1-6 | `--gpu-vendor intel` が「exit 5 (#550 で実装予定)」のまま。実装済み (#550/#582) で、CLAUDE.md・tuning-guide と矛盾 | `docs/cli-spec.md:56` ↔ `allaganeye/cli.py:130-139` |
+| P1-7 | CLAUDE.md が「音声昇格」を現役機能として記述。実際は `AUDIO_FROZEN: Final[bool] = True` (#327) で Fanfare スキャンは常にスキップ。`audio/refs/` 行も `war_room.npz` (#306 同梱済) 未反映、「WR 参照 (#301) 同梱後に」の未来形記述も古い | CLAUDE.md §検知アルゴリズム ↔ `allaganeye/audio/__init__.py:48` |
+
+### 設計上の地雷 (実装前に固定すべき制約)
+
+| ID | 問題 | 場所 |
+| --- | --- | --- |
+| P1-8 | #809 の wiring 順序依存。`capture_region.py` は production import ゼロ (pure additive で安全) だが、#809 (Pass 1 領域輝度適応) だけが先に wire されると、scorebar 系 probe (絶対座標 Primary + 中央跨ぎ必須 Rescue) は full-frame 前提のままなので VTuber 録画で (a) 全暗転が `non_fl` 分類で除去、(b) trailing drop が確定 False 連発で最終試合喪失、が同時に起きる。#809 の受け入れ条件に「scorebar 局在化 consumer の同時/先行 wiring、最低でも region ≠ FULL_FRAME 時は trailing drop 無効化 gate」の明記が必要 | `allaganeye/video/capture_region.py`、`allaganeye/video/detector.py:943-947,1176-1182` |
+
+## P2: 重要な改善
+
+### コア検知パイプライン
+
+- **P2-1** [確実] trailing drop が単一検出器に全依存: classify 側は majority vote + re-probe + audio の多重防御なのに drop 側は `_has_scorebar_v2` 単発のみ (`detector.py:1977`)。`audio_hits` 流用で「窓内に Fanfare ピークがあれば keep」を追加可能だが、`AUDIO_FROZEN=True` の間は no-op (対策設計では見送り、#805 に記録)
+- **P2-2** [確実] trailing drop に opt-out gate がない: 「released path を触る分岐は明示 gate に閉じ込める」教訓に対する唯一の例外 (`detector.py:413-421`)。escape hatch (`--keep-trailing` 等) が必要
+- **P2-3** [確実] v2 decode path の read に timeout 保護がない: legacy は `subprocess.run(timeout=)` 保護があったが、v2 の `stream.read(_FRAME_SIZE)` は無期限ブロック可能で ffmpeg ハング時に detect 全体が永久停止する堅牢性 regression (`detector.py:644-653`、`gpu_detector.py:666-676`)
+- **P2-4** [要検証] `_borderline_pseudo_regions` (#576 A5) にコスト上限がない: brightness 15-55 の待機画面が長時間続く録画で Pass 2 probe が非有界に増える (1h で ~14,400 ffmpeg 起動の試算) (`detector.py:1548-1578`)
+- **P2-5** [要検証] audio scan の全長一括処理は 8h 級録画でピーク十数 GB のメモリ (`audio/scan.py:66`、`audio/features.py:98-109`)。frozen 中は実害なし、解凍前にチャンク化が必要
+- **P2-6** [確実] `capture_region.py` が detector の saturated-run / emblem 計算ロジックを複製しており、片側修正で「OBS parity」が silent に壊れる構造 (`capture_region.py:199-299` ↔ `detector.py:1140-1238`)
+
+### CLI / export
+
+- **P2-7** [確実] `allaganeye export` だけが cli.py のエラーハンドリング枠組みの外: `AllaganEyeError` 未捕捉で raw traceback + exit 1。`--json` モードで summary 終端行が emit されず wire 契約が破れる (`commands/export.py:118-249`、`cli.py:588-625`)
+- **P2-8** [確実] JSON wire の Python 層 encoding 自衛がない: `sys.stdout.reconfigure(encoding="utf-8")` 相当がなく Rust 側の `PYTHONIOENCODING` 注入頼み。CLI 単体 + cp932 console で非 ASCII path が壊れる (`export/wire.py:24`、`commands/export.py:48`)
+- **P2-9** [確実] `ExportSummary.skipped` がどの経路でも increment されず常に 0 (`export/schema.py:43`)
+- **P2-10** [確実] export は output_dir を検証も mkdir もしない (split/detect と非対称)。`-o` 先が無いと全 match ffmpeg fail → exit 1 (doc は exit 2 と主張 = doc 側も誤り)
+- **P2-11** [確実] `debug-brightness --interval 0` (または負値) で `_generate_timestamps` が無限ループ → hang/OOM (`commands/debug_brightness.py:48` → `detector.py:775-782`)
+- **P2-12** [要検証] system_info の Windows probe が `wmic` 依存: wmic 非搭載の Win11 24H2+ クリーン環境で AMD/Intel-only 機の vendor 検出が全滅し GUI export が libx264 固定に silent degrade (`system_info.py:99` ほか)
+- **P2-40** [要検証] export の cancel 応答性: stderr `readline()` ブロック依存 + timeout 無しで ffmpeg 無出力 stall 時に worker が永久待ち。Windows CLI では `f.result()` ブロック中に Ctrl+C ハンドラ実行が遅延しうる (`export/ffmpeg_runner.py:119-126`、`commands/export.py:184-190`)
+
+### GUI
+
+- **P2-13** [確実] `metadataStore.loadErrorState` を表示する UI が存在せず、load 失敗 (zod 違反/JSON 破損/BOM) が無言で「No metadata」になる (`metadataStore.ts:280`)。P1-2 と連鎖
+- **P2-14** [確実] export reducer: `cancelling` 中の `PROGRESS_COMPLETE` が未処理で「中断中…」のまま永久スタック。復帰ボタンも disabled でアプリ再起動が必要 (`screens/reducers/export.ts:34-37`)
+- **P2-15** [確実] `start_export` が stderr を pipe したまま drain しない: 大量 stderr で子がブロックし export ハングの可能性 + crash 時 traceback が失われる。`start_detect` は tail 収集しており非対称 (`lib.rs:2777`)
+- **P2-16** [確実] `start_export` の `expect("tracked just inserted")` がユーザー cancel との race で panic しうる (正常 cancel が「アプリ内部エラー」報告に化ける) (`lib.rs:2849-2854`)
+- **P2-17** [確実] 境界編集 apply 後も `*_display` 文字列が再計算されず、数値と表示が矛盾した metadata.json が永続化される (`metadataStore.ts:163-173`)
+- **P2-18** [確実] 試合名 (name) 編集が apply で黙って消える (normalize が name を strip + `clearDraft()` でセッション内からも消失) (`metadataStore.ts:184-211`)
+- **P2-19** [確実] `load_metadata` が UTF-8 BOM 付き metadata.json を「invalid JSON」で拒否: CLAUDE.md の encoding checklist が明示する既知クラス (`lib.rs:87-100`)
+- **P2-20** [確実] 命名トークン `{start}` の GUI 表示 (`1-23-41`) と Python 実出力 (通算分 `83-41`) が 1 時間以降で食い違う (`ExportScreen.tsx:1003` ↔ `export/pool.py:55-59`)
+- **P2-21** [確実] thumbnail ffmpeg の Semaphore が invoke 単位で生成され画面全体ではアンバウンド並列 (試合 N 件 = N 本同時 spawn)。#670 (responsiveness) の主因候補はサーバではなくこれ + progress イベント無間引き (`lib.rs:1201`)
+
+### テスト
+
+- **P2-22** [確実] v0.3.0 split SHA-256 baseline (`obs-*.split.json`) に自動比較テストが存在しない: splitter regression は「generator 再実行 + 手動 diff」でしか検出できない
+- **P2-23** [確実] export wire protocol e2e の skip 前提が誤り: docstring は「sample video 必要」と claim するが実際は lavfi 自前生成で動画不要。slow marker で CI から外れ GUI⇔Python 契約の唯一の e2e が常に deselect。SIGINT cancel テストは実行環境が存在しない dead test (`tests/test_export_wire_protocol.py`)。注意: CI の BtbN ffmpeg は LGPL で libx264 非同梱
+- **P2-24** [確実] VTuber ground truth (±10s gate、commit 済み) が pytest に未配線で消費者は手動実験 script のみ。#809 wiring 着手時の gate 不在構造
+
+### ドキュメント
+
+- **P2-25** [確実] worker auto 上限「min(cpu_count, 24)」が 6 doc 7 箇所に残存 — 実装は 32 (cli-spec:53,262,446 / video-processing:51,378 / benchmarks:78 / tuning-guide:173,249)
+- **P2-26** [確実] CPU Pass 1 の説明が「タイムスタンプごとの並列 `-ss` プローブ」のまま — 実装は #214 以降チャンク分割デコード (CLAUDE.md §データフロー / video-processing.md)
+- **P2-27** [確実] video-processing.md の #576 新 path 説明が中間設計のまま (「output seek + Python 側 sampling」と記載、実装は dual seek + `select` filter)
+- **P2-28** [確実] tuning-guide「デフォルト = --no-gpu」は誤り — 実際は codec ベース auto (#414)
+- **P2-29** [確実] CLAUDE.md モジュール表に v0.2〜v0.3 の新 module 群が未掲載 (capture_region / export/ package / commands/export / encoder_slots / metadata_types / integrity / system_info / detection 3 module / tools)。§コマンドにも `allaganeye export` がない
+- **P2-30** [確実] CLAUDE.md / design-overview の L2 が「開発中」のまま (v0.2.0 2026-04-26 / v0.2.1 2026-05-16 リリース済み)。L3 行も VTuber 保留 (2026-06 re-plan) 未反映
+- **P2-31** [確実] scorebar-detection-design.md が #803 (中央跨ぎ選択 + 幅上限 1440px、doc の「最長 run」記述は実装と逆) / #797 trailing drop / #811 localize_scorebar を未反映
+- **P2-32** [確実] system-architecture.md の起動経路・export 経路が #752/#761 以前のまま (同一 doc 内 §2.6 と矛盾)。quickstart.md §1.3 の ZIP フォルダ構成も旧レイアウト
+- **P2-33** [確実] versioning.md「バージョン管理場所: pyproject.toml のみ」 — 実際は tauri.conf.json / package.json 含め 3 箇所。release skill の bump grep では JSON を検出できず bump 漏れの温床
+- **P2-34** [確実] cli-spec: detect 節に `--progress-format` と `--gpu-vendor` がない / export 節の `--quiet`・`--concurrency` (切り詰めのみ・`copy` 時 1 slot 固定)・exit 2 の記述 3 点が実装不一致
+- **P2-35** [確実] developer-setup.md が「LGPL 推奨」と書きつつ Windows 手順は GPL の `winget Gyan.FFmpeg` を「推奨」 — #508 方針と自己矛盾
+
+### Issue トラッカー
+
+- **P2-36** [確実・要ユーザー確認] #412 の前提コードが消失: PR #323 (28 分超 segment 二段スキャン、2026-04-17 merge) の `_refine_long_segments` 等が main・v0.1.x tag・develop-0.3.0 のどの系譜にも存在しない (tag 内容 + code search で確認)。元 bug #317 は #793 の A5 で再修正済み
+- **P2-37** [確実] QSV/AMF decode hwaccel の残タスクが orphan 化: コード・CLAUDE.md が「#762 で wire 予定」と参照する #762 は not_planned close 済み、後継 issue ゼロ
+- **P2-38** [確実] #805 が triage 未了 (priority/deferred なし) のまま 2 週間。規約上「deferred なし = v0.3.0 必須」に該当するが実働なし
+- **P2-39** [確実] PR #811 が約束した guard repo への follow-up issue (VTuber VOD の FP 3 点: 短署名衝突 / moov>10MB buffer / cp932 crash) が未起票
+
+## P3: 軽微
+
+### コード (コア)
+
+- GPU 診断ログが AMD 構成で常に「decode active」誤報告 (`gpu_detector.py:341-358`)
+- `_probe_scorebar_context` が ffmpeg 不在 (VideoProcessingError) をログなしで None に握る (`scorebar.py:73-88`)
+- merge probe / re-probe で不要な低解像度 probe が常時実行され ffmpeg 起動 2 倍 (`scorebar.py:58-67`)
+- probe.py の duration 非数値文字列で uncaught ValueError (exit 3 でなく exit 1) (`probe.py:153`)
+- metadata_writer の atomic write に fsync なし (OS クラッシュで torn file の可能性) (`metadata_writer.py:52-57`)
+- `min_match_duration` 縮小が trailing drop 検査窓を縮める隠れ結合 (`detector.py:1958`)
+- rescue path の bar_width exclusive/inclusive 1px 不整合 (`detector.py:1306` ↔ `:1183`)
+- `_largest_component_region` の `import cv2` unguarded (`capture_region.py:143`)、`y_bottom` docstring の inclusive/exclusive 不整合 (`capture_region.py:59-69`)
+- GPU chunk 失敗時の fallback が実行中 chunk の完走 join を待つ (遅延が不可視) (`gpu_detector.py:287-294`)
+- `metadata_types.py` の `workers: float | None` 型劣化 (codegen 元 schema 側の問題)
+- `detection/format.py` が dead module (production 未使用、private 版が生存) + `disabled_emitter()` production 未使用
+
+### コード (export / CLI / scripts)
+
+- cancel・失敗時の部分書き出し .mp4 が残置される (`ffmpeg_runner.py:120-122,263-276`)
+- `--concurrency` 0/負値が silent 無視 (`commands/export.py:180-181`)
+- `{idx}` なし `--name-pattern` の filename 衝突未検証 (`export/pool.py:38-52`)
+- stderr_tail から GPU エラー行が progress noise で押し出されうる (`ffmpeg_runner.py:128-148`)
+- AMF failure patterns 3 件が実機未検証
+- dead parameter 2 件 (`pool.py:38` codec / `validate-fps-retirement.py:142` source_fps)
+- `scripts/regen_audio_refs.py` と `allaganeye/tools/regen_audio_refs.py` がほぼ完全重複
+- stale コメント「Patterns mirror gui/src-tauri/src/lib.rs:1738+」(Rust 側は #761 移管で削除済み) (`ffmpeg_runner.py:39`)
+- stale branch pin 2 件: `scripts/cleanup-claude-branches.sh:94` (develop-0.2.0 固定 → 新 branch が掃除されない) / `.github/workflows/check-pr-checklist-test.yml:10` (develop-0.3.0 push でテストが走らない)
+
+### GUI
+
+- sample mode でキーボード nudge が read-only を貫通 (`PreviewScreen.tsx:515-544`)
+- DraftRestoreModal だけ focus trap・Escape なし (a11y-policy 乖離)
+- ExportScreen の `listen()` mount race で unlisten リーク (DropScreen の cancelled パターンと非対称)
+- 死にコード/未使用依存: `cancelRequestedRef` (書き込みのみ)、Cargo.toml 未使用 5 件 (hyper / tokio-util / urlencoding / percent-encoding / dirs)、`clear_recent` UI 不在、`@tauri-apps/api` が devDependencies
+- capabilities の `shell:allow-execute` / `shell:allow-spawn` 過剰権限 (#545 で独自 command 化済みのため未使用)
+- `register_video` token が解放されず累積 (`lib.rs:846-850`)
+- ConfirmExitModal 文言「中間ファイルは破棄」が実態 (部分 .mp4 残置) と不一致
+- load 時 mtime 取得が read 後で TOCTOU が silent overwrite 側に倒れる (`metadataStore.ts:246-251`)
+- `untrack_child` の Job handle drop による意図しない tree kill (異常系のみ、要検証) (`lib.rs:1735-1739`)
+- 受理拡張子 (.avi 受理/.m4v 拒否) とエラーヒント (逆) の不整合 (`DropScreen.tsx:46` ↔ `error.rs:180-181`)
+- detect-progress イベントのスロットリングなし (#670 関連) (`DetectingScreen.tsx:477-523`)
+
+### テスト
+
+- ErrorModal に jest-axe 未適用 (a11y-policy「全 modal」と矛盾)
+- flow.integration の invoke mock default が寛容 (`Promise.resolve()`) で新 command の silent pass
+- `tests/scripts/test_*.sh` 3 本が CI 未配線
+- test_regression_330 が import 時に ffmpeg subprocess 実行 (collection 低速化)
+- `tests/baselines/v0.3.0/README.md` の「Rust 側 unit test」参照が stale (正は `tests/test_export_ffmpeg_runner.py`)
+- detection cache の `_CACHE_SENSITIVE_FILES` 手動列挙 (capture_region 配線時に追加忘れリスク)
+- legacy fps filter path テスト群は現状正当。env var 削除時にテスト整理を同時実施 (削除 issue に明記要)
+
+### ドキュメント / プロセス
+
+- skills の `../../docs/` 相対リンク 14 件が 1 階層不足で broken (正: `../../../docs/`) (review-pr 5 / iterate-review 4 / scope-guard 1 / create-task 1 ほか)
+- gui-development.md の CI「3 ジョブ」(実際 8) + テスト一覧が bootstrap 時点
+- release-process.md §手動リリース手順に「Python 3.11.9 embed」残存 (同 doc 内 #752 記述と矛盾)
+- versioning.md「Director」旧用語
+- metadata-spec §将来の拡張に #810 未掲載
+- cli-spec の行番号参照 drift (`:521`)、metadata.json トップレベル表に新 field 5 件欠落 (抜粋であることの明記なし)
+- output-spec の適用範囲に detect コマンド不在
+- design/bundle/README.md のバンドル内パス不一致 (歴史的 artifact、注記 1 行で可)
+- issue 本文の鮮度切れ: #518 (scaffold 実装済みで question の役目終了) / #670 (v0.3.0 re-scope 未反映) / #753 (checklist 乖離) / #326 (着手条件成立済みで放置) / #376 (-V conflict なし、意味論判断のみ) / #804 (deferred 付与曖昧)
+- PR #808 の typer/click pin 恒久対応が未起票
+- #765 の参照先 #762 が not_planned close 済みで再評価 checkpoint の一部が宙
+
+## 健全確認事項 (突合して問題なし)
+
+- subprocess encoding は CLI コア全域で cp932 暗黙依存ゼロ (#656 系教訓の完全反映)。Rust 側 3 層 (PYTHONIOENCODING / byte-level read / from_utf8_lossy) も detect/export とも堅牢
+- metadata-spec ↔ metadata_types ↔ zod ↔ writer/migrations は完全一致 (#612 codegen + CI drift gate が機能)。tauri-commands.md も 26 command 一致
+- CI: typer/click pin (#808)、BtbN immutable pin、`defaults.run.shell` 化など既知の罠はすべて対処済み
+- NVENC 14 pattern / QSV `Error creating a MFX session` の教訓反映、scorebar 閾値の実測根拠 docstring、リソース管理 (Popen/tempfile) はほぼ完璧
+- L3 新規コード (#807/#811) は production import ゼロの pure additive で released path を構造的に保護
+- #793 (fps filter retirement) は env var gate + 自動 legacy fallback で教訓どおり
+- GUI store テストの独立性 (beforeEach reset)、schema 4 面 drift gate、jest-axe (ErrorModal 以外) は良好
+
+## 横断的な構造所見
+
+1. **「commit 済みだが未配線」の資産が 4 つ**: warnings scaffold / VTuber ground truth / split SHA baseline / format.py。配線だけで価値が出る (warnings scaffold は #805 の最小緩和にそのまま使える)
+2. **cancel path だけ品質が一段低い**: detect 中断は kill せず (P1-1)、export 中断は完了 race でスタック (P2-14)、kill 後は partial file 残置。cancel ライフサイクルの横断的な揃えが必要
+3. **doc drift は 2 パターンに収斂**: 「複数 doc への値の複製」と「実装後の『予定』文言残存」。metadata-spec 方式 (正 1 箇所 + リンク) の水平展開で構造的に再発を減らせる
+4. **issue 追跡の死角は「closed 側から open 側への参照切れ」3 類型**: merge されたのに系譜から消えた (#323→#412) / 残タスク追記直後に not_planned close (#762) / PR 本文の「別 issue で」が未起票 (PR #811→guard)
+
+## v0.3.0 リリースへの示唆
+
+現在の v0.3.0 active set は #481 (minimap) と #670 (responsiveness) の実装 2 本 + #805 の方針判断 (VTuber pillar は park 済み、性能 pillar は消化済み)。#805 は「v0.3.0 で warnings 記録 (最小) + escape hatch を入れ、非破壊化は #805 本体で」という段階案がコスト最小。#670 は本監査でフロント側 2 点 (thumbnail 並列アンバウンド + progress 無間引き) が主因候補と特定済み。

--- a/docs/superpowers/plans/2026-06-10-audit-w1-phase0-g1.md
+++ b/docs/superpowers/plans/2026-06-10-audit-w1-phase0-g1.md
@@ -1,0 +1,694 @@
+# Audit Remediation Wave 1 — Phase 0 + PR G1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wave 1 の起点を作る — 監査対応 issue 7 本の起票 + issue アクション 2 件 (Phase 0) と、最初の PR である G1 (slow マーカー配線修正 + 規約 enforcement、spec/監査レポート同梱コミット) を完成させる。
+
+**Architecture:** Phase 0 は gh 操作のみ (Iron Law 2 の AskUserQuestion ゲート付き、controller = 主セッションで実行)。G1 は (1) マーカー違反 2 ファイルの修正 → (2) 「`slow_*` サブマーカー ⇒ `slow` 必須」契約を pytest collection hook で機械化 (TDD)、の順で 1 branch / 1 PR。G2〜N3 の残り 7 PR は本 plan のスコープ外で、各着手時に個別 plan を作成する (spec §Wave 1 詳細に設計・AC 確定済み)。
+
+**Tech Stack:** gh CLI (Git Bash、日本語本文は HEREDOC + `--body-file -`)、pytest (collection hook / marker)、ruff / pyright。
+
+**参照 (必読):**
+
+- spec: `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` (§Wave 1 詳細 / §新規 issue 起票一覧)
+- findings: `docs/audits/2026-06-10-full-audit.md` (P1-3 が G1 の対象)
+- issue 書式: `docs/issue-policy.md` §2-3 (テンプレート・ラベル・40 字タイトル・`作成:` 行)
+- PR 規約: `docs/l2-workflow.md` §PR 作成 Pre-flight / §Self-Test Report 規約
+
+**前提条件 / 事実 (2026-06-10 時点の実測):**
+
+- working tree clean (audit red test は `stash@{0}` 退避済み)、branch `develop-0.3.0`
+- `docs/audits/2026-06-10-full-audit.md` と `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` は**未コミットで存在する** (本 PR で同梱コミット — 決定事項 (b))
+- マーカー違反の全量: `tests/test_v030_baseline_regression.py` (4 テスト、`slow_detect` 単独) / `tests/test_scorebar_regression.py:297-299` `TestPerformance` と `:412-414` `TestNoResolutionCompat` (`slow_detect`+`baseline_regen`、`slow` なし)。`tests/test_integration.py` は `pytestmark = pytest.mark.slow` (L27) で適合済み
+- `tests/conftest.py` に `pytest_collection_modifyitems` は未定義 (新設して衝突しない)
+- `tests/__init__.py` が存在するため `from tests.conftest import ...` が可能
+- session-id: 本 plan の作業では `audit-w1-20260610` を使う
+
+**spec からの設計確定 1 件 (G1):** spec §G1 は「conftest の `_ffmpeg_interval` cooldown を `slow_*` にも拡張」としていたが、enforcement hook が「`slow_*` ⇒ `slow`」を collection 時に強制するため、`get_closest_marker("slow")` のままで不変条件が成立する。**cooldown 拡張は実装しない** (YAGNI)。Task 9 で spec 側にこの確定を追記する。
+
+---
+
+## File Structure
+
+| 区分 | path | 責務 |
+| --- | --- | --- |
+| Create | `tests/test_marker_conventions.py` | enforcement helper の純関数ユニットテスト |
+| Modify | `tests/test_v030_baseline_regression.py` | docstring 訂正 + module pytestmark 化 (slow + slow_detect) |
+| Modify | `tests/test_scorebar_regression.py` | 2 class に `@pytest.mark.slow` 追加 |
+| Modify | `tests/conftest.py` | `slow_submarker_violations()` 純関数 + `pytest_collection_modifyitems` hook |
+| Modify | `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` | G1 cooldown 拡張の不要化を追記 |
+| Commit only | `docs/audits/2026-06-10-full-audit.md` / 上記 spec | 既に内容完成、本 PR の先頭 commit で追加 |
+
+---
+
+## Phase 0: issue 起票 + issue アクション
+
+> Phase 0 は AskUserQuestion を使うため**主セッション (controller) で実行する** (subagent に出さない)。
+
+### Task 1: Iron Law 2 確認ゲート
+
+**Files:** なし (対話のみ)
+
+- [ ] **Step 1: 起票対象 7 件の表を提示して確認を取る**
+
+AskUserQuestion で以下を提示する。質問 1: spec §新規 issue 起票一覧の **行 1〜7** (G1/G2/G3/G5/N1/N2/N3) を、Task 2 の本文サンプル (G1 の body 全文を例示) とともに「全件 OK / 個別調整 / やめる」の 3 択で確認。質問 2: #805 への優先度 label を「P2-medium を今付与し、deferred は G4 マージ後 (段階 2 持ち越し確定時) に付与 (Recommended)」「P1-high (v0.3.0 ゲート扱い)」「label なし継続」の 3 択で確認。
+
+- [ ] **Step 2: 回答を記録**
+
+「個別調整」の場合は調整内容を反映してから Task 2 へ。「やめる」なら Phase 0 を中断し Idios の指示を仰ぐ。
+
+### Task 2: 7 issue の起票
+
+**Files:** なし (gh のみ)。すべて `--assignee "Idios"`。各 body 末尾に `作成: audit-w1-20260610`。
+
+- [ ] **Step 1: G1 issue を起票し番号を捕捉**
+
+```bash
+G1=$(gh issue create --repo Idios/kobutachan-allaganeye \
+  --title "[bug] v0.3.0 baseline regression が slow マーカー規約から漏れている" \
+  --label "bug" --label "P1-high" --assignee "Idios" \
+  --body-file - <<'EOF' | grep -oE '[0-9]+$'
+## 概要
+`tests/test_v030_baseline_regression.py` の 4 テストが `slow_detect` 単独付与のため、testing-guide.md の「slow はサブマーカーのスーパーセット」契約に違反し、documented コマンドのどれからも実行されない。
+
+## 該当コード
+- `tests/test_v030_baseline_regression.py:28,62,143,181` (`@pytest.mark.slow_detect` 単独)
+- `tests/test_scorebar_regression.py:297-299,412-414` (同型違反: `slow_detect`+`baseline_regen` のみ)
+- `pyproject.toml:53` (addopts `-m 'not slow and not baseline_regen'`)
+
+## 問題
+(a) `ALLAGANEYE_SAMPLE_VIDEO_DIR` が設定された環境では bare `pytest` が数時間級の実動画 detect を実行する。(b) `pytest -m slow` / `pytest -m "slow or baseline_regen"` は v030 baseline を deselect するため、bit-exact gate を「回したつもりで回っていない」。(c) conftest の GPU cooldown (`slow` のみ参照) も効かない。詳細: docs/audits/2026-06-10-full-audit.md P1-3。
+
+## 修正方針
+module pytestmark 化 (`[pytest.mark.slow, pytest.mark.slow_detect]`) + scorebar_regression 2 class へ `slow` 追加 + 「slow_* ⇒ slow」を pytest collection hook で機械的に強制する (再発防止)。設計: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §G1。
+
+作成: audit-w1-20260610
+EOF
+)
+echo "G1=#$G1"
+```
+
+Expected: `G1=#<番号>` が出力される (以降の Task で `$G1` を参照するため、番号を控える)。
+
+- [ ] **Step 2: G2 issue を起票**
+
+```bash
+G2=$(gh issue create --repo Idios/kobutachan-allaganeye \
+  --title "[bug] GUI: detect 中断がプロセスを kill しない" \
+  --label "bug" --label "P1-high" --label "l2a-gui" --assignee "Idios" \
+  --body-file - <<'EOF' | grep -oE '[0-9]+$'
+## 概要
+DetectingScreen の「中断」は phase 遷移のみで `kill_tracked_processes` を呼ばず、Python detect + 最大 32 本の ffmpeg が走り続ける。drop 画面から同一動画への二重 detect も起動できる。
+
+## 該当コード
+- `gui/src/screens/DetectingScreen.tsx:314-321` (コメント「Real ffmpeg kill ships in #523's PR」のまま #523/#756 後も未配線)
+- `gui/src/__tests__/flow.integration.test.tsx:334` (describe 名が「detecting cancel triggers kill_tracked_processes」だが中身はウィンドウ close 経路)
+
+## 問題
+中断後もリソースを消費し続け、二重 detect で同一 output dir へ 2 プロセスが書き込みうる。detect イベントに run 識別子がなく、新画面が旧 run のイベントを拾いうる。詳細: docs/audits/2026-06-10-full-audit.md P1-1。
+
+## 修正方針
+cancelling phase で `kill_tracked_processes` を invoke してから CANCEL_CONFIRMED。detect イベントへ run id を付与し越境イベントを遮断。誤名テストを実態に合わせて修正。設計: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §G2。実機 Tauri 検証が必要 (Iron Law 6)。
+
+作成: audit-w1-20260610
+EOF
+)
+echo "G2=#$G2"
+```
+
+- [ ] **Step 3: G3 issue を起票**
+
+```bash
+G3=$(gh issue create --repo Idios/kobutachan-allaganeye \
+  --title "[bug] GUI: OUT<IN を apply でき metadata が読込不能になる" \
+  --label "bug" --label "P1-high" --label "l2a-gui" --assignee "Idios" \
+  --body-file - <<'EOF' | grep -oE '[0-9]+$'
+## 概要
+境界編集で `end_time < start_time` を無検証で metadata.json に書き込め、次回 load が zod refine で reject → load エラーは UI のどこにも表示されず「No metadata」の空画面になり、GUI 内に復旧手段がない。
+
+## 該当コード
+- `gui/src/screens/PreviewScreen.tsx` (nudge / TC 入力 / FrameStrip に相互クランプなし)
+- `gui/src/state/metadataStore.ts:152-176` (`normalizeForPersistence` が start/end 素通し)、`:163-173` (`*_display` を旧値コピー)、`:280` (`loadErrorState` を表示する UI なし)
+- `gui/src/types/metadata.schema.ts:29-31` (load 側 refine)
+
+## 問題
+「不正書き込み → 読込拒否 → 無言の空画面」の三段連鎖 (audit P1-2 + P2-13 + P2-17)。apply 後は display 文字列も数値と矛盾したまま永続化される。詳細: docs/audits/2026-06-10-full-audit.md。
+
+## 修正方針
+UI 相互クランプ + apply 前 validation + Rust `apply_changes` の schema guard (多層防御)。loadErrorState の表示先を配線。normalize 時に display を `utils/time.ts` で再生成。設計: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §G3。実機 Tauri 検証が必要。
+
+作成: audit-w1-20260610
+EOF
+)
+echo "G3=#$G3"
+```
+
+- [ ] **Step 4: G5 issue を起票**
+
+```bash
+G5=$(gh issue create --repo Idios/kobutachan-allaganeye \
+  --title "[doc] cli-spec / CLAUDE.md の P1 級 drift 修正" \
+  --label "doc" --label "P1-high" --assignee "Idios" \
+  --body-file - <<'EOF' | grep -oE '[0-9]+$'
+## 概要
+一次仕様書に実害級の誤り 3 点: export index 基数 / gpu-vendor intel「実装予定」/ CLAUDE.md 音声昇格 (frozen 未反映)。
+
+## 対象箇所
+1. `docs/cli-spec.md:353-354` — `--include`/`--exclude` を「0 始まり」と記載
+2. `docs/cli-spec.md:56` — `intel` は「exit 5 (#550 で実装予定)」と記載
+3. `CLAUDE.md` §検知アルゴリズム「音声昇格」+ §コマンド `--no-audio` 注釈 + `audio/refs/` 行
+
+## 誤記内容 / 矛盾内容
+| 現状の記載 | 正 |
+| --- | --- |
+| include/exclude は 0 始まり | 実装は metadata の 1 始まり `index` と照合 (`allaganeye/commands/export.py:149`、GUI も 1 始まりを送信) |
+| intel は exit 5 (実装予定) | #550/#582 で実装済み (`allaganeye/cli.py:130-139`) |
+| 音声昇格が動作する (デフォルト有効) | `AUDIO_FROZEN: Final[bool] = True` (#327) で常にスキップ。`fanfare.npz` 記載も `war_room.npz` (#306) 未反映 |
+
+## 対応方針
+P1 級 3 点のみ最小修正 (P2 doc drift は W6 で SSoT 規約適用とセット)。詳細: docs/audits/2026-06-10-full-audit.md P1-5/6/7、設計: spec §G5。
+
+作成: audit-w1-20260610
+EOF
+)
+echo "G5=#$G5"
+```
+
+- [ ] **Step 5: N1 issue を起票**
+
+```bash
+N1=$(gh issue create --repo Idios/kobutachan-allaganeye \
+  --title "[task] CI guard: sh test 配線 + branch pin の develop-* 化" \
+  --label "task" --label "P2-medium" --assignee "Idios" \
+  --body-file - <<'EOF' | grep -oE '[0-9]+$'
+## 概要
+CI 未配線の test harness と develop-0.2.0 固定 pin 2 件を解消し、stale worktree 掃除を実施する。
+
+## 期待値 (あるべき姿)
+`tests/scripts/test_*.sh` 3 本が CI で実行され、cleanup script と checklist-test workflow が現行 develop branch (develop-*) に追従する。N1 マージ後に stale worktree 9 本が安全手順 (dry-run → Iron Law 2 確認 → apply) で掃除される。
+
+## 現状
+`scripts/cleanup-claude-branches.sh:94` と `.github/workflows/check-pr-checklist-test.yml:10` が develop-0.2.0 固定のため、merged branch が掃除されず (実害: v0.2.x 期の stale worktree 9 本が残存)、develop-0.3.0 への push で checklist-test が走らない。sh test 3 本は CI 参照ゼロ。
+
+## ユーザー影響・重要性
+ユーザー直接影響なし、開発インフラの腐敗防止 + 再発防止基盤。
+
+## 確認項目 / 作業項目
+- [ ] ci.yml に `tests/scripts/test_*.sh` 3 本の実行 step を追加
+- [ ] check-pr-checklist-test.yml の push trigger を `develop-*` 化
+- [ ] cleanup-claude-branches.sh の merged 判定を `origin/develop-*` 走査に一般化
+- [ ] マージ後: branches → worktrees の 2 段 dry-run → Iron Law 2 確認 → apply (spec §N1 マージ後アクション)
+
+## 対応方針
+設計: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §N1。GitHub Actions の既知の罠は memory/feedback 既録テンプレに従う。
+
+作成: audit-w1-20260610
+EOF
+)
+echo "N1=#$N1"
+```
+
+- [ ] **Step 6: N2 issue を起票**
+
+```bash
+N2=$(gh issue create --repo Idios/kobutachan-allaganeye \
+  --title "[task] skill 改修: 追跡切れ防止チェックの追加" \
+  --label "task" --label "P2-medium" --label "l2-workflow" --assignee "Idios" \
+  --body-file - <<'EOF' | grep -oE '[0-9]+$'
+## 概要
+監査で検出した「closed 側から open 側への参照切れ」3 類型 (audit 横断所見 4) を skill 改修で構造的に防ぐ。
+
+## 期待値 (あるべき姿)
+/close-issue がクローズ前に PR 本文の「別 issue で追跡予定」宣言の行き先実在を確認し、/release の deferred レビューが issue 本文鮮度と not_planned close の残タスクを検出する。version bump grep が tauri.conf.json / package.json も拾う。skills 内 broken link 14 件が解消されている。
+
+## 現状
+PR #811 の guard repo follow-up 未起票、#762 not_planned close による残タスク orphan 化、versioning.md「pyproject.toml のみ」前提の bump grep、`.claude/skills/*/SKILL.md` の `../../docs/` リンク 14 件 (1 階層不足) が放置されている。
+
+## ユーザー影響・重要性
+開発プロセスの再発防止基盤 (issue 追跡の死角解消)。
+
+## 確認項目 / 作業項目
+- [ ] close-issue: 「別 issue で追跡」宣言の行き先確認 step を追加
+- [ ] release: deferred レビューに本文鮮度 + not_planned 残タスク確認を追加、bump grep に *.json を追加
+- [ ] skills の `../../docs/` → `../../../docs/` 一括修正 (14 件)
+- [ ] empirical-prompt-tuning protocol で検証し Self-Test Report に記録
+
+## 対応方針
+設計: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §N2。skill 改修 PR 規約 (CLAUDE.md §skill 改修ワークフロー) に従う。
+
+作成: audit-w1-20260610
+EOF
+)
+echo "N2=#$N2"
+```
+
+- [ ] **Step 7: N3 issue を起票**
+
+```bash
+N3=$(gh issue create --repo Idios/kobutachan-allaganeye \
+  --title "[doc] doc SSoT 規約の明文化 + release gate 追記" \
+  --label "doc" --label "P2-medium" --assignee "Idios" \
+  --body-file - <<'EOF' | grep -oE '[0-9]+$'
+## 概要
+「同じ仕様値を複数 doc に書かない (正 1 箇所 + 参照リンク)」規約の明文化と、release checklist への監査 P1 ゲート追記。W6 (doc 一括再同期) の前提。
+
+## 対象箇所
+- `docs/coding-conventions.md` (または適切な既存 doc — 追加前に `grep -n '^## '` で全 section を確認し重複回避)
+- `docs/release-process.md` (リリース前チェック)
+
+## 誤記内容 / 矛盾内容
+規約不在の実害: workers 上限「24」が 6 doc 7 箇所に複製されたまま実装 (32) と drift (audit P2-25)。同型 drift が P2-26〜28 等で反復。
+
+## 対応方針
+SSoT 規約 (仕様値の正は cli-spec / metadata-spec / 実装 docstring のいずれか 1 箇所、他はリンク。CLAUDE.md は索引として要約可・数値は出典リンク併記) を規約化し、release-process に「監査 P1 (spec Wave 1) 全クローズ確認」を追記。設計: spec §N3。
+
+作成: audit-w1-20260610
+EOF
+)
+echo "N3=#$N3"
+```
+
+- [ ] **Step 8: 起票結果の検証**
+
+```bash
+gh issue list --repo Idios/kobutachan-allaganeye --search "audit-w1-20260610" --state open
+```
+
+Expected: 7 件 (G1/G2/G3/G5/N1/N2/N3) が列挙される。番号一覧を spec §新規 issue 起票一覧の各行末尾に `→ #N` 形式で追記する (Task 9 の spec 編集と同時でよい)。
+
+### Task 3: #809 受け入れ条件追記
+
+**Files:** なし (gh のみ)
+
+- [ ] **Step 1: 既存 body を取得して追記版を作る**
+
+```bash
+gh issue view 809 --repo Idios/kobutachan-allaganeye --json body --jq .body > /tmp/809-body.md
+cat >> /tmp/809-body.md <<'EOF'
+
+## 受け入れ条件追記 (2026-06-10 audit P1-8)
+
+wiring 順序依存の構造リスク対策 (詳細: docs/audits/2026-06-10-full-audit.md P1-8):
+
+- [ ] scorebar 局在化 consumer (P2) を本 issue の wiring と同時または先行して導入する
+- [ ] 上記が間に合わない場合でも、region != FULL_FRAME 時は `_drop_post_match_trailing` を無効化する gate を入れる (full-frame 前提の scorebar probe 群が VTuber layout で系統的 False を返し、全暗転 non_fl 化 + trailing drop 誤爆の複合事故になるため)
+- [ ] `tests/detection_cache.py` の `_CACHE_SENSITIVE_FILES` に `capture_region.py` を追加する
+EOF
+```
+
+- [ ] **Step 2: body を更新し確認**
+
+```bash
+gh issue edit 809 --repo Idios/kobutachan-allaganeye --body-file /tmp/809-body.md
+gh issue view 809 --repo Idios/kobutachan-allaganeye --json body --jq .body | tail -8
+```
+
+Expected: 追記した 3 checkbox が表示される。
+
+### Task 4: #805 triage コメント + label
+
+**Files:** なし (gh のみ)
+
+- [ ] **Step 1: triage コメントを投稿**
+
+```bash
+gh issue comment 805 --repo Idios/kobutachan-allaganeye --body-file - <<'EOF'
+triage (2026-06-10 監査対応、spec: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §G4):
+
+- **段階 1 (v0.3.0 で実施)**: trailing drop の warnings[] 記録 (`post_match_trailing_dropped` + start/end context) + escape hatch `--keep-trailing`。本 issue に紐づく PR として提出する
+- **段階 2 (本 issue で継続)**: 非破壊化 (NotRequired フラグ方式)。#373 (末尾打ち切り情報の metadata 記録) と schema 設計を統合検討
+- audio corroboration 案 (audit P2-1) は `AUDIO_FROZEN=True` の間 no-op のため見送り。#327 解凍時に再評価
+
+作成: audit-w1-20260610
+EOF
+```
+
+- [ ] **Step 2: label を付与 (Task 1 質問 2 の回答に従う)**
+
+```bash
+# Recommended 回答の場合:
+gh issue edit 805 --repo Idios/kobutachan-allaganeye --add-label "P2-medium"
+gh issue view 805 --repo Idios/kobutachan-allaganeye --json labels --jq '[.labels[].name]'
+```
+
+Expected: `["risk","P2-medium"]` (deferred は G4 マージ後・段階 2 持ち越し確定時に付与)。
+
+---
+
+## PR G1: slow マーカー配線修正 + 規約 enforcement
+
+> ここからはコード作業。subagent 実行可。元 issue は Task 2 Step 1 の `$G1`。
+
+### Task 5: branch 作成 + spec / 監査レポートの同梱コミット
+
+**Files:**
+
+- Add: `docs/audits/2026-06-10-full-audit.md` (作成済み・未コミット)
+- Add: `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` (作成済み・未コミット)
+- Add: `docs/superpowers/plans/2026-06-10-audit-w1-phase0-g1.md` (本 plan、作成済み・未コミット)
+
+- [ ] **Step 1: clean 確認と branch 作成**
+
+```bash
+cd /e/projects/kobutachan-tools/kobutachan-allaganeye
+git status --short   # 出力が docs/ の untracked 3 件 (audit / spec / 本 plan) のみであること
+git fetch origin develop-0.3.0
+git checkout -b claude/audit-w1-g1 origin/develop-0.3.0
+```
+
+Expected: branch `claude/audit-w1-g1` が最新 base から作成される。
+
+- [ ] **Step 2: docs を commit (決定事項 (b))**
+
+```bash
+git add docs/audits/2026-06-10-full-audit.md docs/superpowers/specs/2026-06-10-audit-remediation-design.md docs/superpowers/plans/2026-06-10-audit-w1-phase0-g1.md
+git commit -m "doc: 2026-06-10 全体監査レポートと remediation 設計 spec を追加 (#${G1})
+
+Wave 1 最初の PR に同梱する決定 (spec §決定事項 option b) に従い、
+監査 findings の恒久記録 (P1-1..8 / P2-1..40 / P3) と対策プログラム設計を commit する。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+Expected: commit 成功。docs/ のみの単一 scope commit (preuse hook 適合)。
+
+### Task 6: マーカー違反の修正 (red → green を collect-only で実証)
+
+**Files:**
+
+- Modify: `tests/test_v030_baseline_regression.py:1-28,62,143,181`
+- Modify: `tests/test_scorebar_regression.py:297-299,412-414`
+
+- [ ] **Step 1: 現状の誤配線を記録 (= failing 状態の実証)**
+
+```bash
+python -m pytest --collect-only -q -m slow 2>&1 | grep -c "test_v030_baseline_regression" || true
+python -m pytest --collect-only -q 2>&1 | grep -c "test_v030_baseline_regression" || true
+```
+
+Expected: 1 行目 `0` (slow で選ばれない = バグ)、2 行目 `0` 以外 (bare pytest に紛れ込む = バグ。`ALLAGANEYE_SAMPLE_VIDEO_DIR` 未設定でも collection には載る)。
+
+- [ ] **Step 2: test_v030_baseline_regression.py を module pytestmark 化**
+
+docstring 3 行目の誤認記述を訂正し、module pytestmark を追加、4 箇所の単独 decorator を削除する。
+
+```python
+# 冒頭 (L1-5) を以下に置換:
+"""v0.3.0 baseline regression tests (#576 S7.2 / S9.2).
+
+slow + slow_detect マーカー: 実動画必須。`pytest -m slow` / `-m slow_detect` で実行し、
+bare pytest からは addopts (`-m 'not slow and not baseline_regen'`) により除外される。
+Idios 環境または ALLAGANEYE_SAMPLE_VIDEO_DIR が設定されたマシンで実行。
+"""
+```
+
+```python
+# import 群の直後 (現 L13 `import pytest` の後、`_REPO_ROOT = ...` の前) に追加:
+pytestmark = [pytest.mark.slow, pytest.mark.slow_detect]
+```
+
+L28, L62, L143, L181 の `@pytest.mark.slow_detect` 行を 4 箇所とも削除する (module pytestmark に集約)。
+
+- [ ] **Step 3: test_scorebar_regression.py の 2 class に slow を追加**
+
+```python
+# L297-299 (TestPerformance):
+@pytest.mark.slow
+@pytest.mark.slow_detect
+@pytest.mark.baseline_regen
+class TestPerformance:
+```
+
+```python
+# L412-414 (TestNoResolutionCompat):
+@pytest.mark.slow
+@pytest.mark.slow_detect
+@pytest.mark.baseline_regen
+class TestNoResolutionCompat:
+```
+
+(いずれも既存 2 decorator の上に `@pytest.mark.slow` を 1 行追加するだけ)
+
+- [ ] **Step 4: 選択が反転したことを検証**
+
+```bash
+python -m pytest --collect-only -q -m slow 2>&1 | grep -c "test_v030_baseline_regression"
+python -m pytest --collect-only -q 2>&1 | grep -c "test_v030_baseline_regression" || true
+python -m pytest --collect-only -q -m slow 2>&1 | grep -c "TestPerformance"
+```
+
+Expected: 1 行目 `0` 以外 (slow で選ばれる)、2 行目 `0` (bare から除外)、3 行目 `0` 以外。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_v030_baseline_regression.py tests/test_scorebar_regression.py
+git commit -m "fix(test): v0.3.0 baseline と scorebar regression を slow マーカー契約に整合 (#${G1})
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 7: enforcement helper (TDD)
+
+**Files:**
+
+- Create: `tests/test_marker_conventions.py`
+- Modify: `tests/conftest.py` (末尾に追加)
+
+- [ ] **Step 1: failing unit test を書く**
+
+`tests/test_marker_conventions.py` を新規作成:
+
+```python
+"""slow_* サブマーカー規約 guard のユニットテスト (audit 2026-06-10 P1-3 再発防止).
+
+enforcement 本体は tests/conftest.py の pytest_collection_modifyitems。
+ここではその純関数 slow_submarker_violations() を検証する。
+"""
+
+from tests.conftest import slow_submarker_violations
+
+
+def test_detects_submarker_without_slow():
+    mapping = {
+        "tests/test_x.py::test_a": {"slow_detect"},
+        "tests/test_x.py::test_b": {"slow_detect", "baseline_regen"},
+    }
+    assert slow_submarker_violations(mapping) == [
+        "tests/test_x.py::test_a",
+        "tests/test_x.py::test_b",
+    ]
+
+
+def test_accepts_submarker_with_slow():
+    mapping = {
+        "tests/test_x.py::test_a": {"slow", "slow_detect"},
+        "tests/test_x.py::test_b": {"slow", "slow_gpu", "baseline_regen"},
+    }
+    assert slow_submarker_violations(mapping) == []
+
+
+def test_ignores_unrelated_markers():
+    mapping = {
+        "tests/test_x.py::test_a": {"parametrize"},
+        "tests/test_x.py::test_b": set(),
+        "tests/test_x.py::test_c": {"slow"},
+    }
+    assert slow_submarker_violations(mapping) == []
+```
+
+- [ ] **Step 2: fail を確認**
+
+```bash
+python -m pytest tests/test_marker_conventions.py -v
+```
+
+Expected: FAIL (`ImportError: cannot import name 'slow_submarker_violations'`)。
+
+- [ ] **Step 3: 実装 (純関数 + collection hook)**
+
+`tests/conftest.py` の末尾に追加:
+
+```python
+_SLOW_SUBMARKERS = frozenset({"slow_probe", "slow_detect", "slow_pipeline", "slow_gpu"})
+
+
+def slow_submarker_violations(marker_names_by_nodeid: dict[str, set[str]]) -> list[str]:
+    """slow_* サブマーカーを持つのに slow を持たない nodeid を返す.
+
+    testing-guide.md の「slow はサブマーカーのスーパーセット」契約を機械化する
+    (audit 2026-06-10 P1-3: 違反すると documented コマンドから test が漏れる)。
+    """
+    return sorted(
+        nodeid
+        for nodeid, names in marker_names_by_nodeid.items()
+        if names & _SLOW_SUBMARKERS and "slow" not in names
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """collection 時に slow マーカー契約違反を即エラーにする (deselect より前に全 item を検査)."""
+    mapping = {item.nodeid: {m.name for m in item.iter_markers()} for item in items}
+    violations = slow_submarker_violations(mapping)
+    if violations:
+        raise pytest.UsageError(
+            "slow_* submarker without 'slow' (testing-guide.md の slow スーパーセット契約違反): "
+            + ", ".join(violations)
+        )
+```
+
+- [ ] **Step 4: pass + 全体 collection の無違反を確認**
+
+```bash
+python -m pytest tests/test_marker_conventions.py -v
+python -m pytest --collect-only -q > /dev/null && echo COLLECT_OK
+```
+
+Expected: 3 件 PASS / `COLLECT_OK` (違反が残っていれば UsageError で非ゼロ exit)。
+
+- [ ] **Step 5: guard が実際に効くことを一時違反で実証 (手動 red)**
+
+`tests/test_scorebar_regression.py` の L297 `@pytest.mark.slow` を一時的に削除して:
+
+```bash
+python -m pytest --collect-only -q 2>&1 | tail -3
+git checkout -- tests/test_scorebar_regression.py
+```
+
+Expected: `UsageError: slow_* submarker without 'slow' ... TestPerformance` を含むエラーで非ゼロ exit → その後 `git checkout` で復元。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_marker_conventions.py tests/conftest.py
+git commit -m "test: slow_* サブマーカー単独付与を collection 時に拒否する規約 guard を追加 (#${G1})
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 8: 全体検証 (Iron Law 6 path 別チェック)
+
+**Files:** なし
+
+- [ ] **Step 1: Python 系チェックを全部回す**
+
+```bash
+ruff check . && ruff format --check . && pyright && python -m pytest
+```
+
+Expected: すべて pass。bare pytest は fast suite のみ実行 (v030 baseline は除外済み)、かつ collection hook が全 item を検査して green。
+
+- [ ] **Step 2: マーカー選択マトリクスの最終確認**
+
+```bash
+python -m pytest --collect-only -q -m slow 2>&1 | grep -c "test_v030_baseline_regression"
+python -m pytest --collect-only -q -m "slow or baseline_regen" 2>&1 | grep -c "test_v030_baseline_regression"
+python -m pytest --collect-only -q -m slow_detect 2>&1 | grep -c "test_v030_baseline_regression"
+```
+
+Expected: 3 行とも `0` 以外 (documented な 3 コマンドすべてで gate が回る)。
+
+### Task 9: spec への確定事項追記
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` §G1
+
+- [ ] **Step 1: cooldown 拡張の不要化を spec に反映**
+
+§G1 の設計 bullet `conftest の \`_ffmpeg_interval\` cooldown の発動条件を \`slow\` に加えて \`slow_*\` サブマーカーにも拡張` を以下に置換:
+
+```text
+conftest の `_ffmpeg_interval` cooldown は現行 (`slow` のみ参照) を維持する — enforcement hook が「slow_* ⇒ slow」を collection 時に強制するため、拡張は冗長 (2026-06-10 plan で確定)
+```
+
+あわせて §新規 issue 起票一覧の行 1〜7 の末尾に Phase 0 で得た実番号 (`→ #N`) を追記する。
+
+- [ ] **Step 2: lint + Commit**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | grep "2026-06-10-audit-remediation-design" || echo LINT_OK
+git add docs/superpowers/specs/2026-06-10-audit-remediation-design.md
+git commit -m "doc: spec に G1 cooldown 確定と issue 実番号を反映 (#${G1})
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+Expected: `LINT_OK` (violation 出力なし) → commit 成功。
+
+### Task 10: PR 作成 (Iron Law 6 Pre-flight)
+
+**Files:** なし
+
+- [ ] **Step 1: Pre-flight Step 0 (ハードゲート)**
+
+```bash
+gh pr list --repo Idios/kobutachan-allaganeye --search "${G1}" --state open
+```
+
+Expected: 0 件 (既存 PR があれば STOP して Idios に確認)。
+
+- [ ] **Step 2: Pre-flight Step 1-3 (base 同期確認)**
+
+```bash
+git fetch origin develop-0.3.0
+git log HEAD..origin/develop-0.3.0 --oneline
+```
+
+Expected: 出力 0 行。出力がある場合は取り込み commit の touched files と本 PR (tests/conftest.py 等) の交差を確認し、交差すれば rebase + 再検証。
+
+- [ ] **Step 3: Pre-flight Step 4 (並行 PR 重複再確認)**
+
+```bash
+gh pr list --repo Idios/kobutachan-allaganeye --search "${G1}" --state all
+```
+
+Expected: 0 件。
+
+- [ ] **Step 4: Pre-flight Step 5 (Codex adversarial-review)**
+
+`/codex:adversarial-review` を invoke する。focus: 「pytest collection hook の追加が既存 test 選択を変えないか / pytestmark 化による marker 意味の変化 / Iron Law 3 (scope creep) / docs 同梱 commit の妥当性」。Codex CLI が fail した場合は superpowers `requesting-code-review` subagent に fallback し、PR 本文に Codex fallback notice を必須記載 (CLAUDE.md §Token 枯渇時の fallback)。
+
+- [ ] **Step 5: push + PR 作成**
+
+```bash
+git push -u origin claude/audit-w1-g1
+gh pr create --repo Idios/kobutachan-allaganeye --base develop-0.3.0 \
+  --title "fix(test): v0.3.0 baseline の slow マーカー配線修正 + 規約 guard (Refs #${G1})" \
+  --body-file - <<EOF
+## 概要
+audit P1-3 対応 (Refs #${G1})。spec: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §G1。
+監査レポート + remediation spec を先頭 commit で同梱 (決定事項 option b、docs と tests の 2 scope を含むが per-commit では単一 scope)。
+
+## 変更内容
+- 監査レポート / remediation spec の追加 (docs)
+- test_v030_baseline_regression.py: module pytestmark 化 (slow + slow_detect) + docstring 訂正
+- test_scorebar_regression.py: TestPerformance / TestNoResolutionCompat に slow 追加
+- tests/conftest.py: slow_* ⇒ slow 契約の collection-time enforcement (+ 純関数 unit test)
+
+## Self-Test Report
+- [x] ruff check . / ruff format --check . / pyright / pytest 全 pass
+- [x] collect-only マトリクス: -m slow / -m "slow or baseline_regen" / -m slow_detect すべてで v030 baseline が select、bare pytest では deselect
+- [x] enforcement の実効性: slow を一時除去すると UsageError で collection が fail することを確認
+- 実動画での slow 実行は本 PR では不要 (マーカー配線のみ、テスト本体・検知ロジック無変更)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 6: issue へ完了コメント + 後続**
+
+```bash
+gh issue comment ${G1} --repo Idios/kobutachan-allaganeye \
+  --body "完了: audit-w1-20260610 → PR #<上で得た PR 番号>。マーカー配線修正 + enforcement 追加。"
+```
+
+PR 作成後は `/iterate-review <PR#>` で review-fix ループへ。マージ後のクローズは `/close-issue ${G1}` (Iron Law 4)。
+
+---
+
+## 後続 (本 plan のスコープ外、順序のみ)
+
+G1 マージ後、spec §Wave 1 の残り 7 PR を just-in-time plan で進める。推奨順: **G5 (doc、最小) → N1 (CI guard → マージ後 worktree 掃除) → N3 (SSoT 規約、W6 の前提) → G4 (#805 段階 1、G1 の gate で検証) → G2 / G3 (GUI、実機検証依頼) → N2 (skill、empirical-prompt-tuning)**。各 plan 作成時に本 plan と同様に対象ファイルを実測してから書く。

--- a/docs/superpowers/plans/2026-06-10-audit-w1-phase0-g1.md
+++ b/docs/superpowers/plans/2026-06-10-audit-w1-phase0-g1.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **注記 (2026-06-10 /iterate-review Round 3)**: 本 plan は point-in-time の実行 artifact。G1 実装確定の正は spec §G1 と `tests/conftest.py` / `tests/test_marker_conventions.py` を参照のこと (review round での強化により本 plan のコードサンプルから乖離あり: hook の tryfirst 付与 / エラーメッセージの複数行化 + ASCII 化 / 手動 red 実証の pytester 統合テスト置換)。
+
 **Goal:** Wave 1 の起点を作る — 監査対応 issue 7 本の起票 + issue アクション 2 件 (Phase 0) と、最初の PR である G1 (slow マーカー配線修正 + 規約 enforcement、spec/監査レポート同梱コミット) を完成させる。
 
 **Architecture:** Phase 0 は gh 操作のみ (Iron Law 2 の AskUserQuestion ゲート付き、controller = 主セッションで実行)。G1 は (1) マーカー違反 2 ファイルの修正 → (2) 「`slow_*` サブマーカー ⇒ `slow` 必須」契約を pytest collection hook で機械化 (TDD)、の順で 1 branch / 1 PR。G2〜N3 の残り 7 PR は本 plan のスコープ外で、各着手時に個別 plan を作成する (spec §Wave 1 詳細に設計・AC 確定済み)。

--- a/docs/superpowers/plans/2026-06-10-audit-w1-phase0-g1.md
+++ b/docs/superpowers/plans/2026-06-10-audit-w1-phase0-g1.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-> **注記 (2026-06-10 /iterate-review Round 3)**: 本 plan は point-in-time の実行 artifact。G1 実装確定の正は spec §G1 と `tests/conftest.py` / `tests/test_marker_conventions.py` を参照のこと (review round での強化により本 plan のコードサンプルから乖離あり: hook の tryfirst 付与 / エラーメッセージの複数行化 + ASCII 化 / 手動 red 実証の pytester 統合テスト置換)。
+**注記 (2026-06-10 /iterate-review Round 3)**: 本 plan は point-in-time の実行 artifact。G1 実装確定の正は spec §G1 と `tests/conftest.py` / `tests/test_marker_conventions.py` を参照のこと (review round での強化により本 plan のコードサンプルから乖離あり: hook の tryfirst 付与 / エラーメッセージの複数行化 + ASCII 化 / 手動 red 実証の pytester 統合テスト置換)。
 
 **Goal:** Wave 1 の起点を作る — 監査対応 issue 7 本の起票 + issue アクション 2 件 (Phase 0) と、最初の PR である G1 (slow マーカー配線修正 + 規約 enforcement、spec/監査レポート同梱コミット) を完成させる。
 

--- a/docs/superpowers/specs/2026-06-10-audit-remediation-design.md
+++ b/docs/superpowers/specs/2026-06-10-audit-remediation-design.md
@@ -40,7 +40,7 @@ v0.3.0 リリース条件への追加: **Wave 1 の全 issue クローズ** (= P
 - 設計:
   - `test_v030_baseline_regression.py` に `pytestmark = [pytest.mark.slow, pytest.mark.slow_detect]` を追加 (他 slow ファイルと同形)。docstring の「CI default deselect」誤認記述も訂正
   - conftest の `_ffmpeg_interval` cooldown は現行 (`slow` のみ参照) を維持する — enforcement hook が「`slow_*` ⇒ `slow`」を collection 時に強制するため、拡張は冗長 (2026-06-10 plan で確定)
-  - meta-test (新規): tests/ 配下のソースを走査し、`slow_probe/slow_detect/slow_pipeline/slow_gpu` を付与したテスト (またはファイル) が `slow` を併せ持つことを assert する。実装方式はソーススキャン (前例: `tests/test_ascii_guard.py`)。testing-guide.md:33 の「slow = サブマーカーのスーパーセット」契約を機械化する
+  - enforcement (新規): `pytest_collection_modifyitems` hook (tryfirst) が全 collected item の marker を検査し、`slow_probe/slow_detect/slow_pipeline/slow_gpu` を持つのに `slow` を持たない item があれば UsageError で collection を fail させる。純関数 `slow_submarker_violations()` は unit test で検証。testing-guide.md:33 の「slow = サブマーカーのスーパーセット」契約を機械化する (実装時にソーススキャン案から hook 方式へ変更 — runtime enforcement の方が網羅的、2026-06-10 plan 実行で確定)
 - 受け入れ条件案: `pytest -m slow --collect-only` が v030 baseline 4 テストを select する / bare `pytest --collect-only` が select しない / meta-test が `slow_detect` 単独付与の fixture コードで fail することをユニットで実証
 - 検証: Python path チェック (ruff / pyright / pytest)。実動画実行は不要 (配線のみ)
 

--- a/docs/superpowers/specs/2026-06-10-audit-remediation-design.md
+++ b/docs/superpowers/specs/2026-06-10-audit-remediation-design.md
@@ -1,0 +1,246 @@
+# 2026-06-10 全体監査 remediation 設計
+
+## 背景・目的
+
+2026-06-10 の全体監査 ([`docs/audits/2026-06-10-full-audit.md`](../../audits/2026-06-10-full-audit.md)、以下「監査レポート」) で約 60 件の findings (P1×8 / P2×40 / P3 多数) と横断的な構造パターン 4 つを検出した。本設計はその **対策 (remediation)** と **再発防止 (prevention)** のプログラム全体を定義する。finding ID (P1-1 等) は監査レポートの定義を参照する。
+
+## 決定事項 (2026-06-10 Idios 確認済み)
+
+| 論点 | 決定 |
+| --- | --- |
+| 即時処置 2 件 | 実施済み (park branch 2 本 push / red test stash 退避) |
+| v0.3.0 との関係 | **P1 を v0.3.0 リリースゲート化**。P2 は並行消化分と v0.3.1+/deferred に振り分け。再発防止は v0.3.0 サイクル内に導入 |
+| issue 粒度 | **PR 単位グループ** (1 issue = 1 PR で消化できる作業単位、見込み 14-18 本) |
+| 再発防止の採用機構 | CI/test guard 強化 + skill 改修 + doc SSoT 規約の 3 本 (定期 full audit は不採用) |
+| プログラム構造 | **案 A: 優先度駆動 Wave 方式** (Wave 1 = ゲート + 基盤 → Wave 2 = P2 テーマ → Wave 3 = 棚卸し + P3) |
+| 本 spec + 監査レポートのコミット | Wave 1 最初の PR に同梱 (option b、2026-06-10 確定) |
+
+## 追跡方法
+
+- 親 issue は作らない (#753 で実証された「親 issue 本文が腐る」回避)。**本 spec が正**で、各 issue 本文の冒頭に本 spec への参照行を 1 行入れる
+- 新規 label は追加しない (L3 spec §5 の規約に従う)。優先度 label (P1-high 等) と既存 label のみ使用
+- 進捗は issue の open/close で追跡し、Wave 完了時に本 spec の該当節へ完了日を追記する
+
+## 全体構造
+
+```text
+Wave 1 (v0.3.0 リリースゲート + 再発防止基盤): G1-G5 + N1-N3 ... 8 PR、ほぼ全部並列可
+Wave 2 (P2 テーマ消化): W1-W6 ... 5-7 PR、Wave 1 完了後に並列
+Wave 3 (issue 棚卸し + P3 batch): PR なし、gh 操作中心 (bulk は実行直前に再確認ゲート)
+```
+
+v0.3.0 リリース条件への追加: **Wave 1 の全 issue クローズ** (= P1 全消化)。Wave 2 は v0.3.0 に間に合った分だけ取り込み、残りは v0.3.x へ繰り越し可。Wave 3 はリリースと独立。
+
+## Wave 1 詳細
+
+### G1: test marker 配線修正 + marker 規約 meta-test
+
+- 対応: P1-3 (+ 再発防止)
+- 変更箇所: `tests/test_v030_baseline_regression.py` / `tests/conftest.py` / 新規 `tests/test_marker_conventions.py`
+- 設計:
+  - `test_v030_baseline_regression.py` に `pytestmark = [pytest.mark.slow, pytest.mark.slow_detect]` を追加 (他 slow ファイルと同形)。docstring の「CI default deselect」誤認記述も訂正
+  - conftest の `_ffmpeg_interval` cooldown の発動条件を `slow` に加えて `slow_*` サブマーカーにも拡張
+  - meta-test (新規): tests/ 配下のソースを走査し、`slow_probe/slow_detect/slow_pipeline/slow_gpu` を付与したテスト (またはファイル) が `slow` を併せ持つことを assert する。実装方式はソーススキャン (前例: `tests/test_ascii_guard.py`)。testing-guide.md:33 の「slow = サブマーカーのスーパーセット」契約を機械化する
+- 受け入れ条件案: `pytest -m slow --collect-only` が v030 baseline 4 テストを select する / bare `pytest --collect-only` が select しない / meta-test が `slow_detect` 単独付与の fixture コードで fail することをユニットで実証
+- 検証: Python path チェック (ruff / pyright / pytest)。実動画実行は不要 (配線のみ)
+
+### G2: GUI detect 中断の kill 配線
+
+- 対応: P1-1
+- 変更箇所: `gui/src/screens/DetectingScreen.tsx` / `gui/src-tauri/src/lib.rs` (run id) / `gui/src/__tests__/flow.integration.test.tsx`
+- 設計:
+  - cancelling phase で `kill_tracked_processes` を invoke してから `CANCEL_CONFIRMED` に遷移
+  - detect イベントの run 識別: `start_detect` 起動ごとに run id を払い出し、`detect-progress` / 完了イベントに含める。フロントは現在 run の id 以外を無視 (越境イベント遮断)。具体的な払い出し方式 (戻り値 vs payload) は実装計画で確定
+  - 「detecting cancel triggers kill_tracked_processes (#756)」と名乗りながら別経路を検証している flow.integration の describe を修正し、実際に中断クリック → kill invoke を検証するテストを追加
+- 受け入れ条件案: 中断クリックで `kill_tracked_processes` が invoke される (unit) / 中断後に旧 run のイベントが UI に反映されない (unit) / 実機: 中断後に ffmpeg プロセスが残らない (Idios 実機検証)
+- 検証: GUI path チェック (lint / typecheck / test / build / cargo check) + **Tauri 実機検証を AskUserQuestion で依頼** (Iron Law 6)
+
+### G3: GUI metadata 境界検証 + load エラー可視化
+
+- 対応: P1-2、P2-13、P2-17
+- 変更箇所: `gui/src/screens/PreviewScreen.tsx` / `gui/src/state/metadataStore.ts` / `gui/src/screens/DetectingScreen.tsx` or `CompleteScreen.tsx` / `gui/src-tauri/src/lib.rs` (apply guard)
+- 設計:
+  - 境界編集 (nudge / TC 入力 / FrameStrip) に相互クランプを入れ、apply 前 validation で `end_time > start_time` を強制 (UI ブロック)。Rust `apply_changes` にも同 guard を追加し AppError で返す (多層防御)
+  - `loadErrorState` の表示先を配線: detect 完了後の load 失敗は error ルーティング (既存の専用 error view)、CompleteScreen の空状態にも loadErrorState を表示。`restore()` の load 失敗も成功扱いしない
+  - `normalizeForPersistence` で `start_display`/`end_display`/`duration_display` を `utils/time.ts` の既存フォーマッタで再生成 (CLI 形式と同一仕様)
+- 受け入れ条件案: end<=start が UI でブロックされる / 不正値が Rust 側でも reject される / load 失敗時にエラー内容が画面に出る / apply 後の display 文字列が数値と一致する
+- 検証: GUI path チェック + Tauri 実機検証依頼
+
+### G4: #805 段階 1 — trailing drop の痕跡記録 + escape hatch
+
+- 対応: P1-4、P2-2 (P2-1 の audio corroboration は `AUDIO_FROZEN=True` の間 no-op のため**見送り**、#805 に記録)
+- 紐づけ: **既存 #805** (新規 issue なし)。#805 へ「段階 1 を v0.3.0 で実施、段階 2 (非破壊化) は本 issue で継続」の triage コメントを先に投稿
+- 変更箇所: `allaganeye/detection/warnings.py` / `allaganeye/video/detector.py` / `allaganeye/config.py` + `cli.py` (flag) / `docs/metadata-spec.md` / `docs/cli-spec.md`
+- 設計:
+  - `WARNING_CODES` に `post_match_trailing_dropped` を追加し、drop 時に `warnings[]` へ `{code, context: {start, end}}` を記録 (`MetadataWarning` は forward-compat 設計済みのため schema_version bump 不要、GUI zod は unknown code 受容済み)
+  - escape hatch: `--keep-trailing` flag (split / detect 共通、`SplitConfig.keep_trailing: bool = False`)。True なら `_drop_post_match_trailing` を skip。「released path を触る分岐は明示 gate に」教訓への整合
+  - doc: cli-spec へ flag 追記、metadata-spec の warning code 表へ追記 (同 PR 内)
+- 受け入れ条件案: drop 発生時に warnings[] へ記録される (unit) / `--keep-trailing` で drop が無効化される (unit) / v0.3.0 baseline 5 本の detect projection (matches+gaps) が bit-exact 維持 (G1 修正後の slow gate で実証) / warnings field 追加が compare-baseline.py の projection に影響しないことを確認
+- 検証: Python path チェック + **実動画 baseline gate (`pytest -m slow_detect`) + Idios 実機確認を依頼** (detector.py 変更のため Iron Law 6 実機 trigger に該当)
+
+### G5: doc P1 修正 (即時分のみ)
+
+- 対応: P1-5、P1-6、P1-7
+- 変更箇所: `docs/cli-spec.md` (include/exclude 基数、intel 行) / `CLAUDE.md` (音声昇格 frozen 化、war_room.npz、未来形記述)
+- 設計: P1 級の誤りのみ最小修正。CLAUDE.md モジュール表更新等の P2 doc drift は W6 (SSoT 規約適用とセット) に残す
+- 受け入れ条件案: 3 点の記述が実装と一致 / markdownlint pass
+- 検証: `bash scripts/check-markdownlint.sh`
+
+### N1: CI/インフラ guard
+
+- 対応: P3 (stale branch pin 2 件、test_*.sh 未配線)
+- 変更箇所: `.github/workflows/ci.yml` / `.github/workflows/check-pr-checklist-test.yml` / `scripts/cleanup-claude-branches.sh`
+- 設計:
+  - ci.yml の hook-test 系 job に `tests/scripts/test_check_error_hint_drift.sh` 等 3 本の実行 step を追加
+  - `check-pr-checklist-test.yml` の push trigger を `develop-*` パターン化
+  - `cleanup-claude-branches.sh` の merged 判定を `origin/develop-*` 走査に一般化 (現状 develop-0.2.0 固定で新 branch がいつまでも掃除されない)
+- 受け入れ条件案: CI green / sh test 3 本が CI ログに出る / develop-0.3.0 への push で checklist-test が走る
+- 備考: GitHub Actions の既知の罠 (`${{ matrix.* }}` × step shell、pwsh redirect) は memory/feedback 既録のテンプレに従う
+- **マージ後アクション (stale worktree 掃除)**: ① 修正済み `cleanup-claude-branches.sh` を dry-run → 対象一覧確認 → apply (merged `claude/*` branch 削除) → ② `scripts/cleanup-worktrees.sh` を dry-run → 確認 → apply (orphan worktree 削除)。対象見込み 9 本 (lane-v-pr1〜5 / l2-workflow-458・459 / pr657b-rust-stdout / hopeful-herschel)。未 merge branch (L3 park 3 本: l3-809-pass1-region-wiring / l3-p2-region-detection / l3-vtuber-replan、現役 v030-wave-c) は merged/orphan 判定で自動保護され、dirty worktree は `git worktree remove` の既定動作で拒否されるため安全。**3 件以上の削除のため apply 前に Iron Law 2 の一覧提示 + AskUserQuestion 確認を行う**
+
+### N2: skill 改修 (追跡切れ防止)
+
+- 対応: P2-39 類型 (PR 本文の追跡予定が未起票) / P2-33 (version bump grep) / P3 (skills broken link 14 件)
+- 変更箇所: `.claude/skills/close-issue/SKILL.md` / `.claude/skills/release/SKILL.md` / skills 各所の相対リンク
+- 設計:
+  - close-issue: クローズ前チェックに「対象 issue を閉じた PR (および同 PR の本文・レビュー) に『別 issue で追跡』『follow-up』等の宣言があれば、行き先 issue 番号の実在を確認。未起票なら起票提案」を追加
+  - release: deferred レビューに「open issue 本文と直近コメント・spec の矛盾チェック (本文鮮度)」「リリース区間内に not_planned close された issue をコード内参照 (`wired in #N` 等) から検出し残タスクの行き先確認」を追加。version bump の grep 対象に `*.json` (tauri.conf.json / package.json) を追加
+  - skills の `../../docs/` → `../../../docs/` 一括修正 (14 件)
+- 検証: **skill 改修 PR は empirical-prompt-tuning protocol** (fresh subagent dispatch + 構造化 reflection、Self-Test Report 記載) に従う (CLAUDE.md §skill 改修ワークフロー)
+
+### N3: doc SSoT 規約の明文化 + release gate 追記
+
+- 対応: 再発防止 (doc 値複製 drift の構造的根絶)。**W6 の前提**
+- 変更箇所: `docs/coding-conventions.md` (または適切な既存 doc — 追加前に `grep -n '^## '` で全 section を確認し重複回避、memory 教訓) / `docs/release-process.md`
+- 設計:
+  - SSoT 規約: 「仕様値・定数・挙動説明の正は 1 doc (cli-spec / metadata-spec / 実装 docstring のいずれか) に置き、他 doc はリンク参照する。CLAUDE.md は索引として要約可だが数値を書く場合は出典リンク併記」を規約化。違反の代表事例 (workers 24 が 7 箇所複製) を背景として記載
+  - release-process のリリース前チェックに「監査 P1 (本 spec Wave 1) 全クローズ確認」を追記 (既存節との重複を grep 確認の上)
+- 検証: markdownlint
+
+### Wave 1 の PR なしアクション
+
+| アクション | 内容 |
+| --- | --- |
+| #809 受け入れ条件追記 | P1-8 の順序依存 gate 制約 (「scorebar 局在化 consumer の同時/先行 wiring、最低でも region ≠ FULL_FRAME 時は trailing drop 無効化」「`_CACHE_SENSITIVE_FILES` へ capture_region.py 追加」) を issue 本文に追記 |
+| #805 triage コメント | 「段階 1 (G4) を v0.3.0、非破壊化 (段階 2) は本 issue 継続。audio corroboration は frozen 解除後に再評価」を投稿し、優先度 label を付与 |
+| stale worktree 掃除 | **N1 マージ後**に N1 §マージ後アクション の手順 (branches → worktrees の 2 段、各 dry-run → Iron Law 2 確認 → apply) で実施。見込み 9 本 |
+
+## Wave 2 詳細 (テーマ概要 — 詳細は各実装計画で)
+
+### W1: export/CLI 整合
+
+- 対応: P2-7 / P2-8 / P2-9 / P2-10 / P2-11 / P2-20 / P2-40 + export 系 P3 (concurrency 検証、partial file 掃除、stderr_tail、dead param、stale comment、`{idx}` 衝突検査)
+- 骨子: export command を split/detect と同じ `except AllaganEyeError` → exit code マッピングに収める / json モード突入時に stdout reconfigure + stdin buffer 読み / skipped 計上 / output_dir mkdir / debug-brightness interval guard (exit 5) / `{start}` を Python 側 H-MM-SS に統一 (GUI 表示と一致させる)
+- 注意: exit code 体系の変更は cli-spec / output-spec の同時更新を伴う (W6 と重なる箇所は W1 側で正を書く)
+
+### W2: GUI export/cancel 安定化
+
+- 対応: P2-14 / P2-15 / P2-16 + cancel 系 P3 (listen leak、cancelRequestedRef、ConfirmExit 文言)
+- 骨子: reducer に `cancelling + PROGRESS_COMPLETE → completed` 遷移追加 / start_export に bounded stderr tail drain (start_detect と同型) / `expect` を stdout 先取りで排除
+
+### W3: GUI metadata/polish
+
+- 対応: P2-18 / P2-19 / P2-21 + GUI 系 P3 (mtime 順序、sample nudge、拡張子整合、register_video 累積、capabilities 過剰権限、未使用依存)
+- 骨子: name/type_override の in-memory 保持 (apply 後消失の解消) / load 系の BOM strip / thumbnail Semaphore の `OnceLock` static 化 / mtime を read 前に取得
+- 注意: detect-progress 間引き等の本格 responsiveness は W3 でやらず、**#670 に本監査の分析 (thumbnail 並列 + イベント無間引きが主因候補) を追記して #670 実装で消化**
+
+### W4: core 堅牢化
+
+- 対応: P2-3 / P2-4 / P2-6 + core 系 P3 (GPU 診断ログ、lo-probe skip、probe duration parse、scorebar logger、format.py dead module 整理)
+- 骨子: v2 decode read に全体 deadline (watchdog) / `_borderline_pseudo_regions` の合計長 cap — **cap 値は実測 (待機画面が長い実録画で Pass 2 probe 数を計測) してから決定** / saturated-run・emblem 計算を共有ヘルパに抽出 (capture_region との複製解消) / `detection/format.py` は private 版を寄せて import に置換 or 削除
+- 検証: detector.py 変更のため実動画 baseline gate (bit-exact) + 実機検証依頼が必須
+
+### W5: テスト配線拡充
+
+- 対応: P2-22 / P2-23 / P2-24 + test 系 P3 (ErrorModal axe、flow mock default、regression_330 lazy 化、baselines README stale 参照)
+- 骨子: split SHA-256 照合の slow test 追加 (detect Class A と同型) / wire e2e の docstring・skip guard 修正 + SIGINT dead test の扱い決定 (削除 or 明示 xfail) / VTuber ground truth ±10s 照合を pytest 化 (`ALLAGANEYE_VTUBER_VIDEO_DIR` 新設、`slow` + `slow_detect` 両 marker — G1 規約準拠)
+
+### W6: doc 一括再同期 (N3 の SSoT 規約適用)
+
+- 対応: P2-25〜P2-35 の残り (G5 で 3 点先行済み) + doc 系 P3
+- 骨子: workers 32 / Pass 1 チャンク方式 / #576 記述 / GPU default auto / CLAUDE.md モジュール表・L2 リリース済み・L3 VTuber 保留 / scorebar-detection-design の #803/#797/#811 反映 / system-architecture・quickstart の #752/#761 反映 / versioning 3 箇所 / cli-spec detect・export 節 / developer-setup の BtbN LGPL 手順昇格 / gui-development CI 表 ほか
+- 分割可: 「CLI/コマンド仕様系」と「アーキテクチャ説明系」の 2 PR に分けてよい (issue は 1 本)
+- 規約: 修正時に SSoT 規約 (N3) を適用し、複製値はリンク化する
+
+## Wave 3 詳細 (issue 棚卸し + P3 batch)
+
+PR を伴わない gh 操作。**3 件以上の編集・起票・クローズを伴うため、実行直前に対象一覧を提示して AskUserQuestion で再確認する** (Iron Law 2)。
+
+| 対象 | アクション | 根拠 |
+| --- | --- | --- |
+| #412 | close (前提消滅) or 全面書き直し — **PR #323 のコードが系譜から消失している事象の周知 + 再 land 要否判断とセット** | P2-36 |
+| #518 | close して残作業 (emitter/GUI 表示) を task として書き直し、または本文 rescope。G4 が warning emitter の実例第 1 号になる | 棚卸し F8 |
+| #753 | checklist を現状に同期 (CLAUDE.md 更新済み・サンプル VOD 入手済みのチェック、label 新設禁止の注記、#480 P1 完了の反映) | 棚卸し F7 |
+| #670 | 本文に v0.3.0 re-scope の経緯 + 本監査の主因候補分析 (thumbnail 並列 / イベント無間引き) を追記 | 棚卸し F6、P2-21 |
+| #804 | deferred 付与 (v0.3.x 扱い) か v0.3.0 必須かを明示判断 | 棚卸し F11 |
+| #326 | re-triage (着手条件「L2 完了後」成立済み) | 棚卸し F9 |
+| #376 | 維持で可。実装時の両義性 (`split -v`=verbose) を本文に注記 or wontfix 判断 | 棚卸し F12 |
+| #765 | 参照先 #762 close に伴う再評価 checkpoint の記述更新 | 棚卸し |
+| #327 (audio frozen) | P2-1 (corroboration 案) と P2-5 (メモリ) を解凍条件の検討材料として追記 | P2-1、P2-5 |
+| 新規: #762 後継 | [task] QSV/AMF decode hwaccel の扱い確定 (wire する or wontfix を code コメント + CLAUDE.md + release-process から参照解消) | P2-37 |
+| 新規: system_info | [bug] wmic 非搭載環境で GPU vendor 検出が全滅 (要実機確認、`Get-CimInstance` fallback 案) | P2-12 |
+| 新規: typer pin | [task] typer<0.25 / click<8.4 pin の恒久対応 (P3-low) | 棚卸し F13 |
+| 新規 (guard repo): | [bug] VTuber VOD FP 3 点 (短署名衝突 / moov>10MB buffer / cp932 crash) — kobutachan-allaganeye-guard 側 | P2-39 |
+| P3 batch | Wave 1/2 の PR に同梱しきれなかった P3 をテーマ別 batch issue (deferred、上限 3 本) にまとめるか見送りを判断 | P3 全般 |
+
+## 検証方針 (横断)
+
+| 変更 path | 必須チェック | 追加検証 |
+| --- | --- | --- |
+| Python (G1/G4/W1/W4/W5) | `ruff check .` / `ruff format --check .` / `pyright` / `pytest` | detector.py 変更 (G4/W4) は実動画 baseline gate (`pytest -m slow_detect`、G1 修正後) + AskUserQuestion で実機検証依頼 |
+| GUI (G2/G3/W2/W3) | `npm run lint` / `typecheck` / `test` / `build` / `cargo check` | Tauri 実機起動の検証を AskUserQuestion で依頼 |
+| docs (G5/N3/W6) | `bash scripts/check-markdownlint.sh` | — |
+| CI/workflows (N1) | workflow 構文 + CI 実走確認 | — |
+| skills (N2) | empirical-prompt-tuning protocol + Self-Test Report | — |
+
+全 PR で Iron Law 6 Pre-flight (Step 0-5、`/codex:adversarial-review` 含む) を実施。PR 作成後は `/iterate-review` で review-fix ループ。
+
+## 順序依存・リスク
+
+- **N3 → W6**: SSoT 規約が doc 一括修正の前提
+- **G1 → G4/W4**: baseline gate が正しく回ることが detector 変更検証の前提
+- **G3 → W3**: 同ファイル (metadataStore.ts) のため Wave 順で直列化
+- **G2 → W2**: 同領域 (lib.rs / cancel path) のため G2 先行
+- detector.py は G4 と W4 で 2 回触る (Wave 跨ぎのためコンフリクトなし、レビュー 2 回のコストのみ)
+- W6 と W1 で cli-spec が重なる: exit code 等 W1 が実装を変える箇所は W1 側 PR で doc も書き、W6 は W1 マージ後に残りを同期
+- リスク: G4 の warnings[] 追加が将来 schema validation を厳格化した consumer を壊す可能性 → `MetadataWarning` の forward-compat 規約 (unknown code 受容) を G4 のテストで pin する
+
+## 新規 issue 起票一覧 (Iron Law 2 確認用)
+
+起票実行前にこの表で最終確認する。prefix・本文は `/create-task` (issue-policy.md) に従い、本文冒頭に本 spec への参照を入れる。
+
+| # | タイトル案 | prefix | label 案 | Wave |
+| --- | --- | --- | --- | --- |
+| 1 | v0.3.0 baseline regression が slow marker 規約から漏れ documented コマンドで実行されない | bug | P1-high | 1 (G1) |
+| 2 | GUI: detect 中断がプロセスを kill せず二重 detect が可能 | bug | P1-high, l2a-gui | 1 (G2) |
+| 3 | GUI: OUT<IN を apply でき metadata.json が読込不能 + load エラー非表示 | bug | P1-high, l2a-gui | 1 (G3) |
+| 4 | cli-spec / CLAUDE.md の P1 級 drift 修正 (export index 基数 / intel / 音声 frozen) | doc | P1-high | 1 (G5) |
+| 5 | CI guard: tests/scripts/*.sh 配線 + branch pin の develop-* 化 | task | P2-medium | 1 (N1) |
+| 6 | skill 改修: close-issue / release に追跡切れ防止チェック + version grep *.json + broken link 修正 | task | P2-medium, l2-workflow | 1 (N2) |
+| 7 | doc SSoT 規約の明文化 + release gate に監査 P1 クローズ確認を追加 | doc | P2-medium | 1 (N3) |
+| 8 | export/CLI 整合 (エラー枠組み / encoding 自衛 / skipped / output_dir / interval guard / {start}) | bug | P2-medium | 2 (W1) |
+| 9 | GUI export/cancel 安定化 (cancelling スタック / stderr drain / expect race) | bug | P2-medium, l2a-gui | 2 (W2) |
+| 10 | GUI metadata/polish (name 消失 / BOM / mtime 順序 / thumbnail 並列) | bug | P2-medium, l2a-gui | 2 (W3) |
+| 11 | core 堅牢化 (v2 read timeout / pseudo-region cap / saturated-run 共有ヘルパ) | bug | P2-medium | 2 (W4) |
+| 12 | テスト配線拡充 (split SHA gate / wire e2e / VTuber ground truth pytest 化) | task | P2-medium | 2 (W5) |
+| 13 | doc 一括再同期 (SSoT 規約適用、P2-25〜35 残り + P3 doc 系) | doc | P2-medium | 2 (W6) |
+| 14 | QSV/AMF decode hwaccel の扱い確定 (#762 後継) | task | P3-low | 3 |
+| 15 | system_info: wmic 非搭載環境で GPU vendor 検出が全滅する | bug | P2-medium, deferred | 3 |
+| 16 | typer<0.25 / click<8.4 pin の恒久対応 | task | P3-low, deferred | 3 |
+| 17 | (guard repo) VTuber VOD FP 3 点 (短署名衝突 / moov buffer / cp932) | bug | — | 3 |
+
+既存 issue 紐づけ: G4 → #805 / #670 追記 / #809 AC 追記 / #327 追記 / #412・#518・#753・#326・#376・#765・#804 は棚卸しアクション。
+
+## スコープ外 (明示)
+
+- P2-1 audio corroboration: `AUDIO_FROZEN=True` の間 no-op のため見送り (#805 と #327 に記録)
+- P2-5 audio scan メモリ: 同上、#327 解凍条件に記録
+- 定期 full audit の release gate 化: 不採用 (決定事項)
+- #481 (minimap) / #670 (responsiveness) の実装そのもの: 既存の v0.3.0 active set として本プログラムの外 (ただし #670 へ分析結果を提供)
+- VTuber pillar 本体 (#809/#810 の wiring): park 継続。本プログラムは制約の明文化 (P1-8) のみ行う
+
+## 完了の定義
+
+- Wave 1: 新規 7 issue クローズ + G4 PR マージ (#805 自体は段階 2 のため open 継続) + PR なしアクション 3 件 (#809 追記 / #805 triage / worktree 掃除) 完了 → v0.3.0 リリースゲート解除
+- Wave 2: 6 issue クローズ (v0.3.0 に間に合わない分は v0.3.x へ繰り越し可、繰り越し時は本 spec に追記)
+- Wave 3: 棚卸し表の全行に決着 (実施 or 明示的見送り) + 新規 issue 起票完了

--- a/docs/superpowers/specs/2026-06-10-audit-remediation-design.md
+++ b/docs/superpowers/specs/2026-06-10-audit-remediation-design.md
@@ -39,7 +39,7 @@ v0.3.0 リリース条件への追加: **Wave 1 の全 issue クローズ** (= P
 - 変更箇所: `tests/test_v030_baseline_regression.py` / `tests/conftest.py` / 新規 `tests/test_marker_conventions.py`
 - 設計:
   - `test_v030_baseline_regression.py` に `pytestmark = [pytest.mark.slow, pytest.mark.slow_detect]` を追加 (他 slow ファイルと同形)。docstring の「CI default deselect」誤認記述も訂正
-  - conftest の `_ffmpeg_interval` cooldown の発動条件を `slow` に加えて `slow_*` サブマーカーにも拡張
+  - conftest の `_ffmpeg_interval` cooldown は現行 (`slow` のみ参照) を維持する — enforcement hook が「`slow_*` ⇒ `slow`」を collection 時に強制するため、拡張は冗長 (2026-06-10 plan で確定)
   - meta-test (新規): tests/ 配下のソースを走査し、`slow_probe/slow_detect/slow_pipeline/slow_gpu` を付与したテスト (またはファイル) が `slow` を併せ持つことを assert する。実装方式はソーススキャン (前例: `tests/test_ascii_guard.py`)。testing-guide.md:33 の「slow = サブマーカーのスーパーセット」契約を機械化する
 - 受け入れ条件案: `pytest -m slow --collect-only` が v030 baseline 4 テストを select する / bare `pytest --collect-only` が select しない / meta-test が `slow_detect` 単独付与の fixture コードで fail することをユニットで実証
 - 検証: Python path チェック (ruff / pyright / pytest)。実動画実行は不要 (配線のみ)
@@ -211,13 +211,13 @@ PR を伴わない gh 操作。**3 件以上の編集・起票・クローズを
 
 | # | タイトル案 | prefix | label 案 | Wave |
 | --- | --- | --- | --- | --- |
-| 1 | v0.3.0 baseline regression が slow marker 規約から漏れ documented コマンドで実行されない | bug | P1-high | 1 (G1) |
-| 2 | GUI: detect 中断がプロセスを kill せず二重 detect が可能 | bug | P1-high, l2a-gui | 1 (G2) |
-| 3 | GUI: OUT<IN を apply でき metadata.json が読込不能 + load エラー非表示 | bug | P1-high, l2a-gui | 1 (G3) |
-| 4 | cli-spec / CLAUDE.md の P1 級 drift 修正 (export index 基数 / intel / 音声 frozen) | doc | P1-high | 1 (G5) |
-| 5 | CI guard: tests/scripts/*.sh 配線 + branch pin の develop-* 化 | task | P2-medium | 1 (N1) |
-| 6 | skill 改修: close-issue / release に追跡切れ防止チェック + version grep *.json + broken link 修正 | task | P2-medium, l2-workflow | 1 (N2) |
-| 7 | doc SSoT 規約の明文化 + release gate に監査 P1 クローズ確認を追加 | doc | P2-medium | 1 (N3) |
+| 1 | v0.3.0 baseline regression が slow marker 規約から漏れ documented コマンドで実行されない → #812 | bug | P1-high | 1 (G1) |
+| 2 | GUI: detect 中断がプロセスを kill せず二重 detect が可能 → #813 | bug | P1-high, l2a-gui | 1 (G2) |
+| 3 | GUI: OUT<IN を apply でき metadata.json が読込不能 + load エラー非表示 → #814 | bug | P1-high, l2a-gui | 1 (G3) |
+| 4 | cli-spec / CLAUDE.md の P1 級 drift 修正 (export index 基数 / intel / 音声 frozen) → #815 | doc | P1-high | 1 (G5) |
+| 5 | CI guard: tests/scripts/*.sh 配線 + branch pin の develop-* 化 → #816 | task | P2-medium | 1 (N1) |
+| 6 | skill 改修: close-issue / release に追跡切れ防止チェック + version grep *.json + broken link 修正 → #817 | task | P2-medium, l2-workflow | 1 (N2) |
+| 7 | doc SSoT 規約の明文化 + release gate に監査 P1 クローズ確認を追加 → #818 | doc | P2-medium | 1 (N3) |
 | 8 | export/CLI 整合 (エラー枠組み / encoding 自衛 / skipped / output_dir / interval guard / {start}) | bug | P2-medium | 2 (W1) |
 | 9 | GUI export/cancel 安定化 (cancelling スタック / stderr drain / expect race) | bug | P2-medium, l2a-gui | 2 (W2) |
 | 10 | GUI metadata/polish (name 消失 / BOM / mtime 順序 / thumbnail 並列) | bug | P2-medium, l2a-gui | 2 (W3) |

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -37,7 +37,7 @@ pytest -v
 | `slow_gpu` | GPU アクセラレーション必須テスト | 除外 |
 | `baseline_regen` | ベースライン再生成時のみ必要なテスト | 除外 |
 
-`slow` および `baseline_regen` マーカーは `addopts = "-m 'not slow and not baseline_regen'"` で除外される。「slow はサブマーカーのスーパーセット」契約は `tests/conftest.py` の collection hook が機械的に強制しており、`slow_*` サブマーカーを単独付与すると、違反 item を collect する pytest 実行 (bare / `-m` 指定 / CI を含む) が `UsageError` (exit 4) で fail する (#812)。未登録マーカーの typo (例: `slow_detec`) は addopts の `--strict-markers` が collection エラーで弾く (#812)。
+`slow` および `baseline_regen` マーカーは `addopts = "-m 'not slow and not baseline_regen'"` で除外される。「slow はサブマーカーのスーパーセット」契約は `tests/conftest.py` の collection hook が機械的に強制しており、`slow_*` サブマーカーを単独付与すると、違反 item を collect する pytest 実行 (bare / `-m` 指定 / CI を含む) が `UsageError` (exit 4) で fail する (#812)。未登録マーカーの typo (例: `slow_detec`) は ini option `strict_markers = true` (pyproject.toml) が collection エラーで弾く (#812。addopts 内の `--strict-markers` は pytest 9.x で no-op のため不可)。
 
 ### マーカーの使い分け
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -37,7 +37,7 @@ pytest -v
 | `slow_gpu` | GPU アクセラレーション必須テスト | 除外 |
 | `baseline_regen` | ベースライン再生成時のみ必要なテスト | 除外 |
 
-`slow` および `baseline_regen` マーカーは `addopts = "-m 'not slow and not baseline_regen'"` で除外される。
+`slow` および `baseline_regen` マーカーは `addopts = "-m 'not slow and not baseline_regen'"` で除外される。「slow はサブマーカーのスーパーセット」契約は `tests/conftest.py` の collection hook が機械的に強制しており、`slow_*` サブマーカーを単独付与すると全 pytest 実行が `UsageError` (exit 4) で fail する (#812)。
 
 ### マーカーの使い分け
 
@@ -54,17 +54,18 @@ pytest -m slow_pipeline
 # GPU テストのみ
 pytest -m slow_gpu
 
-# slow テスト全体（サブマーカー全含む、baseline_regen 除外）
+# slow テスト全体（サブマーカー全含む。baseline_regen 付きテストも slow を
+# 併せ持つため、現状は下の "slow or baseline_regen" と同一集合になる、#812）
 pytest -m slow
 
-# baseline_regen 含む全テスト（ベースライン再生成時）
+# baseline_regen 含む全テスト（ベースライン再生成時の明示形）
 pytest -m "slow or baseline_regen"
 ```
 
 ### 開発時の推奨テスト実行パターン
 
 1. **コード変更後**: `pytest`（ユニットテストのみ、数秒）
-2. **PR 作成前**: `pytest -m slow`（全 slow テスト）
+2. **PR 作成前**: `pytest -m slow`（全 slow テスト。baseline_regen 付き class も含む、#812）
 3. **検出アルゴリズム変更時**: `pytest -m "slow or baseline_regen"`（ベースライン検証含む）
 4. **probe 周りの変更確認**: `pytest -m slow_probe`（高速確認）
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -37,7 +37,7 @@ pytest -v
 | `slow_gpu` | GPU アクセラレーション必須テスト | 除外 |
 | `baseline_regen` | ベースライン再生成時のみ必要なテスト | 除外 |
 
-`slow` および `baseline_regen` マーカーは `addopts = "-m 'not slow and not baseline_regen'"` で除外される。「slow はサブマーカーのスーパーセット」契約は `tests/conftest.py` の collection hook が機械的に強制しており、`slow_*` サブマーカーを単独付与すると、違反 item を collect する pytest 実行 (bare / `-m` 指定 / CI を含む) が `UsageError` (exit 4) で fail する (#812)。
+`slow` および `baseline_regen` マーカーは `addopts = "-m 'not slow and not baseline_regen'"` で除外される。「slow はサブマーカーのスーパーセット」契約は `tests/conftest.py` の collection hook が機械的に強制しており、`slow_*` サブマーカーを単独付与すると、違反 item を collect する pytest 実行 (bare / `-m` 指定 / CI を含む) が `UsageError` (exit 4) で fail する (#812)。未登録マーカーの typo (例: `slow_detec`) は addopts の `--strict-markers` が collection エラーで弾く (#812)。
 
 ### マーカーの使い分け
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -37,7 +37,7 @@ pytest -v
 | `slow_gpu` | GPU アクセラレーション必須テスト | 除外 |
 | `baseline_regen` | ベースライン再生成時のみ必要なテスト | 除外 |
 
-`slow` および `baseline_regen` マーカーは `addopts = "-m 'not slow and not baseline_regen'"` で除外される。「slow はサブマーカーのスーパーセット」契約は `tests/conftest.py` の collection hook が機械的に強制しており、`slow_*` サブマーカーを単独付与すると全 pytest 実行が `UsageError` (exit 4) で fail する (#812)。
+`slow` および `baseline_regen` マーカーは `addopts = "-m 'not slow and not baseline_regen'"` で除外される。「slow はサブマーカーのスーパーセット」契約は `tests/conftest.py` の collection hook が機械的に強制しており、`slow_*` サブマーカーを単独付与すると、違反 item を collect する pytest 実行 (bare / `-m` 指定 / CI を含む) が `UsageError` (exit 4) で fail する (#812)。
 
 ### マーカーの使い分け
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ markers = [
     "baseline_regen: marks tests only needed during baseline regeneration",
     "real_audio_scan: opt out of the autouse _run_audio_scan mock (#288)",
 ]
-addopts = "-m 'not slow and not baseline_regen'"
+addopts = "-m 'not slow and not baseline_regen' --strict-markers"
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,9 @@ markers = [
     "baseline_regen: marks tests only needed during baseline regeneration",
     "real_audio_scan: opt out of the autouse _run_audio_scan mock (#288)",
 ]
-addopts = "-m 'not slow and not baseline_regen' --strict-markers"
+addopts = "-m 'not slow and not baseline_regen'"
+# addopts 内の --strict-markers は pytest 9.x で no-op (ini override 化のため)。ini option で有効化する (#812)
+strict_markers = true
 
 [tool.ruff]
 target-version = "py311"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,10 +169,15 @@ def slow_submarker_violations(marker_names_by_nodeid: dict[str, set[str]]) -> li
     )
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """collection 時に slow マーカー契約違反を即エラーにする (deselect より前に全 item を検査)."""
+    """collection 時に slow マーカー契約違反を即エラーにする.
+
+    tryfirst で builtin の -m deselection より前に全 item を検査する
+    (deselect 後では addopts で除外された違反が素通りするため)。
+    """
     mapping = {item.nodeid: {m.name for m in item.iter_markers()} for item in items}
     violations = slow_submarker_violations(mapping)
     if violations:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,7 @@ def _clear_allaganeye_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 # --- slow_* submarker convention enforcement ---
 
+# pyproject.toml [tool.pytest.ini_options].markers に登録した slow_* と一致させること
 _SLOW_SUBMARKERS = frozenset({"slow_probe", "slow_detect", "slow_pipeline", "slow_gpu"})
 
 
@@ -182,6 +183,6 @@ def pytest_collection_modifyitems(
     violations = slow_submarker_violations(mapping)
     if violations:
         raise pytest.UsageError(
-            "slow_* submarker without 'slow' (testing-guide.md の slow スーパーセット契約違反): "
-            + ", ".join(violations)
+            "slow_* submarker without 'slow' (testing-guide.md の slow スーパーセット契約違反):\n"
+            + "\n".join(f"  {nid}  → @pytest.mark.slow を追加" for nid in violations)
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,5 +184,5 @@ def pytest_collection_modifyitems(
     if violations:
         raise pytest.UsageError(
             "slow_* submarker without 'slow' (testing-guide.md の slow スーパーセット契約違反):\n"
-            + "\n".join(f"  {nid}  → @pytest.mark.slow を追加" for nid in violations)
+            + "\n".join(f"  {nid}  -> @pytest.mark.slow を追加" for nid in violations)
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,3 +149,34 @@ def _clear_allaganeye_env(monkeypatch: pytest.MonkeyPatch) -> None:
     path.
     """
     monkeypatch.delenv("ALLAGANEYE_DETECT_FPS_FILTER", raising=False)
+
+
+# --- slow_* submarker convention enforcement ---
+
+_SLOW_SUBMARKERS = frozenset({"slow_probe", "slow_detect", "slow_pipeline", "slow_gpu"})
+
+
+def slow_submarker_violations(marker_names_by_nodeid: dict[str, set[str]]) -> list[str]:
+    """slow_* サブマーカーを持つのに slow を持たない nodeid を返す.
+
+    testing-guide.md の「slow はサブマーカーのスーパーセット」契約を機械化する
+    (audit 2026-06-10 P1-3: 違反すると documented コマンドから test が漏れる)。
+    """
+    return sorted(
+        nodeid
+        for nodeid, names in marker_names_by_nodeid.items()
+        if names & _SLOW_SUBMARKERS and "slow" not in names
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """collection 時に slow マーカー契約違反を即エラーにする (deselect より前に全 item を検査)."""
+    mapping = {item.nodeid: {m.name for m in item.iter_markers()} for item in items}
+    violations = slow_submarker_violations(mapping)
+    if violations:
+        raise pytest.UsageError(
+            "slow_* submarker without 'slow' (testing-guide.md の slow スーパーセット契約違反): "
+            + ", ".join(violations)
+        )

--- a/tests/test_marker_conventions.py
+++ b/tests/test_marker_conventions.py
@@ -1,10 +1,18 @@
-"""slow_* サブマーカー規約 guard のユニットテスト (audit 2026-06-10 P1-3 再発防止).
+"""slow_* サブマーカー規約 guard のテスト (audit 2026-06-10 P1-3 再発防止).
 
 enforcement 本体は tests/conftest.py の pytest_collection_modifyitems。
-ここではその純関数 slow_submarker_violations() を検証する。
+純関数 slow_submarker_violations() の unit、_SLOW_SUBMARKERS と pyproject.toml
+の同期 pin、pytester による hook 統合 (tryfirst 挙動) を検証する。
 """
 
-from tests.conftest import slow_submarker_violations
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import _SLOW_SUBMARKERS, slow_submarker_violations
+
+pytest_plugins = ["pytester"]
 
 
 def test_detects_submarker_without_slow():
@@ -33,3 +41,52 @@ def test_ignores_unrelated_markers():
         "tests/test_x.py::test_c": {"slow"},
     }
     assert slow_submarker_violations(mapping) == []
+
+
+def test_submarker_set_matches_pyproject():
+    """_SLOW_SUBMARKERS が pyproject.toml の markers 登録と drift していないことを pin する."""
+    pyproject = tomllib.loads(
+        (Path(__file__).resolve().parent.parent / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    declared = {
+        m.split(":")[0].strip()
+        for m in pyproject["tool"]["pytest"]["ini_options"]["markers"]
+    }
+    assert {name for name in declared if name.startswith("slow_")} == set(
+        _SLOW_SUBMARKERS
+    )
+
+
+def test_guard_fires_before_addopts_deselection(pytester: pytest.Pytester) -> None:
+    """tryfirst 化の核心挙動を pin する (#812 回帰防止).
+
+    addopts の -m deselection で除外される違反 (slow_detect+baseline_regen で
+    slow 欠落) でも、guard が deselection より前に全 item を検査して
+    UsageError (exit 4) で fail することを隔離環境で検証する。
+    """
+    pytester.makeini(
+        """
+        [pytest]
+        addopts = -m 'not slow and not baseline_regen'
+        markers =
+            slow: superset marker
+            slow_detect: detection submarker
+            baseline_regen: baseline regeneration only
+        """
+    )
+    pytester.makeconftest("from tests.conftest import pytest_collection_modifyitems\n")
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.slow_detect
+        @pytest.mark.baseline_regen
+        def test_violating():
+            pass
+        """
+    )
+    result = pytester.runpytest("--collect-only", "-q")
+    assert result.ret == 4
+    result.stderr.fnmatch_lines(["*slow_* submarker without 'slow'*"])

--- a/tests/test_marker_conventions.py
+++ b/tests/test_marker_conventions.py
@@ -1,0 +1,35 @@
+"""slow_* サブマーカー規約 guard のユニットテスト (audit 2026-06-10 P1-3 再発防止).
+
+enforcement 本体は tests/conftest.py の pytest_collection_modifyitems。
+ここではその純関数 slow_submarker_violations() を検証する。
+"""
+
+from tests.conftest import slow_submarker_violations
+
+
+def test_detects_submarker_without_slow():
+    mapping = {
+        "tests/test_x.py::test_a": {"slow_detect"},
+        "tests/test_x.py::test_b": {"slow_detect", "baseline_regen"},
+    }
+    assert slow_submarker_violations(mapping) == [
+        "tests/test_x.py::test_a",
+        "tests/test_x.py::test_b",
+    ]
+
+
+def test_accepts_submarker_with_slow():
+    mapping = {
+        "tests/test_x.py::test_a": {"slow", "slow_detect"},
+        "tests/test_x.py::test_b": {"slow", "slow_gpu", "baseline_regen"},
+    }
+    assert slow_submarker_violations(mapping) == []
+
+
+def test_ignores_unrelated_markers():
+    mapping = {
+        "tests/test_x.py::test_a": {"parametrize"},
+        "tests/test_x.py::test_b": set(),
+        "tests/test_x.py::test_c": {"slow"},
+    }
+    assert slow_submarker_violations(mapping) == []

--- a/tests/test_marker_conventions.py
+++ b/tests/test_marker_conventions.py
@@ -59,6 +59,17 @@ def test_submarker_set_matches_pyproject():
     )
 
 
+def test_strict_markers_enabled(pytestconfig: pytest.Config) -> None:
+    """strict_markers が ini option として有効なことを pin する (#812).
+
+    addopts 内の --strict-markers は pytest 9.x で silent no-op になる
+    (ini override 化され第 1 parse でしか消費されない) ため、ini option での
+    有効化を機械検証する。これが効かないと未登録マーカーの typo
+    (例: slow_detec) が guard と addopts 除外の両方を素通りする。
+    """
+    assert pytestconfig.getini("strict_markers")
+
+
 def test_guard_fires_before_addopts_deselection(pytester: pytest.Pytester) -> None:
     """tryfirst 化の核心挙動を pin する (#812 回帰防止).
 

--- a/tests/test_scorebar_regression.py
+++ b/tests/test_scorebar_regression.py
@@ -294,6 +294,7 @@ class TestMatchDurations:
 # --- 3. Performance: scorebar overhead ---
 
 
+@pytest.mark.slow
 @pytest.mark.slow_detect
 @pytest.mark.baseline_regen
 class TestPerformance:
@@ -409,6 +410,7 @@ def _load_legacy_baseline(name: str) -> dict | None:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+@pytest.mark.slow
 @pytest.mark.slow_detect
 @pytest.mark.baseline_regen
 class TestNoResolutionCompat:

--- a/tests/test_v030_baseline_regression.py
+++ b/tests/test_v030_baseline_regression.py
@@ -1,6 +1,7 @@
 """v0.3.0 baseline regression tests (#576 S7.2 / S9.2).
 
-slow_detect マーカー: 実動画必須、CI default deselect。
+slow + slow_detect マーカー: 実動画必須。`pytest -m slow` / `-m slow_detect` で実行し、
+bare pytest からは addopts (`-m 'not slow and not baseline_regen'`) により除外される。
 Idios 環境または ALLAGANEYE_SAMPLE_VIDEO_DIR が設定されたマシンで実行。
 """
 
@@ -11,6 +12,8 @@ import sys
 from pathlib import Path
 
 import pytest
+
+pytestmark = [pytest.mark.slow, pytest.mark.slow_detect]
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _BASELINE_DIR = _REPO_ROOT / "tests" / "baselines" / "v0.3.0"
@@ -25,7 +28,6 @@ _CLASS_A_BASELINES = [
 ]
 
 
-@pytest.mark.slow_detect
 @pytest.mark.parametrize("label,relpath", _CLASS_A_BASELINES)
 def test_class_a_bit_exact(label, relpath, sample_video_dir, tmp_output_dir):
     """new path で detect を回し Class A baseline と matches/gaps が完全一致 (#576 S3 / S9.2)."""
@@ -59,7 +61,6 @@ def test_class_a_bit_exact(label, relpath, sample_video_dir, tmp_output_dir):
     )
 
 
-@pytest.mark.slow_detect
 @pytest.mark.parametrize("label,relpath", _CLASS_A_BASELINES)
 def test_class_a_intermediate_audit_no_regress(
     label, relpath, sample_video_dir, tmp_output_dir, monkeypatch
@@ -140,7 +141,6 @@ def test_class_a_intermediate_audit_no_regress(
 _CLASS_B_BASELINE = ("obs-20260118", "20260118/2026-01-18 22-15-18.mkv")
 
 
-@pytest.mark.slow_detect
 def test_class_b_regenerated(sample_video_dir, tmp_output_dir):
     """Class B (obs-20260118) は本 PR で regenerate された baseline と一致 (#576 S3)."""
     label, relpath = _CLASS_B_BASELINE
@@ -178,7 +178,6 @@ def test_class_b_regenerated(sample_video_dir, tmp_output_dir):
     )
 
 
-@pytest.mark.slow_detect
 @pytest.mark.parametrize(
     "vendor,timestamps",
     [


### PR DESCRIPTION
## 概要
audit P1-3 対応 (Refs #812)。spec: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §G1。
2026-06-10 全体監査レポート + remediation spec + 実装 plan を先頭 commit で同梱 (spec §決定事項 option b、Idios 承認済み。docs と tests の 2 scope を含むが per-commit では単一 scope)。

## 変更内容
- 監査レポート / remediation spec / Wave1 plan の追加 (docs、先頭 commit)
- `test_v030_baseline_regression.py`: module pytestmark 化 (slow + slow_detect) + docstring 訂正
- `test_scorebar_regression.py`: TestPerformance / TestNoResolutionCompat に slow 追加 (同型違反の解消)
- `tests/conftest.py`: 「slow_* ⇒ slow」契約の collection-time enforcement (純関数 + unit test 3 件)
  - tryfirst 化: builtin の `-m` deselection より前に全 item を検査する順序を、pluggy の暗黙 LIFO に依存せず明示的に保証 (Round 2 の決定実験で「現行 pytest では tryfirst なしでも先行する」ことを確認済み。tryfirst は将来の hook 登録順変化への保険で、挙動契約は pytester 統合テストが pin)
  - UsageError に nodeid ごとの修正方法を併記 / `_SLOW_SUBMARKERS` に pyproject 同期義務コメント
  - U+2192 を ASCII `->` に置換 (ascii guard 違反を全体検証で検出・修正)
- spec へ実装確定 2 点を反映 (cooldown 拡張は enforcement により不要 / enforcement は hook 方式)

## Self-Test Report
- [x] `ruff check .` / `ruff format --check .` / `pyright` 全 pass
- [x] `python -m pytest` 全 pass (1300 passed, 1 skipped, 51 deselected (Round 1 のテスト 2 件追加後の実測) — ascii guard 含む)
- [x] collect-only マトリクス: `-m slow` / `-m "slow or baseline_regen"` / `-m slow_detect` すべてで v030 baseline 12 件が select、bare pytest では 0 件 (red 0/12 → green 12/0 を実証)
- [x] enforcement の実効性: `@pytest.mark.slow` を一時除去すると bare collect-only でも UsageError (exit 4) で fail することを確認 (Round 2 決定実験により tryfirst の有無に依らず成立することを確認済み)
- [x] markdownlint: 同梱 docs 3 本 + spec 編集すべて violation ゼロ
- 実動画での slow 実行は本 PR では不要 (マーカー配線 + collection hook のみ。検知ロジック・テスト本体は無変更)

## Codex fallback notice
Iron Law 6 Pre-flight Step 5 の `/codex:adversarial-review` は本セッション環境で利用不可のため、CLAUDE.md §Token 枯渇時の fallback (C6) に従い superpowers requesting-code-review 型 subagent で adversarial review を実施。focus: Iron Law 3 / collection hook の破壊シナリオ (単一ファイル・-k・--co・bare・hooks 独立 conftest・xdist) / マーカー意味論 / encoding (cp932) / 同 issue root cause。verdict: **Ready to merge** (Minor 1 件 = spec 記述乖離は本 PR 内で修正済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


