### PR TITLE
doc: cli-spec / CLAUDE.md / output-spec の P1 級 drift 修正 (Refs #815)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ allaganeye split <video_path> -o <dir>  # 出力先指定
 allaganeye split <video_path> --gpu     # GPU アクセラレーション検知
 allaganeye split <video_path> --workers 8  # ワーカー数指定
 allaganeye split <video_path> --no-cache   # キャッシュ無視で再検知
-allaganeye split <video_path> --no-audio   # 音声昇格を無効化（視覚のみ）
+allaganeye split <video_path> --no-audio   # 音声昇格の無効化フラグ（#327 で凍結中のため現在は常にスキップ）
 allaganeye split <video_path> --quiet      # 進捗抑制（出力ファイルのみ）
 allaganeye split <video_path> -v           # verbose（環境情報・パイプライン統計を表示、#336）
 allaganeye --version                       # バージョン表示（短縮形: -V、#337）
@@ -99,7 +99,7 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | `audio/features.py` | log-mel スペクトログラム計算と保存 |
 | `audio/matcher.py` | 参照 BGM と target の相互相関で peak 検出 |
 | `audio/scan.py` | 動画全域を走査して Fanfare ピークを返す |
-| `audio/refs/` | 同梱参照特徴量（`fanfare.npz`） |
+| `audio/refs/` | 同梱参照特徴量（`fanfare.npz` / `war_room.npz`、#306） |
 | `commands/detect.py` | detect コマンド。検知のみ実行し metadata.json を出力 (#463) |
 | `detection/` | 検知パイプラインの共有ヘルパ (#463)。`format.py` (フォーマッタ) / `metadata_writer.py` (atomic read/write) |
 | `gui/` | L2a Tauri GUI (React 19 + TS + Vite + Zustand + zod)。`#483` で bootstrap、`#463` で data 層、`#464` で画面骨格 + CSS Modules、`#516` で `[元に戻す]` 機能、`#514` で排他管理 (mtime 検知 + ConflictModal)、`#587` で a11y polish (focus trap / Escape / DisabledTooltip / jest-axe)。詳細は [docs/gui-development.md](docs/gui-development.md) / [docs/design/README.md](docs/design/README.md) / [docs/ui-architecture.md](docs/ui-architecture.md) / [docs/ui-interaction-spec.md](docs/ui-interaction-spec.md) (#590, UI 部品ごとの操作 → 状態遷移 / store mutation / 例外処理) / [docs/a11y-policy.md](docs/a11y-policy.md) (#587, screen reader scope / キーボード全機能 / focus visible 等) |
@@ -131,12 +131,12 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 8. `filter_blackouts_with_scorebar()` で各暗転領域の前後フレームのスコアバー有無を判定し、暗転を分類（`match_boundary` / `in_match` / `non_fl`）。V2 検出 (`_has_scorebar_v2`) は 1920x1080 リサイズ後に **two-path OR semantics** で GC 紋章 3 点 AND 判定 (#307, #522): **Primary=absolute `_EMBLEM_POSITIONS`** (pre-#522 validated)、**Rescue=dynamic span (`_find_scorebar_horizontal_range`) + `_EMBLEM_RELATIVE_POSITIONS` 相対比**。Primary pass で short-circuit、両 path fail で False。`raw_rgb` None / opencv 未インストール時のみ None → V1 (`_has_scorebar`, channel-std + edge) フォールバック。1080p OBS validated set の挙動を完全保持しつつ 4K Game DVR の HUD スケール差異は Rescue で救済
 9. `non_fl`（非FL暗転）と短い `in_match`（試合内暗転）を除外。隣接する `match_boundary` ペア間の短いギャップをマージ
 
-**音声昇格**（`--no-audio` 未指定時、#288）
+**音声昇格**（#288。**現在は凍結中 #327**: `AUDIO_FROZEN=True` のため `--no-audio` の値に関わらずスキャンは常にスキップされ、verbose では `audio=frozen` と表示される #384。以下は解凍時の挙動）
 
 - `audio/scan.py` で動画全域の音声から Fanfare ピーク（log-mel 相関 sim ≥ 0.65）を抽出
 - `in_match` 分類された暗転のうち、暗転終了後 0-60s 以内に Fanfare ピークがあるものを `match_boundary` に昇格
 - スコアバー残像で誤分類された試合境界（例: 2026-04-08 57:53）を救済
-- 既知の制約: Fanfare は試合中にも弱いピーク（sim 0.65-0.75）を出すため、本条件のみでは偽陽性が混入しうる。WR 参照 (#301) 同梱後に WR→Fanfare 間隔による (B) 条件を追加して偽陽性除去
+- 既知の制約: Fanfare は試合中にも弱いピーク（sim 0.65-0.75）を出すため、本条件のみでは偽陽性が混入しうる。WR 参照は #306 で同梱済み（`war_room.npz`）。解凍時に WR→Fanfare 間隔による (B) 条件を追加して偽陽性を除去する計画（#327 の解凍判断と合わせて再評価）
 
 **フィルタリング・抽出**
 10. `min(min_blackout_duration, _REFINED_MIN_BLACKOUT)` 未満の短い暗転を除外（リスポーン暗転の誤判定防止）

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -53,7 +53,7 @@ allaganeye split --from-metadata <metadata.json> [OPTIONS]
 | `--workers` | auto | 検知の並列ワーカー数（デフォルト: 自動=`min(cpu_count, 24)`） |
 | `--gpu` | `false` | GPU アクセラレーション検知を強制（チャンク並列デコード）。利用不可時は CPU フォールバック。**`--no-gpu` と同時指定は排他エラー (exit 5) (#419)** |
 | `--no-gpu` | `false` | GPU を無効化し CPU 検知を強制する。**`--gpu` と同時指定は排他エラー (exit 5) (#419)** |
-| `--gpu-vendor` | `auto` | 使用する GPU vendor を明示指定 (#546 / #553)。値: `auto` / `nvidia` / `amd` / `intel`。**実装済みは `nvidia` (cuvid, #546) と `amd` (d3d11va + hwdownload, #553)**。`intel` は **exit 5** (#550 で実装予定)。probe に無い vendor を要求すると exit 5。default は probe 結果から `_VENDOR_PREFERENCE` (nvidia > amd > intel) 順で実装済み vendor を選ぶ |
+| `--gpu-vendor` | `auto` | 使用する GPU vendor を明示指定 (#546 / #553 / #550 / #582)。値: `auto` / `nvidia` / `amd` / `intel`。**3 vendor すべて実装済み** (`nvidia`=cuvid #546 / `amd`=d3d11va+hwdownload #553 / `intel`=QSV+hwdownload #550 h264/hevc/av1 + #582 vp9)。probe に無い vendor を要求すると exit 5。default は probe 結果から `_VENDOR_PREFERENCE` (nvidia > amd > intel) 順で選ぶ |
 | `--no-cache` | `false` | キャッシュされた検知結果を無視して再検知する |
 | `--no-audio` | `false` | 音声ベースの試合境界昇格（Fanfare スキャン）を無効化する。**現在は音声モジュールが凍結中（#327）のため、本フラグの値に関わらずスキャンは常にスキップされる。verbose 出力では `audio=frozen` と表示される (#384)** |
 | `--dry-run` | `false` | 検知のみ実行し分割しない（検知結果はキャッシュに保存される） |
@@ -350,8 +350,8 @@ echo '<metadata-json>' | allaganeye export --stdin [...]
 | `--codec copy\|h264` | `copy` | `copy` (FFmpeg `-c copy`、無劣化分割) または `h264` (NVENC / QSV / AMF / libx264 で再エンコード) |
 | `--concurrency N` | SKU テーブル値 | 同時 export スロット数を上書き (`enumerate_h264_encoders` が返す値のデフォルト: RTX 5090 → 3、RTX 4090/4080/4070 → 2、RTX 4060 / 不明 NVIDIA → 1、QSV / AMF / libx264 → 1) |
 | `--name-pattern PATTERN` | `{idx:03}_{type}_{start}.mp4` | 出力ファイル名テンプレート。使用可能トークン: `{idx}` / `{idx:03}` / `{type}` / `{start}` / `{date}` |
-| `--include I,J,K` | (すべて対象) | 0 始まりの match index フィルタ (カンマ区切り)。`--exclude` との併用時は `include - exclude` が有効集合 |
-| `--exclude I,J,K` | (なし) | 0 始まりの match index 除外フィルタ (カンマ区切り)。`type_override == "skip"` の match は本フラグに関係なく常に除外 |
+| `--include I,J,K` | (すべて対象) | metadata の `matches[].index` (**1 始まり**) と照合する match フィルタ (カンマ区切り)。`--exclude` との併用時は `include - exclude` が有効集合 |
+| `--exclude I,J,K` | (なし) | metadata の `matches[].index` (**1 始まり**) と照合する除外フィルタ (カンマ区切り)。`type_override == "skip"` の match は本フラグに関係なく常に除外 |
 | `--quiet` | `false` | 進捗出力を抑制 (success/error 行は stderr に出力される)。`--json` と排他 |
 | `--json` | `false` | stdout に JSON Lines を emit する (GUI subprocess wire protocol)。`--quiet` と排他 |
 

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -345,7 +345,7 @@ allaganeye split <video_path> --dry-run       # 検知のみ、分割しない
 allaganeye split <video_path> --gpu           # GPU アクセラレーション検知
 allaganeye split <video_path> --workers 8     # ワーカー数指定
 allaganeye split <video_path> --no-cache      # キャッシュ無視で再検知
-allaganeye split <video_path> --no-audio      # 音声昇格を無効化
+allaganeye split <video_path> --no-audio      # 音声昇格の無効化フラグ（#327 で凍結中のため現在は常にスキップ）
 allaganeye split <video_path> -v              # verbose 出力
 allaganeye split <video_path> -q              # 進捗抑制
 
@@ -422,7 +422,7 @@ bump 手順:
 1. `scripts/installer/requirements-pyinstaller.txt` の 2 行 (`pyinstaller==<ver>` + `pyinstaller-hooks-contrib==<ver>`) を更新
 2. Idios の手元で `pwsh -File scripts/build-portable-zip.ps1 -Version <test-ver> -SkipArchive` を実行、frozen output が生成されることを確認
 3. CI smoke-test (Lv A `--version` / Lv B `detect` 3s / integrity exit 7 fall-through) が PASS することを確認
-4. 実機 split (1:25 動画 1 本) で audio / video detection + GUI export が動作することを Idios 実機検証
+4. 実機 split (1:25 動画 1 本) で video detection (+ audio module の frozen build での import 健全性) + GUI export が動作することを Idios 実機検証
 
 bump 頻度: 4-6 か月毎を目安、PyInstaller 公式 release notes を確認して numpy / scipy / cv2 hook の互換性を事前確認する。
 

--- a/docs/output-spec.md
+++ b/docs/output-spec.md
@@ -163,4 +163,4 @@ Metadata: <metadata.json path>
 | `export --codec copy` | `{idx:03}_{type}_{start}.mp4` (match ごと) | ストリームコピー MP4 (再エンコードなし)。`split` 出力と同じバイト内容を既存 `metadata.json` から生成 |
 | `export --codec h264` | `{idx:03}_{type}_{start}.mp4` (match ごと) | 再エンコード MP4 (NVENC / QSV / AMF / libx264 fallback)。スロット数 = NVENC engine 数 (RTX 5090 → 3、RTX 4090 → 2 等)。iGPU / ソフトウェア encoder は 1 スロット |
 | `export --json` | stdout: NDJSON ストリーム | 1 行 1 JSON イベント (progress / fallback / result / error / summary)。Tauri GUI subprocess が使用する wire protocol |
-| `--include I,J,K` / `--exclude I,J,K` | 0 始まりの index で match をフィルタ | `type_override="skip"` の match はこれらのフラグに関係なく常に除外 |
+| `--include I,J,K` / `--exclude I,J,K` | metadata の `matches[].index` (**1 始まり**) と照合して match をフィルタ | `type_override="skip"` の match はこれらのフラグに関係なく常に除外 |

--- a/docs/superpowers/plans/2026-05-18-nvenc-parallel-export.md
+++ b/docs/superpowers/plans/2026-05-18-nvenc-parallel-export.md
@@ -3639,7 +3639,7 @@ echo '<metadata-json>' | allaganeye export --stdin [...]
 - `--codec copy|h264` — `copy` (FFmpeg `-c copy` 無劣化分割) / `h264` (NVENC / QSV / AMF / libx264 再エンコード)。default `copy`。
 - `--concurrency N` — slot 数 override。指定しなければ `enumerate_h264_encoders` の自動検出 (SKU table) を採用。
 - `--name-pattern PATTERN` — 出力ファイル名。tokens: `{idx}` / `{idx:03}` / `{type}` / `{start}` / `{date}`。default `{idx:03}_{type}_{start}.mp4`。
-- `--include / --exclude` — 0-based match index による絞り込み (カンマ区切り)。`--include` 指定で list 外は skip、`--exclude` 指定で list 内を skip。同時指定すると `--include ∩ ¬--exclude`。
+- `--include / --exclude` — 1-based match index (metadata の `matches[].index`) による絞り込み (カンマ区切り)。`--include` 指定で list 外は skip、`--exclude` 指定で list 内を skip。同時指定すると `--include ∩ ¬--exclude`。
 - `--quiet` — progress 出力を抑制。
 - `--json` — stdout に JSON Lines (`{"type":"progress",...}` 等) を吐く。`--quiet` と排他。GUI subprocess 用。
 

--- a/docs/superpowers/plans/2026-06-10-audit-w1-g5.md
+++ b/docs/superpowers/plans/2026-06-10-audit-w1-g5.md
@@ -1,0 +1,245 @@
+# Audit Remediation Wave 1 — G5 (doc P1 修正) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 一次仕様書の実害級 drift 3 点 (export index 基数 / gpu-vendor intel「実装予定」/ CLAUDE.md 音声昇格 frozen 未反映) を実装と一致させる (#815、audit P1-5/6/7)。
+
+**Architecture:** doc-only の最小修正。`docs/cli-spec.md` 2 箇所 + `CLAUDE.md` 3 箇所を exact replace し、1 branch / 1 PR (commit は file 単位で 2 つ)。P2 級 doc drift (workers 24 等) は W6 (#818 後の doc 一括) 扱いで**触らない** (Iron Law 3)。
+
+**Tech Stack:** Edit (exact string replace) / markdownlint / gh CLI (HEREDOC)。
+
+**参照:** spec `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` §G5 / findings `docs/audits/2026-06-10-full-audit.md` P1-5/6/7 / issue #815。
+
+**実装側の事実 (2026-06-10 実測済み — plan 作成時に検証済みのため再確認は任意):**
+
+- `allaganeye/commands/export.py:149` は `idx = int(raw["index"])` で metadata の **1 始まり** `index` と照合 (metadata-spec §Match「1 始まりの順序番号」、GUI も 1 始まりを送信)
+- intel (QSV) は実装済み: `allaganeye/cli.py:130-139` + `allaganeye/video/gpu_detector.py` (#550 h264/hevc/av1、#582 vp9)。CLAUDE.md §GPU モード の vendor bullet とも一致
+- `allaganeye/audio/__init__.py:48` = `AUDIO_FROZEN: Final[bool] = True` (#327)。`allaganeye/audio/refs/` には `fanfare.npz` と `war_room.npz` (#306) の 2 つが実在。cli-spec:58 は凍結を正しく記載済み (こちらが文言の手本)
+
+---
+
+## File Structure
+
+| 区分 | path | 変更内容 |
+| --- | --- | --- |
+| Modify | `docs/cli-spec.md:56` | --gpu-vendor の intel 行を「3 vendor 実装済み」に |
+| Modify | `docs/cli-spec.md:353-354` | --include/--exclude の「0 始まり」を 1 始まり index 照合に |
+| Modify | `CLAUDE.md:55` | --no-audio コマンド注釈に凍結を反映 |
+| Modify | `CLAUDE.md:102` | audio/refs 行に war_room.npz を追加 |
+| Modify | `CLAUDE.md:134-139` | 音声昇格 block の凍結明記 + 未来形記述の更新 |
+| Commit only | `docs/superpowers/plans/2026-06-10-audit-w1-g5.md` | 本 plan (G1 と同じ同梱慣行) |
+
+### Task 1: branch 作成 + plan 同梱 commit
+
+**Files:** 本 plan (untracked → commit)
+
+- [ ] **Step 1: clean 確認と branch 作成**
+
+```bash
+cd /e/projects/kobutachan-tools/kobutachan-allaganeye
+git status --short   # untracked が本 plan のみであること
+git fetch origin develop-0.3.0
+git checkout -b claude/audit-w1-g5 origin/develop-0.3.0
+```
+
+- [ ] **Step 2: plan を commit**
+
+```bash
+git add docs/superpowers/plans/2026-06-10-audit-w1-g5.md
+git commit -F - <<'EOF'
+doc: G5 (doc P1 修正) の実装 plan を追加 (#815)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+### Task 2: cli-spec.md の 2 箇所修正
+
+**Files:** Modify: `docs/cli-spec.md:56,353-354`
+
+- [ ] **Step 1: intel 行 (L56) を置換**
+
+現在 (1 行、太字部のみ注目):
+
+```text
+| `--gpu-vendor` | `auto` | 使用する GPU vendor を明示指定 (#546 / #553)。値: `auto` / `nvidia` / `amd` / `intel`。**実装済みは `nvidia` (cuvid, #546) と `amd` (d3d11va + hwdownload, #553)**。`intel` は **exit 5** (#550 で実装予定)。probe に無い vendor を要求すると exit 5。default は probe 結果から `_VENDOR_PREFERENCE` (nvidia > amd > intel) 順で実装済み vendor を選ぶ |
+```
+
+置換後:
+
+```text
+| `--gpu-vendor` | `auto` | 使用する GPU vendor を明示指定 (#546 / #553 / #550 / #582)。値: `auto` / `nvidia` / `amd` / `intel`。**3 vendor すべて実装済み** (`nvidia`=cuvid #546 / `amd`=d3d11va+hwdownload #553 / `intel`=QSV+hwdownload #550 h264/hevc/av1 + #582 vp9)。probe に無い vendor を要求すると exit 5。default は probe 結果から `_VENDOR_PREFERENCE` (nvidia > amd > intel) 順で選ぶ |
+```
+
+- [ ] **Step 2: --include / --exclude (L353-354) を置換**
+
+現在:
+
+```text
+| `--include I,J,K` | (すべて対象) | 0 始まりの match index フィルタ (カンマ区切り)。`--exclude` との併用時は `include - exclude` が有効集合 |
+| `--exclude I,J,K` | (なし) | 0 始まりの match index 除外フィルタ (カンマ区切り)。`type_override == "skip"` の match は本フラグに関係なく常に除外 |
+```
+
+置換後:
+
+```text
+| `--include I,J,K` | (すべて対象) | metadata の `matches[].index` (**1 始まり**) と照合する match フィルタ (カンマ区切り)。`--exclude` との併用時は `include - exclude` が有効集合 |
+| `--exclude I,J,K` | (なし) | metadata の `matches[].index` (**1 始まり**) と照合する除外フィルタ (カンマ区切り)。`type_override == "skip"` の match は本フラグに関係なく常に除外 |
+```
+
+- [ ] **Step 3: lint 確認 (commit 前に必ず確認、`;` 連結禁止)**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | grep -E "^docs/cli-spec" && echo "LINT_VIOLATION" || echo "LINT_OK"
+```
+
+Expected: `LINT_OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/cli-spec.md
+git commit -F - <<'EOF'
+doc: cli-spec の export index 基数と gpu-vendor intel 記述を実装に同期 (#815)
+
+- --include/--exclude: 「0 始まり」→ metadata matches[].index (1 始まり) 照合
+  (実装: allaganeye/commands/export.py:149、audit P1-5)
+- --gpu-vendor: intel「exit 5 実装予定」→ 3 vendor 実装済み (#550/#582、audit P1-6)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+### Task 3: CLAUDE.md の 3 箇所修正
+
+**Files:** Modify: `CLAUDE.md:55,102,134-139`
+
+- [ ] **Step 1: --no-audio コマンド注釈 (L55) を置換**
+
+現在:
+
+```text
+allaganeye split <video_path> --no-audio   # 音声昇格を無効化（視覚のみ）
+```
+
+置換後:
+
+```text
+allaganeye split <video_path> --no-audio   # 音声昇格の無効化フラグ（#327 で凍結中のため現在は常にスキップ）
+```
+
+- [ ] **Step 2: audio/refs 行 (L102) を置換**
+
+現在:
+
+```text
+| `audio/refs/` | 同梱参照特徴量（`fanfare.npz`） |
+```
+
+置換後:
+
+```text
+| `audio/refs/` | 同梱参照特徴量（`fanfare.npz` / `war_room.npz`、#306） |
+```
+
+- [ ] **Step 3: 音声昇格 block (L134-139) を置換**
+
+現在:
+
+```text
+**音声昇格**（`--no-audio` 未指定時、#288）
+
+- `audio/scan.py` で動画全域の音声から Fanfare ピーク（log-mel 相関 sim ≥ 0.65）を抽出
+- `in_match` 分類された暗転のうち、暗転終了後 0-60s 以内に Fanfare ピークがあるものを `match_boundary` に昇格
+- スコアバー残像で誤分類された試合境界（例: 2026-04-08 57:53）を救済
+- 既知の制約: Fanfare は試合中にも弱いピーク（sim 0.65-0.75）を出すため、本条件のみでは偽陽性が混入しうる。WR 参照 (#301) 同梱後に WR→Fanfare 間隔による (B) 条件を追加して偽陽性除去
+```
+
+置換後:
+
+```text
+**音声昇格**（#288。**現在は凍結中 #327**: `AUDIO_FROZEN=True` のため `--no-audio` の値に関わらずスキャンは常にスキップされ、verbose では `audio=frozen` と表示される #384。以下は解凍時の挙動）
+
+- `audio/scan.py` で動画全域の音声から Fanfare ピーク（log-mel 相関 sim ≥ 0.65）を抽出
+- `in_match` 分類された暗転のうち、暗転終了後 0-60s 以内に Fanfare ピークがあるものを `match_boundary` に昇格
+- スコアバー残像で誤分類された試合境界（例: 2026-04-08 57:53）を救済
+- 既知の制約: Fanfare は試合中にも弱いピーク（sim 0.65-0.75）を出すため、本条件のみでは偽陽性が混入しうる。WR 参照は #306 で同梱済み（`war_room.npz`）。解凍時に WR→Fanfare 間隔による (B) 条件を追加して偽陽性を除去する計画（#327 の解凍判断と合わせて再評価）
+```
+
+- [ ] **Step 4: lint 確認 (commit 前)**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | grep -E "^CLAUDE.md" && echo "LINT_VIOLATION" || echo "LINT_OK"
+```
+
+Expected: `LINT_OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -F - <<'EOF'
+doc: CLAUDE.md の音声昇格を frozen (#327) 実態に同期 (#815)
+
+- --no-audio 注釈と音声昇格 block に凍結を明記 (audio=frozen #384)
+- audio/refs に war_room.npz (#306) を反映、「WR 同梱後に」の未来形を解消
+  (audit P1-7。実装: allaganeye/audio/__init__.py:48 AUDIO_FROZEN=True)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+### Task 4: Pre-flight + PR 作成 + /iterate-review 自走
+
+**Files:** なし (gh のみ)
+
+- [ ] **Step 1: Pre-flight Step 0 (ハードゲート) / Step 1-2 (base 同期) / Step 4 (重複再確認)**
+
+```bash
+gh pr list --repo Idios/kobutachan-allaganeye --search "815" --state open      # 0 件
+git fetch origin develop-0.3.0 && git log HEAD..origin/develop-0.3.0 --oneline # 0 行
+gh pr list --repo Idios/kobutachan-allaganeye --search "815" --state all      # 0 件
+```
+
+0 件 / 0 行でなければ STOP して状況確認。
+
+- [ ] **Step 2: Pre-flight Step 5 (adversarial review、C6 fallback)**
+
+`/codex:adversarial-review` は disable-model-invocation のため、CLAUDE.md §C6 に従い requesting-code-review 型 subagent で代替 (focus: 「修正後の記述が実装と一致するか両側照合 / 同ファイル内の隣接 stale 記述の見落とし / Iron Law 3 (W6 領域への越境がないか)」)。PR body に Codex fallback notice を記載。
+
+- [ ] **Step 3: push + PR 作成**
+
+```bash
+git push -u origin claude/audit-w1-g5
+gh pr create --repo Idios/kobutachan-allaganeye --base develop-0.3.0 \
+  --title "doc: cli-spec / CLAUDE.md の P1 級 drift 修正 (Refs #815)" \
+  --body-file - <<'EOF'
+## 概要
+audit P1-5/6/7 対応 (Refs #815)。spec: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §G5。
+一次仕様書の実害級誤り 3 点のみを最小修正 (P2 doc drift は W6 #818 系で別途)。
+
+## 変更内容
+- cli-spec: --include/--exclude を 1 始まり `matches[].index` 照合に訂正 / --gpu-vendor intel を「3 vendor 実装済み」に更新
+- CLAUDE.md: 音声昇格の凍結 (#327, audio=frozen #384) を明記 / audio/refs に war_room.npz (#306) 反映 / 「WR 同梱後に」未来形を解消
+- 実装 plan の同梱 (G1 と同じ慣行)
+
+## Self-Test Report
+- [x] markdownlint: 変更 2 ファイル violation ゼロ
+- [x] 実装照合: export.py:149 (1 始まり) / cli.py:130-139 (intel 実装済み) / audio/__init__.py:48 (AUDIO_FROZEN=True) / audio/refs/ に war_room.npz 実在
+- doc-only のため Python/GUI チェックは対象外 (Iron Law 6 path 別)
+
+## Codex fallback notice
+/codex:adversarial-review は disable-model-invocation のため C6 fallback で adversarial review を代替実施 (結果は本文または review コメント参照)。
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 4: issue 着手/完了コメント + /iterate-review 自走**
+
+```bash
+gh issue comment 815 --repo Idios/kobutachan-allaganeye \
+  --body "完了: audit-w1-20260610 → PR #<番号>。doc P1 3 点を実装に同期。"
+```
+
+その後、controller が `/iterate-review <PR#>` を agent 自動で invoke する (CLAUDE.md §/iterate-review workflow)。マージ後は `/close-issue 815`。

--- a/docs/superpowers/specs/2026-05-18-nvenc-parallel-export-design.md
+++ b/docs/superpowers/specs/2026-05-18-nvenc-parallel-export-design.md
@@ -384,7 +384,7 @@ echo '<metadata-json>' | allaganeye export --stdin [...同上 flag]
 #   --name-pattern PATTERN  {idx:03}_{type}_{start}.mp4 等 (default: GUI と同じ)
 #   --quiet                 progress bar 抑制 (出力 path のみ)
 #   --json                  stdout に JSON lines emit (GUI subprocess 用、--quiet と排他)
-#   --include / --exclude   match index による絞り込み (0-based、metadata の matches[].index)
+#   --include / --exclude   match index による絞り込み (1-based、metadata の matches[].index)
 
 # Exit code:
 #   0: 全 match success (skipped を除く)

--- a/docs/superpowers/specs/2026-06-10-audit-remediation-design.md
+++ b/docs/superpowers/specs/2026-06-10-audit-remediation-design.md
@@ -130,7 +130,7 @@ v0.3.0 リリース条件への追加: **Wave 1 の全 issue クローズ** (= P
 ### W1: export/CLI 整合
 
 - 対応: P2-7 / P2-8 / P2-9 / P2-10 / P2-11 / P2-20 / P2-40 + export 系 P3 (concurrency 検証、partial file 掃除、stderr_tail、dead param、stale comment、`{idx}` 衝突検査)
-- 骨子: export command を split/detect と同じ `except AllaganEyeError` → exit code マッピングに収める / json モード突入時に stdout reconfigure + stdin buffer 読み / skipped 計上 / output_dir mkdir / debug-brightness interval guard (exit 5) / `{start}` を Python 側 H-MM-SS に統一 (GUI 表示と一致させる)
+- 骨子: export command を split/detect と同じ `except AllaganEyeError` → exit code マッピングに収める / json モード突入時に stdout reconfigure + stdin buffer 読み / skipped 計上 / output_dir mkdir / debug-brightness interval guard (exit 5) / `{start}` を Python 側 H-MM-SS に統一 (GUI 表示と一致させる) / `--include`・`--exclude` help への基数 (1 始まり) 明記 + 範囲外 index の警告検討 (PR #820 Round 1 finding #4 由来、2026-06-11 Idios 判断で W1 へ)
 - 注意: exit code 体系の変更は cli-spec / output-spec の同時更新を伴う (W6 と重なる箇所は W1 側で正を書く)
 
 ### W2: GUI export/cancel 安定化


### PR DESCRIPTION
## 概要
audit P1-5/6/7 対応 (Refs #815)。spec: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §G5。
一次仕様書の実害級誤りのみを最小修正 (P2 doc drift は W6 #818 系で別途)。

## 変更内容
- cli-spec: `--include`/`--exclude` を 1 始まり `matches[].index` 照合に訂正 / `--gpu-vendor` intel を「3 vendor 実装済み (#550/#582)」に更新
- CLAUDE.md: 音声昇格の凍結 (#327, `audio=frozen` #384) を明記 / audio/refs に `war_room.npz` (#306) 反映 / 「WR 同梱後に」未来形を解消
- output-spec: adversarial review (I-1) で検出した P1-5 同一クラスの「0 始まり」残存を同表現で訂正 (#815 対象箇所へ追加済み、Idios 承認 (A))
- 実装 plan の同梱 (G1 と同じ慣行)
- (/iterate-review Round 1) developer-setup.md の凍結反映 2 箇所 (--no-audio 注釈 / PyInstaller bump 手順を「video detection + audio module の import 健全性」に精緻化)
- (/iterate-review Round 1、Idios 承認) nvenc 設計 spec:387 / plan:3642 の「0-based」自己矛盾を 1-based に訂正
- (/iterate-review Round 1、Idios 判断) export help の基数明記 + 範囲外 index 警告を remediation spec §W1 へ deferred 追記

## Self-Test Report
- [x] markdownlint: 変更 8 ファイル (cli-spec / CLAUDE.md / output-spec / developer-setup / nvenc 設計 spec・plan / remediation spec / 本 plan) すべて violation ゼロ (Round 1 修正後に再実行)
- [x] 実装照合 (subagent 2 段レビュー + adversarial review で独立再検証):
  - `allaganeye/commands/export.py:149` = `int(raw["index"])`、`split_matches.py:1355` = `i + 1` (1 始まり)
  - intel QSV 4 codec (h264/hevc/vp9/av1) が `gpu_detector.py` の登録と一致
  - `allaganeye/audio/__init__.py:48` = `AUDIO_FROZEN=True`、`audio/refs/` に war_room.npz 実在、`audio=frozen` は `split_matches.py:555` と一致
- doc-only のため Python/GUI チェックは対象外 (Iron Law 6 path 別)

## Codex fallback notice
Iron Law 6 Pre-flight Step 5 の `/codex:adversarial-review` は disable-model-invocation のため、CLAUDE.md §C6 に従い requesting-code-review 型 subagent で adversarial review を代替実施。verdict: With fixes → I-1 (output-spec 残存) を本 PR 内で修正済み、他 Critical/Important ゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- iterate-review:deferred:start -->
## Deferred Findings (managed by /iterate-review)

- [W1] Round 1: export CLI help 基数 (1 始まり) 明記 + 範囲外 index 警告 → deferred-to: spec §W1 骨子へ追記済み (Wave 2 起票時に issue 化、Idios 承認 2026-06-11)
- [C] Round 3: stale worktree 3 本由来のローカル lint noise (3,410 violation) → deferred-to: #816 (既存、追記コメント済み。掃除で解消)

<!-- iterate-review:deferred:end -->


