### PR TITLE
feat(l3): 検出土台 Phase 0/1/2 - presence エンジン + 帯 anchor/crop + localize 分類 (Refs #821)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,8 @@ MP4/MKV入力 → probe.py（ffprobe でメタデータ取得）
 | `video/probe.py` | ffprobe でメタデータ取得（解像度、fps、長さ） |
 | `video/detector.py` | ffmpeg 並列プローブで暗転検知、試合境界抽出（CPU モード） |
 | `video/gpu_detector.py` | GPU アクセラレーション検知（チャンク並列デコード） |
+| `video/capture_region.py` | 検出 ROI（`CaptureRegion`）の解決。scorebar 帯 anchor の多フレーム consensus（`detect_scorebar_band_region`）/ FULL_FRAME 縮退。`--vtuber` gate 内でのみ有効（L3 Phase 1。検出 subsystem の現状 map は [docs/detection-map.md](docs/detection-map.md)） |
+| `video/presence.py` | presence（scorebar 在/不在）ベースの試合検出エンジン + GT 突合ハーネス基盤（L3 Phase 1。2 信号 fusion 再アーキ spec 参照） |
 | `video/scorebar.py` | スコアバーフィルタリング（暗転分類・試合内/非FL判定）+ 音声昇格 |
 | `video/splitter.py` | FFmpeg で動画分割（-c copy） |
 | `audio/extract.py` | ffmpeg で音声 PCM 抽出 |
@@ -198,6 +200,7 @@ export ALLAGANEYE_SAMPLE_VIDEO_DIR=/path/to/videos
 - MKV: OBSの長時間録画（30-80GB、複数試合を含む）
 - サブディレクトリ（`20260116/` 等）: 手動で試合分割済みのMP4（`YYYYMMDD_N.mp4`）
 - 未設定の場合、`sample_video_dir` fixture を使うテスト（`slow` マーカー）はスキップされる
+- VTuber/masked 系 slow テスト用 VOD は別変数 `ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER`（既定 `E:/allaganeye-samples`）。詳細は [`docs/testing-guide.md`](docs/testing-guide.md) §サンプル動画データの設定
 
 ## Portable ZIP 哲学
 

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -149,6 +149,14 @@ def split(
             "Currently frozen: audio scan is always skipped regardless of this flag.",
         ),
     ] = False,
+    vtuber: Annotated[
+        bool,
+        typer.Option(
+            "--vtuber",
+            help="VTuber recording (game inset): use scorebar-band anchor for "
+            "detection. Omit for OBS full-frame (default).",
+        ),
+    ] = False,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -211,6 +219,7 @@ def split(
                 workers=workers,
                 no_cache=no_cache,
                 no_audio=no_audio,
+                vtuber=vtuber,
             )
             from allaganeye.commands.split_matches import run_split_from_metadata
 
@@ -239,6 +248,7 @@ def split(
             workers=workers,
             no_cache=no_cache,
             no_audio=no_audio,
+            vtuber=vtuber,
         )
 
         from allaganeye.commands.split_matches import run_split
@@ -319,6 +329,14 @@ def detect(
             "Currently frozen: audio scan is always skipped regardless of this flag.",
         ),
     ] = False,
+    vtuber: Annotated[
+        bool,
+        typer.Option(
+            "--vtuber",
+            help="VTuber recording (game inset): use scorebar-band anchor for "
+            "detection. Omit for OBS full-frame (default).",
+        ),
+    ] = False,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -388,6 +406,7 @@ def detect(
             workers=workers,
             no_cache=no_cache,
             no_audio=no_audio,
+            vtuber=vtuber,
         )
 
         from allaganeye.commands.detect import run_detect

--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -153,6 +153,7 @@ def split(
         bool,
         typer.Option(
             "--vtuber",
+            hidden=True,
             help="VTuber recording (game inset): use scorebar-band anchor for "
             "detection. Omit for OBS full-frame (default).",
         ),
@@ -333,6 +334,7 @@ def detect(
         bool,
         typer.Option(
             "--vtuber",
+            hidden=True,
             help="VTuber recording (game inset): use scorebar-band anchor for "
             "detection. Omit for OBS full-frame (default).",
         ),

--- a/allaganeye/commands/detect.py
+++ b/allaganeye/commands/detect.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import typer
 
 from allaganeye.commands.split_matches import (
+    _audio_status_str,
     _auto_sample_interval,
     _build_metadata_payload,
     _build_system_info,
@@ -38,6 +39,7 @@ from allaganeye.commands.split_matches import (
     _run_audio_scan,
     _run_detection,
     _save_cache,
+    _workers_summary_str,
     build_brightness_samples,
 )
 from allaganeye.config import SplitConfig
@@ -156,6 +158,21 @@ def run_detect(
             )
 
         audio_hits = _run_audio_scan(video_path, config, show=show, verbose=verbose)
+
+        if show and verbose:
+            # run_split の cache-miss summary と同形 (PR #823 R2)。vtuber token
+            # は検出 mode の provenance を stdout に残す (cache-hit 側は
+            # _display_cache_hit_params が担う)。
+            typer.echo(
+                f"Detecting match boundaries "
+                f"(interval={effective_interval}s, "
+                f"threshold={config.blackout_threshold}, "
+                f"workers={_workers_summary_str(config.workers)}, "
+                f"min_match={config.min_match_duration}s, "
+                f"min_blackout={config.min_blackout_duration}s, "
+                f"audio={_audio_status_str(config.no_audio)}, "
+                f"vtuber={'on' if config.vtuber else 'off'})"
+            )
 
         detect_stats: DetectionStats | None = {} if verbose else None
 

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -754,6 +754,9 @@ def _run_detection(
         "min_blackout_duration": config.min_blackout_duration,
         "gpu_vendor": gpu_vendor,
         "use_gpu": use_gpu,
+        # L3 B6: VTuber game-inset recording -> scorebar-band anchor region.
+        # False (default) keeps FULL_FRAME = OBS bit-exact behavior.
+        "vtuber": config.vtuber,
         "workers": config.workers,
         "src_resolution": (metadata["width"], metadata["height"]),
         "codec": metadata.get("codec"),

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -176,7 +176,8 @@ def run_split(
             f"workers={_workers_summary_str(config.workers)}, "
             f"min_match={config.min_match_duration}s, "
             f"min_blackout={config.min_blackout_duration}s, "
-            f"audio={_audio_status_str(config.no_audio)})"
+            f"audio={_audio_status_str(config.no_audio)}, "
+            f"vtuber={'on' if config.vtuber else 'off'})"
         )
 
     detect_stats: DetectionStats | None = {} if verbose else None
@@ -513,6 +514,9 @@ def _display_cache_hit_params(cache_path: Path, config: SplitConfig) -> None:
     # Live-probe AUDIO_FROZEN so the verbose line mirrors `_run_audio_scan`
     # behaviour for the current run, same as the cache-miss summary.
     cached_no_audio = bool(params.get("no_audio", config.no_audio))
+    # vtuber は cache key (PR #823) に含まれるため hit 時は config と一致するが、
+    # 表示は cache 記録値を正とする (legacy cache は key なし = False)。
+    cached_vtuber = bool(params.get("vtuber", False))
 
     typer.echo(header)
     typer.echo(
@@ -521,7 +525,8 @@ def _display_cache_hit_params(cache_path: Path, config: SplitConfig) -> None:
         f"threshold={params.get('blackout_threshold', '?')}, "
         f"min_match={params.get('min_match_duration', '?')}s, "
         f"min_blackout={params.get('min_blackout_duration', '?')}s, "
-        f"audio={_audio_status_str(cached_no_audio)}"
+        f"audio={_audio_status_str(cached_no_audio)}, "
+        f"vtuber={'on' if cached_vtuber else 'off'}"
     )
 
 

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -1745,6 +1745,7 @@ def _save_cache(
             "min_match_duration": config.min_match_duration,
             "min_blackout_duration": config.min_blackout_duration,
             "no_audio": config.no_audio,
+            "vtuber": config.vtuber,
         },
         "boundaries": boundaries,
     }
@@ -1796,12 +1797,16 @@ def _load_cache(
         return None
 
     params = data.get("params", {})
+    # vtuber は detection path を切り替えるため cache key に含める (gate の cache
+    # bypass 防止)。key なし legacy cache は --vtuber 導入前 = 標準 path の結果
+    # なので False と同値に扱う。
     if (
         params.get("sample_interval") != effective_interval
         or params.get("blackout_threshold") != config.blackout_threshold
         or params.get("min_match_duration") != config.min_match_duration
         or params.get("min_blackout_duration") != config.min_blackout_duration
         or params.get("no_audio") != config.no_audio
+        or params.get("vtuber", False) != config.vtuber
     ):
         logger.debug("Cache parameter mismatch")
         return None

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -21,6 +21,7 @@ class SplitConfig:
     workers: int | None = None
     no_cache: bool = False
     no_audio: bool = False
+    vtuber: bool = False
 
     def __post_init__(self) -> None:
         if self.workers is not None and self.workers < 1:

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -89,6 +89,21 @@ def region_mean(frame: np.ndarray, region: CaptureRegion) -> float:
     return float(frame[y0:y1, x0:x1].mean())
 
 
+def band_region_from_localization(
+    loc: ScorebarLocalization, *, probe_w: int, probe_h: int
+) -> CaptureRegion:
+    """probe px の scorebar 局在化を正規化 scorebar 帯 ROI に変換する。
+
+    検出 (brightness / motion) を測る最 clean 領域。`loc.confidence` を引き継ぎ
+    `source="band"` を付ける。範囲外座標は clamp する。
+    """
+    x = loc.x_left / probe_w
+    y = loc.y_top / probe_h
+    w = (loc.x_right - loc.x_left) / probe_w
+    h = (loc.y_bottom - loc.y_top) / probe_h
+    return CaptureRegion(x, y, w, h, confidence=loc.confidence, source="band").clamp()
+
+
 @dataclass
 class RegionTimeline:
     """Coarse region (Pass 1) + per-segment precise regions (#480/#481)."""

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -333,6 +333,23 @@ def _emblem_and_margin(
     return min_ratio
 
 
+def localize_from_rgb_bytes(
+    raw: bytes | None, *, height: int, width: int
+) -> ScorebarLocalization | None:
+    """RGB24 probe bytes を decode して :func:`localize_scorebar` にかける共有 helper.
+
+    raw が None (probe 失敗) なら None を返す。probe 失敗と localizer miss を
+    呼び出し側で区別したい場合は raw の None を先に判定すること
+    (例: ``scorebar._localize_present_from_raw``)。呼び出し元 3 箇所
+    (presence / scorebar / detector の帯 anchor) の reshape boilerplate を一元化し、
+    probe 次元変更時の drift を防ぐ (PR #823 R3 dedup)。
+    """
+    if raw is None:
+        return None
+    frame = np.frombuffer(raw, dtype=np.uint8).reshape(height, width, 3)
+    return localize_scorebar(frame)
+
+
 def localize_scorebar(
     frame: np.ndarray,
     *,

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -9,6 +9,7 @@ bit-exact; see spec section 3.4 / M4).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -424,3 +425,39 @@ def detect_region_blackout_overlap(
     return _largest_component_region(
         mask, min_area_frac=min_area_frac, source="tierA", confidence=0.8
     )
+
+
+_BAND_CONSENSUS_MIN_HITS = 2
+"""帯 consensus に必要な最小局在化成功数。これ未満は FULL_FRAME 縮退。"""
+
+
+def detect_scorebar_band_region(
+    *,
+    duration: float,
+    probe_w: int,
+    probe_h: int,
+    localize_fn: Callable[[float], ScorebarLocalization | None],
+    num_samples: int = 8,
+    min_hits: int = _BAND_CONSENSUS_MIN_HITS,
+) -> CaptureRegion:
+    """疎な多フレーム localize の median consensus で安定 scorebar 帯 ROI を返す。
+
+    *localize_fn* は timestamp → ScorebarLocalization|None。動画 I/O は呼び出し側が
+    bind する (テストは合成関数を注入)。成功局在化が *min_hits* 未満なら FULL_FRAME
+    (OBS / 局在化不能時の安全縮退)。成功時は各座標の median を取り
+    `band_region_from_localization` で正規化帯 ROI に変換する。
+    """
+    if duration <= 0 or num_samples < 1:
+        return FULL_FRAME
+    times = [duration * (i + 1) / (num_samples + 1) for i in range(num_samples)]
+    hits = [loc for t in times if (loc := localize_fn(t)) is not None]
+    if len(hits) < min_hits:
+        return FULL_FRAME
+    median_loc = ScorebarLocalization(
+        x_left=int(np.median([h.x_left for h in hits])),
+        x_right=int(np.median([h.x_right for h in hits])),
+        y_top=int(np.median([h.y_top for h in hits])),
+        y_bottom=int(np.median([h.y_bottom for h in hits])),
+        confidence=float(np.median([h.confidence for h in hits])),
+    )
+    return band_region_from_localization(median_loc, probe_w=probe_w, probe_h=probe_h)

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -32,6 +32,10 @@ class CaptureRegion:
         h = min(max(self.h, 0.0), 1.0 - y)
         return CaptureRegion(x, y, w, h, self.confidence, self.source)
 
+    def is_full_frame(self) -> bool:
+        """領域 = frame 全体か (OBS 縮退判定 / bit-exact 分岐に使用)。"""
+        return self.x == 0.0 and self.y == 0.0 and self.w == 1.0 and self.h == 1.0
+
     def to_dict(self) -> dict:
         return {
             "x": self.x,
@@ -69,6 +73,20 @@ class ScorebarLocalization:
 
 
 FULL_FRAME = CaptureRegion(0.0, 0.0, 1.0, 1.0, confidence=1.0, source="fallback")
+
+
+def region_mean(frame: np.ndarray, region: CaptureRegion) -> float:
+    """2D gray frame (H,W) を正規化矩形 *region* で crop し平均輝度を返す。
+
+    crop が空になる場合も最低 1px に clamp する。整数次元 frame では
+    FULL_FRAME のとき結果は ``float(frame.mean())`` と一致する (bit-exact 縮退)。
+    """
+    h, w = frame.shape[:2]
+    x0 = max(0, min(round(region.x * w), w - 1))
+    y0 = max(0, min(round(region.y * h), h - 1))
+    x1 = max(x0 + 1, min(round((region.x + region.w) * w), w))
+    y1 = max(y0 + 1, min(round((region.y + region.h) * h), h))
+    return float(frame[y0:y1, x0:x1].mean())
 
 
 @dataclass

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -430,6 +430,15 @@ def detect_region_blackout_overlap(
 _BAND_CONSENSUS_MIN_HITS = 2
 """帯 consensus に必要な最小局在化成功数。これ未満は FULL_FRAME 縮退。"""
 
+_CLUSTER_Y_TOL = 60
+"""y_top クラスタリングの許容差 (probe px)。これ以内の y_top は同一クラスタ。
+
+localize は per-frame noisy で、真の scorebar (y_top~0) と下部 HUD 誤検出
+(y_top~540-582) が混在しうる。両者を別クラスタに分け dominant を選ぶための
+許容差。scorebar 帯高 ~45px に対し十分広く、真クラスタ内の +-stride ばらつき
+(18 vs 20 等) は 1 クラスタにまとめる。
+"""
+
 
 def detect_scorebar_band_region(
     *,
@@ -440,12 +449,15 @@ def detect_scorebar_band_region(
     num_samples: int = 8,
     min_hits: int = _BAND_CONSENSUS_MIN_HITS,
 ) -> CaptureRegion:
-    """疎な多フレーム localize の median consensus で安定 scorebar 帯 ROI を返す。
+    """疎な多フレーム localize の dominant-cluster consensus で安定 scorebar 帯 ROI を返す。
 
     *localize_fn* は timestamp -> ScorebarLocalization|None。動画 I/O は呼び出し側が
     bind する (テストは合成関数を注入)。成功局在化が *min_hits* 未満なら FULL_FRAME
-    (OBS / 局在化不能時の安全縮退)。成功時は各座標の median を取り
-    `band_region_from_localization` で正規化帯 ROI に変換する。
+    (OBS / 局在化不能時の安全縮退)。成功時は hits を y_top で `_CLUSTER_Y_TOL`
+    クラスタリングし、最大クラスタ (同数なら平均 confidence) の各座標 median を取り
+    `band_region_from_localization` で正規化帯 ROI に変換する。これにより真の
+    scorebar (y_top~0) と下部 HUD 誤検出が混在しても between-clusters の garbage
+    band を避ける (spec section 3.6)。
     """
     if duration <= 0 or num_samples < 1:
         return FULL_FRAME
@@ -453,11 +465,28 @@ def detect_scorebar_band_region(
     hits = [loc for t in times if (loc := localize_fn(t)) is not None]
     if len(hits) < min_hits:
         return FULL_FRAME
+    # localize is per-frame noisy (upper-half best-hit scan can lock onto lower
+    # HUD; spec section 3.6). Cluster hits by y_top and take the largest cluster
+    # (true scorebar is dominant across in-match samples), so a noise-mixed
+    # median cannot produce a between-clusters garbage band.
+    hits_sorted = sorted(hits, key=lambda h: h.y_top)
+    clusters: list[list[ScorebarLocalization]] = []
+    for h in hits_sorted:
+        if clusters and h.y_top - clusters[-1][-1].y_top <= _CLUSTER_Y_TOL:
+            clusters[-1].append(h)
+        else:
+            clusters.append([h])
+    best = max(
+        clusters,
+        key=lambda c: (len(c), sum(h.confidence for h in c) / len(c)),
+    )
+    if len(best) < min_hits:
+        return FULL_FRAME
     median_loc = ScorebarLocalization(
-        x_left=int(np.median([h.x_left for h in hits])),
-        x_right=int(np.median([h.x_right for h in hits])),
-        y_top=int(np.median([h.y_top for h in hits])),
-        y_bottom=int(np.median([h.y_bottom for h in hits])),
-        confidence=float(np.median([h.confidence for h in hits])),
+        x_left=int(np.median([h.x_left for h in best])),
+        x_right=int(np.median([h.x_right for h in best])),
+        y_top=int(np.median([h.y_top for h in best])),
+        y_bottom=int(np.median([h.y_bottom for h in best])),
+        confidence=float(np.median([h.confidence for h in best])),
     )
     return band_region_from_localization(median_loc, probe_w=probe_w, probe_h=probe_h)

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -442,7 +442,7 @@ def detect_scorebar_band_region(
 ) -> CaptureRegion:
     """疎な多フレーム localize の median consensus で安定 scorebar 帯 ROI を返す。
 
-    *localize_fn* は timestamp → ScorebarLocalization|None。動画 I/O は呼び出し側が
+    *localize_fn* は timestamp -> ScorebarLocalization|None。動画 I/O は呼び出し側が
     bind する (テストは合成関数を注入)。成功局在化が *min_hits* 未満なら FULL_FRAME
     (OBS / 局在化不能時の安全縮退)。成功時は各座標の median を取り
     `band_region_from_localization` で正規化帯 ROI に変換する。

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -211,6 +211,40 @@ def _resolve_workers(workers: int | None) -> int:
     return min(os.cpu_count() or 4, 32)
 
 
+def _resolve_detect_region(video_path: Path, duration_hint: float) -> CaptureRegion:
+    """Stage 0: scorebar 帯 anchor を解決する。失敗時は FULL_FRAME (OBS 安全縮退)。
+
+    OBS (全画面 game) では localize がインセット帯を見つけられず consensus が
+    成立しないため FULL_FRAME に縮退し、検出は現行と bit-exact になる。VTuber は
+    帯 ROI が解決される。anchor の例外は決して検出を壊さない (FULL_FRAME に握り潰す)。
+    """
+    from allaganeye.video.capture_region import (
+        detect_scorebar_band_region,
+        localize_scorebar,
+    )
+
+    def _localize_at(t: float):
+        raw = _probe_frame_rgb_hires(video_path, t)
+        if raw is None:
+            return None
+        frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+            _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+        )
+        return localize_scorebar(frame)
+
+    try:
+        return detect_scorebar_band_region(
+            duration=duration_hint,
+            probe_w=_SCOREBAR_V2_PROBE_WIDTH,
+            probe_h=_SCOREBAR_V2_PROBE_HEIGHT,
+            localize_fn=_localize_at,
+        )
+    except Exception:
+        # Anchor failure must never break detect: degrade to FULL_FRAME so the
+        # OBS / error path stays bit-exact with the pre-region behavior.
+        return FULL_FRAME
+
+
 def detect_match_boundaries(
     video_path: Path,
     *,
@@ -279,6 +313,12 @@ def detect_match_boundaries(
             "Cannot determine video duration. Provide duration_hint via probe."
         )
 
+    # Stage 0 (#753 / B4): resolve a scorebar-band anchor before any scan.
+    # OBS (full-frame game) -> localize finds no inset band, consensus fails ->
+    # FULL_FRAME (detection stays bit-exact with the pre-region behavior).
+    # VTuber -> a scorebar-band ROI is resolved and threaded into Pass1/GPU/Pass2.
+    detect_region = _resolve_detect_region(video_path, duration_hint)
+
     # Pass 1: scan for blackout frames
     pass1_start = time.monotonic()
     resolved_mode = "CPU"
@@ -299,6 +339,7 @@ def detect_match_boundaries(
                 source_fps_num=source_fps_num,
                 source_fps_den=source_fps_den,
                 source_fps=source_fps,
+                region=detect_region,
             )
             resolved_mode = "GPU"
         except VideoProcessingError:
@@ -313,6 +354,7 @@ def detect_match_boundaries(
                 source_fps_num=source_fps_num,
                 source_fps_den=source_fps_den,
                 source_fps=source_fps,
+                region=detect_region,
             )
             resolved_mode = "CPU (GPU fallback)"
     else:
@@ -326,6 +368,7 @@ def detect_match_boundaries(
             source_fps_num=source_fps_num,
             source_fps_den=source_fps_den,
             source_fps=source_fps,
+            region=detect_region,
         )
     pass1_elapsed = time.monotonic() - pass1_start
 
@@ -385,6 +428,7 @@ def detect_match_boundaries(
         duration_hint,
         workers,
         progress_callback=refine_progress_callback,
+        region=detect_region,
     )
     pass2_elapsed = time.monotonic() - pass2_start
     if stats is not None:

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -451,6 +451,8 @@ def detect_match_boundaries(
             duration_hint,
             height,
             workers,
+            band_region=detect_region,
+            vtuber=vtuber,
             audio_hits=audio_hits,
             stats=stats,
             progress_callback=scorebar_progress_callback,
@@ -468,11 +470,12 @@ def detect_match_boundaries(
         classifications=region_classifications,
         stats=stats,
     )
-    # #797: drop a trailing post-match run (final match ended, recording
-    # continued into lobby/city) when its early candidate-match window shows
-    # no scorebar at any strided probe point (+ window-end probe). Only
-    # runs when scorebar classification is available (src_resolution set).
-    if src_resolution is not None:
+    # #797: drop a trailing post-match run when its early candidate-match window
+    # shows no scorebar at any strided probe point. Skipped for VTuber
+    # (vtuber=True): _drop_post_match_trailing probes v2 (absolute coords) which
+    # FNs on an inset scorebar and would silently drop a real VTuber final match
+    # (spec section 8.1 P2-d / Codex #1). VTuber trailing is handled in Phase 3.
+    if src_resolution is not None and not vtuber:
         segments = _drop_post_match_trailing(
             segments,
             video_path,

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -805,11 +805,20 @@ def _generate_timestamps(duration: float, interval: float) -> list[float]:
     return timestamps
 
 
-def _probe_single_frame(video_path: Path, timestamp: float) -> float:
+def _probe_single_frame(
+    video_path: Path,
+    timestamp: float,
+    region: CaptureRegion = FULL_FRAME,
+) -> float:
     """Probe a single frame's mean brightness using ffmpeg -ss seek.
 
     Uses input seeking (``-ss`` before ``-i``) for fast keyframe-based
     access, then decodes exactly one frame at 320x180 grayscale.
+
+    Brightness is computed via :func:`_frame_brightness`, so *region*
+    defaults to ``FULL_FRAME`` (the 1-D ``float(frame.mean())`` path is
+    byte-identical to the pre-region behavior; a band region reshapes the
+    raw buffer to ``(_SAMPLE_HEIGHT, _SAMPLE_WIDTH)`` and crops).
 
     Returns the mean brightness (0-255).  Returns 255.0 on probe failure
     (treated as non-blackout to avoid false positives).
@@ -848,7 +857,8 @@ def _probe_single_frame(video_path: Path, timestamp: float) -> float:
     if len(result.stdout) < _FRAME_SIZE:
         return 255.0  # incomplete frame, treat as non-blackout
 
-    return float(np.frombuffer(result.stdout[:_FRAME_SIZE], dtype=np.uint8).mean())
+    frame = np.frombuffer(result.stdout[:_FRAME_SIZE], dtype=np.uint8)
+    return _frame_brightness(frame, region)
 
 
 def _probe_frame_rgb(
@@ -1710,6 +1720,7 @@ def _refine_blackout_regions(
     total_duration: float,
     workers: int | None = None,
     progress_callback: Callable[[int, int], None] | None = None,
+    region: CaptureRegion = FULL_FRAME,
 ) -> list[tuple[float, float]]:
     """Re-probe blackout regions at fine interval for precise duration.
 
@@ -1721,6 +1732,10 @@ def _refine_blackout_regions(
     to publish the total, then once per completed probe with the running
     ``(completed, total)``.  This lets callers drive a progress bar during
     the long ThreadPoolExecutor wait (#366).
+
+    *region* is forwarded to :func:`_probe_single_frame` for per-frame
+    brightness.  It defaults to ``FULL_FRAME`` so the OBS Pass 2 path stays
+    bit-exact with the pre-region behavior (#753 / Task B2).
     """
     if not blackout_regions:
         return blackout_regions
@@ -1747,7 +1762,8 @@ def _refine_blackout_regions(
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         futures = {
-            pool.submit(_probe_single_frame, video_path, t): t for t in sorted_probes
+            pool.submit(_probe_single_frame, video_path, t, region): t
+            for t in sorted_probes
         }
         completed = 0
         for future in as_completed(futures):

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -245,7 +245,15 @@ def _resolve_detect_region(video_path: Path, duration_hint: float) -> CaptureReg
             "scorebar band anchor failed; degrading to FULL_FRAME", exc_info=True
         )
         return FULL_FRAME
-    logger.debug("band anchor resolved: %s", region)
+    if region.is_full_frame():
+        # consensus-miss (非例外縮退) も silent にしない (R5): --vtuber 明示 run
+        # が FULL_FRAME (汚染 path) で続行することを痕跡に残す。
+        logger.warning(
+            "band anchor found no scorebar-band consensus; "
+            "continuing with FULL_FRAME (--vtuber)"
+        )
+    else:
+        logger.debug("band anchor resolved: %s", region)
     return region
 
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -254,6 +254,7 @@ def detect_match_boundaries(
     min_match_duration: float = 300.0,
     min_blackout_duration: float = 3.0,
     use_gpu: bool = False,
+    vtuber: bool = False,
     workers: int | None = None,
     src_resolution: tuple[int, int] | None = None,
     codec: str | None = None,
@@ -313,11 +314,13 @@ def detect_match_boundaries(
             "Cannot determine video duration. Provide duration_hint via probe."
         )
 
-    # Stage 0 (#753 / B4): resolve a scorebar-band anchor before any scan.
-    # OBS (full-frame game) -> localize finds no inset band, consensus fails ->
-    # FULL_FRAME (detection stays bit-exact with the pre-region behavior).
-    # VTuber -> a scorebar-band ROI is resolved and threaded into Pass1/GPU/Pass2.
-    detect_region = _resolve_detect_region(video_path, duration_hint)
+    # Stage 0 (#753 / B4-rev): resolve a scorebar-band anchor before any scan.
+    # Stage 0 band anchor runs only when VTuber is explicit (spec section 3.6).
+    # OBS (vtuber=False) stays FULL_FRAME -> current bit-exact. localize also
+    # succeeds on OBS, so auto-detection is not possible -> the flag gates it.
+    detect_region = (
+        _resolve_detect_region(video_path, duration_hint) if vtuber else FULL_FRAME
+    )
 
     # Pass 1: scan for blackout frames
     pass1_start = time.monotonic()

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -231,7 +231,7 @@ def _resolve_detect_region(video_path: Path, duration_hint: float) -> CaptureReg
         )
 
     try:
-        return detect_scorebar_band_region(
+        region = detect_scorebar_band_region(
             duration=duration_hint,
             probe_w=_SCOREBAR_V2_PROBE_WIDTH,
             probe_h=_SCOREBAR_V2_PROBE_HEIGHT,
@@ -240,7 +240,13 @@ def _resolve_detect_region(video_path: Path, duration_hint: float) -> CaptureReg
     except Exception:
         # Anchor failure must never break detect: degrade to FULL_FRAME so the
         # OBS / error path stays bit-exact with the pre-region behavior.
+        # R4: 縮退自体は意図的設計だが、silent にせず痕跡を残す (診断性のみ)。
+        logger.warning(
+            "scorebar band anchor failed; degrading to FULL_FRAME", exc_info=True
+        )
         return FULL_FRAME
+    logger.debug("band anchor resolved: %s", region)
+    return region
 
 
 def detect_match_boundaries(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -220,17 +220,15 @@ def _resolve_detect_region(video_path: Path, duration_hint: float) -> CaptureReg
     """
     from allaganeye.video.capture_region import (
         detect_scorebar_band_region,
-        localize_scorebar,
+        localize_from_rgb_bytes,
     )
 
     def _localize_at(t: float):
-        raw = _probe_frame_rgb_hires(video_path, t)
-        if raw is None:
-            return None
-        frame = np.frombuffer(raw, dtype=np.uint8).reshape(
-            _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+        return localize_from_rgb_bytes(
+            _probe_frame_rgb_hires(video_path, t),
+            height=_SCOREBAR_V2_PROBE_HEIGHT,
+            width=_SCOREBAR_V2_PROBE_WIDTH,
         )
-        return localize_scorebar(frame)
 
     try:
         return detect_scorebar_band_region(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -17,6 +17,7 @@ import numpy as np
 from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
 from allaganeye.ffmpeg_path import find_ffmpeg
+from allaganeye.video.capture_region import CaptureRegion, FULL_FRAME, region_mean
 
 
 class MatchBoundary(TypedDict):
@@ -99,6 +100,19 @@ def _resolve_fps_rational(
     )
 
 
+def _frame_brightness(frame: np.ndarray, region: CaptureRegion = FULL_FRAME) -> float:
+    """CPU scan の 1-D grayscale buffer (320*180,) の平均輝度。
+
+    FULL_FRAME のときは 1-D のまま ``float(frame.mean())`` (現行と bit-exact、
+    reshape による丸め経路変化なし)。band region のときのみ
+    ``(_SAMPLE_HEIGHT, _SAMPLE_WIDTH)`` に reshape して ``region_mean`` で crop する。
+    """
+    if region.is_full_frame():
+        return float(frame.mean())
+    frame2d = frame.reshape(_SAMPLE_HEIGHT, _SAMPLE_WIDTH)
+    return region_mean(frame2d, region)
+
+
 def _sample_chunk_frames(
     stream: IO[bytes] | None,
     chunk_start: float,
@@ -107,6 +121,7 @@ def _sample_chunk_frames(
     fps_den: int,
     expected_frames: int,
     is_tail_chunk: bool,
+    region: CaptureRegion = FULL_FRAME,
 ) -> dict[float, float]:
     """Sample frames from a pre-filtered stream (#576 select-filter path).
 
@@ -161,7 +176,7 @@ def _sample_chunk_frames(
             break
         if emit_count < len(chunk_timestamps):
             frame = np.frombuffer(raw, dtype=np.uint8)
-            brightness = float(frame.mean())
+            brightness = _frame_brightness(frame, region)
             results[chunk_timestamps[emit_count]] = brightness
         emit_count += 1
 
@@ -432,6 +447,7 @@ def _decode_chunk_cpu(
     source_fps_den: int | None = None,
     source_fps: float | None = None,
     is_tail_chunk: bool = False,
+    region: CaptureRegion = FULL_FRAME,
 ) -> dict[float, float]:
     """Decode a chunk in CPU mode.
 
@@ -453,6 +469,7 @@ def _decode_chunk_cpu(
             chunk_start,
             chunk_end,
             sample_interval,
+            region,
         )
 
     fps_num, fps_den = _resolve_fps_rational(
@@ -469,6 +486,7 @@ def _decode_chunk_cpu(
         fps_num,
         fps_den,
         is_tail_chunk,
+        region,
     )
 
 
@@ -478,6 +496,7 @@ def _decode_chunk_cpu_legacy(
     chunk_start: float,
     chunk_end: float,
     sample_interval: float,
+    region: CaptureRegion = FULL_FRAME,
 ) -> dict[float, float]:
     """Legacy fps-filter chunk decode (pre-#576). Kept for env var rollback.
 
@@ -536,7 +555,7 @@ def _decode_chunk_cpu_legacy(
 
     while offset + _FRAME_SIZE <= len(data) and frame_idx < len(chunk_timestamps):
         frame = np.frombuffer(data[offset : offset + _FRAME_SIZE], dtype=np.uint8)
-        results[chunk_timestamps[frame_idx]] = float(frame.mean())
+        results[chunk_timestamps[frame_idx]] = _frame_brightness(frame, region)
         offset += _FRAME_SIZE
         frame_idx += 1
 
@@ -557,6 +576,7 @@ def _decode_chunk_cpu_v2(
     fps_num: int,
     fps_den: int,
     is_tail_chunk: bool,
+    region: CaptureRegion = FULL_FRAME,
 ) -> dict[float, float]:
     """New path: dual seek + select filter + -fps_mode passthrough (#576 Option 1).
 
@@ -649,6 +669,7 @@ def _decode_chunk_cpu_v2(
                     fps_den=fps_den,
                     expected_frames=expected_frames,
                     is_tail_chunk=is_tail_chunk,
+                    region=region,
                 )
                 proc.wait(timeout=max(300, int(chunk_duration * 2)))
                 # Read stderr from temp file (no pipe backpressure issue)
@@ -701,6 +722,7 @@ def _scan_cpu(
     source_fps_num: int | None = None,
     source_fps_den: int | None = None,
     source_fps: float | None = None,
+    region: CaptureRegion = FULL_FRAME,
 ) -> dict[float, float]:
     """CPU mode: chunked decode (output seek + Python N-th sampling, #576).
 
@@ -746,6 +768,7 @@ def _scan_cpu(
                 source_fps_den=source_fps_den,
                 source_fps=source_fps,
                 is_tail_chunk=is_tail,
+                region=region,
             ): (c_start, c_ts)
             for c_start, c_end, c_ts, is_tail in chunks
         }

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -14,11 +14,13 @@ import numpy as np
 
 from allaganeye.exceptions import STDERR_TAIL_BYTES, VideoProcessingError
 from allaganeye.ffmpeg_path import find_ffmpeg
+from allaganeye.video.capture_region import FULL_FRAME, CaptureRegion
 from allaganeye.video.detector import (
     SEEK_LEAD_SECONDS,
     _FRAME_SIZE,
     _SAMPLE_HEIGHT,
     _SAMPLE_WIDTH,
+    _frame_brightness,
     _generate_timestamps,
     _resolve_fps_rational,
     _sample_chunk_frames,
@@ -172,6 +174,7 @@ def scan_gpu(
     source_fps_num: int | None = None,
     source_fps_den: int | None = None,
     source_fps: float | None = None,
+    region: CaptureRegion = FULL_FRAME,
 ) -> dict[float, float]:
     """GPU mode: chunked parallel decode (#576: new path or legacy via env var).
 
@@ -281,6 +284,7 @@ def scan_gpu(
                 source_fps_den=source_fps_den,
                 source_fps=source_fps,
                 is_tail_chunk=is_tail,
+                region=region,
             ): (chunk_start, chunk_end)
             for chunk_start, chunk_end, chunk_timestamps, is_tail in chunks
         }
@@ -371,11 +375,16 @@ def _decode_chunk(
     source_fps_den: int | None = None,
     source_fps: float | None = None,
     is_tail_chunk: bool = False,
+    region: CaptureRegion = FULL_FRAME,
 ) -> tuple[dict[float, float], str]:
     """GPU chunk decode dispatcher (#576).
 
     Falls back to legacy fps-filter path when env var
     ``ALLAGANEYE_DETECT_FPS_FILTER=1`` or no rational fps supplied.
+
+    *region* (default ``FULL_FRAME``) selects the brightness sub-rectangle and
+    is threaded to the brightness site so GPU stays bit-exact with the CPU
+    ``_frame_brightness`` path (Phase 1 B3, Codex #8).
     """
     use_legacy = _use_legacy_fps_filter() or (
         source_fps_num is None and source_fps_den is None and source_fps is None
@@ -389,6 +398,7 @@ def _decode_chunk(
             codec=codec,
             chunk_timestamps=chunk_timestamps,
             vendor=vendor,
+            region=region,
         )
 
     fps_num, fps_den = _resolve_fps_rational(
@@ -407,6 +417,7 @@ def _decode_chunk(
         fps_num,
         fps_den,
         is_tail_chunk,
+        region=region,
     )
 
 
@@ -418,6 +429,7 @@ def _decode_chunk_legacy(
     codec: str | None = None,
     chunk_timestamps: list[float] | None = None,
     vendor: str | None = None,
+    region: CaptureRegion = FULL_FRAME,
 ) -> tuple[dict[float, float], str]:
     """Legacy fps-filter chunk decode (pre-#576). Kept for env var rollback.
 
@@ -538,7 +550,7 @@ def _decode_chunk_legacy(
         # (can happen with keyframe-aligned -ss seeks near chunk_end).
         while offset + _FRAME_SIZE <= len(data) and frame_idx < len(chunk_timestamps):
             frame = np.frombuffer(data[offset : offset + _FRAME_SIZE], dtype=np.uint8)
-            results[chunk_timestamps[frame_idx]] = float(frame.mean())
+            results[chunk_timestamps[frame_idx]] = _frame_brightness(frame, region)
             offset += _FRAME_SIZE
             frame_idx += 1
     else:
@@ -548,7 +560,7 @@ def _decode_chunk_legacy(
         # pass chunk_timestamps from scan_gpu.
         while offset + _FRAME_SIZE <= len(data):
             frame = np.frombuffer(data[offset : offset + _FRAME_SIZE], dtype=np.uint8)
-            brightness = float(frame.mean())
+            brightness = _frame_brightness(frame, region)
             timestamp = round(chunk_start + frame_idx * sample_interval, 4)
             if timestamp < chunk_end:
                 results[timestamp] = brightness
@@ -569,6 +581,7 @@ def _decode_chunk_v2(
     fps_num: int,
     fps_den: int,
     is_tail_chunk: bool,
+    region: CaptureRegion = FULL_FRAME,
 ) -> tuple[dict[float, float], str]:
     """New GPU chunk decode: dual seek + select filter (#576 Option 1).
 
@@ -672,6 +685,7 @@ def _decode_chunk_v2(
                     fps_den=fps_den,
                     expected_frames=expected_frames,
                     is_tail_chunk=is_tail_chunk,
+                    region=region,
                 )
                 proc.wait(timeout=max(300, int(chunk_duration * 2)))
                 # Read stderr from temp file (no pipe backpressure issue)

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -10,7 +10,7 @@ the Phase 3 cutover.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 
@@ -81,3 +81,28 @@ def segment_presence(
         for r in merged
         if r[1] - r[0] >= t_min_match
     ]
+
+
+def refine_boundary(
+    t_true: float,
+    t_false: float,
+    present_at: Callable[[float], bool],
+    *,
+    tol: float,
+) -> float:
+    """Binary-search the present<->absent transition between two times.
+
+    Precondition: ``present_at(t_true)`` is True and ``present_at(t_false)``
+    is False.  ``t_true`` and ``t_false`` may be in either order (forward =
+    match end, backward = match start).  Returns the midpoint of the final
+    bracket, accurate to within ``tol`` seconds.
+    """
+    lo_true = t_true
+    hi_false = t_false
+    while abs(lo_true - hi_false) > tol:
+        mid = (lo_true + hi_false) / 2.0
+        if present_at(mid):
+            lo_true = mid
+        else:
+            hi_false = mid
+    return (lo_true + hi_false) / 2.0

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -11,6 +11,7 @@ the Phase 3 cutover.
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -135,3 +136,44 @@ def localize_present_at(video_path: Path, timestamp: float) -> PresenceSample:
     if loc is None:
         return PresenceSample(time=timestamp, present=False, confidence=0.0)
     return PresenceSample(time=timestamp, present=True, confidence=loc.confidence)
+
+
+def _grid_timestamps(duration: float, stride: float) -> list[float]:
+    """Inclusive 0..duration grid at ``stride`` spacing (duration endpoint kept)."""
+    if stride <= 0:
+        raise ValueError("stride must be > 0")
+    n = int(duration // stride)
+    times = [round(i * stride, 6) for i in range(n + 1)]
+    if not times or times[-1] < duration:
+        times.append(round(duration, 6))
+    return times
+
+
+def scan_presence(
+    video_path: Path,
+    duration: float,
+    *,
+    stride: float,
+    workers: int,
+    sample_fn: Callable[[float], PresenceSample] | None = None,
+) -> list[PresenceSample]:
+    """Sample scorebar presence across the whole video on a uniform grid.
+
+    ``sample_fn`` maps a timestamp to a :class:`PresenceSample`; it defaults
+    to :func:`localize_present_at` bound to ``video_path`` (the production
+    path).  Tests inject a synthetic ``sample_fn`` to stay fast.  Results are
+    returned sorted by time ascending.
+    """
+
+    def _default(t: float) -> PresenceSample:
+        return localize_present_at(video_path, t)
+
+    fn = sample_fn if sample_fn is not None else _default
+
+    times = _grid_timestamps(duration, stride)
+    results: dict[float, PresenceSample] = {}
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(fn, t): t for t in times}
+        for fut in futures:
+            results[futures[fut]] = fut.result()
+    return [results[t] for t in times]

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -12,6 +12,16 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from allaganeye.video.capture_region import localize_scorebar
+from allaganeye.video.detector import (
+    _SCOREBAR_V2_PROBE_HEIGHT,
+    _SCOREBAR_V2_PROBE_WIDTH,
+    _probe_frame_rgb_hires,
+)
 
 
 @dataclass(frozen=True)
@@ -106,3 +116,22 @@ def refine_boundary(
         else:
             hi_false = mid
     return (lo_true + hi_false) / 2.0
+
+
+def localize_present_at(video_path: Path, timestamp: float) -> PresenceSample:
+    """Probe one hi-res frame and report scorebar presence at ``timestamp``.
+
+    Bridges the production frame source (``_probe_frame_rgb_hires``, 1920x1080
+    RGB24) and the P1 localizer (``localize_scorebar``).  Probe failure or
+    a None localization both yield ``present=False`` (safe absent).
+    """
+    raw = _probe_frame_rgb_hires(video_path, timestamp)
+    if raw is None:
+        return PresenceSample(time=timestamp, present=False, confidence=0.0)
+    frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+        _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+    )
+    loc = localize_scorebar(frame)
+    if loc is None:
+        return PresenceSample(time=timestamp, present=False, confidence=0.0)
+    return PresenceSample(time=timestamp, present=True, confidence=loc.confidence)

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -1,0 +1,30 @@
+"""Presence-based match detection (scorebar present/absent as the signal).
+
+Phase 1 of the presence-detection engine (spec
+docs/superpowers/specs/2026-05-29-presence-based-detection-engine-design.md).
+This module is ADDITIVE and NOT wired into the production detection path;
+it exists for the offline validation harness only.  The brightness-based
+``detector.detect_match_boundaries`` remains the production detector until
+the Phase 3 cutover.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PresenceSample:
+    """One time-grid sample: whether the scorebar is present at ``time``."""
+
+    time: float
+    present: bool
+    confidence: float
+
+
+@dataclass(frozen=True)
+class PresenceMatch:
+    """A detected FL match segment in seconds (presence-based)."""
+
+    start: float
+    end: float

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -10,6 +10,7 @@ the Phase 3 cutover.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 
@@ -28,3 +29,55 @@ class PresenceMatch:
 
     start: float
     end: float
+
+
+def segment_presence(
+    samples: Sequence[PresenceSample],
+    *,
+    t_gap: float,
+    t_min_match: float,
+) -> list[PresenceMatch]:
+    """Collapse present/absent samples into match segments.
+
+    Two-directional debounce:
+    - absent gaps shorter than ``t_gap`` between two present runs are
+      absorbed (treated as in-match: covers mid-match scorebar loss such
+      as death blackout / full-screen UI).
+    - present runs shorter than ``t_min_match`` are discarded (transient
+      false positives).
+
+    ``samples`` must be sorted by ``time`` ascending.  Returns matches with
+    start/end at the first/last present sample time of each surviving run
+    (boundary refinement to sub-stride precision happens separately in
+    :func:`detect_matches_by_presence`).
+    """
+    # 1. Build present runs as mutable [start, end] pairs.
+    present_runs: list[list[float]] = []
+    current: list[float] | None = None
+    for s in samples:
+        if s.present:
+            if current is None:
+                current = [s.time, s.time]
+            else:
+                current[1] = s.time
+        else:
+            if current is not None:
+                present_runs.append(current)
+                current = None
+    if current is not None:
+        present_runs.append(current)
+
+    # 2. Merge runs whose inter-run gap is shorter than t_gap.
+    merged: list[list[float]] = []
+    for run in present_runs:
+        if merged and run[0] - merged[-1][1] < t_gap:
+            merged[-1][1] = run[1]
+        else:
+            merged.append(list(run))
+
+    # 3. Drop runs shorter than t_min_match; emit matches.
+    return [
+        PresenceMatch(start=r[0], end=r[1])
+        for r in merged
+        if r[1] - r[0] >= t_min_match
+    ]

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -118,14 +118,25 @@ def refine_boundary(
     return (lo_true + hi_false) / 2.0
 
 
-def localize_present_at(video_path: Path, timestamp: float) -> PresenceSample:
+def localize_present_at(
+    video_path: Path, timestamp: float, *, raise_on_probe_failure: bool = False
+) -> PresenceSample:
     """Probe one hi-res frame and report scorebar presence at ``timestamp``.
 
     Bridges the production frame source (``_probe_frame_rgb_hires``, 1920x1080
     RGB24) and the P1 localizer (``localize_scorebar``).  Probe failure or
     a None localization both yield ``present=False`` (safe absent).
+
+    ``raise_on_probe_failure=True`` は probe 失敗 (raw None) を
+    ``VideoProcessingError`` として raise する。``scan_presence`` がこの seam で
+    decode 系統故障 (全 probe None) を per-probe 隔離 + 全滅 fail-loud 判定に
+    乗せる (R4: raw None を absent 変換だけにすると系統故障が silent 化する)。
     """
     raw = _probe_frame_rgb_hires(video_path, timestamp)
+    if raw is None and raise_on_probe_failure:
+        raise VideoProcessingError(
+            f"hi-res probe returned no frame at t={timestamp:.3f}s"
+        )
     loc = localize_from_rgb_bytes(
         raw, height=_SCOREBAR_V2_PROBE_HEIGHT, width=_SCOREBAR_V2_PROBE_WIDTH
     )
@@ -162,7 +173,8 @@ def scan_presence(
     """
 
     def _default(t: float) -> PresenceSample:
-        return localize_present_at(video_path, t)
+        # raw None (decode 失敗) も probe 失敗として隔離・全滅判定に乗せる (R4)。
+        return localize_present_at(video_path, t, raise_on_probe_failure=True)
 
     fn = sample_fn if sample_fn is not None else _default
 

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -15,9 +15,8 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
-import numpy as np
-
-from allaganeye.video.capture_region import localize_scorebar
+from allaganeye.exceptions import VideoProcessingError
+from allaganeye.video.capture_region import localize_from_rgb_bytes
 from allaganeye.video.detector import (
     _SCOREBAR_V2_PROBE_HEIGHT,
     _SCOREBAR_V2_PROBE_WIDTH,
@@ -127,12 +126,9 @@ def localize_present_at(video_path: Path, timestamp: float) -> PresenceSample:
     a None localization both yield ``present=False`` (safe absent).
     """
     raw = _probe_frame_rgb_hires(video_path, timestamp)
-    if raw is None:
-        return PresenceSample(time=timestamp, present=False, confidence=0.0)
-    frame = np.frombuffer(raw, dtype=np.uint8).reshape(
-        _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+    loc = localize_from_rgb_bytes(
+        raw, height=_SCOREBAR_V2_PROBE_HEIGHT, width=_SCOREBAR_V2_PROBE_WIDTH
     )
-    loc = localize_scorebar(frame)
     if loc is None:
         return PresenceSample(time=timestamp, present=False, confidence=0.0)
     return PresenceSample(time=timestamp, present=True, confidence=loc.confidence)
@@ -172,10 +168,23 @@ def scan_presence(
 
     times = _grid_timestamps(duration, stride)
     results: dict[float, PresenceSample] = {}
+    failures: list[VideoProcessingError] = []
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {pool.submit(fn, t): t for t in times}
         for fut in futures:
-            results[futures[fut]] = fut.result()
+            t = futures[fut]
+            try:
+                results[t] = fut.result()
+            except VideoProcessingError as e:
+                # per-probe 縮退 (PR #823 R3): 同型 pool (_probe_scorebar_context /
+                # _refine_blackout_regions) と同じく 1 probe の失敗で全 scan を
+                # 落とさず safe absent にする。
+                results[t] = PresenceSample(time=t, present=False, confidence=0.0)
+                failures.append(e)
+    if failures and len(failures) == len(times):
+        # 全 probe 失敗は系統故障 (ffmpeg 不在等)。silent な全 absent にせず
+        # fail-loud で上流に伝える。
+        raise failures[0]
     return [results[t] for t in times]
 
 

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -177,3 +177,42 @@ def scan_presence(
         for fut in futures:
             results[futures[fut]] = fut.result()
     return [results[t] for t in times]
+
+
+def detect_matches_by_presence(
+    video_path: Path,
+    duration: float,
+    *,
+    stride: float,
+    t_gap: float,
+    t_min_match: float,
+    tol: float,
+    workers: int,
+) -> list[PresenceMatch]:
+    """Top-level presence detector: scan -> segment -> refine boundaries.
+
+    1. ``scan_presence`` samples the whole video on a ``stride`` grid.
+    2. ``segment_presence`` debounces and yields coarse matches (boundaries
+       at sample times).
+    3. each coarse boundary is refined within a one-stride bracket using
+       ``refine_boundary``.  Matches touching the video edges (t<=0 or
+       t>=duration within one stride) keep the edge unrefined.
+    """
+    samples = scan_presence(video_path, duration, stride=stride, workers=workers)
+    coarse = segment_presence(samples, t_gap=t_gap, t_min_match=t_min_match)
+
+    def present_at(t: float) -> bool:
+        return localize_present_at(video_path, t).present
+
+    refined: list[PresenceMatch] = []
+    for m in coarse:
+        if m.start - stride < 0.0:
+            start = 0.0
+        else:
+            start = refine_boundary(m.start, m.start - stride, present_at, tol=tol)
+        if m.end + stride > duration:
+            end = duration
+        else:
+            end = refine_boundary(m.end, m.end + stride, present_at, tol=tol)
+        refined.append(PresenceMatch(start=start, end=end))
+    return refined

--- a/allaganeye/video/presence.py
+++ b/allaganeye/video/presence.py
@@ -10,6 +10,7 @@ the Phase 3 cutover.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -22,6 +23,8 @@ from allaganeye.video.detector import (
     _SCOREBAR_V2_PROBE_WIDTH,
     _probe_frame_rgb_hires,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -193,10 +196,17 @@ def scan_presence(
                 # 落とさず safe absent にする。
                 results[t] = PresenceSample(time=t, present=False, confidence=0.0)
                 failures.append(e)
-    if failures and len(failures) == len(times):
-        # 全 probe 失敗は系統故障 (ffmpeg 不在等)。silent な全 absent にせず
-        # fail-loud で上流に伝える。
-        raise failures[0]
+    if failures:
+        if len(failures) == len(times):
+            # 全 probe 失敗は系統故障 (ffmpeg 不在等)。silent な全 absent にせず
+            # fail-loud で上流に伝える。
+            raise failures[0]
+        # 部分故障も痕跡を残す (R5 可視化): absent 化した probe 数を warning。
+        logger.warning(
+            "%d/%d presence probes failed; treated as absent",
+            len(failures),
+            len(times),
+        )
     return [results[t] for t in times]
 
 
@@ -223,7 +233,20 @@ def detect_matches_by_presence(
     coarse = segment_presence(samples, t_gap=t_gap, t_min_match=t_min_match)
 
     def present_at(t: float) -> bool:
-        return localize_present_at(video_path, t).present
+        try:
+            return localize_present_at(
+                video_path, t, raise_on_probe_failure=True
+            ).present
+        except VideoProcessingError:
+            # refine 中の probe 失敗は absent 扱いで続行するが、境界が最大
+            # 1 stride ずれうるため silent にしない (R5 可視化。probe-failure
+            # semantics の統一は設計 issue で後続)。
+            logger.warning(
+                "presence probe failed during boundary refine at t=%.3fs; "
+                "treating as absent",
+                t,
+            )
+            return False
 
     refined: list[PresenceMatch] = []
     for m in coarse:

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -382,6 +382,9 @@ def classify_blackout(
     duration: float,
     height: int,
     workers: int | None = None,
+    *,
+    band_region: CaptureRegion = FULL_FRAME,
+    vtuber: bool = False,
 ) -> str:
     """Classify a blackout region by scorebar context.
 
@@ -411,6 +414,18 @@ def classify_blackout(
     - ``"non_fl"``: neither side has scorebar -> non-FL blackout (#109)
     - ``"unknown"``: all probes failed on either side -> keep boundary (safe)
     """
+    if vtuber:
+        # VTuber path: position-independent localize as the sole signal
+        # (spec section 8.1 P2-a). The OBS v2 body below is left untouched.
+        return _classify_blackout_localize(
+            video_path,
+            region,
+            duration,
+            height,
+            workers,
+            band_region=band_region,
+        )
+
     pre_timestamps = sorted(set(max(0.0, region[0] - d) for d in (3.0, 2.0, 1.0)))
     post_timestamps = sorted(set(min(duration, region[1] + d) for d in (1.0, 2.0, 3.0)))
 

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -26,7 +26,11 @@ from allaganeye.video.detector import (
     _probe_frame_rgb_hires,
     _resolve_workers,
 )
-from allaganeye.video.capture_region import CaptureRegion, localize_scorebar
+from allaganeye.video.capture_region import (
+    CaptureRegion,
+    FULL_FRAME,  # noqa: F401  # used as default by B2/B3 in this Phase 2 group
+    localize_scorebar,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +62,11 @@ def _probe_scorebar_context(
 ) -> tuple[list[bool | None], list[bytes | None], list[bool | None]]:
     """Probe multiple timestamps and return has_scorebar + raw frames.
 
-    Returns a tuple of two lists aligned with *timestamps*:
+    Returns a tuple of three lists aligned with *timestamps*:
     - scorebar results: True/False/None per frame
     - raw RGB frame bytes: bytes/None per frame (low-res for static detection)
+    - localize-present results: True/False/None per frame (populated only when
+      with_localize=True and method is v2; otherwise all None)
 
     When ``_SCOREBAR_METHOD == "v2"``, probes at 1920x1080 for GC-emblem
     3-point AND detection.  V2 False is used as-is (no V1 fallback) to

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -696,6 +696,9 @@ def _merge_boundary_pairs(
     duration: float,
     height: int,
     workers: int | None,
+    *,
+    band_region: CaptureRegion = FULL_FRAME,
+    vtuber: bool = False,
 ) -> tuple[list[tuple[float, float]], list[str]]:
     """Merge consecutive match_boundary pairs separated by non-FL content.
 
@@ -730,14 +733,23 @@ def _merge_boundary_pairs(
                 probe_points = [
                     gap_start + (gap_end - gap_start) * k / 10 for k in range(1, 10)
                 ]
-                probe_results, _, _ = _probe_scorebar_context(
-                    video_path,
-                    probe_points,
-                    height,
-                    workers,
-                )
-                all_valid = all(r is not None for r in probe_results)
-                any_scorebar = any(r is True for r in probe_results)
+                if vtuber:
+                    _, _, probe_signal = _probe_scorebar_context(
+                        video_path,
+                        probe_points,
+                        height,
+                        workers,
+                        with_localize=True,
+                    )
+                else:
+                    probe_signal, _, _ = _probe_scorebar_context(
+                        video_path,
+                        probe_points,
+                        height,
+                        workers,
+                    )
+                all_valid = all(r is not None for r in probe_signal)
+                any_scorebar = any(r is True for r in probe_signal)
                 if all_valid and not any_scorebar:
                     merged_region = (regions[i][0], regions[i + 1][1])
                     logger.info(
@@ -750,7 +762,7 @@ def _merge_boundary_pairs(
                         merged_region[0],
                         merged_region[1],
                         gap,
-                        probe_results,
+                        probe_signal,
                     )
                     merged.append(merged_region)
                     merged_cls.append("match_boundary")
@@ -763,7 +775,7 @@ def _merge_boundary_pairs(
                     regions[i + 1][0],
                     regions[i + 1][1],
                     gap,
-                    probe_results,
+                    probe_signal,
                 )
         merged.append(regions[i])
         merged_cls.append(classifications[i])

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
-from allaganeye.video.capture_region import CaptureRegion
 from allaganeye.video.detector import (
     DetectionStats,
     _SAMPLE_WIDTH,
@@ -19,14 +18,34 @@ from allaganeye.video.detector import (
     _SCOREBAR_ROI_X_START,
     _SCOREBAR_ROI_Y_END,
     _SCOREBAR_ROI_Y_START,
+    _SCOREBAR_V2_PROBE_HEIGHT,
+    _SCOREBAR_V2_PROBE_WIDTH,
     _has_scorebar,
     _has_scorebar_v2,
     _probe_frame_rgb,
     _probe_frame_rgb_hires,
     _resolve_workers,
 )
+from allaganeye.video.capture_region import CaptureRegion, localize_scorebar
 
 logger = logging.getLogger(__name__)
+
+
+def _localize_present_from_raw(raw: bytes | None) -> bool | None:
+    """hi-res RGB probe bytes -> localize-present (True/False). None on probe failure.
+
+    Reshapes the 1920x1080 RGB probe buffer and runs the position-independent
+    localizer (``localize_scorebar``).  A successfully decoded frame yields
+    True/False (a clean localizer miss is treated as absent, not unknown, so
+    majority vote behaves like the v2 path).  Only a missing frame (raw None)
+    yields None.  Used by the VTuber classification path; OBS never calls it.
+    """
+    if raw is None:
+        return None
+    frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+        _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+    )
+    return localize_scorebar(frame) is not None
 
 
 def _probe_scorebar_context(
@@ -34,7 +53,9 @@ def _probe_scorebar_context(
     timestamps: list[float],
     height: int,
     workers: int | None,
-) -> tuple[list[bool | None], list[bytes | None]]:
+    *,
+    with_localize: bool = False,
+) -> tuple[list[bool | None], list[bytes | None], list[bool | None]]:
     """Probe multiple timestamps and return has_scorebar + raw frames.
 
     Returns a tuple of two lists aligned with *timestamps*:
@@ -107,9 +128,21 @@ def _probe_scorebar_context(
             else:
                 scorebar_results[t] = _has_scorebar(raw_frames[t], height)
 
+        # localize-present from the hi-res frames already decoded for v2
+        # (additive; OBS production passes with_localize=False -> all None,
+        # so existing callers stay bit-exact).
+        localize_results: dict[float, bool | None] = {}
+        if with_localize and use_v2:
+            for t in unique_ts:
+                localize_results[t] = _localize_present_from_raw(hi_raws.get(t))
+        else:
+            for t in unique_ts:
+                localize_results[t] = None
+
     return (
         [scorebar_results[t] for t in timestamps],
         [raw_frames[t] for t in timestamps],
+        [localize_results[t] for t in timestamps],
     )
 
 
@@ -274,10 +307,10 @@ def classify_blackout(
     pre_timestamps = sorted(set(max(0.0, region[0] - d) for d in (3.0, 2.0, 1.0)))
     post_timestamps = sorted(set(min(duration, region[1] + d) for d in (1.0, 2.0, 3.0)))
 
-    pre_results, pre_frames = _probe_scorebar_context(
+    pre_results, pre_frames, _pre_loc = _probe_scorebar_context(
         video_path, pre_timestamps, height, workers
     )
-    post_results, post_frames = _probe_scorebar_context(
+    post_results, post_frames, _post_loc = _probe_scorebar_context(
         video_path, post_timestamps, height, workers
     )
 
@@ -312,11 +345,11 @@ def classify_blackout(
         pre_re_results: list[bool | None] = []
         post_re_results: list[bool | None] = []
         if pre_re_timestamps:
-            pre_re_results, _ = _probe_scorebar_context(
+            pre_re_results, _, _ = _probe_scorebar_context(
                 video_path, pre_re_timestamps, height, workers
             )
         if post_re_timestamps:
-            post_re_results, _ = _probe_scorebar_context(
+            post_re_results, _, _ = _probe_scorebar_context(
                 video_path, post_re_timestamps, height, workers
             )
         pre_has_re = _majority_scorebar(pre_re_results)
@@ -559,7 +592,7 @@ def _merge_boundary_pairs(
                 probe_points = [
                     gap_start + (gap_end - gap_start) * k / 10 for k in range(1, 10)
                 ]
-                probe_results, _ = _probe_scorebar_context(
+                probe_results, _, _ = _probe_scorebar_context(
                     video_path,
                     probe_points,
                     height,

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -304,9 +304,9 @@ def _classify_blackout_localize(
     pre_has = _majority_scorebar(pre_loc)
     post_has = _majority_scorebar(post_loc)
 
-    # Re-probe further out when neither side localized a scorebar (#524 mirror):
-    # a true boundary whose flanks both land in a fade/loading would otherwise
-    # classify as non_fl and be dropped.
+    # Re-probe further out when neither side localized (see classify_blackout's
+    # #524 rationale): a true boundary whose flanks both land in a fade/loading
+    # would otherwise classify as non_fl.
     if pre_has is not True and post_has is not True:
         region_width = region[1] - region[0]
         existing_pre = set(pre_timestamps)
@@ -348,9 +348,10 @@ def _classify_blackout_localize(
     pre_mad = _band_mad_min(pre_frames, height, band_region)
     post_mad = _band_mad_min(post_frames, height, band_region)
     logger.info(
-        "VTUBER_MAD region=[%.1f-%.1f] pre_mad=%s post_mad=%s",
+        "VTUBER_MAD region=[%.1fs-%.1fs] band=%s pre_mad=%s post_mad=%s",
         region[0],
         region[1],
+        band_region.source,
         f"{pre_mad:.3f}" if pre_mad is not None else "na",
         f"{post_mad:.3f}" if post_mad is not None else "na",
     )

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -570,6 +570,8 @@ def filter_blackouts_with_scorebar(
     height: int,
     workers: int | None = None,
     *,
+    band_region: CaptureRegion = FULL_FRAME,
+    vtuber: bool = False,
     audio_hits: Sequence[BgmHit] | None = None,
     stats: DetectionStats | None = None,
     progress_callback: Callable[[int, int], None] | None = None,
@@ -611,7 +613,13 @@ def filter_blackouts_with_scorebar(
     total_regions = len(blackout_regions)
     for idx, region in enumerate(blackout_regions):
         classification = classify_blackout(
-            video_path, region, duration, height, workers
+            video_path,
+            region,
+            duration,
+            height,
+            workers,
+            band_region=band_region,
+            vtuber=vtuber,
         )
         if progress_callback is not None:
             progress_callback(idx + 1, total_regions)
@@ -670,7 +678,14 @@ def filter_blackouts_with_scorebar(
         stats["audio_promotions"] = audio_promotions
 
     return _merge_boundary_pairs(
-        video_path, kept, classifications, duration, height, workers
+        video_path,
+        kept,
+        classifications,
+        duration,
+        height,
+        workers,
+        band_region=band_region,
+        vtuber=vtuber,
     )
 
 

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
+from allaganeye.video.capture_region import CaptureRegion
 from allaganeye.video.detector import (
     DetectionStats,
     _SAMPLE_WIDTH,
@@ -135,6 +136,7 @@ Threshold 0.5 sits well inside the gap.
 def _is_static_from_frames(
     raw_frames: Sequence[bytes | None],
     height: int,
+    region: CaptureRegion | None = None,
 ) -> bool:
     """Detect static screens (loading/result) via scorebar ROI frame diff.
 
@@ -155,10 +157,16 @@ def _is_static_from_frames(
     if len(valid) < 2:
         return False
 
-    x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
-    x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
-    y1 = int(height * _SCOREBAR_ROI_Y_START)
-    y2 = int(height * _SCOREBAR_ROI_Y_END)
+    if region is None:
+        x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
+        x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
+        y1 = int(height * _SCOREBAR_ROI_Y_START)
+        y2 = int(height * _SCOREBAR_ROI_Y_END)
+    else:
+        x1 = max(0, int(region.x * _SAMPLE_WIDTH))
+        x2 = min(_SAMPLE_WIDTH, int((region.x + region.w) * _SAMPLE_WIDTH))
+        y1 = max(0, int(region.y * height))
+        y2 = min(height, int((region.y + region.h) * height))
 
     rois = []
     for raw in valid:

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -26,11 +26,7 @@ from allaganeye.video.detector import (
     _probe_frame_rgb_hires,
     _resolve_workers,
 )
-from allaganeye.video.capture_region import (
-    CaptureRegion,
-    FULL_FRAME,  # noqa: F401  # used as default by B2/B3 in this Phase 2 group
-    localize_scorebar,
-)
+from allaganeye.video.capture_region import CaptureRegion, FULL_FRAME, localize_scorebar
 
 logger = logging.getLogger(__name__)
 
@@ -276,6 +272,108 @@ def _has_nearby_fanfare_hit(
         if lo <= hit["timestamp"] <= hi:
             return hit
     return None
+
+
+def _classify_blackout_localize(
+    video_path: Path,
+    region: tuple[float, float],
+    duration: float,
+    height: int,
+    workers: int | None = None,
+    *,
+    band_region: CaptureRegion = FULL_FRAME,
+) -> str:
+    """Classify a blackout by position-independent scorebar presence (VTuber).
+
+    Uses ``localize_scorebar`` majority on 3 pre + 3 post frames as the sole
+    signal (motion is NOT ANDed in Phase 2 -- P2-a / spec section 8.1).  Mirrors
+    the v2 re-probe fallback (#524) for the both-absent case.  Band-MAD is
+    emitted to the log for Phase 3 calibration but does not affect the label.
+
+    Returns ``"in_match"`` / ``"match_boundary"`` / ``"non_fl"`` / ``"unknown"``.
+    """
+    pre_timestamps = sorted(set(max(0.0, region[0] - d) for d in (3.0, 2.0, 1.0)))
+    post_timestamps = sorted(set(min(duration, region[1] + d) for d in (1.0, 2.0, 3.0)))
+
+    _, pre_frames, pre_loc = _probe_scorebar_context(
+        video_path, pre_timestamps, height, workers, with_localize=True
+    )
+    _, post_frames, post_loc = _probe_scorebar_context(
+        video_path, post_timestamps, height, workers, with_localize=True
+    )
+    pre_has = _majority_scorebar(pre_loc)
+    post_has = _majority_scorebar(post_loc)
+
+    # Re-probe further out when neither side localized a scorebar (#524 mirror):
+    # a true boundary whose flanks both land in a fade/loading would otherwise
+    # classify as non_fl and be dropped.
+    if pre_has is not True and post_has is not True:
+        region_width = region[1] - region[0]
+        existing_pre = set(pre_timestamps)
+        existing_post = set(post_timestamps)
+        pre_re_ts = [
+            t
+            for t in sorted(
+                set(max(0.0, region[0] - (region_width + d)) for d in (3.0, 2.0, 1.0))
+            )
+            if t not in existing_pre
+        ]
+        post_re_ts = [
+            t
+            for t in sorted(
+                set(
+                    min(duration, region[1] + (region_width + d))
+                    for d in (1.0, 2.0, 3.0)
+                )
+            )
+            if t not in existing_post
+        ]
+        if pre_re_ts:
+            _, _, pre_re_loc = _probe_scorebar_context(
+                video_path, pre_re_ts, height, workers, with_localize=True
+            )
+            pre_re = _majority_scorebar(pre_re_loc)
+            if pre_re is not None:
+                pre_has = pre_re
+        if post_re_ts:
+            _, _, post_re_loc = _probe_scorebar_context(
+                video_path, post_re_ts, height, workers, with_localize=True
+            )
+            post_re = _majority_scorebar(post_re_loc)
+            if post_re is not None:
+                post_has = post_re
+
+    # Band-MAD telemetry for Phase 3 calibration -- emitted only, NOT used in
+    # classification (P2-a). Grep "VTUBER_MAD" in logs to collect distributions.
+    pre_mad = _band_mad_min(pre_frames, height, band_region)
+    post_mad = _band_mad_min(post_frames, height, band_region)
+    logger.info(
+        "VTUBER_MAD region=[%.1f-%.1f] pre_mad=%s post_mad=%s",
+        region[0],
+        region[1],
+        f"{pre_mad:.3f}" if pre_mad is not None else "na",
+        f"{post_mad:.3f}" if post_mad is not None else "na",
+    )
+
+    if pre_has is None or post_has is None:
+        classification = "unknown"
+    elif pre_has and post_has:
+        classification = "in_match"
+    elif pre_has or post_has:
+        classification = "match_boundary"
+    else:
+        classification = "non_fl"
+
+    logger.debug(
+        "vtuber classify region [%.1f-%.1f] (%.1fs): pre=%s post=%s -> %s",
+        region[0],
+        region[1],
+        region[1] - region[0],
+        pre_has,
+        post_has,
+        classification,
+    )
+    return classification
 
 
 def classify_blackout(

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -26,7 +26,11 @@ from allaganeye.video.detector import (
     _probe_frame_rgb_hires,
     _resolve_workers,
 )
-from allaganeye.video.capture_region import CaptureRegion, FULL_FRAME, localize_scorebar
+from allaganeye.video.capture_region import (
+    FULL_FRAME,
+    CaptureRegion,
+    localize_from_rgb_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +46,10 @@ def _localize_present_from_raw(raw: bytes | None) -> bool | None:
     """
     if raw is None:
         return None
-    frame = np.frombuffer(raw, dtype=np.uint8).reshape(
-        _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+    loc = localize_from_rgb_bytes(
+        raw, height=_SCOREBAR_V2_PROBE_HEIGHT, width=_SCOREBAR_V2_PROBE_WIDTH
     )
-    return localize_scorebar(frame) is not None
+    return loc is not None
 
 
 def _probe_scorebar_context(

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -172,29 +172,21 @@ Threshold 0.5 sits well inside the gap.
 """
 
 
-def _is_static_from_frames(
+def _band_mad_min(
     raw_frames: Sequence[bytes | None],
     height: int,
     region: CaptureRegion | None = None,
-) -> bool:
-    """Detect static screens (loading/result) via scorebar ROI frame diff.
+) -> float | None:
+    """Min MAD of the scorebar ROI across consecutive frame pairs.
 
-    Computes the mean absolute difference (MAD) of the scorebar ROI pixels
-    between consecutive frame pairs.  If the **minimum** MAD across all
-    pairs is below threshold, the frames show a static screen.
-
-    Using min() tolerates a single screen transition within the window
-    (one pair may have high MAD from a screen change, but the next pair
-    will be static).  False positives from ffmpeg keyframe aliasing are
-    mitigated by the A1+A2 checks in ``_has_scorebar``, which reduce the
-    number of blackouts reaching the ``in_match`` classification path
-    where this check is applied.
-
-    Returns False if fewer than 2 valid frames are provided.
+    Returns None when fewer than 2 valid frames are given, or when a band
+    ``region`` collapses to an empty crop (degenerate / sub-pixel band at
+    320x180; Codex #4).  ``region is None`` uses the absolute ``_SCOREBAR_ROI_*``
+    ROI exactly as before (bit-exact).
     """
     valid = [r for r in raw_frames if r is not None]
     if len(valid) < 2:
-        return False
+        return None
 
     if region is None:
         x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
@@ -206,29 +198,40 @@ def _is_static_from_frames(
         x2 = min(_SAMPLE_WIDTH, int((region.x + region.w) * _SAMPLE_WIDTH))
         y1 = max(0, int(region.y * height))
         y2 = min(height, int((region.y + region.h) * height))
+        if x2 <= x1 or y2 <= y1:
+            return None  # degenerate band crop (Codex #4) -> no usable signal
 
     rois = []
     for raw in valid:
         frame = np.frombuffer(raw, dtype=np.uint8).reshape(height, _SAMPLE_WIDTH, 3)
         rois.append(frame[y1:y2, x1:x2, :].astype(np.int16))
 
-    mads = []
-    for i in range(len(rois) - 1):
-        mad = float(np.mean(np.abs(rois[i] - rois[i + 1])))
-        mads.append(mad)
+    mads = [float(np.mean(np.abs(rois[i] - rois[i + 1]))) for i in range(len(rois) - 1)]
+    return min(mads)
 
-    min_mad = min(mads)
+
+def _is_static_from_frames(
+    raw_frames: Sequence[bytes | None],
+    height: int,
+    region: CaptureRegion | None = None,
+) -> bool:
+    """Detect static screens (loading/result) via scorebar ROI frame diff.
+
+    Returns False if fewer than 2 valid frames are provided or the band ROI is
+    degenerate.  ``region is None`` keeps the absolute-ROI behavior (bit-exact).
+    """
+    min_mad = _band_mad_min(raw_frames, height, region)
+    if min_mad is None:
+        return False
+
     is_static = min_mad < _STATIC_SCREEN_MAD_THRESHOLD
-
     logger.debug(
-        "static_screen: frames=%d mads=%s min=%.2f thr=%.1f -> %s",
-        len(raw_frames),
-        [f"{m:.2f}" for m in mads],
+        "static_screen: min=%.2f thr=%.1f region=%s -> %s",
         min_mad,
         _STATIC_SCREEN_MAD_THRESHOLD,
+        "absolute" if region is None else "band",
         is_static,
     )
-
     return is_static
 
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -78,7 +78,7 @@ allaganeye 0.1.1 (ffmpeg 8.1, Python 3.12.10, Windows 11)
   Disk: 1359.5 / 3726.0 GB free on E:
 Probing: recording.mkv
   Duration: 10228.7s, Resolution: 1920x1080, FPS: 60.00, Codec: h264
-Detecting match boundaries (interval=3.0s, threshold=15.0, workers=auto, min_match=300.0s, min_blackout=3.0s, audio=frozen)
+Detecting match boundaries (interval=3.0s, threshold=15.0, workers=auto (24), min_match=300.0s, min_blackout=3.0s, audio=frozen, vtuber=off)
 Detecting  #################################### 100%
 Refining   #################################### 100%
 Scorebar   #################################### 100%
@@ -129,7 +129,7 @@ allaganeye 0.1.1 (ffmpeg 8.1, Python 3.12.10, Windows 11)
 Probing: recording.mkv
   Duration: 10228.7s, Resolution: 1920x1080, FPS: 60.00, Codec: h264
 Cache hit: detection params from .detection_cache.json
-  sample_interval=3.0s, threshold=15.0, min_match=300.0s, min_blackout=3.0s, audio=frozen
+  sample_interval=3.0s, threshold=15.0, min_match=300.0s, min_blackout=3.0s, audio=frozen, vtuber=off
 Detected 8 match(es) in recording.mkv (2:50:28) (cached)
   Match 1:   00:00 -   15:17  (15m17s)  [unknown]
   ...

--- a/docs/detection-map.md
+++ b/docs/detection-map.md
@@ -1,0 +1,52 @@
+# 検出 subsystem 現状 map (Phase 0, re-plan #753)
+
+> L3 検出再アーキ ([spec](superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md))
+> の Phase 0 成果物。検出 subsystem の各 layer を **load-bearing / cruft / harmful** に
+> 棚卸しし、git 考古学で「なぜ追加されたか」を記録し、再アーキで触る層の coupling を図示する。
+> アルゴリズムの現行解説は [video-processing.md](video-processing.md) /
+> [scorebar-detection-design.md](scorebar-detection-design.md) を参照 (本 doc は重複させない)。
+
+## 1. 判定の凡例
+
+- **load-bearing**: 撤去・改変すると baseline / 実機が回帰する。再アーキで保持必須。
+- **cruft**: 惰性で残存。動作に寄与が薄く、再アーキで整理候補。
+- **harmful**: 能動的にバグ/脆さの温床 (例: 不可逆削除 × 弱い否定信号)。再アーキで設計見直し対象。
+- **判定保留**: コード読解だけでは確証が持てず、harness 実測 (Phase 2+) で確定する。
+
+## 2. layer インベントリ
+
+> presence.py のシンボル (`localize_present_at` / `scan_presence` / `segment_presence` /
+> `detect_matches_by_presence` / `refine_boundary`) は Phase 1 spec の資産で、§5 で扱う。
+
+| layer (シンボル) | module | 責務 (1 行) | 導入 issue | 判定 |
+| --- | --- | --- | --- | --- |
+| `detect_match_boundaries` | detector.py | 検出 orchestration | #56 | — |
+| `_scan_cpu` / Pass1 | detector.py | brightness 粗スキャン | #56/#68 | — |
+| `_group_blackout_regions` | detector.py | 暗転フレーム→region | #57 | — |
+| `_expand_regions_with_transitions` | detector.py | 遷移拡張 (閾値55) | #71 | — |
+| `_refine_blackout_regions` / Pass2 | detector.py | 0.25s 精密計測 | #77 | — |
+| `_has_scorebar_v2` | detector.py | GC紋章3点AND (絶対座標) | #307/#522 | — |
+| `_has_scorebar` (v1) | detector.py | channel-std+edge fallback | #111 | — |
+| `filter_blackouts_with_scorebar` | scorebar.py | 暗転分類 orchestration | #111 | — |
+| `classify_blackout` | scorebar.py | match_boundary/in_match/non_fl | #111 | — |
+| `_is_static_from_frames` (MAD) | scorebar.py | 静止画面 override | #201/#203 | — |
+| `_merge_boundary_pairs` | scorebar.py | 境界ペアマージ | #111 | — |
+| audio Fanfare promotion | scorebar.py | in_match→boundary 昇格 | #288 | — |
+| `_filter_and_extract_segments` | detector.py | duration filter + segment 抽出 | #77/#388 | — |
+| `_drop_post_match_trailing` | detector.py | 試合後 trailing 不可逆削除 | #797/#806 | — |
+| GPU Pass1 (`scan_gpu`) | gpu_detector.py | チャンク並列 GPU デコード | #37 | — |
+| legacy fps filter path | detector.py | #576 で retire 済の旧 path | #575/#576 | — |
+| `localize_scorebar` (P1) | capture_region.py | 位置独立 scorebar 局在化 | #811 | — |
+| `detect_region_*` (S1/S3) | capture_region.py | VTuber 領域候補 (脆い) | #807 | — |
+
+## 3. git 考古学 (なぜ追加されたか)
+
+(Task 2 で記入)
+
+## 4. coupling 図: `_drop_post_match_trailing` × v2 × membership
+
+(Task 4 で記入)
+
+## 5. 再アーキ (spec) への含意
+
+(Task 5 で記入)

--- a/docs/detection-map.md
+++ b/docs/detection-map.md
@@ -20,24 +20,42 @@
 
 | layer (シンボル) | module | 責務 (1 行) | 導入 issue | 判定 |
 | --- | --- | --- | --- | --- |
-| `detect_match_boundaries` | detector.py | 検出 orchestration | #56 | — |
-| `_scan_cpu` / Pass1 | detector.py | brightness 粗スキャン | #56/#68 | — |
-| `_group_blackout_regions` | detector.py | 暗転フレーム→region | #57 | — |
-| `_expand_regions_with_transitions` | detector.py | 遷移拡張 (閾値55) | #71 | — |
-| `_refine_blackout_regions` / Pass2 | detector.py | 0.25s 精密計測 | #77 | — |
-| `_has_scorebar_v2` | detector.py | GC紋章3点AND (絶対座標) | #307/#522 | — |
-| `_has_scorebar` (v1) | detector.py | channel-std+edge fallback | #111 | — |
-| `filter_blackouts_with_scorebar` | scorebar.py | 暗転分類 orchestration | #111 | — |
-| `classify_blackout` | scorebar.py | match_boundary/in_match/non_fl | #111 | — |
-| `_is_static_from_frames` (MAD) | scorebar.py | 静止画面 override | #201/#203 | — |
-| `_merge_boundary_pairs` | scorebar.py | 境界ペアマージ | #111 | — |
-| audio Fanfare promotion | scorebar.py | in_match→boundary 昇格 | #288 | — |
-| `_filter_and_extract_segments` | detector.py | duration filter + segment 抽出 | #77/#388 | — |
-| `_drop_post_match_trailing` | detector.py | 試合後 trailing 不可逆削除 | #797/#806 | — |
-| GPU Pass1 (`scan_gpu`) | gpu_detector.py | チャンク並列 GPU デコード | #37 | — |
-| legacy fps filter path | detector.py | #576 で retire 済の旧 path | #575/#576 | — |
-| `localize_scorebar` (P1) | capture_region.py | 位置独立 scorebar 局在化 | #811 | — |
-| `detect_region_*` (S1/S3) | capture_region.py | VTuber 領域候補 (脆い) | #807 | — |
+| `detect_match_boundaries` | detector.py | 検出 orchestration | #56 | load-bearing |
+| `_scan_cpu` / Pass1 | detector.py | brightness 粗スキャン | #56/#68 | load-bearing |
+| `_group_blackout_regions` | detector.py | 暗転フレーム→region | #57 | load-bearing |
+| `_expand_regions_with_transitions` | detector.py | 遷移拡張 (閾値55) | #71 | load-bearing (要調整) |
+| `_refine_blackout_regions` / Pass2 | detector.py | 0.25s 精密計測 | #77 | load-bearing |
+| `_has_scorebar_v2` | detector.py | GC紋章3点AND (絶対座標) | #307/#522 | load-bearing (provisional) |
+| `_has_scorebar` (v1) | detector.py | channel-std+edge fallback | #111 | cruft |
+| `filter_blackouts_with_scorebar` | scorebar.py | 暗転分類 orchestration | #111 | load-bearing (再編対象) |
+| `classify_blackout` | scorebar.py | match_boundary/in_match/non_fl | #111 | load-bearing (再編対象) |
+| `_is_static_from_frames` (MAD) | scorebar.py | 静止画面 override | #201/#203 | 判定保留 (脆い) |
+| `_merge_boundary_pairs` | scorebar.py | 境界ペアマージ | #111 | load-bearing |
+| audio Fanfare promotion | scorebar.py | in_match→boundary 昇格 | #288 | load-bearing (FP余地) |
+| `_filter_and_extract_segments` | detector.py | duration filter + segment 抽出 | #77/#388 | load-bearing (backstop) |
+| `_drop_post_match_trailing` | detector.py | 試合後 trailing 不可逆削除 | #797/#806 | harmful |
+| GPU Pass1 (`scan_gpu`) | gpu_detector.py | チャンク並列 GPU デコード | #37 | load-bearing |
+| legacy fps filter path | detector.py | #576 で retire 済の旧 path | #575/#576 | cruft |
+| `localize_scorebar` (P1) | capture_region.py | 位置独立 scorebar 局在化 | #811 | load-bearing (新基盤) |
+| `detect_region_*` (S1/S3) | capture_region.py | VTuber 領域候補 (脆い) | #807 | 判定保留 (脆い) |
+
+### 判定根拠 (脚注)
+
+- **`detect_match_boundaries`**: 検出パイプライン全体の orchestration entry point。撤去不可。
+- **`_scan_cpu` / `_group_blackout_regions` / `_refine_blackout_regions`**: spec §3.1① brightness が境界検出の主軸。spec A.3 で OBS 秒未満精度を実証。load-bearing。
+- **`_expand_regions_with_transitions`**: OBS 録画では境界拾い漏れ防止に必須。ただし VTuber crop では lobby 輝度と重なり過剰 merge が発生する (spec P5 / re-plan #809 Wave F)。load-bearing だが VTuber 対応で閾値調整が必要。
+- **`_has_scorebar_v2`**: OBS で高特異度を実現する GC 紋章 3 点 AND ガード (Codex #3)。`_drop_post_match_trailing` と `_probe_scorebar_context` (scorebar.py) の 2 箇所から呼ばれる hidden coupling がある (Codex #6)。spec Q3 で `localize_scorebar` に置換予定だが parity 実証まで authoritative として温存 (provisional)。
+- **`_has_scorebar` (v1)**: opencv 未インストール時の fallback のみ。実運用では opencv を同梱するため経路はほぼ死んでいる。cruft。
+- **`filter_blackouts_with_scorebar` / `classify_blackout`**: 暗転分類の orchestration と個別判定。spec §5 で primitive を `localize_scorebar` + motion に差し替える再編対象だが現在は load-bearing。
+- **`_is_static_from_frames` (MAD)**: short blackout 限定の局所 override として #201/#203 で追加。spec Q5 で分類補助に昇格予定だが Codex #1 で primary 化が未検証のため判定保留。
+- **`_merge_boundary_pairs`**: 二重境界を 1 ペアにまとめる対症修正。現行パイプラインで必要。流用予定。
+- **audio Fanfare promotion**: scorebar 残像で `in_match` に誤分類された境界を音声で救済 (#288)。Fanfare は試合中にも弱いピークを出すため FP 余地が残る。
+- **`_filter_and_extract_segments`**: `min_match_duration` (default 300 s) でリザルト画面を backstop 除去する。spec §3.5 でこの duration filter が真の backstop と実証されている。
+- **`_drop_post_match_trailing`**: 不可逆削除 × 弱い否定信号 (scorebar 不在) という構造的リスク (#805)。`_has_scorebar_v2` FN 環境では実試合を silent に削除しうる。harmful。
+- **GPU Pass1 (`scan_gpu`)**: `--gpu` 経路の主実装。CPU Pass1 と結果 parity が必要 (Codex #8)。load-bearing。
+- **legacy fps filter path**: #576 で新 path を default 化、env var `ALLAGANEYE_DETECT_FPS_FILTER=1` の rollback 専用。v0.3.x で削除予定。cruft。
+- **`localize_scorebar` (P1)**: 再アーキの分類器核。VTuber 配信の任意 inset 位置に対応する anchor として設計。load-bearing (新基盤)。
+- **`detect_region_*` (S1/S3)**: re-plan R6 で scorebar 帯 anchor を主軸とし S3 を補助に降格。ハーネス実測前は確証が持てないため判定保留。
 
 ## 3. git 考古学 (なぜ追加されたか)
 

--- a/docs/detection-map.md
+++ b/docs/detection-map.md
@@ -77,7 +77,7 @@
 
 ## 4. coupling 図: `_drop_post_match_trailing` × v2 × membership
 
-`_drop_post_match_trailing` (detector.py:1901) は segment 抽出の **後段**で、最終 segment が
+`_drop_post_match_trailing` (detector.py) は segment 抽出の **後段**で、最終 segment が
 post-match trailing (lobby/city) かを **v2 scorebar の不在を根拠に不可逆削除**する。
 
 ```text
@@ -97,7 +97,7 @@ segments 抽出 (_filter_and_extract_segments)
 
 | 変更 | trailing drop への影響 |
 | --- | --- |
-| v2 を localize に置換 (Q3) | trailing drop は v2 を直接呼ぶ (detector.py:1977)。置換すると **第 2 の分類器が暗黙に挙動変化**。localize はリザルト 91% present → trailing を「試合あり」と誤判定し drop し損ねる、逆に VTuber では本物 trailing を切る (R3) |
+| v2 を localize に置換 (Q3) | trailing drop は v2 を直接呼ぶ (`_drop_post_match_trailing` 内の `_has_scorebar_v2` 直接呼び出し)。置換すると **第 2 の分類器が暗黙に挙動変化**。localize はリザルト 91% present → trailing を「試合あり」と誤判定し drop し損ねる、逆に VTuber では本物 trailing を切る (R3) |
 | membership 信号導入 (Q4) | membership は segment 抽出の前段。trailing drop は後段で独立に再判定するため、**2 つの membership 判断が二重化** |
 | #805 非破壊化 | 不可逆削除 → フラグ方式にすると trailing drop の出力契約が変わる |
 

--- a/docs/detection-map.md
+++ b/docs/detection-map.md
@@ -126,7 +126,7 @@ segments 抽出 (_filter_and_extract_segments)
 
 ### 5.4 presence.py 資産 (spec §10)
 
-- `compare_segments` / GT 突合ハーネス → 検証インフラとして存続。
+- `compare_segments` (`tests/presence_harness.py`) / GT 突合ハーネス → 検証インフラとして存続。
 - `localize_present_at` → Stage 2 分類で再利用。
 - `scan_presence` / `segment_presence` / `detect_matches_by_presence` → VTuber + 診断専用に降格 (OBS production 経路では使わない)。
 - branch `claude/l3-p2-region-detection` は Phase 1-2 実装で継続使用。

--- a/docs/detection-map.md
+++ b/docs/detection-map.md
@@ -77,7 +77,35 @@
 
 ## 4. coupling 図: `_drop_post_match_trailing` × v2 × membership
 
-(Task 4 で記入)
+`_drop_post_match_trailing` (detector.py:1901) は segment 抽出の **後段**で、最終 segment が
+post-match trailing (lobby/city) かを **v2 scorebar の不在を根拠に不可逆削除**する。
+
+```text
+segments 抽出 (_filter_and_extract_segments)
+        │
+        ▼
+最終 segment が type=unknown かつ end≈動画末尾 かつ len>=2 か?
+        │ yes
+        ▼
+早期 candidate-match 窓を _TRAILING_PROBE_STRIDE で v2 プローブ
+        │
+        ├─ どれか True / None (probe 失敗) → keep (safe side)
+        └─ 全て False (definite miss)      → segments[:-1]  ← 不可逆削除
+```
+
+### 競合シナリオ (Codex #6 / spec R4)
+
+| 変更 | trailing drop への影響 |
+| --- | --- |
+| v2 を localize に置換 (Q3) | trailing drop は v2 を直接呼ぶ (detector.py:1977)。置換すると **第 2 の分類器が暗黙に挙動変化**。localize はリザルト 91% present → trailing を「試合あり」と誤判定し drop し損ねる、逆に VTuber では本物 trailing を切る (R3) |
+| membership 信号導入 (Q4) | membership は segment 抽出の前段。trailing drop は後段で独立に再判定するため、**2 つの membership 判断が二重化** |
+| #805 非破壊化 | 不可逆削除 → フラグ方式にすると trailing drop の出力契約が変わる |
+
+### 結論 (Phase 1+ への制約)
+
+- spec §3.4 の通り、**Phase 1-3 は v2 を温存**し trailing drop を現状のまま据え置く。
+- membership 統一と #805 非破壊化は **Phase 4 cutover 以降の別 phase**で、trailing drop を新 membership と同じ根拠に統一するか shadow 無効化してから扱う。
+- Phase 2 で localize を shadow 並走させる際、**trailing drop は v2 (authoritative) のまま**にする (localize を trailing drop に配線しない)。
 
 ## 5. 再アーキ (spec) への含意
 

--- a/docs/detection-map.md
+++ b/docs/detection-map.md
@@ -41,7 +41,21 @@
 
 ## 3. git 考古学 (なぜ追加されたか)
 
-(Task 2 で記入)
+> 詳細経緯は [video-processing.md §設計経緯](video-processing.md#設計経緯) に既出。
+> 本節は「対症修正が積層した順序」と「各層が生んだ新たな制約」に絞る。
+
+| 時期 | 契機 (課題) | 追加 layer | 生んだ制約/脆さ |
+| --- | --- | --- | --- |
+| #60 | リスポーン暗転の誤検知 | min_blackout_duration filter | 短い真境界も落ちうる |
+| #71 | 試合境界の未検出 (パターンB) | `_expand_regions_with_transitions` (閾値55) | lobby 輝度依存。VTuber crop で過剰 merge (#809 Wave F) |
+| #77 | 境界未検出 (パターンC) | Pass2 refine + duration filter | — |
+| #107 | キャラダウン暗転 | `in_match` duration guard | — |
+| #108/#109 | 非 FL コンテンツ | `non_fl` 分類 | — |
+| #111 | scorebar 分類統合 | `filter_blackouts_with_scorebar` 一式 | 絶対座標前提 (VTuber inset で破綻 = #480) |
+| #201/#203 | 静止ローディング誤分類 | `_is_static_from_frames` (MAD override) | short blackout 限定の局所 override |
+| #288 | scorebar 残像で境界誤分類 | audio Fanfare promotion | Fanfare 試合中弱ピークで FP 余地 |
+| #307/#522 | scorebar FP | `_has_scorebar_v2` (GC紋章3点AND) | 絶対/相対 two-path。位置特異 = VTuber 不可 |
+| #797/#806 | 試合後 trailing 残存 | `_drop_post_match_trailing` | **不可逆削除 × v2 直接プローブ** (#805/Codex #6) |
 
 ## 4. coupling 図: `_drop_post_match_trailing` × v2 × membership
 

--- a/docs/detection-map.md
+++ b/docs/detection-map.md
@@ -109,4 +109,24 @@ segments 抽出 (_filter_and_extract_segments)
 
 ## 5. 再アーキ (spec) への含意
 
-(Task 5 で記入)
+### 5.1 Phase 1 で保持必須 (load-bearing)
+
+- brightness Pass1/Pass2、duration filter (backstop)、`_merge_boundary_pairs` は OBS で bit-exact 維持。
+- `_has_scorebar_v2` は authoritative 温存 (Q3 provisional)。
+
+### 5.2 Phase 1 で触る (再編)
+
+- `classify_blackout` の検出 primitive を localize+motion 化 (shadow 並走、§2 判定参照)。
+- `_is_static_from_frames` を band-anchor 化 (絶対 ROI → localize bbox、spec §5)。OBS は絶対 ROI 縮退。
+
+### 5.3 触ってはいけない (Phase 4 以降)
+
+- `_drop_post_match_trailing` (harmful だが §4 の通り coupling 故に Phase 1-3 据え置き)。
+- legacy fps filter path (cruft、別 issue で撤去)。
+
+### 5.4 presence.py 資産 (spec §10)
+
+- `compare_segments` / GT 突合ハーネス → 検証インフラとして存続。
+- `localize_present_at` → Stage 2 分類で再利用。
+- `scan_presence` / `segment_presence` / `detect_matches_by_presence` → VTuber + 診断専用に降格 (OBS production 経路では使わない)。
+- branch `claude/l3-p2-region-detection` は Phase 1-2 実装で継続使用。

--- a/docs/output-spec.md
+++ b/docs/output-spec.md
@@ -57,7 +57,7 @@ Error: --quiet and --verbose are mutually exclusive
 | 6 | Dry-run 通知 (`[dry-run] Detect only...` / `Dry run: skipping split`) | [#418](https://github.com/Idios/kobutachan-allaganeye/issues/418) | - | - | - | ◯ | ◯ | × | ❌ |
 | 7 | Cache hit 検知パラメータ (`Cache hit: detection params from ...`) | [#380](https://github.com/Idios/kobutachan-allaganeye/issues/380) | × | ◯ (cache hit 時のみ) | × | × | ◯ | × | ❌ |
 | 8 | Auto-selected / Forced GPU/CPU mode | - | × | ◯ | × | × | ◯ | × | ❌ |
-| 9 | 検知パラメータ summary (`interval=..., threshold=..., workers=auto(N), audio=frozen`) | [#384](https://github.com/Idios/kobutachan-allaganeye/issues/384), [#389](https://github.com/Idios/kobutachan-allaganeye/issues/389) | × | ◯ | × | × | ◯ | × | ❌ |
+| 9 | 検知パラメータ summary (`interval=..., threshold=..., workers=auto(N), audio=frozen, vtuber=off`) | [#384](https://github.com/Idios/kobutachan-allaganeye/issues/384), [#389](https://github.com/Idios/kobutachan-allaganeye/issues/389) | × | ◯ | × | × | ◯ | × | ❌ |
 | 10 | 進捗バー `Detecting` / `Refining` / `Scorebar` | [#368](https://github.com/Idios/kobutachan-allaganeye/issues/368), [#393](https://github.com/Idios/kobutachan-allaganeye/issues/393) | ◯ | ◯ | × | ◯ | ◯ | × | ❌ |
 | 11 | 検知統計 (`Pass 1`, `Pass 2`, `Scorebar`, `Splitting` elapsed 含) | [#386](https://github.com/Idios/kobutachan-allaganeye/issues/386), [#387](https://github.com/Idios/kobutachan-allaganeye/issues/387) | × | ◯ | × | × | ◯ | × | ❌ |
 | 12 | Filter drop 内訳 + unknown match 行 (`Filter: N candidates -> M matches` + `+ N unknown match (録画途中試合)`) | [#388](https://github.com/Idios/kobutachan-allaganeye/issues/388), [#433](https://github.com/Idios/kobutachan-allaganeye/issues/433) | × | ◯ | × | × | ◯ | × | ❌ |

--- a/docs/output-spec.md
+++ b/docs/output-spec.md
@@ -57,7 +57,7 @@ Error: --quiet and --verbose are mutually exclusive
 | 6 | Dry-run 通知 (`[dry-run] Detect only...` / `Dry run: skipping split`) | [#418](https://github.com/Idios/kobutachan-allaganeye/issues/418) | - | - | - | ◯ | ◯ | × | ❌ |
 | 7 | Cache hit 検知パラメータ (`Cache hit: detection params from ...`) | [#380](https://github.com/Idios/kobutachan-allaganeye/issues/380) | × | ◯ (cache hit 時のみ) | × | × | ◯ | × | ❌ |
 | 8 | Auto-selected / Forced GPU/CPU mode | - | × | ◯ | × | × | ◯ | × | ❌ |
-| 9 | 検知パラメータ summary (`interval=..., threshold=..., workers=auto(N), audio=frozen, vtuber=off`) | [#384](https://github.com/Idios/kobutachan-allaganeye/issues/384), [#389](https://github.com/Idios/kobutachan-allaganeye/issues/389) | × | ◯ | × | × | ◯ | × | ❌ |
+| 9 | 検知パラメータ summary (`interval=..., threshold=..., workers=auto (N), audio=frozen, vtuber=off`) | [#384](https://github.com/Idios/kobutachan-allaganeye/issues/384), [#389](https://github.com/Idios/kobutachan-allaganeye/issues/389) | × | ◯ | × | × | ◯ | × | ❌ |
 | 10 | 進捗バー `Detecting` / `Refining` / `Scorebar` | [#368](https://github.com/Idios/kobutachan-allaganeye/issues/368), [#393](https://github.com/Idios/kobutachan-allaganeye/issues/393) | ◯ | ◯ | × | ◯ | ◯ | × | ❌ |
 | 11 | 検知統計 (`Pass 1`, `Pass 2`, `Scorebar`, `Splitting` elapsed 含) | [#386](https://github.com/Idios/kobutachan-allaganeye/issues/386), [#387](https://github.com/Idios/kobutachan-allaganeye/issues/387) | × | ◯ | × | × | ◯ | × | ❌ |
 | 12 | Filter drop 内訳 + unknown match 行 (`Filter: N candidates -> M matches` + `+ N unknown match (録画途中試合)`) | [#388](https://github.com/Idios/kobutachan-allaganeye/issues/388), [#433](https://github.com/Idios/kobutachan-allaganeye/issues/433) | × | ◯ | × | × | ◯ | × | ❌ |

--- a/docs/superpowers/plans/2026-05-29-presence-detection-phase1.md
+++ b/docs/superpowers/plans/2026-05-29-presence-detection-phase1.md
@@ -1,0 +1,1384 @@
+# Presence ベース検出エンジン Phase 1 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** scorebar 有無 (presence/absence) を検出信号とする match 境界検出アルゴリズムと、その精度を ground truth と突合する offline 検証ハーネスを、production 非配線の additive モジュールとして実装し、OBS 5 source で GT-accuracy gate を通す。
+
+**Architecture:** P1 の `localize_scorebar` (1920x1080 RGB frame → `ScorebarLocalization | None`) を present/absent 信号源として再利用する。新規 `allaganeye/video/presence.py` に「純粋なアルゴリズム (debounce/segment 化・境界二分探索)」と「I/O オーケストレーション (time grid sampling)」を責務分離して配置。検証は `tests/presence_harness.py` (純粋な比較メトリクス) + slow sample-gated テストで行う。既存の brightness Pass1 (`detect_match_boundaries`) には一切手を入れない (Phase 3 でカットオーバー)。
+
+**Tech Stack:** Python 3 / numpy / opencv-python-headless / pytest / 既存 ffmpeg probe ヘルパ (`_probe_frame_rgb_hires`)。
+
+---
+
+## 背景と不変条件 (実装者向け前提)
+
+このプロジェクトは FF14 PvP「フロントライン (FL)」の長時間録画を試合単位に分割する CLI ツール。現行の検出は **brightness ベース** (暗転を検出して試合境界とする) だが、VTuber 配信のように game 画面が overlay で囲まれた録画では brightness が overlay に汚染され機能しない。
+
+設計判断 (spec `docs/superpowers/specs/2026-05-29-presence-based-detection-engine-design.md` 参照):
+
+- **FL の scorebar** (画面上部中央の GC 紋章 3 点を含む HUD) は試合中だけ表示される。これを「試合中かどうか」の信号にする。
+- `localize_scorebar(frame)` (実装済) が frame 内に scorebar を見つければ `ScorebarLocalization` を、無ければ `None` を返す。**非 None = present = 試合中**。
+- scorebar は試合中に**短時間消える**ことがある (死亡時の全画面暗転・全画面 UI 等)。よって segment 化には**両方向 debounce** (短い absent gap と短い present spike を吸収) が必要。
+- **Phase 1 は production に配線しない**。新モジュールは既存の検出経路から呼ばれない。CLI 出力・baseline・既存テストは一切変わらない (回帰リスクゼロ)。
+
+**絶対に守ること:**
+
+- 既存ファイル `allaganeye/video/detector.py` / `scorebar.py` / `commands/*.py` の**ロジックを変更しない**。`detector.py` からは関数を **import するだけ** (Phase 1 で touch するのは新規ファイルのみ)。
+- TDD: 各 production 関数は**失敗するテストを先に書く** (Red → Green → Refactor)。
+- このリポジトリでは bare `pytest` / `ruff` は PATH 外。**必ず `python -m pytest` / `python -m ruff` / `python -m pyright`** を使う。
+- 作業ブランチは `claude/l3-p2-region-detection` (この worktree)。base への push やマージはしない。
+
+## 再利用する既存コード (確認済みのシグネチャ)
+
+これらは**変更せず import するだけ**:
+
+- `allaganeye/video/detector.py`:
+  - `_probe_frame_rgb_hires(video_path: Path, timestamp: float) -> bytes | None`
+    1920x1080 の RGB24 raw bytes を返す。失敗時 None。`np.frombuffer(raw, dtype=np.uint8).reshape(1080, 1920, 3)` で frame 化。
+  - `_SCOREBAR_V2_PROBE_WIDTH = 1920` / `_SCOREBAR_V2_PROBE_HEIGHT = 1080`
+- `allaganeye/video/capture_region.py`:
+  - `localize_scorebar(frame: np.ndarray) -> ScorebarLocalization | None`
+    入力は (1080, 1920, 3) uint8 RGB。`ScorebarLocalization(x_left, x_right, y_top, y_bottom, confidence: float)`。
+- `allaganeye/video/probe.py`:
+  - `probe_video(video_path: Path) -> ProbeResult` — `result["duration"]` (float 秒) を使う。
+- `tests/baselines/v0.3.0/ground-truth/obs-*.json` (5 本) — OBS の手動 GT。スキーマ:
+  `{"source_file": "...", "tolerance_sec": 5, "matches": [{"index", "start_time", "end_time", "duration", "type"}]}`
+- `tests/conftest.py`:
+  - `sample_video_dir` fixture — `ALLAGANEYE_SAMPLE_VIDEO_DIR` 未設定なら skip。
+  - `slow` marker — 動画が要るテストに付与。
+
+## ファイル構成
+
+| ファイル | 新規/変更 | 責務 |
+| --- | --- | --- |
+| `allaganeye/video/presence.py` | 新規 | presence 検出アルゴリズム。データ構造 + 純粋関数 (segment/refine) + I/O (scan/detect) |
+| `tests/test_presence.py` | 新規 | presence.py の高速単体テスト (動画不要) |
+| `tests/presence_harness.py` | 新規 | GT 読込 + 検出結果との比較メトリクス (純粋) + 手動実行 CLI |
+| `tests/test_presence_harness.py` | 新規 | presence_harness.py の高速単体テスト (動画不要) |
+| `tests/test_presence_validation.py` | 新規 | slow・sample-gated。OBS 実動画で GT-accuracy gate を assert |
+
+**この計画では上記 5 ファイル以外を変更しない。**
+
+---
+
+## Task 1: データ構造とモジュール骨格
+
+**Files:**
+
+- Create: `allaganeye/video/presence.py`
+- Test: `tests/test_presence.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence.py` を新規作成:
+
+```python
+"""Unit tests for presence-based match detection (no video required)."""
+
+from __future__ import annotations
+
+from allaganeye.video.presence import PresenceMatch, PresenceSample
+
+
+def test_presence_sample_fields():
+    s = PresenceSample(time=12.0, present=True, confidence=0.9)
+    assert s.time == 12.0
+    assert s.present is True
+    assert s.confidence == 0.9
+
+
+def test_presence_match_fields():
+    m = PresenceMatch(start=10.0, end=900.0)
+    assert m.start == 10.0
+    assert m.end == 900.0
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'allaganeye.video.presence'`
+
+- [ ] **Step 3: 最小実装**
+
+`allaganeye/video/presence.py` を新規作成:
+
+```python
+"""Presence-based match detection (scorebar present/absent as the signal).
+
+Phase 1 of the presence-detection engine (spec
+docs/superpowers/specs/2026-05-29-presence-based-detection-engine-design.md).
+This module is ADDITIVE and NOT wired into the production detection path;
+it exists for the offline validation harness only.  The brightness-based
+``detector.detect_match_boundaries`` remains the production detector until
+the Phase 3 cutover.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PresenceSample:
+    """One time-grid sample: whether the scorebar is present at ``time``."""
+
+    time: float
+    present: bool
+    confidence: float
+
+
+@dataclass(frozen=True)
+class PresenceMatch:
+    """A detected FL match segment in seconds (presence-based)."""
+
+    start: float
+    end: float
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check allaganeye/video/presence.py tests/test_presence.py && python -m ruff format --check allaganeye/video/presence.py tests/test_presence.py && python -m pyright allaganeye/video/presence.py`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add allaganeye/video/presence.py tests/test_presence.py
+git commit -m "feat(l3): presence 検出のデータ構造 (Phase 1 Task 1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `segment_presence` — debounce + segment 化 (アルゴリズムの中核)
+
+サンプル列 (present/absent) を試合 segment にまとめる純粋関数。`t_gap` 未満の absent gap は試合内として吸収、`t_min_match` 未満の present run は破棄。
+
+**Files:**
+
+- Modify: `allaganeye/video/presence.py`
+- Test: `tests/test_presence.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence.py` の末尾に追記:
+
+```python
+from allaganeye.video.presence import segment_presence
+
+
+def _samples(spec: list[tuple[float, bool]]) -> list[PresenceSample]:
+    return [PresenceSample(time=t, present=p, confidence=1.0) for t, p in spec]
+
+
+def test_segment_single_match():
+    # present 0..900 (stride 100) -> one match
+    samples = _samples([(t, True) for t in range(0, 1000, 100)])
+    matches = segment_presence(samples, t_gap=30.0, t_min_match=60.0)
+    assert matches == [PresenceMatch(start=0.0, end=900.0)]
+
+
+def test_segment_two_matches_split_by_long_gap():
+    # match A 0..200, absent 300..600 (gap 400 >= t_gap), match B 700..900
+    spec = [(t, True) for t in (0, 100, 200)]
+    spec += [(t, False) for t in (300, 400, 500, 600)]
+    spec += [(t, True) for t in (700, 800, 900)]
+    matches = segment_presence(_samples(spec), t_gap=120.0, t_min_match=60.0)
+    assert matches == [
+        PresenceMatch(start=0.0, end=200.0),
+        PresenceMatch(start=700.0, end=900.0),
+    ]
+
+
+def test_segment_absorbs_short_absent_gap():
+    # short absent at 300 only (gap from 200 to 400 = 200 < t_gap=300) -> merged
+    spec = [(t, True) for t in (0, 100, 200)]
+    spec += [(300, False)]
+    spec += [(t, True) for t in (400, 500, 600)]
+    matches = segment_presence(_samples(spec), t_gap=300.0, t_min_match=60.0)
+    assert matches == [PresenceMatch(start=0.0, end=600.0)]
+
+
+def test_segment_drops_short_present_spike():
+    # isolated present spike 400..450 (duration 50 < t_min_match=60) -> dropped
+    spec = [(t, False) for t in (0, 100, 200, 300)]
+    spec += [(400, True), (450, True)]
+    spec += [(t, False) for t in (600, 700, 800)]
+    matches = segment_presence(_samples(spec), t_gap=120.0, t_min_match=60.0)
+    assert matches == []
+
+
+def test_segment_empty_input():
+    assert segment_presence([], t_gap=30.0, t_min_match=60.0) == []
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence.py -k segment -v`
+Expected: FAIL — `ImportError: cannot import name 'segment_presence'`
+
+- [ ] **Step 3: 最小実装**
+
+`allaganeye/video/presence.py` の末尾に追記:
+
+```python
+def segment_presence(
+    samples: Sequence[PresenceSample],
+    *,
+    t_gap: float,
+    t_min_match: float,
+) -> list[PresenceMatch]:
+    """Collapse present/absent samples into match segments.
+
+    Two-directional debounce:
+    - absent gaps shorter than ``t_gap`` between two present runs are
+      absorbed (treated as in-match: covers mid-match scorebar loss such
+      as death blackout / full-screen UI).
+    - present runs shorter than ``t_min_match`` are discarded (transient
+      false positives).
+
+    ``samples`` must be sorted by ``time`` ascending.  Returns matches with
+    start/end at the first/last present sample time of each surviving run
+    (boundary refinement to sub-stride precision happens separately in
+    :func:`detect_matches_by_presence`).
+    """
+    # 1. Build present runs as mutable [start, end] pairs.
+    present_runs: list[list[float]] = []
+    current: list[float] | None = None
+    for s in samples:
+        if s.present:
+            if current is None:
+                current = [s.time, s.time]
+            else:
+                current[1] = s.time
+        else:
+            if current is not None:
+                present_runs.append(current)
+                current = None
+    if current is not None:
+        present_runs.append(current)
+
+    # 2. Merge runs whose inter-run gap is shorter than t_gap.
+    merged: list[list[float]] = []
+    for run in present_runs:
+        if merged and run[0] - merged[-1][1] < t_gap:
+            merged[-1][1] = run[1]
+        else:
+            merged.append(list(run))
+
+    # 3. Drop runs shorter than t_min_match; emit matches.
+    return [
+        PresenceMatch(start=r[0], end=r[1])
+        for r in merged
+        if r[1] - r[0] >= t_min_match
+    ]
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence.py -v`
+Expected: PASS (全テスト)
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check allaganeye/video/presence.py tests/test_presence.py && python -m ruff format --check allaganeye/video/presence.py tests/test_presence.py && python -m pyright allaganeye/video/presence.py`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add allaganeye/video/presence.py tests/test_presence.py
+git commit -m "feat(l3): segment_presence debounce/segment 化 (Phase 1 Task 2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `refine_boundary` — 境界の二分探索 (純粋・DI)
+
+present/absent の遷移区間を二分探索して遷移時刻を `tol` 精度で特定する。`present_at` コールバックを注入し、動画なしで単体テスト可能にする。
+
+**Files:**
+
+- Modify: `allaganeye/video/presence.py`
+- Test: `tests/test_presence.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence.py` の末尾に追記:
+
+```python
+from allaganeye.video.presence import refine_boundary
+
+
+def test_refine_boundary_finds_transition_forward():
+    # scorebar present for t < 500, absent for t >= 500 (match end)
+    present_at = lambda t: t < 500.0
+    # bracket: t_true=480 (present), t_false=520 (absent)
+    edge = refine_boundary(480.0, 520.0, present_at, tol=1.0)
+    assert abs(edge - 500.0) <= 1.0
+
+
+def test_refine_boundary_finds_transition_backward():
+    # scorebar absent for t < 300, present for t >= 300 (match start)
+    present_at = lambda t: t >= 300.0
+    # bracket: t_true=320 (present), t_false=280 (absent)
+    edge = refine_boundary(320.0, 280.0, present_at, tol=1.0)
+    assert abs(edge - 300.0) <= 1.0
+
+
+def test_refine_boundary_respects_tolerance():
+    present_at = lambda t: t < 500.0
+    edge = refine_boundary(480.0, 520.0, present_at, tol=0.1)
+    assert abs(edge - 500.0) <= 0.1
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence.py -k refine -v`
+Expected: FAIL — `ImportError: cannot import name 'refine_boundary'`
+
+- [ ] **Step 3: 最小実装**
+
+`allaganeye/video/presence.py` の `segment_presence` の後に追記:
+
+```python
+def refine_boundary(
+    t_true: float,
+    t_false: float,
+    present_at: Callable[[float], bool],
+    *,
+    tol: float,
+) -> float:
+    """Binary-search the present<->absent transition between two times.
+
+    Precondition: ``present_at(t_true)`` is True and ``present_at(t_false)``
+    is False.  ``t_true`` and ``t_false`` may be in either order (forward =
+    match end, backward = match start).  Returns the midpoint of the final
+    bracket, accurate to within ``tol`` seconds.
+    """
+    lo_true = t_true
+    hi_false = t_false
+    while abs(lo_true - hi_false) > tol:
+        mid = (lo_true + hi_false) / 2.0
+        if present_at(mid):
+            lo_true = mid
+        else:
+            hi_false = mid
+    return (lo_true + hi_false) / 2.0
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence.py -v`
+Expected: PASS (全テスト)
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check allaganeye/video/presence.py tests/test_presence.py && python -m ruff format --check allaganeye/video/presence.py tests/test_presence.py && python -m pyright allaganeye/video/presence.py`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add allaganeye/video/presence.py tests/test_presence.py
+git commit -m "feat(l3): refine_boundary 二分探索 (Phase 1 Task 3)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `localize_present_at` — frame 取得 → localize ブリッジ
+
+実動画の時刻 `t` から hi-res frame を取り出し、`localize_scorebar` にかけて `PresenceSample` を返す。既存ヘルパ 2 つを mock して高速テストする。
+
+**Files:**
+
+- Modify: `allaganeye/video/presence.py`
+- Test: `tests/test_presence.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence.py` の末尾に追記:
+
+```python
+import numpy as np
+
+from allaganeye.video.capture_region import ScorebarLocalization
+
+
+def test_localize_present_at_present(monkeypatch):
+    import allaganeye.video.presence as presence
+
+    fake_frame_bytes = (np.zeros((1080, 1920, 3), dtype=np.uint8)).tobytes()
+    monkeypatch.setattr(
+        presence, "_probe_frame_rgb_hires", lambda vp, t: fake_frame_bytes
+    )
+    monkeypatch.setattr(
+        presence,
+        "localize_scorebar",
+        lambda frame: ScorebarLocalization(
+            x_left=600, x_right=1300, y_top=20, y_bottom=65, confidence=0.8
+        ),
+    )
+    from pathlib import Path
+
+    sample = presence.localize_present_at(Path("dummy.mkv"), 123.0)
+    assert sample.time == 123.0
+    assert sample.present is True
+    assert sample.confidence == 0.8
+
+
+def test_localize_present_at_absent(monkeypatch):
+    import allaganeye.video.presence as presence
+
+    fake_frame_bytes = (np.zeros((1080, 1920, 3), dtype=np.uint8)).tobytes()
+    monkeypatch.setattr(
+        presence, "_probe_frame_rgb_hires", lambda vp, t: fake_frame_bytes
+    )
+    monkeypatch.setattr(presence, "localize_scorebar", lambda frame: None)
+    from pathlib import Path
+
+    sample = presence.localize_present_at(Path("dummy.mkv"), 50.0)
+    assert sample.present is False
+    assert sample.confidence == 0.0
+
+
+def test_localize_present_at_probe_failure(monkeypatch):
+    import allaganeye.video.presence as presence
+
+    monkeypatch.setattr(presence, "_probe_frame_rgb_hires", lambda vp, t: None)
+    from pathlib import Path
+
+    sample = presence.localize_present_at(Path("dummy.mkv"), 7.0)
+    assert sample.present is False
+    assert sample.confidence == 0.0
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence.py -k localize_present_at -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'localize_present_at'`
+
+- [ ] **Step 3: 最小実装**
+
+`allaganeye/video/presence.py` の import 群に追記 (ファイル冒頭の `from dataclasses import dataclass` の下):
+
+```python
+from pathlib import Path
+
+import numpy as np
+
+from allaganeye.video.capture_region import localize_scorebar
+from allaganeye.video.detector import (
+    _SCOREBAR_V2_PROBE_HEIGHT,
+    _SCOREBAR_V2_PROBE_WIDTH,
+    _probe_frame_rgb_hires,
+)
+```
+
+そしてファイル末尾に関数を追記:
+
+```python
+def localize_present_at(video_path: Path, timestamp: float) -> PresenceSample:
+    """Probe one hi-res frame and report scorebar presence at ``timestamp``.
+
+    Bridges the production frame source (``_probe_frame_rgb_hires``, 1920x1080
+    RGB24) and the P1 localizer (``localize_scorebar``).  Probe failure or
+    a None localization both yield ``present=False`` (safe absent).
+    """
+    raw = _probe_frame_rgb_hires(video_path, timestamp)
+    if raw is None:
+        return PresenceSample(time=timestamp, present=False, confidence=0.0)
+    frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+        _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+    )
+    loc = localize_scorebar(frame)
+    if loc is None:
+        return PresenceSample(time=timestamp, present=False, confidence=0.0)
+    return PresenceSample(time=timestamp, present=True, confidence=loc.confidence)
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence.py -v`
+Expected: PASS (全テスト)
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check allaganeye/video/presence.py tests/test_presence.py && python -m ruff format --check allaganeye/video/presence.py tests/test_presence.py && python -m pyright allaganeye/video/presence.py`
+Expected: エラーなし (private import の `_probe_frame_rgb_hires` 等で ruff 警告が出る場合は `# noqa` ではなく、これらが同 package 内 import である点を確認。問題が出たら `allaganeye.video.detector` からの import はそのまま許容される)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add allaganeye/video/presence.py tests/test_presence.py
+git commit -m "feat(l3): localize_present_at frame→localize ブリッジ (Phase 1 Task 4)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `scan_presence` — time grid サンプリング (I/O オーケストレーション)
+
+`0..duration` を `stride` 間隔で走査し、各時刻で `sample_fn` を並列実行して `PresenceSample` 列を返す。`sample_fn` を注入して高速テストする。
+
+**Files:**
+
+- Modify: `allaganeye/video/presence.py`
+- Test: `tests/test_presence.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence.py` の末尾に追記:
+
+```python
+from allaganeye.video.presence import scan_presence
+
+
+def test_scan_presence_grid_and_order():
+    from pathlib import Path
+
+    # synthetic sample_fn: present for 200 <= t < 500
+    def sample_fn(t: float) -> PresenceSample:
+        return PresenceSample(time=t, present=(200.0 <= t < 500.0), confidence=1.0)
+
+    samples = scan_presence(
+        Path("dummy.mkv"), duration=600.0, stride=100.0, workers=2, sample_fn=sample_fn
+    )
+    # times must be sorted and cover 0,100,...,600
+    assert [s.time for s in samples] == [0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0]
+    assert [s.present for s in samples] == [
+        False, False, True, True, True, False, False
+    ]
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence.py -k scan_presence -v`
+Expected: FAIL — `ImportError: cannot import name 'scan_presence'`
+
+- [ ] **Step 3: 最小実装**
+
+`allaganeye/video/presence.py` の import 群に追記:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+```
+
+ファイル末尾に追記:
+
+```python
+def _grid_timestamps(duration: float, stride: float) -> list[float]:
+    """Inclusive 0..duration grid at ``stride`` spacing (duration endpoint kept)."""
+    if stride <= 0:
+        raise ValueError("stride must be > 0")
+    n = int(duration // stride)
+    times = [round(i * stride, 6) for i in range(n + 1)]
+    if not times or times[-1] < duration:
+        times.append(round(duration, 6))
+    return times
+
+
+def scan_presence(
+    video_path: Path,
+    duration: float,
+    *,
+    stride: float,
+    workers: int,
+    sample_fn: Callable[[float], PresenceSample] | None = None,
+) -> list[PresenceSample]:
+    """Sample scorebar presence across the whole video on a uniform grid.
+
+    ``sample_fn`` maps a timestamp to a :class:`PresenceSample`; it defaults
+    to :func:`localize_present_at` bound to ``video_path`` (the production
+    path).  Tests inject a synthetic ``sample_fn`` to stay fast.  Results are
+    returned sorted by time ascending.
+    """
+    if sample_fn is None:
+        def sample_fn(t: float) -> PresenceSample:  # noqa: E306
+            return localize_present_at(video_path, t)
+
+    times = _grid_timestamps(duration, stride)
+    results: dict[float, PresenceSample] = {}
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(sample_fn, t): t for t in times}
+        for fut in futures:
+            sample = fut.result()
+            results[futures[fut]] = sample
+    return [results[t] for t in times]
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence.py -v`
+Expected: PASS (全テスト)
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check allaganeye/video/presence.py tests/test_presence.py && python -m ruff format --check allaganeye/video/presence.py tests/test_presence.py && python -m pyright allaganeye/video/presence.py`
+Expected: エラーなし (`def sample_fn` の再代入で pyright が文句を言う場合は、内部名を `sample_fn = _default` のように別関数で定義して回避: 下記参照)
+
+> pyright が `sample_fn` 再代入を嫌う場合の代替実装:
+>
+> ```python
+>     resolved_fn = sample_fn
+>     if resolved_fn is None:
+>         resolved_fn = lambda t: localize_present_at(video_path, t)  # noqa: E731
+> ```
+>
+> 以降 `resolved_fn` を使う。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add allaganeye/video/presence.py tests/test_presence.py
+git commit -m "feat(l3): scan_presence time-grid サンプリング (Phase 1 Task 5)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `detect_matches_by_presence` — トップレベル統合 (scan → segment → refine)
+
+scan で得たサンプルを segment 化し、各 match の start/end を 1 stride 幅の bracket で二分探索して精緻化する。
+
+**Files:**
+
+- Modify: `allaganeye/video/presence.py`
+- Test: `tests/test_presence.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence.py` の末尾に追記:
+
+```python
+from allaganeye.video.presence import detect_matches_by_presence
+
+
+def test_detect_matches_by_presence_end_to_end(monkeypatch):
+    import allaganeye.video.presence as presence
+    from pathlib import Path
+
+    # Ground physics: scorebar present for 250 <= t < 740.
+    def present_phys(t: float) -> bool:
+        return 250.0 <= t < 740.0
+
+    monkeypatch.setattr(
+        presence,
+        "localize_present_at",
+        lambda vp, t: PresenceSample(time=t, present=present_phys(t), confidence=1.0),
+    )
+
+    matches = detect_matches_by_presence(
+        Path("dummy.mkv"),
+        duration=1000.0,
+        stride=100.0,
+        t_gap=120.0,
+        t_min_match=60.0,
+        tol=1.0,
+        workers=2,
+    )
+    assert len(matches) == 1
+    # coarse run is 300..700 (grid); refine pulls start->250, end->740
+    assert abs(matches[0].start - 250.0) <= 1.0
+    assert abs(matches[0].end - 740.0) <= 1.0
+
+
+def test_detect_matches_present_at_video_edges(monkeypatch):
+    import allaganeye.video.presence as presence
+    from pathlib import Path
+
+    # present for the entire video -> match spans [0, duration], no refine
+    monkeypatch.setattr(
+        presence,
+        "localize_present_at",
+        lambda vp, t: PresenceSample(time=t, present=True, confidence=1.0),
+    )
+    matches = detect_matches_by_presence(
+        Path("dummy.mkv"),
+        duration=500.0,
+        stride=100.0,
+        t_gap=120.0,
+        t_min_match=60.0,
+        tol=1.0,
+        workers=2,
+    )
+    assert matches == [PresenceMatch(start=0.0, end=500.0)]
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence.py -k detect_matches -v`
+Expected: FAIL — `ImportError: cannot import name 'detect_matches_by_presence'`
+
+- [ ] **Step 3: 最小実装**
+
+`allaganeye/video/presence.py` の末尾に追記:
+
+```python
+def detect_matches_by_presence(
+    video_path: Path,
+    duration: float,
+    *,
+    stride: float,
+    t_gap: float,
+    t_min_match: float,
+    tol: float,
+    workers: int,
+) -> list[PresenceMatch]:
+    """Top-level presence detector: scan -> segment -> refine boundaries.
+
+    1. ``scan_presence`` samples the whole video on a ``stride`` grid.
+    2. ``segment_presence`` debounces and yields coarse matches (boundaries
+       at sample times).
+    3. each coarse boundary is refined within a one-stride bracket using
+       ``refine_boundary``.  Matches touching the video edges (t<=0 or
+       t>=duration within one stride) keep the edge unrefined.
+    """
+    samples = scan_presence(
+        video_path, duration, stride=stride, workers=workers
+    )
+    coarse = segment_presence(samples, t_gap=t_gap, t_min_match=t_min_match)
+
+    def present_at(t: float) -> bool:
+        return localize_present_at(video_path, t).present
+
+    refined: list[PresenceMatch] = []
+    for m in coarse:
+        if m.start - stride < 0.0:
+            start = 0.0
+        else:
+            start = refine_boundary(m.start, m.start - stride, present_at, tol=tol)
+        if m.end + stride > duration:
+            end = duration
+        else:
+            end = refine_boundary(m.end, m.end + stride, present_at, tol=tol)
+        refined.append(PresenceMatch(start=start, end=end))
+    return refined
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence.py -v`
+Expected: PASS (全テスト)
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check allaganeye/video/presence.py tests/test_presence.py && python -m ruff format --check allaganeye/video/presence.py tests/test_presence.py && python -m pyright allaganeye/video/presence.py`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add allaganeye/video/presence.py tests/test_presence.py
+git commit -m "feat(l3): detect_matches_by_presence 統合 (Phase 1 Task 6)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: ハーネス — GT 読込とデータ構造
+
+GT JSON (OBS/VTuber 共通スキーマ) を読み込む純粋関数。
+
+**Files:**
+
+- Create: `tests/presence_harness.py`
+- Test: `tests/test_presence_harness.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence_harness.py` を新規作成:
+
+```python
+"""Unit tests for the presence validation harness (no video required)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.presence_harness import GroundTruth, GroundTruthMatch, load_ground_truth
+
+
+def test_load_ground_truth(tmp_path: Path):
+    gt_file = tmp_path / "gt.json"
+    gt_file.write_text(
+        json.dumps(
+            {
+                "source_file": "20260116/rec.mkv",
+                "tolerance_sec": 5,
+                "matches": [
+                    {"index": 1, "start_time": 49, "end_time": 1054},
+                    {"index": 2, "start_time": 1256, "end_time": 2178},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    gt = load_ground_truth(gt_file)
+    assert isinstance(gt, GroundTruth)
+    assert gt.source_file == "20260116/rec.mkv"
+    assert gt.tolerance_sec == 5.0
+    assert gt.matches == [
+        GroundTruthMatch(start=49.0, end=1054.0),
+        GroundTruthMatch(start=1256.0, end=2178.0),
+    ]
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence_harness.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tests.presence_harness'`
+
+- [ ] **Step 3: 最小実装**
+
+`tests/presence_harness.py` を新規作成:
+
+```python
+"""Offline validation harness for presence-based detection (Phase 1).
+
+Compares presence-detected match segments against ground-truth annotations
+(OBS baselines + VTuber manual GT) and reports matched / missed / spurious
+counts and boundary errors.  Pure comparison logic lives here so it can be
+unit-tested without video; the slow end-to-end runs live in
+``tests/test_presence_validation.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GroundTruthMatch:
+    """A ground-truth FL match interval in seconds."""
+
+    start: float
+    end: float
+
+
+@dataclass(frozen=True)
+class GroundTruth:
+    """Parsed ground-truth file."""
+
+    source_file: str
+    tolerance_sec: float
+    matches: list[GroundTruthMatch]
+
+
+def load_ground_truth(path: Path) -> GroundTruth:
+    """Load a ground-truth JSON (OBS / VTuber shared schema)."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    matches = [
+        GroundTruthMatch(start=float(m["start_time"]), end=float(m["end_time"]))
+        for m in data["matches"]
+    ]
+    return GroundTruth(
+        source_file=str(data["source_file"]),
+        tolerance_sec=float(data["tolerance_sec"]),
+        matches=matches,
+    )
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence_harness.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check tests/presence_harness.py tests/test_presence_harness.py && python -m ruff format --check tests/presence_harness.py tests/test_presence_harness.py && python -m pyright tests/presence_harness.py`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/presence_harness.py tests/test_presence_harness.py
+git commit -m "feat(l3): 検証ハーネス GT 読込 (Phase 1 Task 7)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: ハーネス — `compare_segments` メトリクス (純粋)
+
+検出 segment と GT を tolerance 付きで突合し、matched / missed / spurious と境界誤差を返す。
+
+**Files:**
+
+- Modify: `tests/presence_harness.py`
+- Test: `tests/test_presence_harness.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence_harness.py` の末尾に追記:
+
+```python
+from allaganeye.video.presence import PresenceMatch
+from tests.presence_harness import ComparisonResult, compare_segments
+
+
+def _gt(pairs):
+    return [GroundTruthMatch(start=a, end=b) for a, b in pairs]
+
+
+def test_compare_all_matched_within_tolerance():
+    detected = [PresenceMatch(50.0, 1056.0), PresenceMatch(1257.0, 2176.0)]
+    gt = _gt([(49.0, 1054.0), (1256.0, 2178.0)])
+    res = compare_segments(detected, gt, tolerance=5.0)
+    assert isinstance(res, ComparisonResult)
+    assert res.matched == 2
+    assert res.missed == 0
+    assert res.spurious == 0
+    assert res.max_boundary_error <= 2.0
+
+
+def test_compare_missed_match():
+    detected = [PresenceMatch(50.0, 1056.0)]
+    gt = _gt([(49.0, 1054.0), (1256.0, 2178.0)])
+    res = compare_segments(detected, gt, tolerance=5.0)
+    assert res.matched == 1
+    assert res.missed == 1
+    assert res.spurious == 0
+
+
+def test_compare_spurious_match():
+    detected = [PresenceMatch(50.0, 1056.0), PresenceMatch(4000.0, 4500.0)]
+    gt = _gt([(49.0, 1054.0)])
+    res = compare_segments(detected, gt, tolerance=5.0)
+    assert res.matched == 1
+    assert res.missed == 0
+    assert res.spurious == 1
+
+
+def test_compare_boundary_outside_tolerance_is_not_matched():
+    # end off by 40s (> tol) -> not a match -> missed + spurious
+    detected = [PresenceMatch(50.0, 1100.0)]
+    gt = _gt([(49.0, 1054.0)])
+    res = compare_segments(detected, gt, tolerance=5.0)
+    assert res.matched == 0
+    assert res.missed == 1
+    assert res.spurious == 1
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence_harness.py -k compare -v`
+Expected: FAIL — `ImportError: cannot import name 'compare_segments'`
+
+- [ ] **Step 3: 最小実装**
+
+`tests/presence_harness.py` の import 群に追記:
+
+```python
+from allaganeye.video.presence import PresenceMatch
+```
+
+ファイル末尾に追記:
+
+```python
+@dataclass(frozen=True)
+class ComparisonResult:
+    """Outcome of comparing detected matches against ground truth."""
+
+    matched: int
+    missed: int
+    spurious: int
+    boundary_errors: list[float]
+
+    @property
+    def max_boundary_error(self) -> float:
+        return max(self.boundary_errors) if self.boundary_errors else 0.0
+
+
+def compare_segments(
+    detected: Sequence[PresenceMatch],
+    gt: Sequence[GroundTruthMatch],
+    *,
+    tolerance: float,
+) -> ComparisonResult:
+    """Greedy-match detected segments to GT within ``tolerance`` seconds.
+
+    A detected segment matches a GT match iff both its start and end are
+    within ``tolerance`` of the GT start/end.  Each GT and each detected
+    segment is used at most once.  Unmatched GT -> missed; unmatched
+    detected -> spurious.  ``boundary_errors`` holds, for every matched
+    pair, the start error and the end error (seconds).
+    """
+    used_detected: set[int] = set()
+    matched = 0
+    boundary_errors: list[float] = []
+
+    for g in gt:
+        best_idx: int | None = None
+        best_err: float | None = None
+        for i, d in enumerate(detected):
+            if i in used_detected:
+                continue
+            start_err = abs(d.start - g.start)
+            end_err = abs(d.end - g.end)
+            if start_err <= tolerance and end_err <= tolerance:
+                worst = max(start_err, end_err)
+                if best_err is None or worst < best_err:
+                    best_err = worst
+                    best_idx = i
+        if best_idx is not None:
+            used_detected.add(best_idx)
+            matched += 1
+            boundary_errors.append(abs(detected[best_idx].start - g.start))
+            boundary_errors.append(abs(detected[best_idx].end - g.end))
+
+    missed = len(gt) - matched
+    spurious = len(detected) - len(used_detected)
+    return ComparisonResult(
+        matched=matched,
+        missed=missed,
+        spurious=spurious,
+        boundary_errors=boundary_errors,
+    )
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence_harness.py -v`
+Expected: PASS (全テスト)
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check tests/presence_harness.py tests/test_presence_harness.py && python -m ruff format --check tests/presence_harness.py tests/test_presence_harness.py && python -m pyright tests/presence_harness.py`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/presence_harness.py tests/test_presence_harness.py
+git commit -m "feat(l3): compare_segments 突合メトリクス (Phase 1 Task 8)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: ハーネス CLI — 手動実行エントリポイント
+
+Phase 2 の閾値校正用に、動画 + GT + パラメータを受けてメトリクスを表示する `main()` を追加する。テストは引数パースのみ高速検証。
+
+**Files:**
+
+- Modify: `tests/presence_harness.py`
+- Test: `tests/test_presence_harness.py`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`tests/test_presence_harness.py` の末尾に追記:
+
+```python
+from tests.presence_harness import build_arg_parser
+
+
+def test_build_arg_parser_defaults():
+    parser = build_arg_parser()
+    args = parser.parse_args(
+        ["--video", "v.mkv", "--ground-truth", "gt.json"]
+    )
+    assert args.video == "v.mkv"
+    assert args.ground_truth == "gt.json"
+    assert args.stride == 4.0
+    assert args.t_gap == 30.0
+    assert args.t_min_match == 120.0
+    assert args.tol == 1.0
+    assert args.workers == 8
+
+
+def test_build_arg_parser_overrides():
+    parser = build_arg_parser()
+    args = parser.parse_args(
+        [
+            "--video", "v.mkv",
+            "--ground-truth", "gt.json",
+            "--stride", "3",
+            "--t-gap", "45",
+            "--t-min-match", "90",
+            "--tol", "0.5",
+            "--workers", "16",
+        ]
+    )
+    assert args.stride == 3.0
+    assert args.t_gap == 45.0
+    assert args.t_min_match == 90.0
+    assert args.tol == 0.5
+    assert args.workers == 16
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `python -m pytest tests/test_presence_harness.py -k arg_parser -v`
+Expected: FAIL — `ImportError: cannot import name 'build_arg_parser'`
+
+- [ ] **Step 3: 最小実装**
+
+`tests/presence_harness.py` の import 群に追記:
+
+```python
+import argparse
+```
+
+ファイル末尾に追記 (暫定パラメータは spec §4.6 の暫定値。`t_gap=30 / t_min_match=120` は現行 `min_match_duration=300` より保守的に小さめ、Phase 2 で校正):
+
+```python
+def build_arg_parser() -> argparse.ArgumentParser:
+    """CLI for manual harness runs (Phase 2 threshold calibration)."""
+    p = argparse.ArgumentParser(description="Presence detection validation harness")
+    p.add_argument("--video", required=True, help="Path to source video")
+    p.add_argument("--ground-truth", required=True, help="Path to ground-truth JSON")
+    p.add_argument("--stride", type=float, default=4.0, help="Coarse grid stride (s)")
+    p.add_argument("--t-gap", type=float, default=30.0, help="Min absent gap = boundary (s)")
+    p.add_argument(
+        "--t-min-match", type=float, default=120.0, help="Min present run = match (s)"
+    )
+    p.add_argument("--tol", type=float, default=1.0, help="Refinement tolerance (s)")
+    p.add_argument("--workers", type=int, default=8, help="Parallel probe workers")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run presence detection on one video and print metrics vs ground truth."""
+    from allaganeye.video.presence import detect_matches_by_presence
+    from allaganeye.video.probe import probe_video
+
+    args = build_arg_parser().parse_args(argv)
+    video = Path(args.video)
+    gt = load_ground_truth(Path(args.ground_truth))
+    duration = float(probe_video(video)["duration"])
+
+    detected = detect_matches_by_presence(
+        video,
+        duration,
+        stride=args.stride,
+        t_gap=args.t_gap,
+        t_min_match=args.t_min_match,
+        tol=args.tol,
+        workers=args.workers,
+    )
+    res = compare_segments(detected, gt.matches, tolerance=gt.tolerance_sec)
+    print(f"source        : {gt.source_file}")
+    print(f"detected      : {len(detected)} matches")
+    print(f"ground truth  : {len(gt.matches)} matches (tol {gt.tolerance_sec}s)")
+    print(f"matched       : {res.matched}")
+    print(f"missed        : {res.missed}")
+    print(f"spurious      : {res.spurious}")
+    print(f"max boundary err: {res.max_boundary_error:.2f}s")
+    return 0 if (res.missed == 0 and res.spurious == 0) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: テストを実行して通過を確認**
+
+Run: `python -m pytest tests/test_presence_harness.py -v`
+Expected: PASS (全テスト)
+
+- [ ] **Step 5: Lint / 型チェック**
+
+Run: `python -m ruff check tests/presence_harness.py tests/test_presence_harness.py && python -m ruff format --check tests/presence_harness.py tests/test_presence_harness.py && python -m pyright tests/presence_harness.py`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/presence_harness.py tests/test_presence_harness.py
+git commit -m "feat(l3): ハーネス CLI エントリポイント (Phase 1 Task 9)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: OBS 検証テスト (slow・sample-gated) — GT-accuracy gate
+
+OBS 5 source の実動画で `detect_matches_by_presence` を回し、手動 GT に対して **missed/spurious ゼロ** と **境界誤差 ≤ tolerance** を assert する。これが Phase 1 の合格ゲート。
+
+> このテストは動画が要るため `ALLAGANEYE_SAMPLE_VIDEO_DIR` 設定環境 (Idios のマシン) でのみ実行される。CI では skip される。**閾値 (stride/t_gap/t_min_match/tol) は暫定値で書き、実行して通らなければ Phase 1 完了報告時に Idios と校正する** (spec §4.6 / Task 完了後の実機検証 trigger)。
+
+**Files:**
+
+- Create: `tests/test_presence_validation.py`
+
+- [ ] **Step 1: テストを書く (このタスクは TDD の「実機ゲート」なので、test = 実行可能な検証スクリプト)**
+
+`tests/test_presence_validation.py` を新規作成:
+
+```python
+"""Slow, sample-gated OBS validation for presence detection (Phase 1 gate).
+
+Runs the presence detector on each OBS source that has a manual ground-truth
+file and asserts the GT-accuracy gate: zero missed, zero spurious, and all
+boundary errors within the GT tolerance.  Requires ALLAGANEYE_SAMPLE_VIDEO_DIR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from allaganeye.video.presence import detect_matches_by_presence
+from allaganeye.video.probe import probe_video
+from tests.presence_harness import compare_segments, load_ground_truth
+
+_GT_DIR = Path(__file__).parent / "baselines" / "v0.3.0" / "ground-truth"
+
+# Provisional thresholds (spec section 4.6). Calibrate with Idios if a gate
+# fails on real footage during Phase 1 sign-off.
+_STRIDE = 4.0
+_T_GAP = 30.0
+_T_MIN_MATCH = 120.0
+_TOL = 1.0
+_WORKERS = 8
+
+
+def _obs_gt_files() -> list[Path]:
+    return sorted(_GT_DIR.glob("obs-*.json"))
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("gt_file", _obs_gt_files(), ids=lambda p: p.stem)
+def test_obs_presence_gt_accuracy(gt_file: Path, sample_video_dir: Path):
+    gt = load_ground_truth(gt_file)
+    video = sample_video_dir / gt.source_file
+    if not video.exists():
+        pytest.skip(f"sample video not found: {video}")
+
+    duration = float(probe_video(video)["duration"])
+    detected = detect_matches_by_presence(
+        video,
+        duration,
+        stride=_STRIDE,
+        t_gap=_T_GAP,
+        t_min_match=_T_MIN_MATCH,
+        tol=_TOL,
+        workers=_WORKERS,
+    )
+    res = compare_segments(detected, gt.matches, tolerance=gt.tolerance_sec)
+
+    assert res.missed == 0, f"{gt_file.stem}: missed {res.missed} matches"
+    assert res.spurious == 0, f"{gt_file.stem}: {res.spurious} spurious matches"
+    assert res.max_boundary_error <= gt.tolerance_sec, (
+        f"{gt_file.stem}: boundary error {res.max_boundary_error:.1f}s "
+        f"> tol {gt.tolerance_sec}s"
+    )
+```
+
+- [ ] **Step 2: collection が壊れていないことを確認 (動画なし環境でも collection は通る)**
+
+Run: `python -m pytest tests/test_presence_validation.py -v`
+Expected: 5 件が **skipped** (ALLAGANEYE_SAMPLE_VIDEO_DIR 未設定なら `sample_video_dir` fixture が skip) — collection error が出ないこと。
+
+- [ ] **Step 3: Lint / 型チェック**
+
+Run: `python -m ruff check tests/test_presence_validation.py && python -m ruff format --check tests/test_presence_validation.py && python -m pyright tests/test_presence_validation.py`
+Expected: エラーなし
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_presence_validation.py
+git commit -m "test(l3): OBS presence GT-accuracy gate (slow, Phase 1 Task 10)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: (Idios 実機検証 trigger) 実動画で slow テストを実行**
+
+> このステップは Idios のマシン (ALLAGANEYE_SAMPLE_VIDEO_DIR 設定済) で行う。Phase 1 の受け入れ判定。
+>
+> Run: `python -m pytest tests/test_presence_validation.py -m slow -v`
+> Expected: 5 source すべて PASS。**失敗時**は missed/spurious/境界誤差を記録し、閾値 (`_STRIDE`/`_T_GAP`/`_T_MIN_MATCH`/`_TOL`) と localize recall を Idios と確認して校正 (spec §4.6 / R2)。校正は別 commit。
+>
+> 併せて wall-time をメモ (spec §6 性能確認)。長尺で実用外なら stride 調整を Phase 1 範囲で検討。
+
+---
+
+## Task 11: 全体テストと最終確認
+
+**Files:** (変更なし — 検証のみ)
+
+- [ ] **Step 1: 高速テスト全体を実行 (回帰がないこと)**
+
+Run: `python -m pytest -q`
+Expected: 既存テスト + 新規高速テストすべて PASS、slow は skip。**既存テストの結果が変わっていないこと** (Phase 1 は additive)。
+
+- [ ] **Step 2: 全体 Lint / 型チェック**
+
+Run: `python -m ruff check . && python -m ruff format --check . && python -m pyright`
+Expected: エラーなし
+
+- [ ] **Step 3: markdownlint (この計画 doc と spec)**
+
+Run: `bash scripts/check-markdownlint.sh`
+Expected: 0 errors
+
+- [ ] **Step 4: 新モジュールが production から参照されていないことを確認 (Phase 1 非配線の担保)**
+
+Run: `python -m pytest tests/test_detector.py tests/test_scorebar.py tests/test_detect.py -q`
+Expected: 既存検出系テスト全 PASS (presence.py を import していないため影響なし)。
+
+加えて、`allaganeye/` 配下の production コードが presence を import していないことを確認:
+
+Run: `grep -rn "import presence\|from allaganeye.video.presence\|presence import" allaganeye/`
+Expected: **0 件** (presence は tests からのみ参照される)。
+
+- [ ] **Step 5: 最終 commit (もし未コミットの調整があれば)**
+
+```bash
+git status --short
+# 差分がなければ何もしない。あれば:
+git add -A && git commit -m "chore(l3): Phase 1 最終調整
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## 受け入れ条件 (Phase 1 完了判定 / 将来の issue `## 受け入れ条件` 原型)
+
+- [ ] `allaganeye/video/presence.py` が presence (localize 非 None) + 両方向 debounce + fine refinement で match segment を返す (`detect_matches_by_presence`)。
+- [ ] 高速単体テスト (動画不要): `segment_presence` / `refine_boundary` / `localize_present_at` / `scan_presence` / `detect_matches_by_presence` / `compare_segments` / `load_ground_truth` が全 PASS。
+- [ ] offline 検証ハーネス (`tests/presence_harness.py`) が GT と検出結果を突合し matched/missed/spurious/境界誤差を返す。CLI (`main`) で手動実行可能。
+- [ ] OBS 5 source の slow 検証テストが存在し、collection error なく skip/PASS する。
+- [ ] **(実機ゲート)** Idios 環境で `tests/test_presence_validation.py -m slow` が 5 source すべて PASS (missed/spurious ゼロ、境界誤差 ≤ tolerance)。失敗時は閾値校正を経て PASS。
+- [ ] 既存の brightness 検出経路 (`detector.py` / `scorebar.py` / CLI) は未変更。production は presence を import していない。既存テスト・baseline は不変。
+- [ ] `ruff check` / `ruff format --check` / `pyright` / `markdownlint` 全 pass。
+
+## Phase 1 がやらないこと (Phase 2/3 へ)
+
+- VTuber 5 source の GT 注釈と VTuber 検証 → **Phase 2** (Idios 作業 + 閾値校正)。
+- brightness Pass1 の撤去・production 配線・再 baseline・bit-exact → GT-accuracy gate 置換・#480 分類統合 → **Phase 3** (カットオーバー)。
+- issue 起票/編集 (新 umbrella + sub-issue、#480 subsume、#809 redefine) → Iron Law 2 で起票時に AskUserQuestion。
+
+## 参照
+
+- spec: `docs/superpowers/specs/2026-05-29-presence-based-detection-engine-design.md`
+- P1 基盤: `allaganeye/video/capture_region.py` (`localize_scorebar` / `ScorebarLocalization`)
+- frame 取得: `allaganeye/video/detector.py` (`_probe_frame_rgb_hires`)
+- GT データ: `tests/baselines/v0.3.0/ground-truth/obs-*.json`, `tests/baselines/v0.3.0/vtuber-primary-ground-truth.json`

--- a/docs/superpowers/plans/2026-05-31-l3-phase0-detection-map.md
+++ b/docs/superpowers/plans/2026-05-31-l3-phase0-detection-map.md
@@ -1,0 +1,455 @@
+# L3 Phase 0: 検出 subsystem 現状 map Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 検出 subsystem (detector.py / scorebar.py / capture_region.py / gpu_detector.py / presence.py) の現状を「git 考古学 + layer ごとの load-bearing / cruft / 有害 判定 + 相互作用 (特に `_drop_post_match_trailing` × `_has_scorebar_v2` × 新 membership の coupling) 」として 1 ドキュメントに集約し、Phase 1+ の再アーキ実装の前提を裏付ける。
+
+**Architecture:** production コード変更ゼロ。新規ドキュメント `docs/detection-map.md` を作成し、既存 docs (`video-processing.md` / `scorebar-detection-design.md` / `system-architecture.md`) と**重複させず相互リンク**する。本 plan の成果物はドキュメント 1 枚 + spec への参照追記のみ。検証は「主張がコード/git の実体と一致するか」のセルフ突合で行う (動画実行不要)。
+
+**Tech Stack:** Markdown (markdownlint CI 準拠) / git log・git blame (考古学) / Read・Grep (コード突合)。
+
+---
+
+## なぜ Phase 0 が独立成果物か
+
+spec ([2026-05-31-l3-detection-rearchitecture-two-signal-design.md](../specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md)) §8 で Phase 0 を独立 phase に定めた。理由:
+
+- Codex adversarial review (2026-05-30) が **`_drop_post_match_trailing` は v2 を直接プローブする hidden 第 2 分類器**であり、新 membership 信号と競合すると指摘 (spec §4 Codex #6 / R4)。この coupling を把握せずに Phase 1+ に入ると、prior pivot (presence 全置換) と同じ「未検証前提で実装 → 破綻」を繰り返す。
+- 検出 subsystem は 7 年分 (#39〜#811、detector.py だけで 42 commit) の対症修正が層状に積もっており、どの層が **load-bearing (壊すと回帰)** / **cruft (惰性で残存)** / **有害 (能動的にバグの温床)** かが未整理。Phase 1 の「OBS 構造保持・分類器のみ差し替え」が安全かは、この棚卸し結果に依存する。
+- 成果物がドキュメント 1 枚なので、production リスクゼロで単体完結する。
+
+## 既存 docs との境界 (重複回避 — memory: PR #783 教訓)
+
+新 doc を書く前に既存 doc を必ず確認すること。**以下は既存 doc が持つので新 doc では繰り返さずリンクする**:
+
+| 既存 doc | 既にカバーしている内容 | 新 doc での扱い |
+| --- | --- | --- |
+| `docs/video-processing.md` | detect/probe/split の **現行アルゴリズム解説** + 設計経緯 (課題 1-7) | アルゴリズム詳細はリンク。新 doc は「layer 判定」を足す |
+| `docs/scorebar-detection-design.md` | `_has_scorebar` v1 / v2 (#307,#522) の **採用根拠** | v2 内部はリンク。新 doc は「v2 が load-bearing か」の判定を足す |
+| `docs/system-architecture.md` | コンポーネント構成・データフロー (CLI/GUI) | リンクのみ |
+
+新 doc `docs/detection-map.md` の固有価値 = **(a) layer 別 keep/cruft/harmful 判定、(b) git 考古学による「なぜ追加されたか」、(c) 再アーキで触る層の coupling 図**。これらは既存 doc にない。
+
+---
+
+## File Structure
+
+- **Create:** `docs/detection-map.md` — Phase 0 の成果物。検出 subsystem の現状 map。
+- **Modify:** `docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md` — §8 Phase 0 行に成果物 doc へのリンクを追記、§13 参照に追加。
+- **Modify:** `docs/video-processing.md` — 既存 doc 側から新 map への相互リンクを 1 行追加 (双方向リンクで発見性確保)。
+
+各タスクは独立した追記で、順に積み上げる。動画実行・production コード変更はない。
+
+---
+
+### Task 1: detection-map.md の骨格 + layer インベントリ
+
+検出 subsystem の全 layer を列挙し、責務 + 主要シンボル + 既存 doc リンクの表を作る。判定列は後続 Task で埋める (この Task では「対象 layer の網羅」が完了基準)。
+
+**Files:**
+
+- Create: `docs/detection-map.md`
+- Reference (読むだけ): `allaganeye/video/detector.py`, `allaganeye/video/scorebar.py`, `allaganeye/video/capture_region.py`, `allaganeye/video/gpu_detector.py`, `allaganeye/video/presence.py`
+
+- [ ] **Step 1: 対象シンボルを Grep で網羅確認**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+grep -nE '^def |^class |^_[A-Z_0-9]+ =' allaganeye/video/detector.py allaganeye/video/scorebar.py allaganeye/video/capture_region.py
+```
+
+Expected: detector.py は `detect_match_boundaries` / `_scan_cpu` / `_group_blackout_regions` / `_expand_regions_with_transitions` / `_refine_blackout_regions` / `_has_scorebar_v2` / `_has_scorebar` / `filter`系 / `_filter_and_extract_segments` / `_drop_post_match_trailing` 等、scorebar.py は `classify_blackout` / `_is_static_from_frames` / `_merge_boundary_pairs` / `filter_blackouts_with_scorebar` / `_has_nearby_fanfare_hit`、capture_region.py は `localize_scorebar` / `detect_region_*` が出力される。この一覧が map の layer 母集合。
+
+- [ ] **Step 2: detection-map.md の骨格を書く**
+
+`docs/detection-map.md` を以下の内容で作成 (layer インベントリ表の判定列は `(Task 3 で判定)` プレースホルダではなく、空欄セル `—` を置き Task 3 で置換する。プレースホルダ文字列は残さない):
+
+```markdown
+# 検出 subsystem 現状 map (Phase 0, re-plan #753)
+
+> L3 検出再アーキ ([spec](superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md))
+> の Phase 0 成果物。検出 subsystem の各 layer を **load-bearing / cruft / harmful** に
+> 棚卸しし、git 考古学で「なぜ追加されたか」を記録し、再アーキで触る層の coupling を図示する。
+> アルゴリズムの現行解説は [video-processing.md](video-processing.md) /
+> [scorebar-detection-design.md](scorebar-detection-design.md) を参照 (本 doc は重複させない)。
+
+## 1. 判定の凡例
+
+- **load-bearing**: 撤去・改変すると baseline / 実機が回帰する。再アーキで保持必須。
+- **cruft**: 惰性で残存。動作に寄与が薄く、再アーキで整理候補。
+- **harmful**: 能動的にバグ/脆さの温床 (例: 不可逆削除 × 弱い否定信号)。再アーキで設計見直し対象。
+- **判定保留**: コード読解だけでは確証が持てず、harness 実測 (Phase 2+) で確定する。
+
+## 2. layer インベントリ
+
+| layer (シンボル) | module | 責務 (1 行) | 導入 issue | 判定 |
+| --- | --- | --- | --- | --- |
+| `detect_match_boundaries` | detector.py | 検出 orchestration | #56 | — |
+| `_scan_cpu` / Pass1 | detector.py | brightness 粗スキャン | #56/#68 | — |
+| `_group_blackout_regions` | detector.py | 暗転フレーム→region | #57 | — |
+| `_expand_regions_with_transitions` | detector.py | 遷移拡張 (閾値55) | #71 | — |
+| `_refine_blackout_regions` / Pass2 | detector.py | 0.25s 精密計測 | #77 | — |
+| `_has_scorebar_v2` | detector.py | GC紋章3点AND (絶対座標) | #307/#522 | — |
+| `_has_scorebar` (v1) | detector.py | channel-std+edge fallback | #111 | — |
+| `filter_blackouts_with_scorebar` | scorebar.py | 暗転分類 orchestration | #111 | — |
+| `classify_blackout` | scorebar.py | match_boundary/in_match/non_fl | #111 | — |
+| `_is_static_from_frames` (MAD) | scorebar.py | 静止画面 override | #201/#203 | — |
+| `_merge_boundary_pairs` | scorebar.py | 境界ペアマージ | #111 | — |
+| audio Fanfare promotion | scorebar.py | in_match→boundary 昇格 | #288 | — |
+| `_filter_and_extract_segments` | detector.py | duration filter + segment 抽出 | #77/#388 | — |
+| `_drop_post_match_trailing` | detector.py | 試合後 trailing 不可逆削除 | #797/#806 | — |
+| GPU Pass1 (`scan_gpu`) | gpu_detector.py | チャンク並列 GPU デコード | #37 | — |
+| legacy fps filter path | detector.py | #576 で retire 済の旧 path | #575/#576 | — |
+| `localize_scorebar` (P1) | capture_region.py | 位置独立 scorebar 局在化 | #811 | — |
+| `detect_region_*` (S1/S3) | capture_region.py | VTuber 領域候補 (脆い) | #807 | — |
+
+## 3. git 考古学 (なぜ追加されたか)
+
+(Task 2 で記入)
+
+## 4. coupling 図: `_drop_post_match_trailing` × v2 × membership
+
+(Task 4 で記入)
+
+## 5. 再アーキ (spec) への含意
+
+(Task 5 で記入)
+```
+
+- [ ] **Step 3: layer インベントリの網羅を Step 1 出力と突合**
+
+Step 1 の Grep 出力に出た主要シンボルが Step 2 の表に漏れなく載っているか目視確認。漏れがあれば表に行を追加。`localize_present_at` 等 presence.py のシンボルは §2 表の脚注に「presence.py は Phase 1 spec の資産、§5 で扱う」と 1 行で言及。
+
+- [ ] **Step 4: markdownlint**
+
+Run:
+
+```bash
+bash scripts/check-markdownlint.sh
+```
+
+Expected: `Summary: 0 error(s)`。エラーが出たら `docs/markdownlint-guide.md` の fix recipe に従う (table の `|` 整形 / fenced code に language 指定 / 見出し前後の空行)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/detection-map.md
+git commit -m "docs(l3): 検出 subsystem map 骨格 + layer インベントリ (Phase 0 Task 1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: git 考古学セクション (§3) を記入
+
+各 layer が「どの課題に対する対症修正か」を git log / docstring から復元する。spec の主張 (積層した対症修正) を実証する。
+
+**Files:**
+
+- Modify: `docs/detection-map.md` (§3 を置換)
+- Reference: git log, 各 module の docstring
+
+- [ ] **Step 1: 各 layer 導入 commit の課題を抽出**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+git log --oneline -- allaganeye/video/detector.py | grep -iE '#71|#77|#107|#108|#109|#111|#201|#203|#288|#307|#522|#797|#806|#576|#575'
+git log --oneline -- allaganeye/video/scorebar.py | head -15
+```
+
+Expected: 課題 1-7 (リスポーン暗転 #60 / パターンB境界欠落 #71 / パターンC #77 / キャラダウン #107 / 非FL #108-109 / 二重境界 / 静止画面誤分類 #201,#203) と scorebar v2 (#307,#522) / trailing drop (#797,#806) の commit が並ぶ。詳細経緯は `docs/video-processing.md` §設計経緯 (課題 1-7) に既出 → リンクする。
+
+- [ ] **Step 2: §3 を時系列の「対症修正の地層」として記入**
+
+`docs/detection-map.md` §3 のプレースホルダ行 `(Task 2 で記入)` を以下構造で置換 (各 entry は「契機の課題 → 追加された layer → それが生んだ新たな脆さ/制約」の 3 点。詳細解説は video-processing.md にリンクし重複させない):
+
+```markdown
+## 3. git 考古学 (なぜ追加されたか)
+
+> 詳細経緯は [video-processing.md §設計経緯](video-processing.md#設計経緯) に既出。
+> 本節は「対症修正が積層した順序」と「各層が生んだ新たな制約」に絞る。
+
+| 時期 | 契機 (課題) | 追加 layer | 生んだ制約/脆さ |
+| --- | --- | --- | --- |
+| #60 | リスポーン暗転の誤検知 | min_blackout_duration filter | 短い真境界も落ちうる |
+| #71 | 試合境界の未検出 (パターンB) | `_expand_regions_with_transitions` (閾値55) | lobby 輝度依存。VTuber crop で過剰 merge (#809 Wave F) |
+| #77 | 境界未検出 (パターンC) | Pass2 refine + duration filter | — |
+| #107 | キャラダウン暗転 | `in_match` duration guard | — |
+| #108/#109 | 非 FL コンテンツ | `non_fl` 分類 | — |
+| #111 | scorebar 分類統合 | `filter_blackouts_with_scorebar` 一式 | 絶対座標前提 (VTuber inset で破綻 = #480) |
+| #201/#203 | 静止ローディング誤分類 | `_is_static_from_frames` (MAD override) | short blackout 限定の局所 override |
+| #288 | scorebar 残像で境界誤分類 | audio Fanfare promotion | Fanfare 試合中弱ピークで FP 余地 |
+| #307/#522 | scorebar FP | `_has_scorebar_v2` (GC紋章3点AND) | 絶対/相対 two-path。位置特異 = VTuber 不可 |
+| #797/#806 | 試合後 trailing 残存 | `_drop_post_match_trailing` | **不可逆削除 × v2 直接プローブ** (#805/Codex #6) |
+```
+
+- [ ] **Step 3: markdownlint**
+
+Run: `bash scripts/check-markdownlint.sh`
+Expected: `Summary: 0 error(s)`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/detection-map.md
+git commit -m "docs(l3): 検出 layer の git 考古学セクション (Phase 0 Task 2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: layer 判定列 (§2) を load-bearing/cruft/harmful で埋める
+
+インベントリ表の判定列を、コード実体 + spec の決定を根拠に確定する。再アーキで「保持必須 / 整理候補 / 見直し対象」が一目で分かる状態にする。
+
+**Files:**
+
+- Modify: `docs/detection-map.md` (§2 表の判定列 `—` を置換)
+- Reference: spec §3.5 (duration filter backstop の検証済み事実), §4 (Codex findings)
+
+- [ ] **Step 1: 判定の根拠をコードで再確認**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+grep -n "min_match_duration" allaganeye/video/detector.py | head
+grep -n "_has_scorebar_v2(" allaganeye/video/detector.py allaganeye/video/scorebar.py
+```
+
+Expected: `min_match_duration` は `detect_match_boundaries` 引数 (default 300) と `_filter_and_extract_segments` / `_drop_post_match_trailing` で使用。`_has_scorebar_v2` は scorebar.py の `_probe_scorebar_context` と detector.py の `_drop_post_match_trailing:1977` から呼ばれる (= v2 の 2 つの consumer)。
+
+- [ ] **Step 2: §2 表の判定列を確定して置換**
+
+各 `—` を以下の判定で置換 (根拠を §2 直後に脚注として 1 行ずつ付す):
+
+- brightness Pass1/Pass2 (`_scan_cpu` / `_refine_blackout_regions` / `_group_blackout_regions`): **load-bearing** — spec §3.1① boundary 主軸、A.3 で OBS 秒未満精度を実証。
+- `_expand_regions_with_transitions`: **load-bearing (但し VTuber で要調整)** — OBS では必須、VTuber crop で過剰 merge (spec P5 / re-plan #809 Wave F)。
+- `_has_scorebar_v2`: **load-bearing (provisional)** — OBS の高特異度ガード (Codex #3)。spec Q3 で localize に置換予定だが parity 実証まで authoritative 温存。
+- `_has_scorebar` (v1): **cruft** — opencv 不在時 fallback のみ。実運用 opencv 同梱で経路ほぼ死。
+- `filter_blackouts_with_scorebar` / `classify_blackout`: **load-bearing (再編対象)** — 分類 orchestration。primitive を localize+motion に差し替え (spec §5)。
+- `_is_static_from_frames`: **load-bearing (昇格対象・要検証)** — Q5 で分類補助に昇格予定だが Codex #1 で primary 化未検証 → **判定保留**寄り。
+- `_merge_boundary_pairs`: **load-bearing** — 二重境界対策。流用。
+- audio Fanfare promotion: **load-bearing (FP 余地あり)** — #288 救済。
+- `_filter_and_extract_segments` (duration filter): **load-bearing (backstop)** — spec §3.5 でリザルト除去の真の backstop と実証。
+- `_drop_post_match_trailing`: **harmful** — 不可逆削除 × 弱い否定信号 (#805) + v2 hidden coupling (Codex #6)。
+- GPU Pass1: **load-bearing** — `--gpu` 経路。CPU と parity 必須 (Codex #8)。
+- legacy fps filter path: **cruft (撤去予定)** — #576 で新 path 既定化、env var rollback のみ。v0.3.x で削除予定。
+- `localize_scorebar`: **load-bearing (新基盤)** — 再アーキの分類器核 + VTuber anchor。
+- `detect_region_*` (S1/S3): **判定保留 (脆い)** — re-plan R6。spec は scorebar 帯 anchor を主軸にし S3 を補助降格。
+
+- [ ] **Step 3: markdownlint**
+
+Run: `bash scripts/check-markdownlint.sh`
+Expected: `Summary: 0 error(s)`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/detection-map.md
+git commit -m "docs(l3): layer の load-bearing/cruft/harmful 判定 (Phase 0 Task 3)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: coupling 図 (§4) — `_drop_post_match_trailing` × v2 × membership
+
+Codex #6 が指摘した hidden coupling を、データフローと「再アーキで何が壊れるか」で図示する。これが Phase 0 の最重要成果。
+
+**Files:**
+
+- Modify: `docs/detection-map.md` (§4 を置換)
+- Reference: `allaganeye/video/detector.py:1901-1993` (`_drop_post_match_trailing` 全体), spec §3.4 / R4
+
+- [ ] **Step 1: trailing drop の v2 依存を行レベルで確認**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+sed -n '1973,1993p' allaganeye/video/detector.py
+```
+
+Expected: `_has_scorebar_v2(_probe_frame_rgb_hires(video_path, probe_at)) is not False` で「scorebar hit か probe 失敗なら keep / 全 probe が definite miss なら drop (`segments[:-1]`)」。= **v2 の False 判定が不可逆削除のトリガ**。
+
+- [ ] **Step 2: §4 を coupling 図 + 競合シナリオで記入**
+
+`(Task 4 で記入)` を以下で置換:
+
+```markdown
+## 4. coupling 図: `_drop_post_match_trailing` × v2 × membership
+
+`_drop_post_match_trailing` (detector.py:1901) は segment 抽出の **後段**で、最終 segment が
+post-match trailing (lobby/city) かを **v2 scorebar の不在を根拠に不可逆削除**する。
+
+\```text
+segments 抽出 (_filter_and_extract_segments)
+        │
+        ▼
+最終 segment が type=unknown かつ end≈動画末尾 かつ len>=2 か?
+        │ yes
+        ▼
+早期 candidate-match 窓を _TRAILING_PROBE_STRIDE で v2 プローブ
+        │
+        ├─ どれか True / None (probe 失敗) → keep (safe side)
+        └─ 全て False (definite miss)      → segments[:-1]  ← 不可逆削除
+\```
+
+### 競合シナリオ (Codex #6 / spec R4)
+
+| 変更 | trailing drop への影響 |
+| --- | --- |
+| v2 を localize に置換 (Q3) | trailing drop は v2 を直接呼ぶ (detector.py:1977)。置換すると **第 2 の分類器が暗黙に挙動変化**。localize はリザルト 91% present → trailing を「試合あり」と誤判定し drop し損ねる、逆に VTuber では本物 trailing を切る (R3) |
+| membership 信号導入 (Q4) | membership は segment 抽出の前段。trailing drop は後段で独立に再判定するため、**2 つの membership 判断が二重化** |
+| #805 非破壊化 | 不可逆削除 → フラグ方式にすると trailing drop の出力契約が変わる |
+
+### 結論 (Phase 1+ への制約)
+
+- spec §3.4 の通り、**Phase 1-3 は v2 を温存**し trailing drop を現状のまま据え置く。
+- membership 統一と #805 非破壊化は **Phase 4 cutover 以降の別 phase**で、trailing drop を新 membership と同じ根拠に統一するか shadow 無効化してから扱う。
+- Phase 2 で localize を shadow 並走させる際、**trailing drop は v2 (authoritative) のまま**にする (localize を trailing drop に配線しない)。
+```
+
+注: 上記の coupling 図は実ファイルでは三連バッククォートの fenced code (language `text`) として書く。
+
+- [ ] **Step 3: markdownlint**
+
+Run: `bash scripts/check-markdownlint.sh`
+Expected: `Summary: 0 error(s)`。fenced code の language 指定 (MD040) と図中の `|` 漏れに注意。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/detection-map.md
+git commit -m "docs(l3): trailing-drop × v2 × membership coupling 図 (Phase 0 Task 4)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: §5 含意 + presence.py 資産整理 + 相互リンク + spec 追記
+
+map の結論を spec の Phase 1+ 実装に接続し、presence.py 資産 (spec §10) の現状を記録し、既存 doc と双方向リンクする。
+
+**Files:**
+
+- Modify: `docs/detection-map.md` (§5 を置換)
+- Modify: `docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md` (§8 / §13)
+- Modify: `docs/video-processing.md` (相互リンク 1 行)
+
+- [ ] **Step 1: §5 含意を記入**
+
+`(Task 5 で記入)` を以下で置換:
+
+```markdown
+## 5. 再アーキ (spec) への含意
+
+### 5.1 Phase 1 で保持必須 (load-bearing)
+
+- brightness Pass1/Pass2、duration filter (backstop)、`_merge_boundary_pairs` は OBS で bit-exact 維持。
+- `_has_scorebar_v2` は authoritative 温存 (Q3 provisional)。
+
+### 5.2 Phase 1 で触る (再編)
+
+- `classify_blackout` の検出 primitive を localize+motion 化 (shadow 並走、§2 判定参照)。
+- `_is_static_from_frames` を band-anchor 化 (絶対 ROI → localize bbox、spec §5)。OBS は絶対 ROI 縮退。
+
+### 5.3 触ってはいけない (Phase 4 以降)
+
+- `_drop_post_match_trailing` (harmful だが §4 の通り coupling 故に Phase 1-3 据え置き)。
+- legacy fps filter path (cruft、別 issue で撤去)。
+
+### 5.4 presence.py 資産 (spec §10)
+
+- `compare_segments` / GT 突合ハーネス → 検証インフラとして存続。
+- `localize_present_at` → Stage 2 分類で再利用。
+- `scan_presence` / `segment_presence` / `detect_matches_by_presence` → VTuber + 診断専用に降格 (OBS production 経路では使わない)。
+- branch `claude/l3-p2-region-detection` は Phase 1-2 実装で継続使用。
+```
+
+- [ ] **Step 2: spec §8 Phase 0 行と §13 参照に map へのリンク追記**
+
+`docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md` の §8 Phase 0 行末尾と §13 参照リストに `docs/detection-map.md` リンクを追加。
+
+§8 の Phase 0 行 (`| **0** | 検出 subsystem の git 考古学...`) の「内容」セル末尾に追記:
+
+```text
+。成果物 = [docs/detection-map.md](../../detection-map.md)
+```
+
+§13 参照リストの現行コード行の直後に新規 bullet:
+
+```markdown
+- Phase 0 成果物: [docs/detection-map.md](../../detection-map.md) (layer 別 keep/cruft/harmful 判定 + git 考古学 + coupling 図)
+```
+
+- [ ] **Step 3: video-processing.md に相互リンク追加**
+
+`docs/video-processing.md` の冒頭 `## 概要` セクション末尾に 1 行追加 (検出 layer の棚卸し map への導線):
+
+```markdown
+> 検出 subsystem の layer 別 load-bearing/cruft/harmful 判定・git 考古学・再アーキ coupling は [detection-map.md](detection-map.md) (L3 Phase 0) を参照。
+```
+
+- [ ] **Step 4: markdownlint + リンク到達性確認**
+
+Run:
+
+```bash
+bash scripts/check-markdownlint.sh
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+test -f docs/detection-map.md && echo "map exists"
+grep -c "detection-map" docs/video-processing.md docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
+```
+
+Expected: `Summary: 0 error(s)` / `map exists` / video-processing.md と spec の双方に detection-map 参照が 1 件以上。相対リンク `../../detection-map.md` が specs/ → docs/ に到達するか確認 (specs/ は docs/superpowers/specs/ なので `../../` で docs/ 直下)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/detection-map.md docs/video-processing.md docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
+git commit -m "docs(l3): map 含意 + presence 資産整理 + 相互リンク (Phase 0 Task 5)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## 受け入れ条件 (Phase 0 完了基準)
+
+- [ ] `docs/detection-map.md` が存在し、§1 凡例 / §2 layer インベントリ (判定列充填) / §3 git 考古学 / §4 coupling 図 / §5 含意 の 5 節を持つ。
+- [ ] §2 の全 layer に load-bearing / cruft / harmful / 判定保留 のいずれかが付き、根拠脚注がある。
+- [ ] §4 に `_drop_post_match_trailing` × v2 × membership の coupling 図 + 競合シナリオ表 + Phase 1+ 制約 (v2 温存) が記載される。
+- [ ] 既存 doc (video-processing.md / scorebar-detection-design.md) と**重複せず相互リンク**している (memory: PR #783 教訓)。
+- [ ] spec §8/§13 から map へのリンクがある (双方向)。
+- [ ] markdownlint `Summary: 0 error(s)`。
+- [ ] production コード (`allaganeye/**`) の変更が 0 (docs のみ)。
+
+## 検証 (動画不要)
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+git diff --name-only develop-0.3.0...HEAD | grep -vE '^docs/' && echo "WARN: non-docs changed" || echo "OK: docs-only"
+bash scripts/check-markdownlint.sh | tail -1
+grep -c '^## ' docs/detection-map.md   # expect 5
+```
+
+Expected: `OK: docs-only` / `Summary: 0 error(s)` / `5`。
+
+## このプランがやらないこと
+
+- production コード変更 (Phase 1 以降)。
+- 動画実機実行 / harness 実行 (Phase 2+)。
+- issue 起票 (Iron Law 2、spec §11 の通り起票時に別途 AskUserQuestion)。
+- v2 retire や trailing drop 改変 (map は「触らない」と結論づけるのが仕事)。

--- a/docs/superpowers/plans/2026-05-31-l3-phase1-band-anchor-crop.md
+++ b/docs/superpowers/plans/2026-05-31-l3-phase1-band-anchor-crop.md
@@ -912,3 +912,311 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - **VTuber GT 注釈・recall/precision 校正** → Phase 3。
 - **full inset 16:9 矩形の metadata 永続化** → P6 / #810、範囲外 (本 plan は検出に帯のみ使用、保持矩形 schema は別途)。
 - **issue 起票** → Iron Law 2、起票時に AskUserQuestion。
+
+---
+
+## 改訂 (2026-05-31): `--vtuber` 明示信号化 (D1 破綻の root-cause 対応)
+
+> **背景**: 当初 plan の B4 は「Stage 0 anchor を無条件実行し、OBS は localize 失敗で
+> FULL_FRAME に縮退」を前提とした。D1 (OBS baseline gate) を実機で回したところ
+> **破綻** — localize は OBS でも成功し (FL scorebar は全画面にも写る)、band region が
+> 返って OBS 境界が秒未満ずれた。実機調査で localize 生出力が per-frame noisy であることも
+> 判明 (spec §3.6)。**確定方針 (user 2026-05-31): auto 推論を全廃し `--vtuber` 明示信号化**。
+> 以下の B4-rev / B5 / B6 / D1-rev / D2-rev が **authoritative** で、上の B4 (auto 版) を
+> supersede する。B1-B3 / C1 / A1-A3 の実装済 commit は salvage (region plumbing は正しい)。
+
+### Task B4-rev: `detect_match_boundaries` の anchor を `vtuber` gate 化
+
+実装済 B4 (commit 21974db) は `_resolve_detect_region` を無条件呼び出し。これを `vtuber: bool` で gate する。**OBS (vtuber=False) は Stage 0 を走らせず `region=FULL_FRAME`** → bit-exact 構造保証。
+
+**Files:**
+
+- Modify: `allaganeye/video/detector.py` (`detect_match_boundaries`)
+- Test: `tests/test_detector.py`
+
+- [ ] **Step 1: Write failing test — vtuber=False は anchor を呼ばず FULL_FRAME**
+
+```python
+def test_detect_skips_anchor_when_not_vtuber(monkeypatch):
+    from allaganeye.video import detector as det
+    called = {"anchor": False}
+    orig = det._resolve_detect_region
+
+    def spy(*a, **k):
+        called["anchor"] = True
+        return orig(*a, **k)
+
+    monkeypatch.setattr(det, "_resolve_detect_region", spy)
+    import inspect
+    sig = inspect.signature(det.detect_match_boundaries)
+    assert "vtuber" in sig.parameters
+    assert sig.parameters["vtuber"].default is False
+
+
+def test_detect_resolves_region_only_when_vtuber(monkeypatch):
+    # vtuber=False -> anchor never called; vtuber=True -> anchor called.
+    # (full run needs video; assert the gate via a lightweight monkeypatch on
+    #  the first thing detect does — see impl. Here we assert the param exists
+    #  and defaults False so OBS callers are unchanged.)
+    from allaganeye.video import detector as det
+    import inspect
+    assert inspect.signature(det.detect_match_boundaries).parameters["vtuber"].default is False
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_detector.py -k "skips_anchor_when_not_vtuber or resolves_region_only_when_vtuber" -v`
+Expected: FAIL (`vtuber` param absent).
+
+- [ ] **Step 3: Add `vtuber: bool = False` param + gate the anchor call**
+
+In `detect_match_boundaries`, add `vtuber: bool = False` (keyword-with-default, near the other flags like `use_gpu`). Replace the unconditional:
+
+```python
+    detect_region = _resolve_detect_region(video_path, duration_hint)
+```
+
+with:
+
+```python
+    # Stage 0 帯 anchor は VTuber 明示時のみ (spec §3.6)。OBS (vtuber=False) は
+    # FULL_FRAME で現行 bit-exact。localize は OBS でも成功するため auto 判別は不可。
+    detect_region = (
+        _resolve_detect_region(video_path, duration_hint)
+        if vtuber
+        else FULL_FRAME
+    )
+```
+
+(All B1-B4 region threading stays; only the resolution is gated.)
+
+- [ ] **Step 4: Run detector suite (bit-exact guard)**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_detector.py -v`
+Expected: PASS — all green. `vtuber=False` default = existing callers unchanged.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+python -m ruff check allaganeye/video/detector.py tests/test_detector.py
+python -m pyright allaganeye/video/detector.py
+git add allaganeye/video/detector.py tests/test_detector.py
+git commit -m "fix(l3): Stage 0 anchor を --vtuber gate 化 (OBS=FULL_FRAME bit-exact, Phase 1 B4-rev)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task B5: `detect_scorebar_band_region` の consensus robust 化 (localize noise 対策)
+
+実機で localize は per-frame noisy (OBS 試合中でも y_top 0 ↔ 540-582 が混在、誤検出 conf 0.69)。VTuber 経路の band 解決が真/偽クラスタ混在で壊れないよう、confidence-filter + dominant cluster を入れる。**VTuber 経路内 (`vtuber=True`) のみ通るので OBS には無影響。**
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py` (`detect_scorebar_band_region`)
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write failing test — 真/偽クラスタ混在で真クラスタを選ぶ**
+
+```python
+def test_band_consensus_rejects_low_conf_and_picks_dominant_cluster():
+    from allaganeye.video.capture_region import (
+        ScorebarLocalization, detect_scorebar_band_region,
+    )
+    # 4 true (y~0, high conf) + 3 noise (y~540, varied conf incl one 0.69)
+    locs = [
+        ScorebarLocalization(600, 1315, 0, 45, 1.0),
+        ScorebarLocalization(600, 1315, 0, 45, 1.0),
+        ScorebarLocalization(604, 1311, 12, 57, 0.52),
+        ScorebarLocalization(600, 1315, 0, 45, 1.0),
+        ScorebarLocalization(1116, 1919, 540, 585, 0.21),
+        ScorebarLocalization(508, 1288, 582, 627, 0.28),
+        ScorebarLocalization(0, 778, 558, 603, 0.69),
+    ]
+    calls = iter(locs)
+    region = detect_scorebar_band_region(
+        duration=400.0, probe_w=1920, probe_h=1080,
+        localize_fn=lambda _t: next(calls), num_samples=7,
+    )
+    # must converge on the true cluster (y~0), NOT the noise-mixed median (y~0.24)
+    assert region.y < 0.05, f"expected true cluster y~0, got {region.y}"
+    assert abs(region.x - 600 / 1920) < 0.05
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_capture_region.py -k "dominant_cluster" -v`
+Expected: FAIL (current plain-median returns y~0.24).
+
+- [ ] **Step 3: Implement cluster-based consensus**
+
+Replace the plain-median body of `detect_scorebar_band_region` (keep signature + FULL_FRAME fallbacks). After collecting `hits`, cluster by `y_top` (the noisy axis) and pick the **largest cluster**, breaking ties by mean confidence; require the chosen cluster to still meet `min_hits`:
+
+```python
+    if len(hits) < min_hits:
+        return FULL_FRAME
+    # localize は per-frame noisy (上半分 best-hit scan; spec §3.6)。
+    # y_top で粗くクラスタリングし最大クラスタを採用 (真 scorebar が支配的の前提)。
+    _CLUSTER_Y_TOL = 60  # probe px。同一 scorebar 帯とみなす y_top 差
+    hits_sorted = sorted(hits, key=lambda h: h.y_top)
+    clusters: list[list] = []
+    for h in hits_sorted:
+        if clusters and h.y_top - clusters[-1][-1].y_top <= _CLUSTER_Y_TOL:
+            clusters[-1].append(h)
+        else:
+            clusters.append([h])
+    # 最大サイズ、同数なら平均 confidence の高い方
+    best = max(
+        clusters,
+        key=lambda c: (len(c), sum(h.confidence for h in c) / len(c)),
+    )
+    if len(best) < min_hits:
+        return FULL_FRAME
+    median_loc = ScorebarLocalization(
+        x_left=int(np.median([h.x_left for h in best])),
+        x_right=int(np.median([h.x_right for h in best])),
+        y_top=int(np.median([h.y_top for h in best])),
+        y_bottom=int(np.median([h.y_bottom for h in best])),
+        confidence=float(np.median([h.confidence for h in best])),
+    )
+    return band_region_from_localization(median_loc, probe_w=probe_w, probe_h=probe_h)
+```
+
+Add `_CLUSTER_Y_TOL` as a module constant with a docstring if preferred. Keep the existing `duration<=0`/`num_samples<1` and `len(hits)<min_hits` guards.
+
+- [ ] **Step 4: Run, verify pass + full capture_region suite**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_capture_region.py -v`
+Expected: PASS — new cluster test + the 3 existing A3 consensus tests still green (the all-true and all-miss cases are unaffected; the below-min case still falls back).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+python -m ruff check allaganeye/video/capture_region.py tests/test_capture_region.py
+python -m pyright allaganeye/video/capture_region.py
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "fix(l3): band consensus を dominant-cluster 化 (localize per-frame noise 対策, Phase 1 B5)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task B6: `--vtuber` CLI flag を detect / split に追加
+
+`detect_match_boundaries(vtuber=...)` を CLI から駆動する。`allaganeye/cli.py` の detect / split コマンドに `--vtuber` boolean flag を足し、検出呼び出しに渡す。
+
+**Files:**
+
+- Modify: `allaganeye/cli.py` (detect / split コマンド)
+- Modify: `allaganeye/commands/detect.py` / `allaganeye/commands/split_matches.py` (vtuber を detect_match_boundaries まで配線)
+- Test: `tests/test_cli.py` (なければ既存 CLI テストファイル) / `tests/test_detect.py` 等
+
+- [ ] **Step 1: 配線経路を確認**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+grep -nE "detect_match_boundaries\(" allaganeye/commands/detect.py allaganeye/commands/split_matches.py
+grep -nE "def detect|def split" allaganeye/cli.py
+```
+
+Expected: detect.py / split_matches.py が `detect_match_boundaries(...)` を呼ぶ箇所、cli.py の detect/split 定義が見える。`vtuber` をこの経路で渡す。
+
+- [ ] **Step 2: Write failing test — --vtuber flag が解析され渡る**
+
+CLI テスト (typer の CliRunner、既存パターンに合わせる) で `allaganeye detect <v> --vtuber` が detect_match_boundaries に `vtuber=True` を渡すことを mock で確認:
+
+```python
+def test_detect_vtuber_flag_passed(monkeypatch, tmp_path):
+    # mock detect_match_boundaries, assert it receives vtuber=True with --vtuber
+    captured = {}
+    from allaganeye.commands import detect as detect_cmd
+
+    def fake_detect(*a, **k):
+        captured["vtuber"] = k.get("vtuber")
+        return []  # no boundaries
+
+    monkeypatch.setattr(detect_cmd, "detect_match_boundaries", fake_detect)
+    # invoke the CLI detect command with --vtuber on a dummy path that probes OK,
+    # OR call the command function directly with vtuber=True.
+    # (Adapt to the existing test style in the repo — see tests/test_detect*.py.)
+```
+
+Adapt to the repo's actual CLI test pattern (read an existing CLI test first; if detect is hard to invoke without a real video, test the command-layer function `detect.py` directly with `vtuber=True` and assert it threads through).
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest -k "vtuber_flag" -v`
+Expected: FAIL (flag/param absent).
+
+- [ ] **Step 4: Add `--vtuber` flag + thread through**
+
+In `cli.py` detect (and split) commands, add:
+
+```python
+    vtuber: bool = typer.Option(
+        False,
+        "--vtuber",
+        help="VTuber 録画 (game inset): scorebar 帯 anchor で検出。"
+        "未指定は OBS 全画面前提 (default)。",
+    ),
+```
+
+Thread `vtuber` into the command-layer call (`detect.py` / `split_matches.py`) and on into `detect_match_boundaries(..., vtuber=vtuber)`.
+
+- [ ] **Step 5: Run CLI tests + lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+python -m pytest -k "vtuber or test_cli or test_detect" -v
+python -m ruff check allaganeye/cli.py allaganeye/commands/detect.py allaganeye/commands/split_matches.py
+python -m pyright allaganeye/cli.py allaganeye/commands/detect.py allaganeye/commands/split_matches.py
+git add allaganeye/cli.py allaganeye/commands/detect.py allaganeye/commands/split_matches.py tests/
+git commit -m "feat(l3): --vtuber CLI flag を detect/split に追加 (Phase 1 B6)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task D1-rev: OBS baseline 回帰 (flag なし = bit-exact gate)
+
+B4-rev 適用後、`allaganeye detect <obs> --no-cache` (vtuber flag なし) が 5 OBS baseline と bit-exact であることを確認。**これが今 fail している gate で、B4-rev で pass すべき。**
+
+- [ ] **Step 1: Run OBS Class A bit-exact (Idios 実機 / sample dir 設定マシン)**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+set ALLAGANEYE_SAMPLE_VIDEO_DIR=E:\royalstraightflesh\videos
+set PYTHONUTF8=1
+python -m pytest tests/test_v030_baseline_regression.py -m slow_detect -v
+```
+
+Expected: PASS — 4 Class A OBS baselines bit-exact (detect は flag なしで FULL_FRAME)。**fail なら B4-rev の gate が効いていない** → STOP。
+
+### Task D2-rev: VTuber 帯 anchor + 帯 crop 受け入れ (`--vtuber` 経由)
+
+`tests/test_vtuber_region_e2e.py` (本セッションで作成済) を `--vtuber` 経路に合わせる。`_resolve_detect_region` 直呼びでなく、`vtuber=True` での band 解決を検証。
+
+- [ ] **Step 1: D2 テストを vtuber=True 経路に更新**
+
+既存 `test_vtuber_region_e2e.py` の `_resolve_detect_region(vod, dur)` 呼び出しは B4-rev 後も有効 (helper 自体は残る)。ただし「detect 全体が `--vtuber` で band を使う」ことも 1 ケース追加し、`--vtuber` なしでは FULL_FRAME になることを対比で示す。
+
+- [ ] **Step 2: Run (sample-gated)**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+set PYTHONUTF8=1
+set ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER=E:\allaganeye-samples
+python -m pytest tests/test_vtuber_region_e2e.py -m slow_detect -v
+```
+
+Expected: PASS (band anchor が VTuber VOD で non-FULL_FRAME を返す or 明示 skip)、`--vtuber` なしは FULL_FRAME。
+
+### 改訂後の受け入れ条件 (上の §受け入れ条件を補正)
+
+- [ ] B4-rev: `detect_match_boundaries(vtuber=False)` は Stage 0 を走らせず FULL_FRAME。`vtuber=True` のみ band 解決。
+- [ ] B5: band consensus が dominant-cluster で localize noise に頑健 (真/偽クラスタ混在 unit)。
+- [ ] B6: `--vtuber` flag が detect/split に存在し `detect_match_boundaries(vtuber=...)` まで配線される。
+- [ ] D1-rev: OBS 5 baseline が **flag なしで** bit-exact (これが破綻していた gate)。
+- [ ] D2-rev: VTuber は `--vtuber` で band 解決、flag なしは FULL_FRAME。
+- [ ] Idios 実機検証 (OBS detect 不変 + `--vtuber` で VTuber 帯 crop + GPU)。

--- a/docs/superpowers/plans/2026-05-31-l3-phase1-band-anchor-crop.md
+++ b/docs/superpowers/plans/2026-05-31-l3-phase1-band-anchor-crop.md
@@ -1,0 +1,914 @@
+# L3 Phase 1: scorebar 帯 anchor + 帯 crop wiring + MAD band-anchor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** VTuber 録画の検出経路を「scorebar 帯に anchor した brightness/motion 測定」で成立させる基盤を作る。OBS は FULL_FRAME 縮退で v0.3.0 baseline と bit-exact を維持し、VTuber は scorebar 帯 crop で境界 blackout を回復する。
+
+**Architecture:** spec ([2026-05-31-l3-detection-rearchitecture-two-signal-design.md](../specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md)) §8 Phase 1 の 3 要素を 3 task group で実装する。**A** = Stage 0 帯 anchor (`localize_scorebar` consensus → scorebar 帯 ROI + 保持矩形)、**B** = Stage 1 帯 crop wiring (#809 の検証済み `region_mean`/`is_full_frame` を再適用し brightness Pass1/Pass2/GPU を帯 crop で駆動)、**C** = `_is_static_from_frames` の band-anchor 化。全変更は **`region.is_full_frame()` 分岐の内側**に閉じ込め、OBS (FULL_FRAME) は現行の数値経路をそのまま通す (bit-exact)。
+
+**Tech Stack:** Python 3 / numpy / OpenCV (`cv2`) / pytest (slow marker for video-gated) / ThreadPoolExecutor。検証は unit (合成 frame) + baseline 回帰 + slow harness (gyawa)。
+
+---
+
+## 適用条件チェック (refactor-pattern)
+
+本 plan は detector.py / scorebar.py / capture_region.py / gpu_detector.py + tests に跨り、#809 (15 files) と同規模。[`docs/refactor-pattern.md`](../../refactor-pattern.md) §1 の Phase 分割閾値 (touched > 30 file or diff > 1000 line) に近い。
+
+- **task group A / B / C は独立 commit・独立に OBS bit-exact を保つ**よう設計した。実行時に diff が閾値を超えそうなら、A / B / C を**別 PR に分割**してよい (各 group が単体で bit-exact gate を通る)。
+- 本 plan は user 承認済 scope「spec §8 Phase 1 の 3 要素全部」を 1 plan にまとめたもの。PR 分割は実装後の判断 (Iron Law 6 Pre-flight 時)。
+
+## spec が要求する Phase 1 gate (受け入れの中心)
+
+- **OBS bit-exact**: 5 baseline (`tests/baselines/v0.3.0/obs-*.metadata.json`) が FULL_FRAME 縮退で完全一致 (検出 timestamp 不変)。
+- **gyawa 帯 crop blackout 回復**: full-frame では拾えない試合境界 blackout が scorebar 帯 crop で回復する (#809 Wave F の drop 5/5 end を帯版で再現)。slow / sample-gated。
+- **production 影響なし**: VTuber 新ロジックは `non-full-frame かつ high-confidence` gate の内側。OBS detect 出力は変わらない。
+
+---
+
+## File Structure
+
+| ファイル | 本 plan での責務 | 変更種別 |
+| --- | --- | --- |
+| `allaganeye/video/capture_region.py` | `is_full_frame` / `region_mean` 再追加 (#809 再利用) + 新規 `detect_scorebar_band_region` (Stage 0 anchor) + 帯 ROI 導出 | Modify |
+| `allaganeye/video/detector.py` | Pass1 brightness サイト (`_sample_chunk_frames` / `_decode_chunk_cpu_legacy`) と Pass2 (`_refine_blackout_regions`) を region 引数化 (FULL_FRAME 既定) + `_frame_brightness` helper + `_resolve_detect_region` | Modify |
+| `allaganeye/video/gpu_detector.py` | GPU chunk brightness を region 引数化 (FULL_FRAME 既定) | Modify |
+| `allaganeye/video/scorebar.py` | `_is_static_from_frames` に band ROI 引数追加 (絶対 ROI 既定で OBS bit-exact) | Modify |
+| `tests/test_capture_region.py` | A: band anchor + region_mean + is_full_frame の unit | Modify |
+| `tests/test_detector.py` | B: 帯 crop brightness の FULL_FRAME 縮退 = 現行一致 unit | Modify |
+| `tests/test_scorebar.py` | C: MAD band-anchor の FULL_FRAME 縮退 unit | Modify (既存) |
+| `tests/test_vtuber_region_e2e.py` | gyawa 帯 crop blackout 回復 slow 受け入れ | Create (現状なし) |
+
+> **実装前に確認済みの事実 (self-review 2026-05-31)**: CPU brightness は 3 サイトで算出される —
+> `_sample_chunk_frames` (detector.py:163-164、`_decode_chunk_cpu_v2` が使用)、
+> `_decode_chunk_cpu_legacy` (:538-539)、`_probe_single_frame` (:828)。**いずれも
+> `np.frombuffer(...)` の 1-D buffer に対し `float(frame.mean())`** を取る (2-D reshape していない)。
+> frame は固定 `320x180` grayscale (`_SAMPLE_WIDTH=320` / `_SAMPLE_HEIGHT=180` / `_FRAME_SIZE=320*180`)。
+> → 帯 crop には 2-D `(180,320)` reshape が必要。`_frame_brightness` は **FULL_FRAME 分岐で 1-D の
+> まま `frame.mean()`** (bit-exact)、**band 分岐でのみ `reshape(_SAMPLE_HEIGHT,_SAMPLE_WIDTH)` してから
+> `region_mean`** とする (B1 で実装)。Pass2 (:1340 は既に `reshape(height,_SAMPLE_WIDTH,3)`) と GPU 経路も
+> 各サイトの frame 形状に合わせて分岐する。
+
+依存: **A → B → C**。A が帯 ROI (`CaptureRegion`) を産み、B がそれで brightness を測り、C が同じ帯で motion を測る。各 group 内は TDD (failing test → impl → pass → commit)。
+
+---
+
+## Task Group A — Stage 0: scorebar 帯 anchor
+
+### Task A1: `is_full_frame` と `region_mean` を capture_region.py に再追加 (#809 再利用)
+
+これらは #809 parked branch (`claude/l3-809-pass1-region-wiring`) で検証済だが現ブランチには無い。spec §10 / re-plan §4 の「#809 wiring 再利用」に従い再追加する。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write failing tests for is_full_frame + region_mean**
+
+`tests/test_capture_region.py` に追加:
+
+```python
+import numpy as np
+from allaganeye.video.capture_region import CaptureRegion, FULL_FRAME, region_mean
+
+
+def test_is_full_frame_true_only_for_unit_rect():
+    assert FULL_FRAME.is_full_frame() is True
+    assert CaptureRegion(0.0, 0.0, 1.0, 1.0).is_full_frame() is True
+    assert CaptureRegion(0.1, 0.0, 0.9, 1.0).is_full_frame() is False
+    assert CaptureRegion(0.0, 0.0, 1.0, 0.5).is_full_frame() is False
+
+
+def test_region_mean_full_frame_equals_frame_mean():
+    frame = np.arange(12, dtype=np.uint8).reshape(3, 4)
+    assert region_mean(frame, FULL_FRAME) == float(frame.mean())
+
+
+def test_region_mean_crops_to_band():
+    frame = np.zeros((10, 10), dtype=np.uint8)
+    frame[0:2, :] = 200  # bright top band
+    # a band region covering only the top 20% should read ~200
+    band = CaptureRegion(0.0, 0.0, 1.0, 0.2)
+    assert region_mean(frame, band) == 200.0
+
+
+def test_region_mean_empty_crop_clamps_to_1px():
+    frame = np.full((10, 10), 50, dtype=np.uint8)
+    degenerate = CaptureRegion(0.999, 0.999, 0.0001, 0.0001)
+    # must not raise / must return a finite mean (>=1px clamp)
+    assert region_mean(frame, degenerate) == 50.0
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_capture_region.py -k "is_full_frame or region_mean" -v`
+Expected: FAIL (`AttributeError: 'CaptureRegion' object has no attribute 'is_full_frame'` / `ImportError: cannot import name 'region_mean'`).
+
+- [ ] **Step 3: Add is_full_frame method + region_mean function**
+
+In `capture_region.py`, add `is_full_frame` method to the `CaptureRegion` dataclass (right after `clamp`):
+
+```python
+    def is_full_frame(self) -> bool:
+        """領域 = frame 全体か (OBS 縮退判定 / bit-exact 分岐に使用)。"""
+        return self.x == 0.0 and self.y == 0.0 and self.w == 1.0 and self.h == 1.0
+```
+
+And add the module-level `region_mean` function (place it after the `FULL_FRAME` constant definition):
+
+```python
+def region_mean(frame: np.ndarray, region: CaptureRegion) -> float:
+    """2D gray frame (H,W) を正規化矩形 *region* で crop し平均輝度を返す。
+
+    crop が空になる場合も最低 1px に clamp する。整数次元 frame では
+    FULL_FRAME のとき結果は ``float(frame.mean())`` と一致する (bit-exact 縮退)。
+    """
+    h, w = frame.shape[:2]
+    x0 = max(0, min(round(region.x * w), w - 1))
+    y0 = max(0, min(round(region.y * h), h - 1))
+    x1 = max(x0 + 1, min(round((region.x + region.w) * w), w))
+    y1 = max(y0 + 1, min(round((region.y + region.h) * h), h))
+    return float(frame[y0:y1, x0:x1].mean())
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_capture_region.py -k "is_full_frame or region_mean" -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/capture_region.py tests/test_capture_region.py
+ruff format --check allaganeye/video/capture_region.py tests/test_capture_region.py
+pyright allaganeye/video/capture_region.py
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "feat(l3): is_full_frame + region_mean を capture_region に再追加 (#809 再利用, Phase 1 A1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task A2: `band_region_from_localization` — localize bbox → 正規化 scorebar 帯 ROI
+
+`localize_scorebar` は probe px の `ScorebarLocalization` (x_left/x_right/y_top/y_bottom, 1920x1080 基準) を返す。これを測定用の正規化 `CaptureRegion` (scorebar 帯) に変換する純関数を作る。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+from allaganeye.video.capture_region import (
+    ScorebarLocalization,
+    band_region_from_localization,
+)
+
+
+def test_band_region_normalizes_probe_px_to_unit_rect():
+    # localize bbox in 1920x1080 probe space
+    loc = ScorebarLocalization(x_left=240, x_right=1680, y_top=18, y_bottom=63, confidence=0.9)
+    region = band_region_from_localization(loc, probe_w=1920, probe_h=1080)
+    assert abs(region.x - 240 / 1920) < 1e-6
+    assert abs(region.y - 18 / 1080) < 1e-6
+    assert abs(region.w - (1680 - 240) / 1920) < 1e-6
+    assert abs(region.h - (63 - 18) / 1080) < 1e-6
+    assert region.confidence == 0.9
+    assert region.source == "band"
+
+
+def test_band_region_clamps_into_unit_square():
+    loc = ScorebarLocalization(x_left=-5, x_right=1925, y_top=-2, y_bottom=70, confidence=0.5)
+    region = band_region_from_localization(loc, probe_w=1920, probe_h=1080)
+    assert region.x >= 0.0 and region.y >= 0.0
+    assert region.x + region.w <= 1.0 + 1e-9
+    assert region.y + region.h <= 1.0 + 1e-9
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_capture_region.py -k band_region -v`
+Expected: FAIL (`ImportError: cannot import name 'band_region_from_localization'`).
+
+- [ ] **Step 3: Implement band_region_from_localization**
+
+In `capture_region.py` (after `region_mean`):
+
+```python
+def band_region_from_localization(
+    loc: ScorebarLocalization, *, probe_w: int, probe_h: int
+) -> CaptureRegion:
+    """probe px の scorebar 局在化を正規化 scorebar 帯 ROI に変換する。
+
+    検出 (brightness / motion) を測る最 clean 領域。`loc.confidence` を引き継ぎ
+    `source="band"` を付ける。範囲外座標は clamp する。
+    """
+    x = loc.x_left / probe_w
+    y = loc.y_top / probe_h
+    w = (loc.x_right - loc.x_left) / probe_w
+    h = (loc.y_bottom - loc.y_top) / probe_h
+    return CaptureRegion(x, y, w, h, confidence=loc.confidence, source="band").clamp()
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_capture_region.py -k band_region -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/capture_region.py tests/test_capture_region.py
+pyright allaganeye/video/capture_region.py
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "feat(l3): band_region_from_localization (localize bbox → 帯 ROI, Phase 1 A2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task A3: `detect_scorebar_band_region` — sparse 多フレーム consensus → 帯 ROI
+
+動画から疎に in-match らしいフレームを sampling し、各フレームで `localize_scorebar` を実行、成功した局在化の **median consensus** で安定した帯 ROI を求める。1 つも局在化できなければ `FULL_FRAME` (OBS / 局在化不能時の安全縮退)。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write failing test (synthetic, sample_fn 注入で動画不要)**
+
+```python
+from allaganeye.video.capture_region import (
+    CaptureRegion,
+    ScorebarLocalization,
+    FULL_FRAME,
+    detect_scorebar_band_region,
+)
+
+
+def test_band_consensus_takes_median_of_localizations():
+    # 3 localized frames (slightly different) + 1 miss (None)
+    locs = [
+        ScorebarLocalization(238, 1678, 18, 63, 0.8),
+        ScorebarLocalization(240, 1680, 18, 63, 0.9),
+        ScorebarLocalization(242, 1682, 20, 65, 0.7),
+        None,
+    ]
+    calls = iter(locs)
+
+    def fake_localize(_t):
+        return next(calls)
+
+    region = detect_scorebar_band_region(
+        duration=400.0, probe_w=1920, probe_h=1080,
+        localize_fn=fake_localize, num_samples=4,
+    )
+    # median x_left = 240 → region.x ≈ 240/1920
+    assert abs(region.x - 240 / 1920) < 1e-3
+    assert region.source == "band"
+    assert region.confidence > 0.0
+
+
+def test_band_consensus_all_miss_falls_back_full_frame():
+    region = detect_scorebar_band_region(
+        duration=400.0, probe_w=1920, probe_h=1080,
+        localize_fn=lambda _t: None, num_samples=4,
+    )
+    assert region.is_full_frame()
+
+
+def test_band_consensus_below_min_hits_falls_back_full_frame():
+    # only 1 hit out of 4 → below consensus quorum → FULL_FRAME
+    locs = [ScorebarLocalization(240, 1680, 18, 63, 0.9), None, None, None]
+    calls = iter(locs)
+    region = detect_scorebar_band_region(
+        duration=400.0, probe_w=1920, probe_h=1080,
+        localize_fn=lambda _t: next(calls), num_samples=4, min_hits=2,
+    )
+    assert region.is_full_frame()
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_capture_region.py -k band_consensus -v`
+Expected: FAIL (`ImportError: cannot import name 'detect_scorebar_band_region'`).
+
+- [ ] **Step 3: Implement detect_scorebar_band_region**
+
+In `capture_region.py`:
+
+```python
+import numpy as np  # (既存 import を確認、なければ追加)
+
+
+_BAND_CONSENSUS_MIN_HITS = 2
+"""帯 consensus に必要な最小局在化成功数。これ未満は FULL_FRAME 縮退。"""
+
+
+def detect_scorebar_band_region(
+    *,
+    duration: float,
+    probe_w: int,
+    probe_h: int,
+    localize_fn: Callable[[float], "ScorebarLocalization | None"],
+    num_samples: int = 8,
+    min_hits: int = _BAND_CONSENSUS_MIN_HITS,
+) -> CaptureRegion:
+    """疎な多フレーム localize の median consensus で安定 scorebar 帯 ROI を返す。
+
+    *localize_fn* は timestamp → ScorebarLocalization|None。動画 I/O は呼び出し側が
+    bind する (テストは合成関数を注入)。成功局在化が *min_hits* 未満なら FULL_FRAME
+    (OBS / 局在化不能時の安全縮退)。成功時は各座標の median を取り
+    `band_region_from_localization` で正規化帯 ROI に変換する。
+    """
+    if duration <= 0 or num_samples < 1:
+        return FULL_FRAME
+    # interior sampling (端の lobby/loading を避け、試合中らしい中央寄りを狙う)
+    times = [duration * (i + 1) / (num_samples + 1) for i in range(num_samples)]
+    hits = [loc for t in times if (loc := localize_fn(t)) is not None]
+    if len(hits) < min_hits:
+        return FULL_FRAME
+    median_loc = ScorebarLocalization(
+        x_left=int(np.median([h.x_left for h in hits])),
+        x_right=int(np.median([h.x_right for h in hits])),
+        y_top=int(np.median([h.y_top for h in hits])),
+        y_bottom=int(np.median([h.y_bottom for h in hits])),
+        confidence=float(np.median([h.confidence for h in hits])),
+    )
+    return band_region_from_localization(median_loc, probe_w=probe_w, probe_h=probe_h)
+```
+
+Ensure `from collections.abc import Callable` is imported at top of `capture_region.py` (add if missing).
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_capture_region.py -k band_consensus -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Full capture_region test + lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+python -m pytest tests/test_capture_region.py -v
+ruff check allaganeye/video/capture_region.py tests/test_capture_region.py
+ruff format --check allaganeye/video/capture_region.py tests/test_capture_region.py
+pyright allaganeye/video/capture_region.py
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "feat(l3): detect_scorebar_band_region (localize 多フレーム consensus, Phase 1 A3)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task Group B — Stage 1: 帯 crop brightness wiring
+
+> 方針: brightness を算出する全サイトに「region 引数 (既定 FULL_FRAME)」を通し、`region_mean(frame, region)` で測る。OBS は FULL_FRAME を渡すので `region_mean` が `frame.mean()` と一致し **bit-exact**。VTuber は A3 の帯 ROI を渡す。
+
+### Task B1: `_decode_chunk_cpu` の brightness 算出を region 経由にする (FULL_FRAME 既定 = bit-exact)
+
+**Files:**
+
+- Modify: `allaganeye/video/detector.py` (`_decode_chunk_cpu` と brightness を算出している箇所)
+- Test: `tests/test_detector.py`
+
+- [ ] **Step 1: 現状の brightness 算出箇所を確認 (self-review 済 — 下記を再確認)**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+grep -nE "brightness = float\(frame\.mean|float\(frame\.mean\(\)\)" allaganeye/video/detector.py
+```
+
+Expected: CPU の brightness 算出は **1-D buffer に対する `float(frame.mean())`** で、`_sample_chunk_frames` (:163-164、`_decode_chunk_cpu_v2` 経由) と `_decode_chunk_cpu_legacy` (:538-539) に出る。frame は `np.frombuffer(...)` のまま (2-D reshape していない)。固定 `320x180` grayscale。**帯 crop には 2-D reshape が必要**。
+
+- [ ] **Step 2: Write failing test — FULL_FRAME=1-D mean bit-exact, band=2-D crop**
+
+`tests/test_detector.py` に追加。`_frame_brightness` は 1-D buffer を受け、FULL_FRAME では 1-D の `.mean()` (現行 bit-exact)、band では `(_SAMPLE_HEIGHT,_SAMPLE_WIDTH)` に reshape して crop することを保証:
+
+```python
+import numpy as np
+from allaganeye.video.capture_region import FULL_FRAME, CaptureRegion
+from allaganeye.video import detector as det
+
+
+def test_frame_brightness_full_frame_is_1d_mean_bitexact():
+    # CPU scan passes a 1-D grayscale buffer (320*180,). FULL_FRAME must
+    # equal float(buf.mean()) EXACTLY (no reshape) for OBS bit-exact.
+    buf = np.arange(det._FRAME_SIZE, dtype=np.uint8)  # 1-D, length 320*180
+    assert det._frame_brightness(buf, FULL_FRAME) == float(buf.mean())
+
+
+def test_frame_brightness_band_reshapes_and_crops():
+    # band branch must reshape the 1-D buffer to (180,320) then crop.
+    buf = np.zeros(det._FRAME_SIZE, dtype=np.uint8)
+    frame2d = buf.reshape(det._SAMPLE_HEIGHT, det._SAMPLE_WIDTH)
+    frame2d[0:9, :] = 100  # top 5% rows bright
+    band = CaptureRegion(0.0, 0.0, 1.0, 0.05)
+    assert det._frame_brightness(buf.reshape(-1), band) == 100.0
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_detector.py -k "frame_brightness" -v`
+Expected: FAIL (`AttributeError: module ... has no attribute '_frame_brightness'`).
+
+- [ ] **Step 4: Add `_frame_brightness` helper (1-D mean for FULL_FRAME, reshape+crop for band)**
+
+In `detector.py`, add the import and helper near `_scan_cpu`:
+
+```python
+from allaganeye.video.capture_region import CaptureRegion, FULL_FRAME, region_mean
+
+
+def _frame_brightness(frame: np.ndarray, region: CaptureRegion = FULL_FRAME) -> float:
+    """CPU scan の 1-D grayscale buffer (320*180,) の平均輝度。
+
+    FULL_FRAME のときは 1-D のまま ``float(frame.mean())`` (現行と bit-exact、
+    reshape による丸め経路変化なし)。band region のときのみ
+    ``(_SAMPLE_HEIGHT, _SAMPLE_WIDTH)`` に reshape して ``region_mean`` で crop する。
+    """
+    if region.is_full_frame():
+        return float(frame.mean())
+    frame2d = frame.reshape(_SAMPLE_HEIGHT, _SAMPLE_WIDTH)
+    return region_mean(frame2d, region)
+```
+
+Then in `_sample_chunk_frames` (:163-164) and `_decode_chunk_cpu_legacy` (:538-539), replace `brightness = float(frame.mean())` with `brightness = _frame_brightness(frame, region)`, threading a `region: CaptureRegion = FULL_FRAME` keyword param down from `_scan_cpu` → `_decode_chunk_cpu` → `_decode_chunk_cpu_v2`/`_legacy` → `_sample_chunk_frames`. Callers that don't pass a region get FULL_FRAME (= current behavior).
+
+IMPORTANT (bit-exact): the FULL_FRAME branch returns `float(frame.mean())` on the **1-D** buffer exactly as the current code does — no reshape in that path — so OBS output is byte-identical.
+
+- [ ] **Step 5: Run new tests + the existing detector unit suite**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+python -m pytest tests/test_detector.py -v
+```
+
+Expected: PASS (new `_frame_brightness` tests + all existing detector tests still green — the FULL_FRAME default keeps current behavior).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/detector.py tests/test_detector.py
+ruff format --check allaganeye/video/detector.py tests/test_detector.py
+pyright allaganeye/video/detector.py
+git add allaganeye/video/detector.py tests/test_detector.py
+git commit -m "feat(l3): Pass1 brightness を region 経由化 (_frame_brightness, FULL_FRAME bit-exact, Phase 1 B1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task B2: `_refine_blackout_regions` (Pass2) の brightness を region 経由にする
+
+**Files:**
+
+- Modify: `allaganeye/video/detector.py` (`_refine_blackout_regions` と内部 probe)
+- Test: `tests/test_detector.py`
+
+- [ ] **Step 1: Pass2 の brightness 算出箇所を特定**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+sed -n '1683,1745p' allaganeye/video/detector.py
+```
+
+Expected: `_refine_blackout_regions` が 0.25s 間隔で再 probe し brightness を測る箇所が見える。
+
+- [ ] **Step 2: Write failing test — Pass2 accepts region kwarg, FULL_FRAME default unchanged**
+
+```python
+def test_refine_accepts_region_kwarg_default_full_frame():
+    import inspect
+    sig = inspect.signature(det._refine_blackout_regions)
+    assert "region" in sig.parameters
+    assert sig.parameters["region"].default is FULL_FRAME
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_detector.py -k "refine_accepts_region" -v`
+Expected: FAIL (`KeyError: 'region'` or assertion error — param absent).
+
+- [ ] **Step 4: Thread region through _refine_blackout_regions**
+
+Add `region: CaptureRegion = FULL_FRAME` keyword param to `_refine_blackout_regions` and route its internal brightness computation through `_frame_brightness(frame, region)`. The probe-frame decode helper used by Pass2 should compute brightness via `_frame_brightness`. FULL_FRAME default = no behavior change for OBS.
+
+- [ ] **Step 5: Run detector suite**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_detector.py -v`
+Expected: PASS (all existing + new).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/detector.py tests/test_detector.py
+pyright allaganeye/video/detector.py
+git add allaganeye/video/detector.py tests/test_detector.py
+git commit -m "feat(l3): Pass2 refine brightness を region 経由化 (FULL_FRAME bit-exact, Phase 1 B2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task B3: GPU Pass1 (`gpu_detector.scan_gpu`) の brightness を region 経由にする
+
+**Files:**
+
+- Modify: `allaganeye/video/gpu_detector.py`
+- Test: `tests/test_gpu_detector.py`
+
+- [ ] **Step 1: GPU brightness 算出箇所を特定**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+grep -nE "\.mean\(\)|frombuffer|reshape|brightness" allaganeye/video/gpu_detector.py | head -20
+```
+
+Expected: GPU chunk デコード後に frame の平均輝度を取る箇所。
+
+- [ ] **Step 2: Write failing test — GPU helper FULL_FRAME parity**
+
+`tests/test_gpu_detector.py` に追加 (GPU 経路の brightness も `_frame_brightness` を共有することを保証。GPU 実機不要、helper の数値一致のみ):
+
+```python
+import numpy as np
+from allaganeye.video.capture_region import FULL_FRAME
+from allaganeye.video import detector as det
+
+
+def test_gpu_brightness_shares_frame_brightness_helper():
+    # GPU path must use the same _frame_brightness so CPU/GPU parity holds (Codex #8)
+    frame = np.arange(180 * 320, dtype=np.uint8).reshape(180, 320)
+    assert det._frame_brightness(frame, FULL_FRAME) == float(frame.mean())
+```
+
+(If gpu_detector computes brightness inline, the fix is to call `detector._frame_brightness`; this test pins the shared helper.)
+
+- [ ] **Step 3: Run, verify it passes only after wiring (or fails if gpu has divergent inline mean)**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_gpu_detector.py -k "brightness" -v`
+Expected: the assertion on `_frame_brightness` passes; the wiring step ensures gpu_detector actually routes through it.
+
+- [ ] **Step 4: Route GPU brightness through `_frame_brightness` + add region kwarg**
+
+In `gpu_detector.py`, add `region: CaptureRegion = FULL_FRAME` to `scan_gpu` (and the chunk decode worker), and replace inline mean with `detector._frame_brightness(frame, region)`. FULL_FRAME default = bit-exact with current GPU output.
+
+- [ ] **Step 5: Run gpu_detector unit suite (mocked; real GPU is Idios 実機検証)**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_gpu_detector.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/gpu_detector.py tests/test_gpu_detector.py
+pyright allaganeye/video/gpu_detector.py
+git add allaganeye/video/gpu_detector.py tests/test_gpu_detector.py
+git commit -m "feat(l3): GPU Pass1 brightness を _frame_brightness 共有化 (CPU/GPU parity, Phase 1 B3)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task B4: `detect_match_boundaries` に Stage 0 anchor を配線 (gate 内、OBS=FULL_FRAME)
+
+A3 の `detect_scorebar_band_region` を `detect_match_boundaries` の先頭で呼び、得た帯 region を Pass1/Pass2/GPU に渡す。**OBS は FULL_FRAME が返るので現行と完全一致**。VTuber は帯 region が渡る。
+
+**Files:**
+
+- Modify: `allaganeye/video/detector.py` (`detect_match_boundaries`)
+- Test: `tests/test_detector.py`
+
+- [ ] **Step 1: Write failing test — OBS-like (no localization) keeps FULL_FRAME path**
+
+```python
+def test_detect_uses_full_frame_when_no_band(monkeypatch):
+    # when band detection returns FULL_FRAME, brightness path is unchanged
+    from allaganeye.video import capture_region as cr
+    monkeypatch.setattr(
+        cr, "detect_scorebar_band_region", lambda **kw: cr.FULL_FRAME
+    )
+    # _frame_brightness with FULL_FRAME == frame.mean() already proven;
+    # this test asserts detect_match_boundaries passes FULL_FRAME through
+    # by checking the resolved region default.
+    import inspect
+    sig = inspect.signature(det.detect_match_boundaries)
+    # region is resolved internally, not a public param — assert the
+    # internal anchor call exists via a probe flag set in B4 impl.
+    assert hasattr(det, "_resolve_detect_region")
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_detector.py -k "uses_full_frame_when_no_band" -v`
+Expected: FAIL (`_resolve_detect_region` absent).
+
+- [ ] **Step 3: Add `_resolve_detect_region` + wire into detect_match_boundaries**
+
+Add a helper that binds `localize_scorebar` to a frame source and calls `detect_scorebar_band_region`, returning FULL_FRAME on any failure:
+
+```python
+def _resolve_detect_region(
+    video_path: Path, duration_hint: float
+) -> CaptureRegion:
+    """Stage 0: scorebar 帯 anchor を解決する。失敗時は FULL_FRAME (OBS 安全縮退)。"""
+    from allaganeye.video.capture_region import (
+        FULL_FRAME,
+        detect_scorebar_band_region,
+    )
+    from allaganeye.video.detector import (
+        _SCOREBAR_V2_PROBE_HEIGHT,
+        _SCOREBAR_V2_PROBE_WIDTH,
+    )
+    from allaganeye.video.capture_region import localize_scorebar
+
+    def _localize_at(t: float):
+        raw = _probe_frame_rgb_hires(video_path, t)
+        if raw is None:
+            return None
+        frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+            _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+        )
+        return localize_scorebar(frame)
+
+    try:
+        return detect_scorebar_band_region(
+            duration=duration_hint,
+            probe_w=_SCOREBAR_V2_PROBE_WIDTH,
+            probe_h=_SCOREBAR_V2_PROBE_HEIGHT,
+            localize_fn=_localize_at,
+        )
+    except Exception:  # noqa: BLE001 - anchor failure must never break detect
+        return FULL_FRAME
+```
+
+In `detect_match_boundaries`, after `duration_hint` validation and before Pass1, resolve the region and pass it to `_scan_cpu` / `scan_gpu` / `_refine_blackout_regions`:
+
+```python
+    detect_region = _resolve_detect_region(video_path, duration_hint)
+    # OBS → FULL_FRAME (bit-exact). VTuber → scorebar band ROI.
+```
+
+Thread `region=detect_region` into the `_scan_cpu(...)`, `scan_gpu(...)`, and `_refine_blackout_regions(...)` calls.
+
+- [ ] **Step 4: Run full detector suite + assert OBS path unchanged**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+python -m pytest tests/test_detector.py -v
+```
+
+Expected: PASS (FULL_FRAME default keeps every existing test green).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/detector.py tests/test_detector.py
+ruff format --check allaganeye/video/detector.py tests/test_detector.py
+pyright allaganeye/video/detector.py
+git add allaganeye/video/detector.py tests/test_detector.py
+git commit -m "feat(l3): detect に Stage 0 帯 anchor 配線 (OBS=FULL_FRAME 縮退, Phase 1 B4)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task Group C — Stage 2 準備: MAD band-anchor 化
+
+### Task C1: `_is_static_from_frames` に band ROI 引数を追加 (絶対 ROI 既定 = OBS bit-exact)
+
+現状 `_is_static_from_frames` は絶対座標 `_SCOREBAR_ROI_*` で MAD を測る (VTuber では誤った場所)。band ROI を任意引数で受け、未指定時は現行絶対 ROI に縮退する。
+
+**Files:**
+
+- Modify: `allaganeye/video/scorebar.py` (`_is_static_from_frames` と呼び出し元)
+- Test: `tests/test_scorebar.py` (なければ Create)
+
+- [ ] **Step 1: Write failing test — default = absolute ROI (unchanged), band arg crops elsewhere**
+
+```python
+import numpy as np
+from allaganeye.video.scorebar import _is_static_from_frames
+from allaganeye.video.capture_region import CaptureRegion
+
+_W = 320
+
+
+def _frame(height, fill):
+    return np.full((height, _W, 3), fill, dtype=np.uint8).tobytes()
+
+
+def test_is_static_default_uses_absolute_roi_unchanged():
+    h = 180
+    # two identical frames → static (MAD 0) under default absolute ROI
+    frames = [_frame(h, 50), _frame(h, 50)]
+    assert _is_static_from_frames(frames, h) is True
+
+
+def test_is_static_band_region_argument_accepted():
+    import inspect
+    sig = inspect.signature(_is_static_from_frames)
+    assert "region" in sig.parameters
+    assert sig.parameters["region"].default is None  # None → absolute ROI
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -k "is_static" -v`
+Expected: FAIL (`region` param absent).
+
+- [ ] **Step 3: Add optional region param to _is_static_from_frames**
+
+Modify the signature to `def _is_static_from_frames(raw_frames, height, region: CaptureRegion | None = None) -> bool:`. When `region is None`, compute the ROI from the existing absolute `_SCOREBAR_ROI_*` constants exactly as today (bit-exact). When a `region` is given, derive the pixel ROI from the normalized `region` (× width/height) instead. Keep the MAD math identical.
+
+```python
+    if region is None:
+        x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
+        x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
+        y1 = int(height * _SCOREBAR_ROI_Y_START)
+        y2 = int(height * _SCOREBAR_ROI_Y_END)
+    else:
+        x1 = max(0, int(region.x * _SAMPLE_WIDTH))
+        x2 = min(_SAMPLE_WIDTH, int((region.x + region.w) * _SAMPLE_WIDTH))
+        y1 = max(0, int(region.y * height))
+        y2 = min(height, int((region.y + region.h) * height))
+```
+
+(Import `CaptureRegion` in scorebar.py.)
+
+- [ ] **Step 4: Run scorebar suite**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -v`
+Expected: PASS (default-ROI behavior unchanged → existing tests green; new band tests pass).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/scorebar.py tests/test_scorebar.py
+ruff format --check allaganeye/video/scorebar.py tests/test_scorebar.py
+pyright allaganeye/video/scorebar.py
+git add allaganeye/video/scorebar.py tests/test_scorebar.py
+git commit -m "feat(l3): _is_static_from_frames に band ROI 引数 (絶対 ROI 既定で bit-exact, Phase 1 C1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task Group D — 受け入れ検証
+
+### Task D1: OBS baseline 回帰 (bit-exact gate)
+
+**Files:**
+
+- Test: `tests/` の baseline 回帰テスト (既存 `test_detector.py` / baseline harness)
+
+- [ ] **Step 1: 既存 baseline 回帰テストの所在を確認**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+grep -rln "baselines/v0.3.0" tests/ | head
+ls tests/baselines/v0.3.0/obs-*.metadata.json
+```
+
+Expected: 5 OBS baseline metadata + それを突合する slow テストが出る。
+
+- [ ] **Step 2: Run the OBS baseline regression (slow, sample-gated)**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+set ALLAGANEYE_SAMPLE_VIDEO_DIR=E:\royalstraightflesh\videos
+python -m pytest -m slow -k "baseline or obs" -v
+```
+
+Expected: PASS — all 5 OBS baselines bit-exact (Phase 1 changes are FULL_FRAME-gated, so OBS detect output is unchanged). **If any baseline differs, STOP**: a non-FULL_FRAME path leaked into OBS — investigate before proceeding (do NOT regenerate baselines).
+
+> 注: timestamp churn (detected_at/generated_at) は非意味的差分。grep 除外して output-neutral を判定 (memory: baseline regen の timestamp churn)。
+
+- [ ] **Step 3: Record result (no commit unless a test file changed)**
+
+bit-exact 確認をこの plan の実行ログに記録。テストコードを変更した場合のみ commit。
+
+---
+
+### Task D2: gyawa 帯 crop blackout 回復 (slow 受け入れ)
+
+**Files:**
+
+- Test: `tests/test_vtuber_region_e2e.py` (なければ Create)
+
+- [ ] **Step 1: Write the slow acceptance test (demonstrated-level, sample-gated)**
+
+`tests/test_vtuber_region_e2e.py` に追加 (gyawa VOD で帯 region 検出 → 帯 crop brightness が full-frame では拾えない blackout を回復することを示す。#809 Wave F の drop-recovery を帯版で):
+
+```python
+import os
+import pytest
+from pathlib import Path
+
+pytestmark = pytest.mark.slow
+
+
+def _gyawa_path() -> Path | None:
+    base = os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER") or r"E:\allaganeye-samples"
+    # gyawa VOD filename (multi-source samples; see memory reference)
+    cands = list(Path(base).glob("*オンサル*")) if Path(base).exists() else []
+    return cands[0] if cands else None
+
+
+@pytest.mark.skipif(_gyawa_path() is None, reason="VTuber sample not available")
+def test_band_crop_recovers_blackout_vs_full_frame():
+    from allaganeye.video.probe import probe_video
+    from allaganeye.video.capture_region import (
+        detect_scorebar_band_region, FULL_FRAME,
+    )
+    from allaganeye.video import detector as det
+
+    video = _gyawa_path()
+    meta = probe_video(video)
+    region = det._resolve_detect_region(video, meta["duration"])
+    # band anchor must succeed on a VTuber inset recording
+    assert not region.is_full_frame(), "band anchor should localize on VTuber VOD"
+    # the recorded #809 Wave F finding: a match-end blackout that is invisible
+    # full-frame becomes visible under band crop. Assert the band-crop detect
+    # finds >= the full-frame detect's match count (recovery, not loss).
+    # (Exact GT match counts are calibrated in Phase 3; here we assert recovery.)
+```
+
+> このテストは demonstrated-level (実機データ依存)。Idios の実機検証 (PYTHONUTF8=1, guard verify は FP のため owner override) で確認する。CI では skip。
+
+- [ ] **Step 2: Run (sample-gated; skips without VTuber sample)**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+set PYTHONUTF8=1
+set ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER=E:\allaganeye-samples
+python -m pytest tests/test_vtuber_region_e2e.py -m slow -v
+```
+
+Expected: PASS if gyawa VOD present (band anchor succeeds, blackout recovers), else SKIP.
+
+- [ ] **Step 3: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check tests/test_vtuber_region_e2e.py
+git add tests/test_vtuber_region_e2e.py
+git commit -m "test(l3): gyawa 帯 crop blackout 回復 slow 受け入れ (Phase 1 D2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## 受け入れ条件 (Phase 1 完了基準)
+
+- [ ] A: `detect_scorebar_band_region` が localize 多フレーム consensus で scorebar 帯 ROI を返し、局在化不能時は FULL_FRAME に縮退する (unit)。
+- [ ] B: brightness Pass1 (`_decode_chunk_cpu`) / Pass2 (`_refine_blackout_regions`) / GPU (`scan_gpu`) が region 経由で測定し、FULL_FRAME 既定で現行と数値一致する (unit + baseline)。
+- [ ] B: `detect_match_boundaries` が Stage 0 anchor を解決し region を全 brightness サイトに渡す。OBS は FULL_FRAME。
+- [ ] C: `_is_static_from_frames` が band ROI 引数を受け、未指定時は絶対 ROI に縮退する (unit)。
+- [ ] D1: OBS 5 baseline が bit-exact (timestamp churn 除く)。
+- [ ] D2: gyawa で帯 anchor 成功 + 帯 crop blackout 回復 (slow / 実機)。
+- [ ] Idios の実機検証 (OBS detect 不変 + VTuber 帯 crop) — Iron Law 6 (logic 変更 + GPU + 長時間動画)。
+
+## このプランがやらないこと (spec の後 Phase / 範囲外)
+
+- **Stage 2 分類の localize+motion 化** (classify_blackout の primitive 差し替え・v2 shadow 並走) → Phase 2。本 plan は C1 で `_is_static_from_frames` に band 引数を**用意するだけ**で、classify への配線は Phase 2。
+- **v2 retire / GT-accuracy gate 化** → Phase 4。
+- **`_drop_post_match_trailing` 改変** → 触らない (Phase 0 map §4 / §5.3、Phase 4 以降)。
+- **VTuber GT 注釈・recall/precision 校正** → Phase 3。
+- **full inset 16:9 矩形の metadata 永続化** → P6 / #810、範囲外 (本 plan は検出に帯のみ使用、保持矩形 schema は別途)。
+- **issue 起票** → Iron Law 2、起票時に AskUserQuestion。

--- a/docs/superpowers/plans/2026-06-01-l3-phase2-localize-classify.md
+++ b/docs/superpowers/plans/2026-06-01-l3-phase2-localize-classify.md
@@ -1,0 +1,1158 @@
+# L3 Phase 2: Stage 2 分類の localize 化 (VTuber 過分割解消) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** VTuber (`--vtuber`) 経路の各 blackout を **scorebar present (localize) 単独**で `match_boundary` / `in_match` / `non_fl` 分類し、短い `in_match` (キャラダウン等の試合中暗転) を除去して VTuber を実用分割にする。OBS (`vtuber=False`) は現行 v2 分類器を一行も変えず bit-exact を維持する。
+
+**Architecture:** spec [2026-05-31-l3-detection-rearchitecture-two-signal-design.md](../specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md) §8 Phase 2 + §8.1 確定事項。分類器は **OBS=v2 authoritative (不変) / VTuber=localize present 単独 authoritative** の 2 経路を `vtuber` flag で分岐する。motion (band-MAD) は **telemetry 収集のみ** (分類に AND しない、配線は Phase 3)。v2 vs localize の parity は production に入れず **harness 専用**で計測する。`localize_scorebar` は `_probe_scorebar_context` が既に decode 済の hi-res frame を再利用する (additive + flag-gate、OBS は localize 非計算)。VTuber では `_drop_post_match_trailing` (v2 直接プローブ) を call site で gate off し、v2 FN による VTuber 最終試合の silent 削除を防ぐ。
+
+**Tech Stack:** Python 3 / numpy / OpenCV (`cv2`) / pytest (slow marker for video-gated) / ThreadPoolExecutor。検証は unit (合成 frame + monkeypatch) + baseline 回帰 + slow harness (OBS parity / VTuber split)。
+
+---
+
+## 適用条件チェック (refactor-pattern)
+
+本 plan は `scorebar.py` / `detector.py` + tests に閉じる (capture_region.py / gpu_detector.py は触らない)。touched file ~5、diff は中規模で [`docs/refactor-pattern.md`](../../refactor-pattern.md) §1 の Phase 分割閾値 (touched > 30 file or diff > 1000 line) 未満。**Phase 0+1+2 をまとめて 1 PR** にする (user 方針: VTuber 実用化まで一貫 land)。
+
+## spec が要求する Phase 2 gate (受け入れの中心)
+
+- **OBS bit-exact**: 5 baseline (`tests/baselines/v0.3.0/obs-*.metadata.json`) が `vtuber=False` で完全一致 (検出 timestamp 不変)。v2 経路は構造的に不変。
+- **VTuber 過分割解消**: `--vtuber` で band crop が拾う試合中暗転 (両側 present の in_match) が分類で除去され、過分割が減る (slow / 実機)。
+- **production 影響なし**: localize 分類は `vtuber=True` の内側のみ。`vtuber=False` (= 既存 CLI default + 既存呼び出し) の出力は不変。
+
+---
+
+## File Structure
+
+| ファイル | 本 plan での責務 | 変更種別 |
+| --- | --- | --- |
+| `allaganeye/video/scorebar.py` | `_localize_present_from_raw` 新規 + `_probe_scorebar_context` に `with_localize` (3-tuple 化) + `_band_mad_min` 抽出 (+#4 guard) + `_classify_blackout_localize` 新規 + `classify_blackout` / `filter_blackouts_with_scorebar` / `_merge_boundary_pairs` に `band_region`/`vtuber` 追加 | Modify |
+| `allaganeye/video/detector.py` | `detect_match_boundaries` が `band_region`/`vtuber` を `filter_blackouts_with_scorebar` に渡す + `_drop_post_match_trailing` call site を `not vtuber` で gate | Modify |
+| `tests/test_scorebar.py` | A/B/C の unit (probe 3-tuple / MAD guard / localize 分類 / 真理値表 / vtuber=False 不変) | Modify |
+| `tests/test_detector.py` | D の unit (trailing-drop vtuber gate / band_region threading) | Modify |
+| `tests/test_l3_phase2_parity.py` | OBS v2-vs-localize parity + VTuber split の slow 受け入れ (sample-gated) | Create |
+
+> **実装前に確認済みの事実 (self-review 2026-06-01)**:
+>
+> - `classify_blackout` の既存 `region` 引数は **blackout (start,end) tuple** (CaptureRegion ではない)。新 ROI 引数は名前衝突を避け **`band_region`** とする。`filter_blackouts_with_scorebar` の `blackout_regions` も tuple list。
+> - `_probe_scorebar_context` は既に lo-res (`_probe_frame_rgb`、motion 用) と hi-res (`_probe_frame_rgb_hires`、v2 用、`use_v2` 時のみ) を両方 decode し、hi_raws は v2 後に破棄している。localize はこの hi_raws を再利用する。
+> - `_probe_scorebar_context` の呼び出しは scorebar.py 内 **5 箇所** (classify pre :277 / post :280 / re-probe pre :315 / re-probe post :318 / merge :562)。3-tuple 化で全 5 箇所の unpack を更新する。
+> - `_drop_post_match_trailing` の呼び出しは detector.py:475-482 (`detect_match_boundaries` 内、`vtuber` がスコープにある)。`_has_scorebar_v2` (絶対座標) を直接プローブするため VTuber inset では全 probe FN → 最終試合 silent 削除 (Codex #1 CRITICAL 確認済)。
+> - `_is_static_from_frames` は OBS v2 経路の short-static override (classify_blackout :354-370) で使われる **bit-exact 経路**。`region is None` (絶対 ROI) 分岐は一切変えない。#4 guard は `else` (band) 分岐にのみ追加する。
+> - audio Fanfare promotion は `AUDIO_FROZEN=True` (`allaganeye/audio/__init__.py:48`、#327/#303) で inert。本 plan では触らない (Codex #6 は frozen 中 moot)。
+
+依存: **A → B → C → D**。A が localize-present probe を産み、B が分類器を作り、C が filter/merge に通し、D が detector に配線する。各 group 内は TDD (failing test → impl → pass → commit)。
+
+---
+
+## Task Group A — localize-present primitive を probe context に追加 (P2-c / Codex #8)
+
+### Task A1: `_localize_present_from_raw` + `_probe_scorebar_context` の `with_localize` (3-tuple 化)
+
+`_probe_scorebar_context` が既に decode 済の hi-res frame に `localize_scorebar` をかけ、localize-present を **第 3 要素**として返す。OBS production は `with_localize=False` (既定) で localize 非計算、戻り値第 3 要素は全 None → 既存 5 caller は `, _` 追加だけで bit-exact。
+
+**Files:**
+
+- Modify: `allaganeye/video/scorebar.py`
+- Test: `tests/test_scorebar.py`
+
+- [ ] **Step 1: Write failing test**
+
+`tests/test_scorebar.py` に追加:
+
+```python
+from allaganeye.video import scorebar as sb
+
+
+def test_probe_context_3tuple_localize_none_by_default(monkeypatch):
+    # with_localize omitted -> 3rd element all None, scorebar/raw unchanged.
+    monkeypatch.setattr(sb, "_probe_frame_rgb", lambda v, t, h: f"lo{t}".encode())
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", lambda v, t: f"hi{t}".encode())
+    monkeypatch.setattr(sb, "_has_scorebar_v2", lambda raw: True)
+    # _localize_present_from_raw must NOT be called when with_localize is False.
+    monkeypatch.setattr(
+        sb, "_localize_present_from_raw",
+        lambda raw: (_ for _ in ()).throw(AssertionError("must not localize")),
+    )
+    scorebar, raw, loc = sb._probe_scorebar_context(
+        Path("x.mp4"), [1.0, 2.0], height=180, workers=1
+    )
+    assert scorebar == [True, True]
+    assert raw == [b"lo1.0", b"lo2.0"]
+    assert loc == [None, None]
+
+
+def test_probe_context_with_localize_populates_3rd(monkeypatch):
+    monkeypatch.setattr(sb, "_probe_frame_rgb", lambda v, t, h: b"lo")
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", lambda v, t: f"hi{t}".encode())
+    monkeypatch.setattr(sb, "_has_scorebar_v2", lambda raw: False)
+    monkeypatch.setattr(sb, "_localize_present_from_raw", lambda raw: raw == b"hi1.0")
+    scorebar, raw, loc = sb._probe_scorebar_context(
+        Path("x.mp4"), [1.0, 2.0], height=180, workers=1, with_localize=True
+    )
+    assert loc == [True, False]
+```
+
+(`from pathlib import Path` が test 先頭にあることを確認、なければ追加。)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -k "probe_context" -v`
+Expected: FAIL (`ValueError: not enough values to unpack (expected 3, got 2)` / `AttributeError: ... _localize_present_from_raw`).
+
+- [ ] **Step 3: Add `_localize_present_from_raw` + thread `with_localize` into `_probe_scorebar_context`**
+
+`scorebar.py` の import に追加 (detector からの import ブロックへ `_SCOREBAR_V2_PROBE_HEIGHT`, `_SCOREBAR_V2_PROBE_WIDTH`、capture_region から `localize_scorebar`):
+
+```python
+from allaganeye.video.detector import (
+    DetectionStats,
+    _SAMPLE_WIDTH,
+    _SCOREBAR_METHOD,
+    _SCOREBAR_ROI_X_END,
+    _SCOREBAR_ROI_X_START,
+    _SCOREBAR_ROI_Y_END,
+    _SCOREBAR_ROI_Y_START,
+    _SCOREBAR_V2_PROBE_HEIGHT,
+    _SCOREBAR_V2_PROBE_WIDTH,
+    _has_scorebar,
+    _has_scorebar_v2,
+    _probe_frame_rgb,
+    _probe_frame_rgb_hires,
+    _resolve_workers,
+)
+from allaganeye.video.capture_region import CaptureRegion, FULL_FRAME, localize_scorebar
+```
+
+(既存の `from allaganeye.video.capture_region import CaptureRegion` 行は上の行で置換する。)
+
+`_probe_scorebar_context` の直前に helper を追加:
+
+```python
+def _localize_present_from_raw(raw: bytes | None) -> bool | None:
+    """hi-res RGB probe bytes -> localize-present (True/False). None on probe failure.
+
+    Reshapes the 1920x1080 RGB probe buffer and runs the position-independent
+    localizer (``localize_scorebar``).  A successfully decoded frame yields
+    True/False (a clean localizer miss is treated as absent, not unknown, so
+    majority vote behaves like the v2 path).  Only a missing frame (raw None)
+    yields None.  Used by the VTuber classification path; OBS never calls it.
+    """
+    if raw is None:
+        return None
+    frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+        _SCOREBAR_V2_PROBE_HEIGHT, _SCOREBAR_V2_PROBE_WIDTH, 3
+    )
+    return localize_scorebar(frame) is not None
+```
+
+`_probe_scorebar_context` の signature に `with_localize: bool = False` を追加し、戻り値を 3-tuple にする。関数末尾の `return` 直前に localize 計算を追加:
+
+```python
+        # localize-present from the hi-res frames already decoded for v2
+        # (additive; OBS production passes with_localize=False -> all None,
+        # so existing callers stay bit-exact).
+        localize_results: dict[float, bool | None] = {}
+        if with_localize and use_v2:
+            for t in unique_ts:
+                localize_results[t] = _localize_present_from_raw(hi_raws.get(t))
+        else:
+            for t in unique_ts:
+                localize_results[t] = None
+
+    return (
+        [scorebar_results[t] for t in timestamps],
+        [raw_frames[t] for t in timestamps],
+        [localize_results[t] for t in timestamps],
+    )
+```
+
+signature 変更:
+
+```python
+def _probe_scorebar_context(
+    video_path: Path,
+    timestamps: list[float],
+    height: int,
+    workers: int | None,
+    *,
+    with_localize: bool = False,
+) -> tuple[list[bool | None], list[bytes | None], list[bool | None]]:
+```
+
+そして scorebar.py 内の **5 つの呼び出し**を 3-tuple unpack に更新:
+
+```python
+# classify_blackout pre/post (:277, :280)
+    pre_results, pre_frames, _pre_loc = _probe_scorebar_context(
+        video_path, pre_timestamps, height, workers
+    )
+    post_results, post_frames, _post_loc = _probe_scorebar_context(
+        video_path, post_timestamps, height, workers
+    )
+# re-probe pre/post (:315, :318)
+            pre_re_results, _, _ = _probe_scorebar_context(
+                video_path, pre_re_timestamps, height, workers
+            )
+            post_re_results, _, _ = _probe_scorebar_context(
+                video_path, post_re_timestamps, height, workers
+            )
+# _merge_boundary_pairs gap probe (:562)
+                probe_results, _, _ = _probe_scorebar_context(
+                    video_path, probe_points, height, workers,
+                )
+```
+
+- [ ] **Step 4: Run, verify pass + full scorebar suite**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -v`
+Expected: PASS (new probe_context tests + all existing scorebar tests green — 3-tuple change is unpack-only for existing callers).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/scorebar.py tests/test_scorebar.py
+ruff format --check allaganeye/video/scorebar.py tests/test_scorebar.py
+pyright allaganeye/video/scorebar.py
+git add allaganeye/video/scorebar.py tests/test_scorebar.py
+git commit -F - <<'EOF'
+feat(l3): _probe_scorebar_context に with_localize (hi-res 再利用, 3-tuple, Phase 2 A1)
+
+OBS は with_localize=False (既定) で localize 非計算・第3要素全None -> 既存 caller bit-exact。
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task Group B — localize present-only 分類器 (P2-a)
+
+### Task B1: `_band_mad_min` 抽出 + band ROI guard (#4) — 絶対 ROI は bit-exact
+
+`_is_static_from_frames` から min-MAD 算出を `_band_mad_min` に分離する (telemetry が float を取れるように)。`region is None` (絶対 ROI) 分岐は一切変えず OBS bit-exact。`else` (band) 分岐に空 ROI guard を追加 (Codex #4、7-8px@180p で nan 化を防ぐ)。
+
+**Files:**
+
+- Modify: `allaganeye/video/scorebar.py`
+- Test: `tests/test_scorebar.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import numpy as np
+from allaganeye.video.scorebar import _band_mad_min, _is_static_from_frames
+from allaganeye.video.capture_region import CaptureRegion
+
+_W = 320
+
+
+def _rgb(height, fill):
+    return np.full((height, _W, 3), fill, dtype=np.uint8).tobytes()
+
+
+def test_band_mad_min_absolute_roi_matches_is_static():
+    # region=None path must stay bit-exact: identical frames -> MAD 0 -> static.
+    frames = [_rgb(180, 50), _rgb(180, 50)]
+    assert _band_mad_min(frames, 180) == 0.0
+    assert _is_static_from_frames(frames, 180) is True
+
+
+def test_band_mad_min_returns_none_for_degenerate_band():
+    # a band so thin it collapses to an empty crop -> None (not nan, not 0).
+    frames = [_rgb(180, 50), _rgb(180, 90)]
+    degenerate = CaptureRegion(0.5, 0.5, 0.0, 0.0)
+    assert _band_mad_min(frames, 180, degenerate) is None
+    # _is_static_from_frames must not raise / must be False for degenerate band.
+    assert _is_static_from_frames(frames, 180, degenerate) is False
+
+
+def test_band_mad_min_none_for_under_two_frames():
+    assert _band_mad_min([_rgb(180, 50)], 180) is None
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -k "band_mad_min" -v`
+Expected: FAIL (`ImportError: cannot import name '_band_mad_min'`).
+
+- [ ] **Step 3: Extract `_band_mad_min`, refactor `_is_static_from_frames`**
+
+`_is_static_from_frames` を以下に置換 (絶対 ROI 分岐の式は現行のまま、band 分岐に guard 追加):
+
+```python
+def _band_mad_min(
+    raw_frames: Sequence[bytes | None],
+    height: int,
+    region: CaptureRegion | None = None,
+) -> float | None:
+    """Min MAD of the scorebar ROI across consecutive frame pairs.
+
+    Returns None when fewer than 2 valid frames are given, or when a band
+    ``region`` collapses to an empty crop (degenerate / sub-pixel band at
+    320x180; Codex #4).  ``region is None`` uses the absolute ``_SCOREBAR_ROI_*``
+    ROI exactly as before (bit-exact).
+    """
+    valid = [r for r in raw_frames if r is not None]
+    if len(valid) < 2:
+        return None
+
+    if region is None:
+        x1 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_START)
+        x2 = int(_SAMPLE_WIDTH * _SCOREBAR_ROI_X_END)
+        y1 = int(height * _SCOREBAR_ROI_Y_START)
+        y2 = int(height * _SCOREBAR_ROI_Y_END)
+    else:
+        x1 = max(0, int(region.x * _SAMPLE_WIDTH))
+        x2 = min(_SAMPLE_WIDTH, int((region.x + region.w) * _SAMPLE_WIDTH))
+        y1 = max(0, int(region.y * height))
+        y2 = min(height, int((region.y + region.h) * height))
+        if x2 <= x1 or y2 <= y1:
+            return None  # degenerate band crop (Codex #4) -> no usable signal
+
+    rois = []
+    for raw in valid:
+        frame = np.frombuffer(raw, dtype=np.uint8).reshape(height, _SAMPLE_WIDTH, 3)
+        rois.append(frame[y1:y2, x1:x2, :].astype(np.int16))
+
+    mads = [float(np.mean(np.abs(rois[i] - rois[i + 1]))) for i in range(len(rois) - 1)]
+    return min(mads)
+
+
+def _is_static_from_frames(
+    raw_frames: Sequence[bytes | None],
+    height: int,
+    region: CaptureRegion | None = None,
+) -> bool:
+    """Detect static screens (loading/result) via scorebar ROI frame diff.
+
+    Returns False if fewer than 2 valid frames are provided or the band ROI is
+    degenerate.  ``region is None`` keeps the absolute-ROI behavior (bit-exact).
+    """
+    min_mad = _band_mad_min(raw_frames, height, region)
+    if min_mad is None:
+        return False
+
+    is_static = min_mad < _STATIC_SCREEN_MAD_THRESHOLD
+    logger.debug(
+        "static_screen: min=%.2f thr=%.1f region=%s -> %s",
+        min_mad,
+        _STATIC_SCREEN_MAD_THRESHOLD,
+        "absolute" if region is None else "band",
+        is_static,
+    )
+    return is_static
+```
+
+- [ ] **Step 4: Run scorebar suite (bit-exact guard for absolute ROI)**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -v`
+Expected: PASS (existing `_is_static_from_frames` tests green — absolute-ROI math unchanged; new `_band_mad_min` tests pass).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/scorebar.py tests/test_scorebar.py
+pyright allaganeye/video/scorebar.py
+git add allaganeye/video/scorebar.py tests/test_scorebar.py
+git commit -F - <<'EOF'
+feat(l3): _band_mad_min 抽出 + band ROI 空 guard (#4, 絶対 ROI bit-exact, Phase 2 B1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task B2: `_classify_blackout_localize` — present 単独分類器 + MAD telemetry
+
+localize-present の pre/post majority で分類する (motion は AND しない、P2-a)。both-absent 時は v2 経路同様 region_width offset で re-probe する。band-MAD は logger.info で emit するだけ (Phase 3 校正用、分類に未使用)。
+
+**Files:**
+
+- Modify: `allaganeye/video/scorebar.py`
+- Test: `tests/test_scorebar.py`
+
+- [ ] **Step 1: Write failing test (localize results injected via monkeypatch)**
+
+```python
+def test_classify_localize_truth_table(monkeypatch):
+    # Inject localize-present per probe set; assert the present-only labels.
+    from allaganeye.video import scorebar as sb
+
+    calls = {"n": 0}
+
+    def fake_probe(video, ts, height, workers, *, with_localize=False):
+        # pre call first, post call second (region_width re-probe not triggered
+        # unless both not-True).
+        calls["n"] += 1
+        present = calls["n"] == 1  # pre present, post absent -> match_boundary
+        return ([None] * len(ts), [b"f"] * len(ts), [present] * len(ts))
+
+    monkeypatch.setattr(sb, "_probe_scorebar_context", fake_probe)
+    monkeypatch.setattr(sb, "_band_mad_min", lambda *a, **k: 1.23)
+    cls = sb._classify_blackout_localize(
+        Path("x.mp4"), (100.0, 103.0), duration=400.0, height=180, workers=1
+    )
+    assert cls == "match_boundary"
+
+
+def test_classify_localize_both_present_is_in_match(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    monkeypatch.setattr(
+        sb, "_probe_scorebar_context",
+        lambda v, ts, h, w, *, with_localize=False: (
+            [None] * len(ts), [b"f"] * len(ts), [True] * len(ts)
+        ),
+    )
+    monkeypatch.setattr(sb, "_band_mad_min", lambda *a, **k: 5.0)
+    cls = sb._classify_blackout_localize(
+        Path("x.mp4"), (100.0, 101.0), duration=400.0, height=180, workers=1
+    )
+    assert cls == "in_match"
+
+
+def test_classify_localize_both_absent_is_non_fl(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    monkeypatch.setattr(
+        sb, "_probe_scorebar_context",
+        lambda v, ts, h, w, *, with_localize=False: (
+            [None] * len(ts), [b"f"] * len(ts), [False] * len(ts)
+        ),
+    )
+    monkeypatch.setattr(sb, "_band_mad_min", lambda *a, **k: 0.1)
+    cls = sb._classify_blackout_localize(
+        Path("x.mp4"), (100.0, 102.0), duration=400.0, height=180, workers=1
+    )
+    assert cls == "non_fl"
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -k "classify_localize" -v`
+Expected: FAIL (`AttributeError: ... _classify_blackout_localize`).
+
+- [ ] **Step 3: Implement `_classify_blackout_localize`**
+
+`classify_blackout` の直前に追加:
+
+```python
+def _classify_blackout_localize(
+    video_path: Path,
+    region: tuple[float, float],
+    duration: float,
+    height: int,
+    workers: int | None = None,
+    *,
+    band_region: CaptureRegion = FULL_FRAME,
+) -> str:
+    """Classify a blackout by position-independent scorebar presence (VTuber).
+
+    Uses ``localize_scorebar`` majority on 3 pre + 3 post frames as the sole
+    signal (motion is NOT ANDed in Phase 2 -- P2-a / spec section 8.1).  Mirrors
+    the v2 re-probe fallback (#524) for the both-absent case.  Band-MAD is
+    emitted to the log for Phase 3 calibration but does not affect the label.
+
+    Returns ``"in_match"`` / ``"match_boundary"`` / ``"non_fl"`` / ``"unknown"``.
+    """
+    pre_timestamps = sorted(set(max(0.0, region[0] - d) for d in (3.0, 2.0, 1.0)))
+    post_timestamps = sorted(set(min(duration, region[1] + d) for d in (1.0, 2.0, 3.0)))
+
+    _, pre_frames, pre_loc = _probe_scorebar_context(
+        video_path, pre_timestamps, height, workers, with_localize=True
+    )
+    _, post_frames, post_loc = _probe_scorebar_context(
+        video_path, post_timestamps, height, workers, with_localize=True
+    )
+    pre_has = _majority_scorebar(pre_loc)
+    post_has = _majority_scorebar(post_loc)
+
+    # Re-probe further out when neither side localized a scorebar (#524 mirror):
+    # a true boundary whose flanks both land in a fade/loading would otherwise
+    # classify as non_fl and be dropped.
+    if pre_has is not True and post_has is not True:
+        region_width = region[1] - region[0]
+        existing_pre = set(pre_timestamps)
+        existing_post = set(post_timestamps)
+        pre_re_ts = [
+            t
+            for t in sorted(
+                set(max(0.0, region[0] - (region_width + d)) for d in (3.0, 2.0, 1.0))
+            )
+            if t not in existing_pre
+        ]
+        post_re_ts = [
+            t
+            for t in sorted(
+                set(min(duration, region[1] + (region_width + d)) for d in (1.0, 2.0, 3.0))
+            )
+            if t not in existing_post
+        ]
+        if pre_re_ts:
+            _, _, pre_re_loc = _probe_scorebar_context(
+                video_path, pre_re_ts, height, workers, with_localize=True
+            )
+            pre_re = _majority_scorebar(pre_re_loc)
+            if pre_re is not None:
+                pre_has = pre_re
+        if post_re_ts:
+            _, _, post_re_loc = _probe_scorebar_context(
+                video_path, post_re_ts, height, workers, with_localize=True
+            )
+            post_re = _majority_scorebar(post_re_loc)
+            if post_re is not None:
+                post_has = post_re
+
+    # Band-MAD telemetry for Phase 3 calibration -- emitted only, NOT used in
+    # classification (P2-a). Grep "VTUBER_MAD" in logs to collect distributions.
+    pre_mad = _band_mad_min(pre_frames, height, band_region)
+    post_mad = _band_mad_min(post_frames, height, band_region)
+    logger.info(
+        "VTUBER_MAD region=[%.1f-%.1f] pre_mad=%s post_mad=%s",
+        region[0],
+        region[1],
+        f"{pre_mad:.3f}" if pre_mad is not None else "na",
+        f"{post_mad:.3f}" if post_mad is not None else "na",
+    )
+
+    if pre_has is None or post_has is None:
+        classification = "unknown"
+    elif pre_has and post_has:
+        classification = "in_match"
+    elif pre_has or post_has:
+        classification = "match_boundary"
+    else:
+        classification = "non_fl"
+
+    logger.debug(
+        "vtuber classify region [%.1f-%.1f] (%.1fs): pre=%s post=%s -> %s",
+        region[0],
+        region[1],
+        region[1] - region[0],
+        pre_has,
+        post_has,
+        classification,
+    )
+    return classification
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -k "classify_localize" -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/scorebar.py tests/test_scorebar.py
+pyright allaganeye/video/scorebar.py
+git add allaganeye/video/scorebar.py tests/test_scorebar.py
+git commit -F - <<'EOF'
+feat(l3): _classify_blackout_localize (present 単独分類 + MAD telemetry, Phase 2 B2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task B3: `classify_blackout` に `band_region`/`vtuber` 追加 (vtuber=True で localize に委譲)
+
+`classify_blackout` に `band_region`/`vtuber` を keyword 追加。`vtuber=True` のとき `_classify_blackout_localize` に委譲、`vtuber=False` は現行 v2 body を一切変えない (bit-exact)。
+
+**Files:**
+
+- Modify: `allaganeye/video/scorebar.py`
+- Test: `tests/test_scorebar.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_classify_blackout_vtuber_delegates_to_localize(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    from allaganeye.video.capture_region import CaptureRegion
+    seen = {}
+
+    def fake_localize(video, region, duration, height, workers=None, *, band_region):
+        seen["band"] = band_region
+        return "in_match"
+
+    monkeypatch.setattr(sb, "_classify_blackout_localize", fake_localize)
+    band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
+    out = sb.classify_blackout(
+        Path("x.mp4"), (10.0, 11.0), 400.0, 180, vtuber=True, band_region=band
+    )
+    assert out == "in_match"
+    assert seen["band"] is band
+
+
+def test_classify_blackout_obs_does_not_call_localize(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    monkeypatch.setattr(
+        sb, "_classify_blackout_localize",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("OBS must not localize")),
+    )
+    # vtuber defaults False -> must take the v2 path (probe returns absent here).
+    monkeypatch.setattr(
+        sb, "_probe_scorebar_context",
+        lambda v, ts, h, w, *, with_localize=False: (
+            [False] * len(ts), [b"f"] * len(ts), [None] * len(ts)
+        ),
+    )
+    out = sb.classify_blackout(Path("x.mp4"), (10.0, 12.0), 400.0, 180)
+    assert out == "non_fl"
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -k "classify_blackout_vtuber or classify_blackout_obs" -v`
+Expected: FAIL (`TypeError: ... unexpected keyword argument 'vtuber'`).
+
+- [ ] **Step 3: Add params + delegation**
+
+`classify_blackout` の signature を変更:
+
+```python
+def classify_blackout(
+    video_path: Path,
+    region: tuple[float, float],
+    duration: float,
+    height: int,
+    workers: int | None = None,
+    *,
+    band_region: CaptureRegion = FULL_FRAME,
+    vtuber: bool = False,
+) -> str:
+```
+
+docstring の直後 (関数本体の先頭、`pre_timestamps = ...` の前) に分岐を追加:
+
+```python
+    if vtuber:
+        # VTuber path: position-independent localize as the sole signal
+        # (spec section 8.1 P2-a). The OBS v2 body below is left untouched.
+        return _classify_blackout_localize(
+            video_path,
+            region,
+            duration,
+            height,
+            workers,
+            band_region=band_region,
+        )
+```
+
+(以降の v2 body は変更しない。)
+
+- [ ] **Step 4: Run scorebar suite**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -v`
+Expected: PASS (vtuber delegation + OBS-no-localize new tests + all existing v2 tests green).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/scorebar.py tests/test_scorebar.py
+pyright allaganeye/video/scorebar.py
+git add allaganeye/video/scorebar.py tests/test_scorebar.py
+git commit -F - <<'EOF'
+feat(l3): classify_blackout に vtuber gate (localize 委譲, OBS v2 不変, Phase 2 B3)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task Group C — filter / merge 配線 (P2-e)
+
+### Task C1: `filter_blackouts_with_scorebar` に `band_region`/`vtuber` を通す
+
+**Files:**
+
+- Modify: `allaganeye/video/scorebar.py`
+- Test: `tests/test_scorebar.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_filter_threads_vtuber_to_classify(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    from allaganeye.video.capture_region import CaptureRegion
+    seen = []
+
+    def fake_classify(video, region, duration, height, workers=None, *, band_region, vtuber):
+        seen.append((vtuber, band_region.source))
+        return "match_boundary"
+
+    monkeypatch.setattr(sb, "classify_blackout", fake_classify)
+    monkeypatch.setattr(sb, "_merge_boundary_pairs", lambda *a, **k: (a[1], a[2]))
+    band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
+    sb.filter_blackouts_with_scorebar(
+        Path("x.mp4"), [(10.0, 12.0)], 400.0, 180, band_region=band, vtuber=True
+    )
+    assert seen == [(True, "band")]
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -k "filter_threads_vtuber" -v`
+Expected: FAIL (`TypeError: ... unexpected keyword argument 'band_region'`).
+
+- [ ] **Step 3: Add params + thread to classify/merge**
+
+`filter_blackouts_with_scorebar` の signature に keyword 追加 (既存 keyword の並びへ):
+
+```python
+def filter_blackouts_with_scorebar(
+    video_path: Path,
+    blackout_regions: list[tuple[float, float]],
+    duration: float,
+    height: int,
+    workers: int | None = None,
+    *,
+    band_region: CaptureRegion = FULL_FRAME,
+    vtuber: bool = False,
+    audio_hits: Sequence[BgmHit] | None = None,
+    stats: DetectionStats | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> tuple[list[tuple[float, float]], list[str]]:
+```
+
+`classify_blackout` 呼び出し (現 :457) を更新:
+
+```python
+        classification = classify_blackout(
+            video_path, region, duration, height, workers,
+            band_region=band_region, vtuber=vtuber,
+        )
+```
+
+末尾の `_merge_boundary_pairs` 呼び出し (現 :516) を更新:
+
+```python
+    return _merge_boundary_pairs(
+        video_path, kept, classifications, duration, height, workers,
+        band_region=band_region, vtuber=vtuber,
+    )
+```
+
+- [ ] **Step 4: Run scorebar suite**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -v`
+Expected: PASS (new threading test + existing tests green — defaults keep OBS behavior).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/scorebar.py tests/test_scorebar.py
+pyright allaganeye/video/scorebar.py
+git add allaganeye/video/scorebar.py tests/test_scorebar.py
+git commit -F - <<'EOF'
+feat(l3): filter_blackouts_with_scorebar に band_region/vtuber 配線 (Phase 2 C1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task C2: `_merge_boundary_pairs` の gap probe を VTuber で localize に切替
+
+**Files:**
+
+- Modify: `allaganeye/video/scorebar.py`
+- Test: `tests/test_scorebar.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_merge_gap_probe_uses_localize_when_vtuber(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    from allaganeye.video.capture_region import CaptureRegion
+    captured = {}
+
+    def fake_probe(video, points, height, workers, *, with_localize=False):
+        captured["with_localize"] = with_localize
+        # gap shows no scorebar by either signal -> eligible to merge.
+        return ([None] * len(points), [b"f"] * len(points), [False] * len(points))
+
+    monkeypatch.setattr(sb, "_probe_scorebar_context", fake_probe)
+    regions = [(10.0, 12.0), (30.0, 32.0)]
+    cls = ["match_boundary", "match_boundary"]
+    band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
+    merged, merged_cls = sb._merge_boundary_pairs(
+        Path("x.mp4"), regions, cls, 400.0, 180, None, band_region=band, vtuber=True
+    )
+    assert captured["with_localize"] is True
+    assert merged == [(10.0, 32.0)]  # localize-absent gap -> merged
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -k "merge_gap_probe_uses_localize" -v`
+Expected: FAIL (`TypeError: ... unexpected keyword argument 'band_region'`).
+
+- [ ] **Step 3: Add params + localize-aware gap signal**
+
+`_merge_boundary_pairs` の signature に keyword 追加:
+
+```python
+def _merge_boundary_pairs(
+    video_path: Path,
+    regions: list[tuple[float, float]],
+    classifications: list[str],
+    duration: float,
+    height: int,
+    workers: int | None,
+    *,
+    band_region: CaptureRegion = FULL_FRAME,
+    vtuber: bool = False,
+) -> tuple[list[tuple[float, float]], list[str]]:
+```
+
+gap probe (現 :562-567) を signal 切替に置換:
+
+```python
+                if vtuber:
+                    _, _, probe_signal = _probe_scorebar_context(
+                        video_path, probe_points, height, workers,
+                        with_localize=True,
+                    )
+                else:
+                    probe_signal, _, _ = _probe_scorebar_context(
+                        video_path, probe_points, height, workers,
+                    )
+                all_valid = all(r is not None for r in probe_signal)
+                any_scorebar = any(r is True for r in probe_signal)
+```
+
+(以降の `if all_valid and not any_scorebar:` merge ロジックは不変。`probe_results` 参照を `probe_signal` に変更。ログ行の `probes=%s, probe_results` も `probe_signal` に更新。)
+
+- [ ] **Step 4: Run scorebar suite**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_scorebar.py -v`
+Expected: PASS (new merge test + existing merge tests green — `vtuber=False` keeps v2 gap probe).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/scorebar.py tests/test_scorebar.py
+pyright allaganeye/video/scorebar.py
+git add allaganeye/video/scorebar.py tests/test_scorebar.py
+git commit -F - <<'EOF'
+feat(l3): _merge_boundary_pairs の gap probe を VTuber で localize 化 (Phase 2 C2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task Group D — detector 配線 + trailing-drop gate (P2-d)
+
+### Task D1: `detect_match_boundaries` で band_region/vtuber を渡し、trailing-drop を VTuber で gate off
+
+**Files:**
+
+- Modify: `allaganeye/video/detector.py`
+- Test: `tests/test_detector.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_filter_call_receives_band_region_and_vtuber():
+    # static check: detect threads detect_region + vtuber into the scorebar filter.
+    import inspect
+    from allaganeye.video import detector as det
+    src = inspect.getsource(det.detect_match_boundaries)
+    assert "band_region=detect_region" in src
+    assert "vtuber=vtuber" in src
+
+
+def test_trailing_drop_gated_off_for_vtuber():
+    import inspect
+    from allaganeye.video import detector as det
+    src = inspect.getsource(det.detect_match_boundaries)
+    # the trailing-drop call must be guarded so it never runs on the VTuber path.
+    assert "if src_resolution is not None and not vtuber:" in src
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_detector.py -k "band_region_and_vtuber or trailing_drop_gated" -v`
+Expected: FAIL (strings absent).
+
+- [ ] **Step 3: Thread params + gate trailing-drop**
+
+`detect_match_boundaries` の `filter_blackouts_with_scorebar` 呼び出し (現 :448-457) に 2 kwarg を追加:
+
+```python
+        refined_regions, region_classifications = filter_blackouts_with_scorebar(
+            video_path,
+            refined_regions,
+            duration_hint,
+            height,
+            workers,
+            band_region=detect_region,
+            vtuber=vtuber,
+            audio_hits=audio_hits,
+            stats=stats,
+            progress_callback=scorebar_progress_callback,
+        )
+```
+
+trailing-drop の gate (現 :475) を変更し、コメントも更新:
+
+```python
+    # #797: drop a trailing post-match run when its early candidate-match window
+    # shows no scorebar at any strided probe point. Skipped for VTuber
+    # (vtuber=True): _drop_post_match_trailing probes v2 (absolute coords) which
+    # FNs on an inset scorebar and would silently drop a real VTuber final match
+    # (spec section 8.1 P2-d / Codex #1). VTuber trailing is handled in Phase 3.
+    if src_resolution is not None and not vtuber:
+        segments = _drop_post_match_trailing(
+            segments,
+            video_path,
+            duration_hint,
+            stats,
+            min_match_duration=min_match_duration,
+        )
+```
+
+- [ ] **Step 4: Run detector suite**
+
+Run: `cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection" && python -m pytest tests/test_detector.py -v`
+Expected: PASS (new gate tests + all existing detector tests green — `vtuber=False` default keeps the trailing-drop running exactly as today for OBS).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check allaganeye/video/detector.py tests/test_detector.py
+ruff format --check allaganeye/video/detector.py tests/test_detector.py
+pyright allaganeye/video/detector.py
+git add allaganeye/video/detector.py tests/test_detector.py
+git commit -F - <<'EOF'
+feat(l3): detect が band_region/vtuber を分類に配線 + trailing-drop を VTuber で gate off (Phase 2 D1)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task Group E — 受け入れ検証
+
+### Task E1: OBS bit-exact 回帰 + 全 unit + lint (subagent 実行可能分)
+
+**Files:**
+
+- Test: 既存 `tests/test_scorebar.py` / `tests/test_detector.py` / baseline harness
+
+- [ ] **Step 1: 全 unit suite (動画不要、subagent が完走できる)**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+python -m pytest -q
+```
+
+Expected: PASS (全 unit green、slow は自動 skip)。
+
+- [ ] **Step 2: 型・lint (PR Pre-flight 前倒し)**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check .
+ruff format --check .
+pyright
+```
+
+Expected: いずれも 0 error。
+
+- [ ] **Step 3: OBS baseline bit-exact (slow / sample-gated、Idios 実機)**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+set ALLAGANEYE_SAMPLE_VIDEO_DIR=E:\royalstraightflesh\videos
+python -m pytest -m slow -k "baseline or obs" -v
+```
+
+Expected: PASS — 5 OBS baseline が bit-exact (`vtuber=False` で v2 経路不変)。**差分が出たら STOP**: `vtuber=False` 経路に変更が漏れている (baseline 再生成は禁止)。timestamp churn (detected_at/generated_at) は非意味的差分として grep 除外して判定 (memory: baseline regen の timestamp churn)。
+
+- [ ] **Step 4: 結果記録 (テストコード変更時のみ commit)**
+
+bit-exact 確認をこの plan の実行ログに記録。
+
+---
+
+### Task E2: VTuber split + v2/localize parity slow 受け入れ (sample-gated、Idios 実機)
+
+**Files:**
+
+- Create: `tests/test_l3_phase2_parity.py`
+
+- [ ] **Step 1: Write the slow acceptance scaffold (demonstrated-level)**
+
+`tests/test_l3_phase2_parity.py`:
+
+```python
+"""Phase 2 受け入れ (slow / sample-gated): VTuber 過分割解消 + OBS v2/localize parity.
+
+実機データ依存 (Idios verify、PYTHONUTF8=1)。CI では sample 未設定で skip。
+parity は production に入れない harness 計測 (spec section 8.1 P2-b)。
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+
+def _vtuber_sample() -> Path | None:
+    base = os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER") or r"E:\allaganeye-samples"
+    cands = list(Path(base).glob("*オンサル*")) if Path(base).exists() else []
+    return cands[0] if cands else None
+
+
+@pytest.mark.skipif(_vtuber_sample() is None, reason="VTuber sample not available")
+def test_vtuber_split_removes_in_match_overspilt():
+    from allaganeye.video.probe import probe_video
+    from allaganeye.video import detector as det
+
+    video = _vtuber_sample()
+    meta = probe_video(video)
+    res = (meta["width"], meta["height"])
+    # vtuber=True path: classifier removes in-match band-crop blackouts.
+    matches_vtuber = det.detect_match_boundaries(
+        video, duration_hint=meta["duration"], src_resolution=res, vtuber=True
+    )
+    # Phase 1 over-split baseline (vtuber=True without Phase 2 classify) split far
+    # more; here we assert the classified result is a sane, small match count.
+    assert 0 < len(matches_vtuber) <= 12, (
+        f"VTuber split should be practical, got {len(matches_vtuber)} matches"
+    )
+
+
+def _obs_sample() -> Path | None:
+    base = os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR")
+    if not base or not Path(base).exists():
+        return None
+    cands = list(Path(base).glob("*.mkv"))
+    return cands[0] if cands else None
+
+
+@pytest.mark.skipif(_obs_sample() is None, reason="OBS sample not available")
+def test_obs_v2_vs_localize_presence_parity(caplog):
+    """v2 (authoritative) と localize の scorebar-present を時間グリッドで突合。
+
+    production には入れない harness 専用計測 (spec section 8.1 P2-b)。一様グリッドで
+    v2-present と localize-present を比較し、不一致を per-sample ログ化する。long
+    非試合区間 (lobby/result) を含む全域で v2/localize の FP/FN 差を可観測にする
+    (Codex #3)。assert は緩く「不一致が極端でない」のみ (閾値校正は Phase 3)。
+    """
+    import logging
+
+    from allaganeye.video.probe import probe_video
+    from allaganeye.video import detector as det
+    from allaganeye.video import scorebar as sb
+
+    video = _obs_sample()
+    meta = probe_video(video)
+    duration = meta["duration"]
+
+    # Uniform interior grid (avoid the very edges).
+    n = 40
+    times = [duration * (i + 1) / (n + 1) for i in range(n)]
+
+    agree = 0
+    disagree = 0
+    with caplog.at_level(logging.INFO):
+        for t in times:
+            raw = det._probe_frame_rgb_hires(video, t)
+            v2 = det._has_scorebar_v2(raw)
+            loc = sb._localize_present_from_raw(raw)
+            if v2 is None or loc is None:
+                continue
+            if v2 == loc:
+                agree += 1
+            else:
+                disagree += 1
+                logging.getLogger(__name__).info(
+                    "PARITY_DIFF t=%.1f v2=%s localize=%s", t, v2, loc
+                )
+        total = agree + disagree
+        logging.getLogger(__name__).info(
+            "PARITY summary: %d/%d agree (%d diffs)", agree, total, disagree
+        )
+
+    assert total > 0, "no valid probes -- check sample video / opencv"
+    # localize should broadly agree with v2 on OBS (the position-independent
+    # localizer finds the same full-screen scorebar). A wildly low agreement
+    # signals a regression worth Idios investigating; calibration is Phase 3.
+    assert agree / total >= 0.6, f"v2/localize parity too low: {agree}/{total}"
+```
+
+> **注**: parity は時間グリッドの scorebar-present 突合で、refined-region 再構築を必要とせず runnable。per-blackout の classification-level parity (より精密) は Idios 実機で `det.detect_match_boundaries` を `stats` 付きで走らせて深掘りしてよい。CI では sample 未設定で skip。
+
+- [ ] **Step 2: Run (sample-gated)**
+
+Run:
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+set PYTHONUTF8=1
+set ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER=E:\allaganeye-samples
+set ALLAGANEYE_SAMPLE_VIDEO_DIR=E:\royalstraightflesh\videos
+python -m pytest tests/test_l3_phase2_parity.py -m slow -v
+```
+
+Expected: VTuber/OBS sample があれば PASS (split 実用域 + parity diff ログ)、無ければ SKIP。
+
+- [ ] **Step 3: Lint + commit**
+
+```bash
+cd "E:/projects/kobutachan-tools/kobutachan-allaganeye/.claude/worktrees/l3-p2-region-detection"
+ruff check tests/test_l3_phase2_parity.py
+git add tests/test_l3_phase2_parity.py
+git commit -F - <<'EOF'
+test(l3): VTuber split + OBS v2/localize parity slow 受け入れ (Phase 2 E2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## 受け入れ条件 (Phase 2 完了基準)
+
+- [ ] A: `_probe_scorebar_context` が hi-res 再利用で localize-present を第3要素に返し、`with_localize=False` (既定) では全 None で既存 caller が bit-exact (unit)。
+- [ ] B: `_classify_blackout_localize` が present 単独で in_match/match_boundary/non_fl を出し、band-MAD を `VTUBER_MAD` ログに emit する (分類に未使用、unit)。`_band_mad_min` の絶対 ROI 分岐は bit-exact、band 空 ROI は None (unit)。
+- [ ] B: `classify_blackout(vtuber=True)` が localize に委譲し、`vtuber=False` は v2 body 不変 (unit)。
+- [ ] C: `filter_blackouts_with_scorebar` / `_merge_boundary_pairs` が band_region/vtuber を通し、VTuber merge gap probe が localize を使う (unit)。
+- [ ] D: `detect_match_boundaries` が分類に band_region/vtuber を配線し、`_drop_post_match_trailing` を `not vtuber` で gate off (unit)。
+- [ ] E1: OBS 5 baseline が bit-exact (timestamp churn 除く、slow / 実機)。全 unit + ruff + pyright green。
+- [ ] E2: VTuber で過分割が実用域に収束、OBS v2/localize parity diff がログ化される (slow / 実機)。
+- [ ] Idios の実機検証 (OBS detect 不変 + VTuber `--vtuber` split 目視 + GPU) — Iron Law 6 (logic 変更 + GPU + 長時間動画)。
+
+## このプランがやらないこと (後 Phase / 範囲外)
+
+- **motion (band-MAD) を分類に AND する配線・閾値校正** → Phase 3 (本 plan は telemetry 収集のみ、spec §8.1 P2-a)。
+- **v2 retire / GT-accuracy gate 化** → Phase 4。
+- **`_drop_post_match_trailing` の非破壊化 / localize 化** → 触らない (VTuber は gate off のみ、map §4 / §5.3、Phase 4 以降)。
+- **VTuber GT 注釈・recall/precision 校正・fallback フラグ** → Phase 3 (全画面 UI が片側 scorebar を隠す偽境界 R3/R3b の恒久対策含む)。
+- **audio Fanfare promotion の VTuber 対応** → 不要 (`AUDIO_FROZEN=True` で inert)。将来 unfreeze 時に再評価する caveat のみ (spec §8.1 P2-g)。
+- **issue 起票** → Iron Law 2、起票時に AskUserQuestion。

--- a/docs/superpowers/specs/2026-05-29-presence-based-detection-engine-design.md
+++ b/docs/superpowers/specs/2026-05-29-presence-based-detection-engine-design.md
@@ -217,3 +217,50 @@ Phase 1/2 = 検証、Phase 3 = 切替。これがブレストの「検証して�
 - #809 wiring (park): [2026-05-27-vtuber-pass1-region-wiring-design.md](2026-05-27-vtuber-pass1-region-wiring-design.md)
 - 現行コード: `allaganeye/video/capture_region.py` (`localize_scorebar` / `ScorebarLocalization`), `allaganeye/video/detector.py` (`detect_match_boundaries` / brightness Pass1 / emblem 定数), `allaganeye/video/scorebar.py` (`filter_blackouts_with_scorebar` = #480 分類), `allaganeye/commands/detect.py` (metadata 出力)
 - 関連 issue: [#480](https://github.com/Idios/kobutachan-allaganeye/issues/480) (分類・本 spec が subsume), [#481](https://github.com/Idios/kobutachan-allaganeye/issues/481) (minimap・範囲外), [#805](https://github.com/Idios/kobutachan-allaganeye/issues/805) (post-match trailing), [#809](https://github.com/Idios/kobutachan-allaganeye/issues/809) (park・redefine 候補), [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753) (re-plan umbrella)
+
+## 付録: Phase 1 実機検証結果と Q3 決定の改訂 (2026-05-30 追記)
+
+> Phase 1 (presence 検出アルゴリズム + offline 検証ハーネス) を実装し
+> (branch `claude/l3-p2-region-detection`、presence.py + presence_harness.py、
+> unit/lint/型/レビュー全 pass)、OBS 実動画で受け入れゲートを実行した結果、
+> **本 spec の中核決定 (§3 Q3「brightness Pass-1 を撤去し presence 単独に全置換」)
+> が OBS では不適切**と実証された。以下に記録し、アーキテクチャを再ブレストする。
+
+### A.1 OBS gate 実機結果 (obs-20260209、20.6GB / 57min)
+
+- **性能 OK**: `detect_matches_by_presence` (stride=4s, workers=8) が 3m16s で完走 (spec §6 の性能懸念クリア)。
+- **精度 FAIL**: `ComparisonResult(matched=1, missed=2, spurious=1)`。検出できた 1 試合の境界誤差は 0.5–2.5s と高精度 (機構は正しい、**signal が不足**)。
+
+### A.2 根本原因: リザルト画面の偽 presence (データ実証)
+
+presence (scorebar 有無) は、試合直後の**リザルト/順位画面が同じ GC 紋章を表示する**ため、連続試合を分離できない。キャッシュ samples 解析 (再 probe なし):
+
+| 区間 | present% | conf 中央値 |
+| --- | --- | --- |
+| GT1 試合 | 98% | 0.60 |
+| inter 1→2 (リザルト画面) | **91%** | 0.42 ← 偽 presence |
+| GT2 試合 | 94% | 1.00 |
+| inter 2→3 (正常 lobby) | 13% | 0.06 |
+| GT3 試合 | 99% | 0.92 |
+
+- inter 1→2 の 91% present が GT1↔GT2 を橋渡し → 閾値スイープで GT1+GT2 が 1 ブロックにマージ。
+- **confidence 閾値では分離不能** (GAP1→2 を下げる閾値で GT1 も崩壊、分布が重なる)。
+- **absent gap 長でも分離不能** (試合間 gap ≈ mid-match 中断 ≈ 8–20s)。spec §4.3 の debounce 前提 (max mid-match 不在 < T_gap < min 試合間 gap) が実データで破れている。
+
+### A.3 決定的データ: 既存 brightness 検出器は OBS で完璧
+
+`tests/baselines/v0.3.0/obs-20260209.metadata.json` (既存 brightness Pass-1 + scorebar 分類) は同動画で 3 試合を**秒未満精度**で検出: M1 40.25..1076.125 / M2 1252.25..2324.5 / M3 2504.0..3370.75 (GT 40..1076 / 1252..2324 / 2504..3370)。**brightness blackout は真の試合境界 (リザルト画面の手前) に存在し、既存検出器はそれを正しく使えている**。presence がマージしたのは、この blackout 信号を持たないため。
+
+### A.4 設計含意 (Q3 改訂方針)
+
+- **Q3「brightness Pass-1 撤去・全置換」は OBS では不適切**。brightness 境界は撤去すべきでない。
+- presence/localize_scorebar の真価は「全置換の検出器」ではなく、**位置独立で頑健な分類器 + VTuber 経路**にある。
+- → re-plan #753 全体 (P1〜P6 の依存・presence の位置づけ) を改めて brainstorm し直す (本 addendum を起点)。
+
+### A.5 Phase 1 コード資産の扱い
+
+- `allaganeye/video/presence.py` + `tests/presence_harness.py` (+ 3 test files) は branch にコミット済・production 非配線。**revert 不要**。再アーキテクチャ下で資産として残す:
+  - `localize_scorebar` 由来の presence 信号 = 頑健な分類器の核。
+  - offline 検証ハーネス (`compare_segments` / GT 突合) = 今後の検証インフラ。
+  - `segment_presence` / `refine_boundary` = blackout 境界と組む際に再利用候補。
+- 新アーキテクチャの spec / plan は別ドキュメントで起こす。

--- a/docs/superpowers/specs/2026-05-29-presence-based-detection-engine-design.md
+++ b/docs/superpowers/specs/2026-05-29-presence-based-detection-engine-design.md
@@ -1,0 +1,219 @@
+# presence ベース検出エンジン 設計 (2026-05-29)
+
+> L3 VTuber 対応の再々設計。re-plan ([#753](https://github.com/Idios/kobutachan-allaganeye/issues/753)) の
+> **P2「scorebar-anchored 領域検出」** から、2026-05-29 のブレストで
+> **「scorebar 有無 (presence/absence) を OBS/VTuber 共通の唯一の検出信号とする core 検出エンジン置換」**
+> へ方針転換した結果をまとめる。本 spec は re-plan の **P2 / P3 / P4 (#480) を統合し supersede** する。
+> P1 (robust scorebar localization, PR #811 マージ済) を基盤として再利用する。
+
+## 1. 背景と方針転換
+
+### 1.1 出発点 (re-plan P2)
+
+re-plan の依存鎖は **P1 (localize) → P2 (region 検出) → P3 (region crop で brightness 検出) → P4 (region-aware 分類 #480)** だった。
+P2 は「scorebar 幾何を anchor に game 矩形を求め、その crop で brightness Pass1 を回して overlay 汚染を除く」ことを狙っていた。
+
+### 1.2 ブレストでの転換
+
+設計対話 (2026-05-29) で以下を順に確定し、P2 の前提自体が不要になった。
+
+1. **エッジ導出 = scorebar のみ (案 A)**: game 矩形の左右・下端を脆い extent 信号 (S3) から導出しない。
+2. **検出信号 = scorebar 有無に昇格**: 「scorebar present = FL 試合中」を直接の match-membership 信号にする。
+   region crop も brightness Pass1 も不要になり、検出と分類 (#480) が 1 信号に統合される。lobby (明るいが scorebar 不在) も捕捉できる。
+3. **OBS も全面 presence 化 + 再 baseline**: OBS/VTuber を統一パイプラインにし、現行の bit-exact hard gate を撤廃する。
+4. **進め方 = GT 突合・検証先行カットオーバー**: released 経路を未検証コードで一括置換しないため、offline 検証ハーネスを先行させ、ground truth と突合してからカットオーバーする。
+
+### 1.3 結論
+
+brightness ベースの Pass1 検出を撤去し、`localize_scorebar` (P1) の present/absence を OBS/VTuber 共通の検出信号にする。
+これは released・検証済みの中核アルゴリズム置換であり、**bit-exact 不変条件の意識的な override** を伴う。
+よって「検証してから切替」を構造として spec に組み込む (§7 / §9)。
+
+## 2. スコープと成果物
+
+### 2.1 成果物
+
+- presence ベース検出アルゴリズム (時系列 localize sampling → debounce segment 化 → fine-localize 境界精緻化)。
+- offline 検証ハーネス (test 動画で presence 境界を GT / 現行と突合し metric を出す。production 非配線)。
+- カットオーバー (brightness Pass1 撤去・再 baseline・bit-exact → GT-accuracy gate・#480 統合・実機検証)。
+
+### 2.2 やらないこと (境界)
+
+- **game region 検出 (原 P2 の game 矩形)**: presence 検出は region を必要としない。region は廃止する。
+- **minimap 切抜き ([#481](https://github.com/Idios/kobutachan-allaganeye/issues/481))**: 別レイヤー。必要なら scorebar 幾何から改めて導出する (本 spec 範囲外)。
+- **scorebar localization 自体の改良**: P1 で完了済。本 spec は P1 を consumer として使うだけ。
+- **metadata schema 変更**: 出力は現行どおり match segments (`matches[]` / `boundaries`)。region フィールドは追加しない。
+
+### 2.3 上位方針 (bit-exact → GT-accuracy)
+
+- 現行の **OBS bit-exact hard gate** (re-plan §5 / P1 §7.1 / #809 等が non-negotiable と宣言) を **撤廃**し、
+  **GT-accuracy gate (tolerance ベース)** に置換する。これは本 spec の前提であり、ブレストで明示的に承認された。
+- 撤廃理由: bit-exact は「OBS 出力を一切変えない」ことを保証する一方、presence 検出が OBS でも現行以上に正しい場合に **改善を block** してしまう。
+  そこで「現行 boundary との一致」ではなく「ground truth との一致」を gate にする。
+
+## 3. 決定事項 (ブレスト 2026-05-29)
+
+| 論点 | 決定 | 根拠 |
+| --- | --- | --- |
+| エッジ導出 (Q1) | **A: scorebar のみ** (extent から幅・edges を導出しない) | crop 不要化の布石。S3 extent は #809 Wave F で脆い |
+| 検出信号 (Q2) | **scorebar 有無 (presence) を検出信号に昇格** | content-fixed・位置独立 (P1 で 5 source 実証)・lobby も捕捉・検出と分類を統合 |
+| OBS bit-exact (Q3) | **全面 presence + 再 baseline** (bit-exact gate 撤廃) | 統一パイプライン。bit-exact は better algorithm を block する |
+| scope / 検証 (Q4) | **進める + GT 突合・検証先行カットオーバー** | released 経路を未検証置換しない。offline 検証を先行 |
+| scorebar 連続性 (domain) | **試合中に短時間消える場面あり** (死亡暗転 / 全画面 UI 等) | debounce / hysteresis 必須 |
+| present 定義 (③) | **localize 非 None = present** | emblem-AND は zero-FP 検証済。confidence しきいは false-absent を招く |
+| 境界 refinement (⑥) | **fine localize のみ** (brightness 完全排除) | presence 純化。timing は tolerance-based GT gate で吸収 |
+| GT (validation) | **VTuber 5 source 全部に手動 GT**、OBS = 現行 baseline | 最強検証。GT-first 方針と整合 |
+
+## 4. アルゴリズム
+
+### 4.1 パイプライン
+
+```text
+① video 入力
+② time grid (stride S) で probe frame 抽出 → 1920x1080 RGB に resize
+③ localize_scorebar(frame) (P1) → 各 sample が present (非 None) / absent (None)
+④ debounce / hysteresis (両方向): 短い absent gap と短い present spike を吸収
+⑤ segment 化: present 連続 = 試合 / absent 連続 (>= T_gap) = 境界・lobby・非 FL
+⑥ 境界 refinement: 各 present<->absent 遷移付近を fine localize (二分探索 / 細 grid) で精緻化 -> t_start / t_end
+⑦ 出力: 試合 segment -> metadata.json (現行 schema 同一)。分類 (#480) は present=FL で統合
+```
+
+OBS・VTuber とも同一パイプラインを通る。probe frame は常に 1920x1080 RGB に正規化し、`localize_scorebar` が位置独立に scorebar を探す (P1 の契約)。
+
+### 4.2 present 定義
+
+- `localize_scorebar(frame)` が `ScorebarLocalization` を返したら **present**、`None` なら **absent**。
+- emblem-AND (GC 紋章 3 点) は #803 negative で zero-FP 検証済のため、非 None 自体が強い present 信号。
+- `confidence` は present/absent 判定には使わない。⑥ refinement と診断 / metric にのみ保持する。
+- 利点: 背景が明るく emblem 彩度が一時的に下がる等の弱 present frame も拾い、false-absent を避ける。
+
+### 4.3 debounce / hysteresis (両方向)
+
+- **absent gap 吸収**: `T_gap` 未満の absent 連続は in-match として吸収する (試合中の死亡暗転 / 全画面 UI による短時間 None を救済)。
+- **present spike 吸収**: `T_min_match` 未満の present 連続は試合とみなさず破棄する (試合外の偶発 present / FP を救済)。
+- 実 boundary = `T_gap` 以上の absent run。実 match = `T_min_match` 以上の present run。
+
+### 4.4 segment 化
+
+- debounce 後、present run を試合 segment、absent run (>= T_gap) を非試合 (境界 / lobby / 非 FL) とする。
+- 検出と分類が統合される: 「present = FL 試合中」が成立するため、従来 `filter_blackouts_with_scorebar` (#480) が担っていた match_boundary / in_match / non_fl 分類は presence 信号に吸収される。
+
+### 4.5 境界 refinement (fine localize)
+
+- coarse scan が present sample `t_i` と absent sample `t_{i+1}` の遷移を検出したら、`(t_i, t_{i+1})` 区間を fine localize (二分探索 or 細 grid) で再評価し、scorebar の出現 / 消失点を `T_tol` 精度で特定する。
+- brightness は一切使わない。よって presence 遷移エッジは現行 brightness blackout エッジと厳密一致しない。
+  splitting は keyframe + padding で数秒のスラックを吸収するため、`T_tol` 精度で実用十分 (§7.3 / §8)。
+
+### 4.6 パラメータ (harness で校正)
+
+| param | 意味 | 暫定 | 制約 |
+| --- | --- | --- | --- |
+| `S` | coarse grid stride | 3-5s (or Pass1 の adaptive `sample_interval` 流用) | `S < min 試合間 gap` (gap を 1-2 sample で捕捉) |
+| `T_gap` | 境界とみなす最小 absent 長 | harness 校正 | `max mid-match 不在 < T_gap < min 試合間 gap` |
+| `T_min_match` | 試合とみなす最小 present 長 | harness 校正 | 試合最短長より短く、FP spike より長い |
+| `T_tol` | GT 突合の許容 boundary 誤差 | harness 校正 (秒オーダー) | split padding 内に収まる |
+
+暫定値の根拠 (prior art): 現行 `min_blackout_duration` / `_REFINED_MIN_BLACKOUT` (短い in-match 暗転の除外しきい)。最終値は §7 ハーネスで実測校正する。
+
+## 5. データ構造 / API
+
+- **再利用 (P1)**: `localize_scorebar(frame: np.ndarray, *, stride, target_ratio) -> ScorebarLocalization | None` (`allaganeye/video/capture_region.py`)。
+  入力は 1920x1080 RGB frame。`ScorebarLocalization(x_left, x_right, y_top, y_bottom, confidence)` は probe px。
+- **新規 (本 spec)**: presence sampling → debounce → segment 化 → fine refinement を行う検出関数群。
+  既存 `detect_match_boundaries` (brightness) と並置する新モジュール / 関数として Phase 1 で追加し (additive)、Phase 3 で production を切替える。
+- **出力**: 試合 segment (start/end) のリスト = 現行 `boundaries` / `matches[]`。metadata.json schema は不変。
+
+## 6. 性能
+
+- `localize` は 1920x1080 RGB + OpenCV (HSV / Sobel / y-scan) で、現行 brightness Pass1 (320x180 grayscale 平均) より大幅に重い。長尺 (2-3h) では本処理がコスト主因。
+- 緩和:
+  - 試合は分オーダーに長いため coarse scan は中程度 stride `S` で十分。dense sampling は遷移付近の ⑥ refinement のみ。
+  - decode を並列化 (現行 `ThreadPoolExecutor` 同様)。`gpu_detector.py` の chunked decode 基盤を 1920x1080 frame 取得に再利用可能。
+  - 必要なら安価な pre-filter (例: 上部帯の彩度) で localize 呼び出しを間引く (YAGNI、harness で必要性判断)。
+- ハーネスで実 wall-time をベンチし、`S` と pre-filter を性能レバーとする。
+
+## 7. OBS / 検証 / カットオーバー
+
+### 7.1 検証ハーネス (offline・production 非配線)
+
+- test 動画ごとに presence 検出を実行し、検出 boundary を GT / 現行アルゴリズムと突合。
+- metric: matched / missed / spurious match 数、boundary 誤差分布、localize recall/precision、wall-time。
+
+### 7.2 GT (ground truth)
+
+- **OBS**: 現行の検証済 5 baseline をそのまま GT に使う (release 済の正解 boundary)。
+- **VTuber**: 5 source すべてに Idios が手動で match 境界 (各試合の start/end) を注釈する (`E:\allaganeye-samples`、guard verify は FP のため owner override 運用 / `PYTHONUTF8=1`)。
+- GT 注釈はカットオーバー前に完了させる。
+
+### 7.3 GT-accuracy gate (tolerance ベース)
+
+- bit-exact gate を撤廃し、以下を gate とする:
+  - **OBS**: 5 baseline の全 match を検出 (missed/spurious ゼロ)、各 boundary 誤差 <= `T_tol`。
+  - **VTuber**: 手動 GT に対し match recall / precision が目標値 (harness で設定) を満たす。
+- 「再 baseline」は新 presence エッジを GT として凍結する操作であり、missed/spurious ゼロ確認後にのみ行う (誤りを真値固定しない)。
+
+### 7.4 カットオーバー手順
+
+1. presence 検出で production の brightness Pass1 を置換。
+2. 新 baseline を生成 (上記 gate 通過確認後に凍結)。
+3. bit-exact 回帰テストを GT-accuracy (tolerance) テストに置換。
+4. 分類 (#480) を presence 信号に統合 (`filter_blackouts_with_scorebar` の役割を整理)。
+5. Idios の実機検証 (OBS + VTuber、Iron Law 6)。
+
+## 8. テスト戦略 / 受け入れ条件
+
+### 8.1 unit (動画不要)
+
+- debounce / segment 化: 合成 present/absent 列 (短 gap / 短 spike / 通常 / lobby) → 期待 segment。純関数。
+- 境界 refinement: 合成遷移 → 期待 t_start/t_end (`T_tol` 内)。
+
+### 8.2 harness (slow・sample-gated)
+
+- 全動画 presence 検出 vs GT。OBS 5 + VTuber 5。matched/missed/spurious、boundary 誤差、wall-time を出力。
+
+### 8.3 受け入れ条件 (issue 化時の原型)
+
+- presence (localize 非 None) + debounce + fine refinement で試合 segment を出力する。
+- OBS: 現行 5 baseline の全 match を検出、missed/spurious ゼロ、boundary 誤差 <= `T_tol`。
+- VTuber: 手動 GT に対し recall/precision が目標値以上。
+- bit-exact gate を GT-accuracy (tolerance) gate に置換。
+- brightness Pass1 を検出経路から撤去。
+- Idios の実機検証 (OBS + VTuber) 完了。
+
+## 9. 段階分解 (Phase 1-3)
+
+| Phase | 内容 | production 影響 | gate |
+| --- | --- | --- | --- |
+| **1** | presence 検出アルゴリズム + offline ハーネス (additive・非配線)。OBS 即検証 (GT=現行 baseline) | なし (baseline 不変) | OBS GT-accuracy 通過 |
+| **2** | VTuber GT 注釈 (5 source) + VTuber 検証。`T_gap`/`S`/`T_tol` 校正 | なし | VTuber GT-accuracy 通過 |
+| **3** | カットオーバー (§7.4)。brightness Pass1 撤去・再 baseline・gate 置換・#480 統合・実機検証 | あり (検出エンジン置換) | 全 GT-accuracy + 実機検証 |
+
+Phase 1/2 = 検証、Phase 3 = 切替。これがブレストの「検証してから切替」の構造実装。各 Phase は独立 PR。
+
+## 10. リスク
+
+| # | リスク | 緩和 |
+| --- | --- | --- |
+| R1 | bit-exact 撤廃で OBS regression を見逃す | GT-accuracy gate (現行 baseline=GT、missed/spurious ゼロ) + 実機検証。Phase 1 で OBS 即検証 |
+| R2 | localize FN (検出漏れ) が `T_gap` を超え実試合を誤分割 | debounce で短 FN 救済。長 FN は harness で localize recall 実測し閾値 / pre-filter 調整 |
+| R3 | localize FP (試合外 present) で false match | emblem-AND zero-FP + `T_min_match` spike 吸収。harness で precision 実測 |
+| R4 | 性能 (localize 重い・長尺) | coarse stride + 並列 + GPU chunked decode 再利用。harness ベンチ |
+| R5 | 再 baseline で誤りを真値固定 | GT-first (missed/spurious ゼロ確認後に凍結)。Idios 実機検証 |
+| R6 | presence エッジ != brightness blackout エッジ (split padding 前提変化) | `T_tol` + keyframe/padding で吸収。harness で boundary 誤差分布確認 |
+| R7 | post-match trailing ([#805](https://github.com/Idios/kobutachan-allaganeye/issues/805)) との関係 | presence では「scorebar 不在 = 試合外」が明示化され #805 の弱い否定信号問題が改善する可能性。逆に localize FN で実 trailing を切る risk は残る。harness で確認し #805 とリンク |
+
+## 11. 未確定 (Iron Law 2 / 5 で user 承認後に確定)
+
+- **issue 起票 / 編集**: 本件は re-plan の「#809 `detect_coarse_region` 再設計」ではなくなった。
+  presence 検出エンジンの新 umbrella + Phase 1-3 の sub-issue を起票し、#480 (分類) を subsume、park 済 #809 を redefine / close する案。issue 操作を伴うため起票時に `AskUserQuestion` で確認する。
+- **閾値の最終値** (`S` / `T_gap` / `T_min_match` / `T_tol`): harness 校正で確定。
+- **VTuber GT 目標値** (recall/precision): harness 実測後に設定。
+
+## 12. 参照
+
+- re-plan overview: [2026-05-28-vtuber-region-boundary-replan-design.md](2026-05-28-vtuber-region-boundary-replan-design.md) (本 spec が P2/P3/P4 を supersede)
+- P1 (基盤・マージ済): [2026-05-29-p1-robust-scorebar-localization-design.md](2026-05-29-p1-robust-scorebar-localization-design.md) (§8.7 multi-source 実証、localize API)
+- Phase 2a: [2026-05-26-vtuber-capture-region-detection-design.md](2026-05-26-vtuber-capture-region-detection-design.md) (§6.3.1 注1 span→幅 不成立 / 注3 OBS↔inset 単フレーム不可)
+- #809 wiring (park): [2026-05-27-vtuber-pass1-region-wiring-design.md](2026-05-27-vtuber-pass1-region-wiring-design.md)
+- 現行コード: `allaganeye/video/capture_region.py` (`localize_scorebar` / `ScorebarLocalization`), `allaganeye/video/detector.py` (`detect_match_boundaries` / brightness Pass1 / emblem 定数), `allaganeye/video/scorebar.py` (`filter_blackouts_with_scorebar` = #480 分類), `allaganeye/commands/detect.py` (metadata 出力)
+- 関連 issue: [#480](https://github.com/Idios/kobutachan-allaganeye/issues/480) (分類・本 spec が subsume), [#481](https://github.com/Idios/kobutachan-allaganeye/issues/481) (minimap・範囲外), [#805](https://github.com/Idios/kobutachan-allaganeye/issues/805) (post-match trailing), [#809](https://github.com/Idios/kobutachan-allaganeye/issues/809) (park・redefine 候補), [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753) (re-plan umbrella)

--- a/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
+++ b/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
@@ -1,0 +1,226 @@
+# L3 検出再アーキテクチャ: 2 信号 fusion 設計 (2026-05-31)
+
+> L3 VTuber 対応の再々々設計。presence 単独全置換 spec
+> ([2026-05-29-presence-based-detection-engine-design.md](2026-05-29-presence-based-detection-engine-design.md))
+> が OBS 実機で破綻した (同 spec 付録 A) ことを起点に、re-plan
+> ([#753](https://github.com/Idios/kobutachan-allaganeye/issues/753)) 全体を再ブレストした結果をまとめる。
+> 本 spec は presence spec の中核決定 (§3 Q3「brightness Pass-1 撤去・presence 単独全置換」) を **supersede** し、
+> re-plan の P1〜P6 を再定義する。P1 (`localize_scorebar`, PR #811 マージ済) を基盤として再利用する。
+>
+> **Status**: brainstorming 完了 / user 承認待ち (spec review gate)
+> **Supersedes**: presence spec §3 Q3 (全置換) / re-plan P2-P4 の依存構造
+> **基づく**: presence spec 付録 A (OBS 実機破綻) + 本セッションの実機データ検証 + Codex adversarial review (2026-05-30)
+
+## 1. 背景: presence 全置換が OBS で破綻した
+
+presence spec は「scorebar 有無 (present/absent) を OBS/VTuber 共通の唯一の検出信号とし、brightness Pass-1 を撤去する」方針だった。Phase 1 を実装し OBS 実機 (obs-20260209、20.6GB/57min) で受け入れゲートを実行した結果、**設計の中核が破綻**した (presence spec 付録 A):
+
+- **性能 OK** (3m16s 完走) だが **精度 FAIL** (`matched=1, missed=2, spurious=1`)。
+- 根本原因: 試合直後の**リザルト/順位画面が同じ GC 紋章を表示**するため、presence が連続試合をマージする。confidence 閾値でも absent-gap 長でも分離不能。
+- **決定的データ**: 既存 brightness 検出器は同動画で 3 試合を秒未満精度で検出。**brightness blackout は真の試合境界 (リザルト画面の手前) に存在し、既存検出器はそれを正しく使えている**。presence がマージしたのは、この blackout 信号を持たないため。
+
+→ 結論 (付録 A.4): **brightness 境界は撤去すべきでない。`localize_scorebar` の真価は「全置換の検出器」ではなく、位置独立で頑健な分類器 + VTuber 経路にある。**
+
+## 2. 本セッションで確定した方針 (5 決定)
+
+| # | 論点 | 決定 | 根拠 |
+| --- | --- | --- | --- |
+| Q1 | scope | **re-plan #753 全体を再設計** | presence の位置づけ・VTuber 境界の出し方を含めて作り直す |
+| Q2 | VTuber 境界信号 | **scorebar anchor から inset 矩形を復元し crop** (#809 crop-brightness wiring 再利用) | #809 Wave F: full-frame では blackout を拾えないが inset crop で Pass1 が blackout を回復 (drop 5/5 end)。脆いのは region 検出 (S3) で crop-brightness 自体は有効 |
+| Q3 | 分類器統一 | **localize に統一する方向。ただし OBS では v2 を authoritative に温存し localize を shadow 並走、parity 実証後に retire (provisional)** | VTuber inset は v2 絶対座標が効かず localize 必須。OBS は 5 baseline で拾えない regression risk があるため、Codex 推奨の incremental (parity 実証ゲート) に従う。**§3.4 / §11 で要再訪** |
+| Q4 | localize の使い方 | **brightness 主 / localize+motion は分類器** (presence timeline は VTuber + 診断に従属) | A.3 実証: blackout = 境界。localize = 「その blackout が真の境界か」を判定する分類器。後述 Codex #2/#4 を自動解消 |
+| Q5 | リザルト除去信号 | **動き/静止判定 (MAD) を分類の補助信号に昇格** | リザルト/順位画面=静止、FL 試合=常時動き。位置・encoder 非依存で OBS/VTuber 両方に効く。**brightness 主では二次補正に降格** (§3.3) |
+
+## 3. アーキテクチャ: 2 信号 fusion (brightness 主)
+
+### 3.1 核心
+
+released 検出器を「全置換」せず、**位置独立な 2 信号を fusion** する。**brightness blackout を boundary 信号の主軸**とし、`localize_scorebar` + 動き判定を**分類器**に充てる。これは「現行 OBS pipeline は既に正しい hybrid であり壊すな」という付録 A の含意の構造化である。
+
+**① boundary 信号 (主・どこに境界がありうるか)**
+
+- 領域 crop の brightness 暗転。A.3 実証: OBS で真の試合境界に秒未満精度で存在。
+- OBS = FULL_FRAME (現行と同じ全画面)。VTuber = scorebar anchor で復元した inset crop (#809 Wave F で blackout 回復を実証)。
+
+**② 分類信号 (各 blackout が真の境界か)**
+
+```text
+classify(blackout) = localize_scorebar(flank_frame) is not None  AND  moving(flank_frame)
+```
+
+- `localize_scorebar` (P1, 位置独立) で blackout の前後フレームに scorebar があるか判定 → 現行 `classify_blackout` の `_has_scorebar_v2` 呼び出しを置換。
+- `moving()` = scorebar 領域の MAD (既存 `_is_static_from_frames`) が閾値超。リザルト/順位画面 = present だが**静止** → 分類上 absent 扱い。
+- 出力分類は現行同一: `match_boundary` / `in_match` / `non_fl`。#480 (region-aware 分類) はこの localize 化に subsume。
+
+**③ 領域 (両信号を測る場所)**
+
+- OBS → FULL_FRAME。VTuber → scorebar anchor から復元した inset 矩形 (P1 `localize_scorebar` の bbox + 16:9 で下端/左右を導出)。
+
+### 3.2 データフロー (OBS / VTuber 統一)
+
+```text
+入力動画
+  │
+  ├─[Stage 0] 領域 anchor   : sparse in-match frame → localize consensus → game 矩形
+  │                            OBS=FULL_FRAME / VTuber=inset rect          [re-plan P1✓ + P2]
+  │
+  ├─[Stage 1] boundary 信号 : 領域 crop で brightness Pass1/Pass2 → 暗転エッジ (主軸)
+  │                            OBS=全画面(現行不変) / VTuber=inset crop(#809再利用)  [P3]
+  │
+  ├─[Stage 2] 分類          : 各 blackout の前後で localize+motion → match_boundary/in_match/non_fl
+  │                            OBS は v2 が authoritative・localize を shadow 並走 (parity 計測) [P4 = #480]
+  │
+  └─[Stage 3] 抽出・後処理  : duration filter (backstop) → segment 抽出 → trailing 整理
+                              → metadata.json (現行 schema 不変)
+```
+
+OBS・VTuber とも同一パイプライン。差は Stage 0 の領域 (FULL_FRAME / inset) と、それに伴う Stage 1 crop / Stage 2 座標のみ。**OBS 経路は分類器 primitive 差し替え + v2 並走のみで、構造は現行を保つ** (最小変更 = regression risk 最小)。
+
+### 3.3 fusion 優先順位 (Codex #4 = 不一致時の真理値表)
+
+brightness を主軸にすることで signal 不一致が構造的に減る。残る組合せの扱い:
+
+| boundary (blackout) | 分類 (localize+motion) | 扱い |
+| --- | --- | --- |
+| あり | match_boundary | 境界として採用 (主経路) |
+| あり | in_match (両側 present+moving) | 試合内暗転。短ければ除外、長ければ境界保持 (現行 `_IN_MATCH_MAX_DURATION` 流用) |
+| あり | non_fl (両側 absent) | 非 FL。除外 (現行同一) |
+| なし | (present 区間) | **boundary を作らない** = リザルト 91% present でも試合化しない (duration filter backstop)。これが presence 全置換との決定的差 |
+| あり | static (present だが静止) | リザルト/順位画面。Q5 で absent 化 → non_fl 寄せ |
+
+**brightness 主では Q5 (motion) は load-bearing でなく二次補正**: リザルト区間は blackout 間 gap が `min_match_duration` (default 300s) 未満なら duration filter で必ず落ちる (§3.5)。Q5 は gap が長いケースの保険。
+
+### 3.4 Q3 provisional の扱い (v2 shadow guard)
+
+Codex review (§4) と本セッションの実機検証で、**「v2 retire」は 5 baseline で拾えない OBS regression risk を持つ**ことが判明した。よって (用語: **authoritative** = production 出力を決める / **shadow** = 並走計測のみで出力に効かせない):
+
+- localize に **API を統一**する (分類の呼び出し口を 1 本化) が、**OBS では v2 を authoritative に温存し、localize+motion を shadow で並走**させて両者の判定差分を harness で計測する。
+- **bit-exact → GT-accuracy 置換は「加えて」**: GT-accuracy (tolerance) gate を新設しつつ、cutover 前の shadow 期間は baseline diff も維持する (Codex #7)。
+- localize+motion が **long 非試合区間 (lobby/result) で v2 と OBS parity (FP/FN ゼロ差)** を実証してから、localize を authoritative に昇格し v2 retire を判断する (Phase 4)。
+- `_drop_post_match_trailing` (#805) は v2 を直接プローブする hidden 第 2 分類器 (§4 Codex #6)。**当面 v2 のまま温存**し、membership 統一は #805 非破壊化と別 phase で扱う。
+
+→ **Q3 の最終形 (v2 retire 可否) は §11 未確定として残す。** 本 spec では「API 統一 + shadow 並走」までを確定範囲とする。
+
+### 3.5 既存パイプラインとの対応 (検証済み事実)
+
+`detect_match_boundaries` 実フロー (`detector.py:267-421`): Pass1 brightness scan → `_group_blackout_regions` → `_expand_regions_with_transitions` → Pass2 `_refine_blackout_regions` → `filter_blackouts_with_scorebar` (#480 分類) → `_filter_and_extract_segments` (duration filter) → `_drop_post_match_trailing`。
+
+- duration filter (`_filter_and_extract_segments:1851,1868`) は `seg_end - seg_start >= min_match_duration` (default 300、`detector.py:205`) で gate。
+- **訂正記録**: 本セッション当初「v2 の位置特異性がリザルト除去に load-bearing」と述べたが、コード追跡の結果 **duration filter が backstop** であり、obs-20260209 の result gap (176s < 300s) は v2 の判定に関係なく落ちる。Codex #2 の指摘どおり。この事実が「brightness 主」決定を強く正当化する。
+
+## 4. Codex adversarial review (2026-05-30) の反映
+
+design-stage で Codex に「2 信号 fusion」案をレビューさせた (read-only)。主要 finding と本 spec での扱い:
+
+| # | Codex finding | 本 spec での扱い |
+| --- | --- | --- |
+| P1-1 | `_is_static_from_frames` は primary 信号として未検証 (min MAD + ハード閾値 0.5、override 限定用途)。重複エンコード/防御静止/動くリザルトで失敗 | Q5 を brightness 主で**二次補正に降格** (§3.3)。MAD は per-source 分布を harness で収集し percentile/多数決化を検討 (§7)。R1 |
+| P1-2 | 「v2 位置特異性が M1/M2 分離に必要」は誇張。duration filter (300s) が backstop | **採用・訂正** (§3.5)。brightness 主で自動解消 |
+| P1-3 | v2 廃止は OBS 高特異度ガードを消す (ゼロ FP 文書化 vs localize リザルト 91% FP) | Q3 を provisional 化、v2 shadow guard 温存 (§3.4)。R2 |
+| P2-4 | 不一致時の fusion 優先順位が未定義 | §3.3 真理値表で定義。OBS は brightness 優先 default |
+| P2-5 | VTuber inset blackout 欠損時の「membership edge ± refine」フォールバックが危険 | 低信頼出力として metadata フラグ、境界 snap と同等扱いしない (§5)。R3 |
+| P2-6 | `_drop_post_match_trailing` が v2 を直接プローブ = hidden 第 2 分類器、新 membership と競合 | v2 温存 + 別 phase (§3.4)。Phase 0 map 対象。R4 |
+| P3-7 | GT-accuracy (tolerance) のみでは OBS regression ガードが弱い | shadow 期間は baseline diff も維持 (§3.4 / §7) |
+| P3-8 | CPU/GPU/fps-filter パリティが cutover risk | 検証 matrix に CPU/GPU/legacy fps を含める (§7)。R5 |
+
+Codex 提案順序 (production 不変のまま shadow trace → MAD calibrate → OBS を baseline-diff + GT-tolerance 両方で gate → VTuber GT 追加) を §8 Phase 構造に採用。
+
+## 5. データ構造 / API
+
+- **再利用 (P1, マージ済)**: `localize_scorebar(frame, *, stride, target_ratio) -> ScorebarLocalization | None` (`capture_region.py`)。入力 1920x1080 RGB、出力 probe px bbox + confidence。
+- **再編 (#480)**: `filter_blackouts_with_scorebar` / `classify_blackout` の scorebar 検出 primitive を `_has_scorebar_v2` → `localize_scorebar` + `moving()` に差し替え。v2 は shadow guard として並走計測。classify/merge/duration ロジックは流用。
+- **新規 (VTuber)**: Stage 0 領域 anchor (sparse localize consensus → inset 矩形)、Stage 1 inset crop wiring (#809 再利用)。
+- **VTuber fallback フラグ**: inset blackout 欠損で membership edge にフォールバックした segment は metadata に低信頼フラグを付け、境界 snap と区別 (Codex #5)。
+- **出力**: 試合 segment = 現行 `matches[]` / `boundaries`。metadata schema 不変 (region フィールドは P6 で別途検討、本 spec 範囲外)。
+
+## 6. やらないこと (境界)
+
+- **presence 全置換** (presence spec の方針): 撤回。brightness Pass-1 は boundary 主軸として存続。
+- **minimap 切抜き** ([#481](https://github.com/Idios/kobutachan-allaganeye/issues/481)): 別レイヤー。
+- **#805 非破壊化**: `_drop_post_match_trailing` の不可逆削除 → フラグ方式は別 phase / 別 issue。本 spec は v2 温存で competing しないことだけ担保。
+- **metadata region フィールド** ([#810](https://github.com/Idios/kobutachan-allaganeye/issues/810)): P6、本 spec 範囲外。
+
+## 7. 検証戦略
+
+### 7.1 unit (動画不要)
+
+- 分類差し替え: 合成フレームで localize+motion 分類 (present+moving / present+static / absent) → 期待ラベル。
+- fusion 真理値表 (§3.3): 合成 blackout × 分類 → 期待 segment。
+- VTuber fallback フラグ: inset blackout 欠損ケース → 低信頼フラグ立つ。
+
+### 7.2 harness (slow・sample-gated、Phase 1 資産流用)
+
+- `compare_segments` (Phase 1) で OBS 5 baseline + VTuber 5 source を GT 突合。matched/missed/spurious、boundary 誤差、wall-time。
+- **v2 vs localize+motion の OBS parity** 計測 (Codex #3): long 非試合区間 (lobby/result) の FP/FN 差分を per-source 出力。
+- **MAD 分布収集** (Codex #1): 真の試合/リザルト/ロビー/ローディングの per-source MAD を出し、閾値 calibrate。
+- **CPU/GPU/legacy-fps parity** (Codex #8): 最低 1 OBS baseline を 3 モードで突合。
+
+### 7.3 gate
+
+- OBS: shadow 期間は baseline diff (現行不変) + GT-accuracy (missed/spurious ゼロ、誤差 ≤ tol) の**両方**。
+- VTuber: 手動 GT に対し recall/precision 目標値 (harness 実測後設定)。
+- v2 retire (§11): localize+motion が OBS parity (FP/FN ゼロ差) を実証してからのみ。
+
+## 8. 段階分解 (Phase 0-4)
+
+| Phase | 内容 | production 影響 | gate |
+| --- | --- | --- | --- |
+| **0** | 検出 subsystem の git 考古学 + 現状 map (ドキュメント化)。各 layer の load-bearing / cruft / 有害判定、`_drop_post_match_trailing`×v2×membership coupling を含む | なし (docs) | user レビュー |
+| **1** | Stage 0 領域 anchor (P1 consensus → inset) + Stage 1 VTuber inset crop wiring (#809 再利用)。OBS=FULL_FRAME 縮退 | なし (VTuber 経路は gate 内) | OBS bit-exact 維持 + gyawa crop blackout 回復 |
+| **2** | Stage 2 分類を localize+motion 化 (#480)。v2 shadow guard 並走。MAD calibrate | なし (v2 が production 判定、localize は shadow) | OBS parity 計測 + baseline diff |
+| **3** | VTuber GT 注釈 (5 source) + VTuber 検証。fusion 真理値表 + fallback フラグ | なし | VTuber GT-accuracy |
+| **4** | cutover: localize を production 判定に昇格 (v2 retire 可否は parity 実証後判断)。GT-accuracy gate 化 | あり (分類器置換) | 全 GT-accuracy + baseline diff + Idios 実機検証 |
+
+Phase 0-3 = 検証・非破壊、Phase 4 = 切替。「検証してから切替」をデータ駆動で。各 Phase 独立 PR。
+
+## 9. re-plan #753 P1-P6 の再定義
+
+| re-plan | 旧定義 | 新定義 (本 spec) |
+| --- | --- | --- |
+| P1 | robust scorebar 局在化 (anchor) | **マージ済** (#811)。Stage 0/2 で consumer として再利用 |
+| P2 | scorebar-anchored 領域検出 (S3 consensus) | Stage 0 領域 anchor。S3 extent は補助、scorebar geometry + 16:9 主軸に簡素化 |
+| P3 | 領域 crop 輝度 wiring | Stage 1 (#809 再利用)。VTuber inset crop |
+| P4 | region-aware 分類 (#480) | Stage 2 = localize+motion 分類。v2 shadow guard 並走 |
+| P5 | adaptive transition expansion | VTuber crop 輝度分布から動的閾値。FULL_FRAME は現行 55 維持 (Phase 3+ で必要時) |
+| P6 | metadata 領域フィールド (#810) | 本 spec 範囲外 (別途) |
+
+依存: Phase 0 (map) → Phase 1 (region+crop) → Phase 2 (分類) → Phase 3 (VTuber 検証) → Phase 4 (cutover)。
+
+## 10. Phase 1 (presence) コード資産の処遇
+
+`presence.py` + `presence_harness.py` + 3 test files (branch `claude/l3-p2-region-detection`、commit 済・production 非配線) の再利用:
+
+- `compare_segments` / GT 突合ハーネス → **存続** (§7 検証インフラの中核)。
+- `localize_present_at` (frame source → localize bridge) → **存続** (Stage 2 分類で再利用)。
+- `scan_presence` / `segment_presence` / `detect_matches_by_presence` (全域 presence timeline) → **VTuber + 診断専用に降格**。brightness 主では OBS production 経路に使わない。revert 不要、harness 資産として保持。
+- `refine_boundary` (二分探索) → boundary 精緻化で再利用候補。
+
+**branch 処遇**: park も land もせず、本再設計の Phase 1-2 実装ブランチとして**継続使用** (#811 ベース、develop-0.3.0)。
+
+## 11. 未確定 (Iron Law 2 / 5 で user 承認後に確定)
+
+- **Q3 最終形 (v2 retire 可否)**: §3.4。localize+motion の OBS parity 実証後に判断。本 spec は「API 統一 + shadow 並走」まで確定。
+- **issue 起票 / 編集**: presence umbrella の再定義、#480 を Stage 2 に再マップ、#809 branch の扱い、#805 非破壊化との phase 分離。**起票時に AskUserQuestion** (Iron Law 2)。
+- **閾値最終値**: MAD 静止閾値、`T_*`、領域 confidence gate、VTuber GT 目標値 → harness 校正。
+- **MAD の昇格形** (Codex #1): min → percentile/多数決化するか harness 分布で判断。
+
+## 12. リスク
+
+| # | リスク | 緩和 |
+| --- | --- | --- |
+| R1 | MAD (motion) が試合/リザルトを誤判定 (Codex #1) | brightness 主で二次補正に降格。per-source 分布で calibrate、percentile/多数決化検討。短 blackout 限定 override から段階昇格 |
+| R2 | v2 retire で 5 baseline 外の OBS regression (Codex #3) | Q3 provisional、v2 shadow guard 並走 + parity 実証ゲート。bit-exact baseline diff を shadow 期間維持 |
+| R3 | VTuber inset blackout 欠損で実試合を誤分割 (Codex #5) | 低信頼フラグ、境界 snap と区別。harness で boundary 誤差確認 |
+| R4 | `_drop_post_match_trailing` × v2 × 新 membership の hidden coupling (Codex #6、#805) | v2 温存、別 phase。Phase 0 map で coupling 明示 |
+| R5 | CPU/GPU/legacy-fps パリティ崩れ (Codex #8、#575) | 検証 matrix に 3 モード。frame-index ベース新 path 前提 |
+| R6 | gyawa 1-source 過学習 (VTuber multi-source) | 5 source 手動 GT + 幾何ベース anchor。data-gated |
+| R7 | brightness 主で VTuber 境界を取り逃す (full-frame では blackout なし) | Stage 1 inset crop で blackout 回復 (#809 Wave F 実証)。領域 anchor が前提 |
+
+## 13. 参照
+
+- presence spec (supersede 対象): [2026-05-29-presence-based-detection-engine-design.md](2026-05-29-presence-based-detection-engine-design.md) (付録 A: OBS 実機破綻)
+- re-plan overview: [2026-05-28-vtuber-region-boundary-replan-design.md](2026-05-28-vtuber-region-boundary-replan-design.md) (P1-P6)
+- P1 (基盤・マージ済): [2026-05-29-p1-robust-scorebar-localization-design.md](2026-05-29-p1-robust-scorebar-localization-design.md)
+- #809 wiring (再利用): [2026-05-27-vtuber-pass1-region-wiring-design.md](2026-05-27-vtuber-pass1-region-wiring-design.md)
+- 現行コード: `allaganeye/video/detector.py` (`detect_match_boundaries` / brightness Pass1/2 / `_has_scorebar_v2` / `_filter_and_extract_segments` / `_drop_post_match_trailing`), `scorebar.py` (`filter_blackouts_with_scorebar` / `classify_blackout` / `_is_static_from_frames`), `capture_region.py` (`localize_scorebar` / S3), `presence.py` (Phase 1 資産)
+- 関連 issue: [#480](https://github.com/Idios/kobutachan-allaganeye/issues/480) (分類・Stage 2 に再マップ), [#481](https://github.com/Idios/kobutachan-allaganeye/issues/481) (minimap・範囲外), [#805](https://github.com/Idios/kobutachan-allaganeye/issues/805) (trailing 非破壊化・別 phase), [#809](https://github.com/Idios/kobutachan-allaganeye/issues/809) (wiring 再利用), [#810](https://github.com/Idios/kobutachan-allaganeye/issues/810) (metadata region・P6), [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753) (re-plan umbrella)

--- a/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
+++ b/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
@@ -169,7 +169,7 @@ Codex 提案順序 (production 不変のまま shadow trace → MAD calibrate �
 
 | Phase | 内容 | production 影響 | gate |
 | --- | --- | --- | --- |
-| **0** | 検出 subsystem の git 考古学 + 現状 map (ドキュメント化)。各 layer の load-bearing / cruft / 有害判定、`_drop_post_match_trailing`×v2×membership coupling を含む | なし (docs) | user レビュー |
+| **0** | 検出 subsystem の git 考古学 + 現状 map (ドキュメント化)。各 layer の load-bearing / cruft / 有害判定、`_drop_post_match_trailing`×v2×membership coupling を含む。成果物 = [docs/detection-map.md](../../detection-map.md) | なし (docs) | user レビュー |
 | **1** | Stage 0 anchor (P1 consensus → scorebar 帯 ROI + 保持矩形) + Stage 1 VTuber 帯 crop wiring (#809 を帯に限定) + MAD ROI の band-anchor 化。OBS=絶対 ROI 縮退 | なし (VTuber 経路は gate 内) | OBS bit-exact 維持 + gyawa 帯 crop blackout 回復 |
 | **2** | Stage 2 分類を localize+motion 化 (#480)。v2 shadow guard 並走。MAD calibrate | なし (v2 が production 判定、localize は shadow) | OBS parity 計測 + baseline diff |
 | **3** | VTuber GT 注釈 (5 source) + VTuber 検証。fusion 真理値表 + fallback フラグ | なし | VTuber GT-accuracy |
@@ -228,4 +228,5 @@ Phase 0-3 = 検証・非破壊、Phase 4 = 切替。「検証してから切替�
 - P1 (基盤・マージ済): [2026-05-29-p1-robust-scorebar-localization-design.md](2026-05-29-p1-robust-scorebar-localization-design.md)
 - #809 wiring (再利用): [2026-05-27-vtuber-pass1-region-wiring-design.md](2026-05-27-vtuber-pass1-region-wiring-design.md)
 - 現行コード: `allaganeye/video/detector.py` (`detect_match_boundaries` / brightness Pass1/2 / `_has_scorebar_v2` / `_filter_and_extract_segments` / `_drop_post_match_trailing`), `scorebar.py` (`filter_blackouts_with_scorebar` / `classify_blackout` / `_is_static_from_frames`), `capture_region.py` (`localize_scorebar` / S3), `presence.py` (Phase 1 資産)
+- Phase 0 成果物: [docs/detection-map.md](../../detection-map.md) (layer 別 keep/cruft/harmful 判定 + git 考古学 + coupling 図)
 - 関連 issue: [#480](https://github.com/Idios/kobutachan-allaganeye/issues/480) (分類・Stage 2 に再マップ), [#481](https://github.com/Idios/kobutachan-allaganeye/issues/481) (minimap・範囲外), [#805](https://github.com/Idios/kobutachan-allaganeye/issues/805) (trailing 非破壊化・別 phase), [#809](https://github.com/Idios/kobutachan-allaganeye/issues/809) (wiring 再利用), [#810](https://github.com/Idios/kobutachan-allaganeye/issues/810) (metadata region・P6), [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753) (re-plan umbrella)

--- a/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
+++ b/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
@@ -199,6 +199,22 @@ Codex 提案順序 (production 不変のまま shadow trace → MAD calibrate �
 
 Phase 0-3 = 検証・非破壊、Phase 4 = 切替。「検証してから切替」をデータ駆動で。各 Phase 独立 PR。
 
+### 8.1 Phase 2 確定事項 (2026-06-01 brainstorming + Codex 設計レビュー)
+
+Phase 2 着手前の軽量 brainstorming (§11 の Phase 2 関連未確定を user 承認で確定) と、その設計に対する Codex adversarial 設計レビュー (read-only、8 finding) の反映。
+
+| # | 論点 | 決定 | 根拠 |
+| --- | --- | --- | --- |
+| P2-a | motion の役割 | **present(localize) 単独を VTuber authoritative 分類器に**。motion(band-MAD) は telemetry 収集のみで分類に AND しない。`AND moving` 配線・閾値は harness 校正後の Phase 3 | Codex #3/#5: 未校正の min-MAD<0.5 を load-bearing 化すると in-match flank の一時静止 (重複 encode / 低動き瞬間) が present→absent flip し偽境界化。観測された過分割 (両側 present の in_match) は present 単独で解消。§3.3「motion は二次補正」と整合 |
+| P2-b | v2 shadow の所在 | **harness 専用**。production OBS 経路は v2 単独で完全不変。localize 分類器を再利用可能な単位にし、harness が 5 baseline の各 blackout で v2/localize を both 呼んで FP/FN parity を per-source 出力 | §3.4 / §7.2。production purity (bit-exact 構造保証)。Codex #7: harness は presence API 再実装でなく同一 classifier を呼び drift 排除 |
+| P2-c | localize 配線 | `_probe_scorebar_context` が既に decode 済の hi-res frame を再利用し localize-present を additive + flag-gate で返す (OBS production は localize 非計算でコスト 0) | Codex #8: 戻り値後方互換で既存 3 caller (classify / #524 re-probe / merge) bit-exact |
+| P2-d | trailing-drop | **VTuber は `_drop_post_match_trailing` を call site で gate off** (`not vtuber`)。v2 内部・OBS 挙動は不変 | Codex #1 (CRITICAL): v2 は VTuber inset で全 probe FN → 最終/混在試合を silent 削除。map §4「Phase 4 まで内部を触らない」制約とも両立 (call gate のみ、内部不変) |
+| P2-e | merge predicate | VTuber の `_merge_boundary_pairs` gap probe も localize-present (present 単独分類器と一貫)。長 result 画面で bar 可視→merge 阻害の edge は duration backstop で大半が落ち、残差は Phase 3 | Codex #2 |
+| P2-f | band MAD guard | `_is_static_from_frames` の region path に 1px clamp + 空 ROI guard (nan 回避)。telemetry の健全性 | Codex #4: 7-8px@180p band で int 切り捨て→空 ROI→nan→誤 moving |
+| P2-g | audio promotion | **対応不要** (`AUDIO_FROZEN=True` #327/#303 で inert、OBS でも未使用)。将来 unfreeze 時に VTuber 相互作用を再評価する caveat のみ | Codex #6 は frozen 中は moot (user 指摘で確認) |
+
+**Phase 2 の既知の限界 (Phase 3 で対処)**: 全画面 UI が片側 flank の scorebar を隠すと偽境界化しうる (R3/R3b、fallback フラグ)。motion AND 配線・MAD 閾値校正・VTuber GT も Phase 3。
+
 ## 9. re-plan #753 P1-P6 の再定義
 
 | re-plan | 旧定義 | 新定義 (本 spec) |
@@ -228,7 +244,7 @@ Phase 0-3 = 検証・非破壊、Phase 4 = 切替。「検証してから切替�
 - **Q3 最終形 (v2 retire 可否)**: §3.4。localize+motion の OBS parity 実証後に判断。本 spec は「API 統一 + shadow 並走」まで確定。
 - **issue 起票 / 編集**: presence umbrella の再定義、#480 を Stage 2 に再マップ、#809 branch の扱い、#805 非破壊化との phase 分離。**起票時に AskUserQuestion** (Iron Law 2)。
 - **閾値最終値**: MAD 静止閾値、`T_*`、領域 confidence gate、VTuber GT 目標値 → harness 校正。
-- **MAD の昇格形** (Codex #1): min → percentile/多数決化するか harness 分布で判断。
+- **MAD の昇格形** (Codex #1): min → percentile/多数決化するか harness 分布で判断。**Phase 2 では motion を分類に AND せず telemetry 収集のみ**とし、配線・昇格形は Phase 3 で校正後に確定 (§8.1 P2-a)。
 
 ## 12. リスク
 

--- a/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
+++ b/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
@@ -26,7 +26,7 @@ presence spec は「scorebar 有無 (present/absent) を OBS/VTuber 共通の唯
 | # | 論点 | 決定 | 根拠 |
 | --- | --- | --- | --- |
 | Q1 | scope | **re-plan #753 全体を再設計** | presence の位置づけ・VTuber 境界の出し方を含めて作り直す |
-| Q2 | VTuber 境界信号 | **scorebar anchor から inset 矩形を復元し crop** (#809 crop-brightness wiring 再利用) | #809 Wave F: full-frame では blackout を拾えないが inset crop で Pass1 が blackout を回復 (drop 5/5 end)。脆いのは region 検出 (S3) で crop-brightness 自体は有効 |
+| Q2 | VTuber 境界信号 | **scorebar 帯を anchor して帯 crop の brightness/motion を測る** (#809 wiring を帯に限定)。full inset 矩形は preview/minimap 用に保持するが検出には使わない (user 指摘 2026-05-31) | #809 Wave F: full-frame では blackout を拾えないが crop で Pass1 が blackout を回復 (drop 5/5 end)。ただし inset 全体だとアバター/オーバーレイ混入で暗転を取り逃すため、最 clean な scorebar 帯に限定 (§3.1③) |
 | Q3 | 分類器統一 | **localize に統一する方向。ただし OBS では v2 を authoritative に温存し localize を shadow 並走、parity 実証後に retire (provisional)** | VTuber inset は v2 絶対座標が効かず localize 必須。OBS は 5 baseline で拾えない regression risk があるため、Codex 推奨の incremental (parity 実証ゲート) に従う。**§3.4 / §11 で要再訪** |
 | Q4 | localize の使い方 | **brightness 主 / localize+motion は分類器** (presence timeline は VTuber + 診断に従属) | A.3 実証: blackout = 境界。localize = 「その blackout が真の境界か」を判定する分類器。後述 Codex #2/#4 を自動解消 |
 | Q5 | リザルト除去信号 | **動き/静止判定 (MAD) を分類の補助信号に昇格** | リザルト/順位画面=静止、FL 試合=常時動き。位置・encoder 非依存で OBS/VTuber 両方に効く。**brightness 主では二次補正に降格** (§3.3) |
@@ -39,8 +39,9 @@ released 検出器を「全置換」せず、**位置独立な 2 信号を fusio
 
 **① boundary 信号 (主・どこに境界がありうるか)**
 
-- 領域 crop の brightness 暗転。A.3 実証: OBS で真の試合境界に秒未満精度で存在。
-- OBS = FULL_FRAME (現行と同じ全画面)。VTuber = scorebar anchor で復元した inset crop (#809 Wave F で blackout 回復を実証)。
+- brightness 暗転で境界候補を出す。A.3 実証: OBS で真の試合境界に秒未満精度で存在。
+- OBS = 全画面 brightness (現行 Pass1 不変)。VTuber = **localize_scorebar の bbox に anchor した scorebar 帯**の brightness (#809 は inset 全体を crop していたが、本 spec はさらに帯に限定)。
+- **VTuber を inset 全体でなく帯に限定する理由** (user 指摘 2026-05-31): inset 内にアバター / webcam / オーバーレイ / マスク画像が合成されると、ローディング暗転でも該当領域が明るいまま残り inset 平均が落ちず**境界を取り逃す** (#809 で full-frame が失敗したのと同じ機序が inset 内でも起きる)。scorebar 帯は game 描画の一部で必ず存在し、オーバーレイが被せられにくい最 clean 領域。ローディング中は game inset 全体が暗転するため帯も暗くなる。
 
 **② 分類信号 (各 blackout が真の境界か)**
 
@@ -49,32 +50,33 @@ classify(blackout) = localize_scorebar(flank_frame) is not None  AND  moving(fla
 ```
 
 - `localize_scorebar` (P1, 位置独立) で blackout の前後フレームに scorebar があるか判定 → 現行 `classify_blackout` の `_has_scorebar_v2` 呼び出しを置換。
-- `moving()` = scorebar 領域の MAD (既存 `_is_static_from_frames`) が閾値超。リザルト/順位画面 = present だが**静止** → 分類上 absent 扱い。
+- `moving()` = **scorebar 帯**の MAD (既存 `_is_static_from_frames` を流用) が閾値超。リザルト/順位画面 = present だが**静止** → 分類上 absent 扱い。VTuber は localize bbox に anchor (既存 ROI は絶対座標 = VTuber では誤った場所を測るため、§5 で band-anchor 化が必要)。
 - 出力分類は現行同一: `match_boundary` / `in_match` / `non_fl`。#480 (region-aware 分類) はこの localize 化に subsume。
 
-**③ 領域 (両信号を測る場所)**
+**③ 領域: 測定 ROI と保持矩形を分離 (user 指摘 2026-05-31)**
 
-- OBS → FULL_FRAME。VTuber → scorebar anchor から復元した inset 矩形 (P1 `localize_scorebar` の bbox + 16:9 で下端/左右を導出)。
+- **測定 ROI** (brightness / motion を測る場所) = scorebar 帯。OBS は全画面 brightness + 現行 motion ROI (上部中央 ≈ scorebar 位置) のまま。VTuber は localize bbox に anchor した帯。
+- **保持矩形** (full inset 16:9 復元) = preview / 将来の minimap (#481) 用に metadata へ保持するが、**検出測定には使わない**。脆い 16:9 矩形推定が失敗しても検出信号は帯側で独立に成立する (re-plan R6 の脆さを検出経路から分離)。
 
 ### 3.2 データフロー (OBS / VTuber 統一)
 
 ```text
 入力動画
   │
-  ├─[Stage 0] 領域 anchor   : sparse in-match frame → localize consensus → game 矩形
-  │                            OBS=FULL_FRAME / VTuber=inset rect          [re-plan P1✓ + P2]
+  ├─[Stage 0] anchor        : sparse in-match frame → localize consensus
+  │                            → 測定 ROI = scorebar 帯 (+ 保持矩形 full inset、preview/minimap 用) [P1✓ + P2]
   │
-  ├─[Stage 1] boundary 信号 : 領域 crop で brightness Pass1/Pass2 → 暗転エッジ (主軸)
-  │                            OBS=全画面(現行不変) / VTuber=inset crop(#809再利用)  [P3]
+  ├─[Stage 1] boundary 信号 : brightness Pass1/Pass2 → 暗転エッジ (主軸)
+  │                            OBS=全画面(現行不変) / VTuber=scorebar 帯 crop(#809 を帯に限定)  [P3]
   │
-  ├─[Stage 2] 分類          : 各 blackout の前後で localize+motion → match_boundary/in_match/non_fl
+  ├─[Stage 2] 分類          : 各 blackout 前後で localize + 帯 motion → match_boundary/in_match/non_fl
   │                            OBS は v2 が authoritative・localize を shadow 並走 (parity 計測) [P4 = #480]
   │
   └─[Stage 3] 抽出・後処理  : duration filter (backstop) → segment 抽出 → trailing 整理
                               → metadata.json (現行 schema 不変)
 ```
 
-OBS・VTuber とも同一パイプライン。差は Stage 0 の領域 (FULL_FRAME / inset) と、それに伴う Stage 1 crop / Stage 2 座標のみ。**OBS 経路は分類器 primitive 差し替え + v2 並走のみで、構造は現行を保つ** (最小変更 = regression risk 最小)。
+OBS・VTuber とも同一パイプライン。差は Stage 0 の測定 ROI (OBS=全画面+絶対 ROI / VTuber=localize bbox anchor の scorebar 帯) と、それに伴う Stage 1 crop / Stage 2 座標のみ。**OBS 経路は分類器 primitive 差し替え + v2 並走のみで、構造は現行を保つ** (最小変更 = regression risk 最小)。
 
 ### 3.3 fusion 優先順位 (Codex #4 = 不一致時の真理値表)
 
@@ -129,8 +131,10 @@ Codex 提案順序 (production 不変のまま shadow trace → MAD calibrate �
 
 - **再利用 (P1, マージ済)**: `localize_scorebar(frame, *, stride, target_ratio) -> ScorebarLocalization | None` (`capture_region.py`)。入力 1920x1080 RGB、出力 probe px bbox + confidence。
 - **再編 (#480)**: `filter_blackouts_with_scorebar` / `classify_blackout` の scorebar 検出 primitive を `_has_scorebar_v2` → `localize_scorebar` + `moving()` に差し替え。v2 は shadow guard として並走計測。classify/merge/duration ロジックは流用。
-- **新規 (VTuber)**: Stage 0 領域 anchor (sparse localize consensus → inset 矩形)、Stage 1 inset crop wiring (#809 再利用)。
-- **VTuber fallback フラグ**: inset blackout 欠損で membership edge にフォールバックした segment は metadata に低信頼フラグを付け、境界 snap と区別 (Codex #5)。
+- **band-anchor 化 (必須・user 指摘 2026-05-31)**: 既存 `_is_static_from_frames` の MAD ROI は絶対座標 (`_SCOREBAR_ROI_*`、上部中央) で、VTuber では誤った場所 (オーバーレイ/余白) を測る。`localize_scorebar` の bbox に anchor して帯 ROI を渡せるよう signature を拡張。OBS は現行絶対 ROI に縮退して bit-exact 維持。
+- **新規 (VTuber)**: Stage 0 anchor (sparse localize consensus → scorebar 帯 ROI + 保持矩形)、Stage 1 帯 crop brightness wiring (#809 を帯に限定して再利用)。
+- **保持矩形 (full inset 16:9)**: preview / 将来 minimap (#481) 用に metadata 保持候補。検出測定には使わない (§3.1③)。schema 追加は P6 で別途。
+- **VTuber fallback フラグ**: 帯 blackout 欠損で membership edge にフォールバックした segment は metadata に低信頼フラグを付け、境界 snap と区別 (Codex #5)。
 - **出力**: 試合 segment = 現行 `matches[]` / `boundaries`。metadata schema 不変 (region フィールドは P6 で別途検討、本 spec 範囲外)。
 
 ## 6. やらないこと (境界)
@@ -152,7 +156,7 @@ Codex 提案順序 (production 不変のまま shadow trace → MAD calibrate �
 
 - `compare_segments` (Phase 1) で OBS 5 baseline + VTuber 5 source を GT 突合。matched/missed/spurious、boundary 誤差、wall-time。
 - **v2 vs localize+motion の OBS parity** 計測 (Codex #3): long 非試合区間 (lobby/result) の FP/FN 差分を per-source 出力。
-- **MAD 分布収集** (Codex #1): 真の試合/リザルト/ロビー/ローディングの per-source MAD を出し、閾値 calibrate。
+- **MAD 分布収集** (Codex #1): 真の試合/リザルト/ロビー/ローディングの per-source MAD を **scorebar 帯 ROI で** 出し、閾値 calibrate。帯内オーバーレイ被覆 (R3b) の SNR も実測。
 - **CPU/GPU/legacy-fps parity** (Codex #8): 最低 1 OBS baseline を 3 モードで突合。
 
 ### 7.3 gate
@@ -166,7 +170,7 @@ Codex 提案順序 (production 不変のまま shadow trace → MAD calibrate �
 | Phase | 内容 | production 影響 | gate |
 | --- | --- | --- | --- |
 | **0** | 検出 subsystem の git 考古学 + 現状 map (ドキュメント化)。各 layer の load-bearing / cruft / 有害判定、`_drop_post_match_trailing`×v2×membership coupling を含む | なし (docs) | user レビュー |
-| **1** | Stage 0 領域 anchor (P1 consensus → inset) + Stage 1 VTuber inset crop wiring (#809 再利用)。OBS=FULL_FRAME 縮退 | なし (VTuber 経路は gate 内) | OBS bit-exact 維持 + gyawa crop blackout 回復 |
+| **1** | Stage 0 anchor (P1 consensus → scorebar 帯 ROI + 保持矩形) + Stage 1 VTuber 帯 crop wiring (#809 を帯に限定) + MAD ROI の band-anchor 化。OBS=絶対 ROI 縮退 | なし (VTuber 経路は gate 内) | OBS bit-exact 維持 + gyawa 帯 crop blackout 回復 |
 | **2** | Stage 2 分類を localize+motion 化 (#480)。v2 shadow guard 並走。MAD calibrate | なし (v2 が production 判定、localize は shadow) | OBS parity 計測 + baseline diff |
 | **3** | VTuber GT 注釈 (5 source) + VTuber 検証。fusion 真理値表 + fallback フラグ | なし | VTuber GT-accuracy |
 | **4** | cutover: localize を production 判定に昇格 (v2 retire 可否は parity 実証後判断)。GT-accuracy gate 化 | あり (分類器置換) | 全 GT-accuracy + baseline diff + Idios 実機検証 |
@@ -178,8 +182,8 @@ Phase 0-3 = 検証・非破壊、Phase 4 = 切替。「検証してから切替�
 | re-plan | 旧定義 | 新定義 (本 spec) |
 | --- | --- | --- |
 | P1 | robust scorebar 局在化 (anchor) | **マージ済** (#811)。Stage 0/2 で consumer として再利用 |
-| P2 | scorebar-anchored 領域検出 (S3 consensus) | Stage 0 領域 anchor。S3 extent は補助、scorebar geometry + 16:9 主軸に簡素化 |
-| P3 | 領域 crop 輝度 wiring | Stage 1 (#809 再利用)。VTuber inset crop |
+| P2 | scorebar-anchored 領域検出 (S3 consensus) | Stage 0 anchor。検出は scorebar 帯 ROI に簡素化 (full 矩形 16:9 推定は検出から分離し preview 用保持に降格) |
+| P3 | 領域 crop 輝度 wiring | Stage 1 (#809 再利用)。VTuber は scorebar 帯 crop (inset 全体でなく) |
 | P4 | region-aware 分類 (#480) | Stage 2 = localize+motion 分類。v2 shadow guard 並走 |
 | P5 | adaptive transition expansion | VTuber crop 輝度分布から動的閾値。FULL_FRAME は現行 55 維持 (Phase 3+ で必要時) |
 | P6 | metadata 領域フィールド (#810) | 本 spec 範囲外 (別途) |
@@ -210,11 +214,12 @@ Phase 0-3 = 検証・非破壊、Phase 4 = 切替。「検証してから切替�
 | --- | --- | --- |
 | R1 | MAD (motion) が試合/リザルトを誤判定 (Codex #1) | brightness 主で二次補正に降格。per-source 分布で calibrate、percentile/多数決化検討。短 blackout 限定 override から段階昇格 |
 | R2 | v2 retire で 5 baseline 外の OBS regression (Codex #3) | Q3 provisional、v2 shadow guard 並走 + parity 実証ゲート。bit-exact baseline diff を shadow 期間維持 |
-| R3 | VTuber inset blackout 欠損で実試合を誤分割 (Codex #5) | 低信頼フラグ、境界 snap と区別。harness で boundary 誤差確認 |
+| R3 | VTuber 帯 blackout 欠損で実試合を誤分割 (Codex #5) | 低信頼フラグ、境界 snap と区別。harness で boundary 誤差確認 |
+| R3b | scorebar 帯にオーバーレイ/テロップが被さる、帯が薄く motion/blackout の SNR が低い (user 指摘の contamination が帯にも及ぶ最悪ケース) | 帯内でも emblem 3 点位置の sub-cell を優先測定。帯高 < 閾値や localize confidence 低下時は低信頼フラグ。multi-source harness で帯 SNR を実測 |
 | R4 | `_drop_post_match_trailing` × v2 × 新 membership の hidden coupling (Codex #6、#805) | v2 温存、別 phase。Phase 0 map で coupling 明示 |
 | R5 | CPU/GPU/legacy-fps パリティ崩れ (Codex #8、#575) | 検証 matrix に 3 モード。frame-index ベース新 path 前提 |
 | R6 | gyawa 1-source 過学習 (VTuber multi-source) | 5 source 手動 GT + 幾何ベース anchor。data-gated |
-| R7 | brightness 主で VTuber 境界を取り逃す (full-frame では blackout なし) | Stage 1 inset crop で blackout 回復 (#809 Wave F 実証)。領域 anchor が前提 |
+| R7 | brightness 主で VTuber 境界を取り逃す (full-frame では blackout なし) | Stage 1 scorebar 帯 crop で blackout 回復 (#809 Wave F は inset 全体で実証、本 spec は帯に限定し contamination 耐性を上げる)。帯 anchor が前提 |
 
 ## 13. 参照
 

--- a/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
+++ b/docs/superpowers/specs/2026-05-31-l3-detection-rearchitecture-two-signal-design.md
@@ -110,6 +110,28 @@ Codex review (§4) と本セッションの実機検証で、**「v2 retire」�
 - duration filter (`_filter_and_extract_segments:1851,1868`) は `seg_end - seg_start >= min_match_duration` (default 300、`detector.py:205`) で gate。
 - **訂正記録**: 本セッション当初「v2 の位置特異性がリザルト除去に load-bearing」と述べたが、コード追跡の結果 **duration filter が backstop** であり、obs-20260209 の result gap (176s < 300s) は v2 の判定に関係なく落ちる。Codex #2 の指摘どおり。この事実が「brightness 主」決定を強く正当化する。
 
+### 3.6 OBS/VTuber 判別: 明示信号 (`--vtuber`) — auto 推論を捨てる (2026-05-31 実機実証)
+
+Phase 1 実装後の OBS bit-exact gate (D1, obs-20260209) で **当初設計の判別ロジックが破綻**し、実機調査で root-cause を確定した。記録と確定方針:
+
+**破綻した当初仮定**: 「OBS では `localize_scorebar` が失敗 (inset 帯が無い) → FULL_FRAME に縮退 → bit-exact」。
+
+**実機が示した事実** (5 OBS + 5 VTuber、`localize_scorebar` bbox 実測):
+
+1. **localize は OBS でも成功する**。FL scorebar は OBS の全画面にも写っており (それが P1 を「位置独立」にしている当の理由)、`detect_scorebar_band_region` consensus が band region を返す → brightness が帯で測られ OBS 境界が秒未満ずれ baseline 破綻 (M1 start 40.25→39.5 等)。
+2. **localize の生出力は per-frame に noisy**。`localize_scorebar` は上半分全 y を走査し best-hit を返すため、OBS 試合中フレームでも約半数で下部 HUD (party list 等) を誤検出 (y_top 0 ↔ 540-582 が混在、誤検出 conf が 0.69 まで上がり confidence 閾値で弾けない)。median consensus が真/偽クラスタ混在で y=0.24 のゴミ region を出した。
+3. OBS 真 scorebar は (x≈0.31, y≈0, w≈0.37, conf 高) に 5 本とも密集する一方、VTuber は (y 0.006–0.367, conf 0.06–0.94) と散在し、**confidence が OBS/VTuber 判別と entangle** する (OBS を守る conf 閾値が VTuber を全 reject)。
+
+**確定方針 (user 2026-05-31)**: localize の noisy な生出力に auto 判別を載せるのは脆い (presence 全置換に続く 2 度目の「OBS gate での仮定破綻」)。よって **OBS/VTuber の auto 推論を全廃し、明示信号で VTuber を示す**:
+
+- **`--vtuber` CLI flag を新設** (boolean、CLI のみ、GUI 連携は別 issue)。
+- **未指定 (= OBS default)**: `detect_match_boundaries` は Stage 0 (帯 anchor) を**走らせず** FULL_FRAME。brightness は現行どおり全画面で測る → **bit-exact が構造的に保証**される (本 §の破綻が原理的に起きない)。
+- **`--vtuber` 指定時のみ**: Stage 0 帯 anchor を解決し band region を Pass1/Pass2/GPU に渡す。
+- **localize robust 化 (Problem 2)**: VTuber band 解決 (`detect_scorebar_band_region`) では confidence-filter + dominant cluster で per-frame noise を抑える。これは VTuber 経路内に閉じ、OBS には無影響。
+- **Phase 1 plumbing (B1–C1) は salvage**: region threading (FULL_FRAME default) は正しく実証済 (254 unit tests)。改訂は B4 の「無条件 anchor → `--vtuber` gate」と consensus robust 化のみ。
+
+> §3.1③ の「OBS は localize bbox に anchor / VTuber も」という記述は本 §で上書きされる: **OBS は Stage 0 を走らせず FULL_FRAME (localize を検出経路で使わない)**。VTuber のみ帯 anchor。
+
 ## 4. Codex adversarial review (2026-05-30) の反映
 
 design-stage で Codex に「2 信号 fusion」案をレビューさせた (read-only)。主要 finding と本 spec での扱い:
@@ -170,7 +192,7 @@ Codex 提案順序 (production 不変のまま shadow trace → MAD calibrate �
 | Phase | 内容 | production 影響 | gate |
 | --- | --- | --- | --- |
 | **0** | 検出 subsystem の git 考古学 + 現状 map (ドキュメント化)。各 layer の load-bearing / cruft / 有害判定、`_drop_post_match_trailing`×v2×membership coupling を含む。成果物 = [docs/detection-map.md](../../detection-map.md) | なし (docs) | user レビュー |
-| **1** | Stage 0 anchor (P1 consensus → scorebar 帯 ROI + 保持矩形) + Stage 1 VTuber 帯 crop wiring (#809 を帯に限定) + MAD ROI の band-anchor 化。OBS=絶対 ROI 縮退 | なし (VTuber 経路は gate 内) | OBS bit-exact 維持 + gyawa 帯 crop blackout 回復 |
+| **1** | `--vtuber` flag 新設 (§3.6) + Stage 0 anchor (P1 consensus → scorebar 帯 ROI、`--vtuber` 時のみ実行・consensus robust 化) + Stage 1 VTuber 帯 crop wiring (#809 を帯に限定) + MAD ROI の band-anchor 化。**OBS (flag なし) は Stage 0 を走らせず FULL_FRAME** | なし (VTuber 経路は `--vtuber` gate 内) | OBS (flag なし) bit-exact 維持 + VTuber (flag あり) 帯 crop blackout 回復 |
 | **2** | Stage 2 分類を localize+motion 化 (#480)。v2 shadow guard 並走。MAD calibrate | なし (v2 が production 判定、localize は shadow) | OBS parity 計測 + baseline diff |
 | **3** | VTuber GT 注釈 (5 source) + VTuber 検証。fusion 真理値表 + fallback フラグ | なし | VTuber GT-accuracy |
 | **4** | cutover: localize を production 判定に昇格 (v2 retire 可否は parity 実証後判断)。GT-accuracy gate 化 | あり (分類器置換) | 全 GT-accuracy + baseline diff + Idios 実機検証 |
@@ -220,6 +242,8 @@ Phase 0-3 = 検証・非破壊、Phase 4 = 切替。「検証してから切替�
 | R5 | CPU/GPU/legacy-fps パリティ崩れ (Codex #8、#575) | 検証 matrix に 3 モード。frame-index ベース新 path 前提 |
 | R6 | gyawa 1-source 過学習 (VTuber multi-source) | 5 source 手動 GT + 幾何ベース anchor。data-gated |
 | R7 | brightness 主で VTuber 境界を取り逃す (full-frame では blackout なし) | Stage 1 scorebar 帯 crop で blackout 回復 (#809 Wave F は inset 全体で実証、本 spec は帯に限定し contamination 耐性を上げる)。帯 anchor が前提 |
+| R8 | auto 判別が localize noise で OBS bit-exact を破壊 (2026-05-31 実証、§3.6) | **auto 推論を全廃し `--vtuber` 明示信号化**。OBS (flag なし) は Stage 0 を走らせず FULL_FRAME = bit-exact 構造保証。VTuber 経路の localize noise (Problem 2) は consensus の confidence-filter + cluster で抑制 (OBS 無影響) |
+| R9 | user が VTuber 動画に `--vtuber` を付け忘れる | 検出は FULL_FRAME で動く (clean fail = OBS 同等の挙動、誤分割でなく under-detect)。OBS 出力を汚さないため安全側。将来 GUI トグル / auto hint は別 issue |
 
 ## 13. 参照
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -85,6 +85,13 @@ export ALLAGANEYE_SAMPLE_VIDEO_DIR=/path/to/videos
 - MKV: OBS の長時間録画（30-80GB、複数試合を含む）
 - サブディレクトリ（`20260116/` 等）: 手動で試合分割済みの MP4（`YYYYMMDD_N.mp4`）
 
+### VTuber 検証用 VOD (`ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER`)
+
+L3 の VTuber/masked 系 slow テスト（`tests/test_l3_phase2_parity.py` / `tests/test_vtuber_region_e2e.py`）は、`ALLAGANEYE_SAMPLE_VIDEO_DIR` とは別の VOD 置き場を `ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER` で参照する（未設定時の既定: `E:/allaganeye-samples`）。
+
+- 配置: 配信者別の FF14 FL VOD（mp4）。未配置・未設定の場合、該当テストは skip される
+- 空文字で設定した場合も未設定と同様に既定 path へフォールバックする（`os.environ.get(...) or` 規約で統一）
+
 ### 音声統合テスト primary 録画 (`ALLAGANEYE_AUDIO_TEST_VIDEO`)
 
 `tests/test_audio_integration.py::test_primary_recording_fanfare_coverage` は、`audio/refs/fanfare.npz` を生成する際に使用した**そのままの**録画を必要とする。`ALLAGANEYE_SAMPLE_VIDEO_DIR` とは別管理。

--- a/docs/video-processing.md
+++ b/docs/video-processing.md
@@ -8,6 +8,8 @@ L1 の動画処理は以下の3段階で構成される:
 2. **detect**: ffmpeg 並列プローブで暗転を検知し、試合境界を特定
 3. **split**: FFmpeg で試合ごとに動画を分割
 
+> 検出 subsystem の layer 別 load-bearing/cruft/harmful 判定・git 考古学・再アーキ coupling は [detection-map.md](detection-map.md) (L3 Phase 0) を参照。
+
 ## probe（メタデータ取得）
 
 ffprobe を使用して以下の情報を取得:

--- a/tests/presence_harness.py
+++ b/tests/presence_harness.py
@@ -10,8 +10,11 @@ unit-tested without video; the slow end-to-end runs live in
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+
+from allaganeye.video.presence import PresenceMatch
 
 
 @dataclass(frozen=True)
@@ -42,4 +45,65 @@ def load_ground_truth(path: Path) -> GroundTruth:
         source_file=str(data["source_file"]),
         tolerance_sec=float(data["tolerance_sec"]),
         matches=matches,
+    )
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    """Outcome of comparing detected matches against ground truth."""
+
+    matched: int
+    missed: int
+    spurious: int
+    boundary_errors: list[float]
+
+    @property
+    def max_boundary_error(self) -> float:
+        return max(self.boundary_errors) if self.boundary_errors else 0.0
+
+
+def compare_segments(
+    detected: Sequence[PresenceMatch],
+    gt: Sequence[GroundTruthMatch],
+    *,
+    tolerance: float,
+) -> ComparisonResult:
+    """Greedy-match detected segments to GT within ``tolerance`` seconds.
+
+    A detected segment matches a GT match iff both its start and end are
+    within ``tolerance`` of the GT start/end.  Each GT and each detected
+    segment is used at most once.  Unmatched GT -> missed; unmatched
+    detected -> spurious.  ``boundary_errors`` holds, for every matched
+    pair, the start error and the end error (seconds).
+    """
+    used_detected: set[int] = set()
+    matched = 0
+    boundary_errors: list[float] = []
+
+    for g in gt:
+        best_idx: int | None = None
+        best_err: float | None = None
+        for i, d in enumerate(detected):
+            if i in used_detected:
+                continue
+            start_err = abs(d.start - g.start)
+            end_err = abs(d.end - g.end)
+            if start_err <= tolerance and end_err <= tolerance:
+                worst = max(start_err, end_err)
+                if best_err is None or worst < best_err:
+                    best_err = worst
+                    best_idx = i
+        if best_idx is not None:
+            used_detected.add(best_idx)
+            matched += 1
+            boundary_errors.append(abs(detected[best_idx].start - g.start))
+            boundary_errors.append(abs(detected[best_idx].end - g.end))
+
+    missed = len(gt) - matched
+    spurious = len(detected) - len(used_detected)
+    return ComparisonResult(
+        matched=matched,
+        missed=missed,
+        spurious=spurious,
+        boundary_errors=boundary_errors,
     )

--- a/tests/presence_harness.py
+++ b/tests/presence_harness.py
@@ -1,0 +1,45 @@
+"""Offline validation harness for presence-based detection (Phase 1).
+
+Compares presence-detected match segments against ground-truth annotations
+(OBS baselines + VTuber manual GT) and reports matched / missed / spurious
+counts and boundary errors.  Pure comparison logic lives here so it can be
+unit-tested without video; the slow end-to-end runs live in
+``tests/test_presence_validation.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class GroundTruthMatch:
+    """A ground-truth FL match interval in seconds."""
+
+    start: float
+    end: float
+
+
+@dataclass(frozen=True)
+class GroundTruth:
+    """Parsed ground-truth file."""
+
+    source_file: str
+    tolerance_sec: float
+    matches: list[GroundTruthMatch]
+
+
+def load_ground_truth(path: Path) -> GroundTruth:
+    """Load a ground-truth JSON (OBS / VTuber shared schema)."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    matches = [
+        GroundTruthMatch(start=float(m["start_time"]), end=float(m["end_time"]))
+        for m in data["matches"]
+    ]
+    return GroundTruth(
+        source_file=str(data["source_file"]),
+        tolerance_sec=float(data["tolerance_sec"]),
+        matches=matches,
+    )

--- a/tests/presence_harness.py
+++ b/tests/presence_harness.py
@@ -9,6 +9,7 @@ unit-tested without video; the slow end-to-end runs live in
 
 from __future__ import annotations
 
+import argparse
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -107,3 +108,54 @@ def compare_segments(
         spurious=spurious,
         boundary_errors=boundary_errors,
     )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """CLI for manual harness runs (Phase 2 threshold calibration)."""
+    p = argparse.ArgumentParser(description="Presence detection validation harness")
+    p.add_argument("--video", required=True, help="Path to source video")
+    p.add_argument("--ground-truth", required=True, help="Path to ground-truth JSON")
+    p.add_argument("--stride", type=float, default=4.0, help="Coarse grid stride (s)")
+    p.add_argument(
+        "--t-gap", type=float, default=30.0, help="Min absent gap = boundary (s)"
+    )
+    p.add_argument(
+        "--t-min-match", type=float, default=120.0, help="Min present run = match (s)"
+    )
+    p.add_argument("--tol", type=float, default=1.0, help="Refinement tolerance (s)")
+    p.add_argument("--workers", type=int, default=8, help="Parallel probe workers")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run presence detection on one video and print metrics vs ground truth."""
+    from allaganeye.video.presence import detect_matches_by_presence
+    from allaganeye.video.probe import probe_video
+
+    args = build_arg_parser().parse_args(argv)
+    video = Path(args.video)
+    gt = load_ground_truth(Path(args.ground_truth))
+    duration = float(probe_video(video)["duration"])
+
+    detected = detect_matches_by_presence(
+        video,
+        duration,
+        stride=args.stride,
+        t_gap=args.t_gap,
+        t_min_match=args.t_min_match,
+        tol=args.tol,
+        workers=args.workers,
+    )
+    res = compare_segments(detected, gt.matches, tolerance=gt.tolerance_sec)
+    print(f"source        : {gt.source_file}")
+    print(f"detected      : {len(detected)} matches")
+    print(f"ground truth  : {len(gt.matches)} matches (tol {gt.tolerance_sec}s)")
+    print(f"matched       : {res.matched}")
+    print(f"missed        : {res.missed}")
+    print(f"spurious      : {res.spurious}")
+    print(f"max boundary err: {res.max_boundary_error:.2f}s")
+    return 0 if (res.missed == 0 and res.spurious == 0) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -11,6 +11,7 @@ from allaganeye.video.capture_region import (
     band_region_from_localization,
     detect_region_blackout_overlap,
     detect_region_variance,
+    detect_scorebar_band_region,
     iou,
     localize_scorebar,
     region_mean,
@@ -475,3 +476,53 @@ def test_band_region_clamps_into_unit_square():
     assert region.x >= 0.0 and region.y >= 0.0
     assert region.x + region.w <= 1.0 + 1e-9
     assert region.y + region.h <= 1.0 + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Task A3: detect_scorebar_band_region (localize 多フレーム consensus)
+# ---------------------------------------------------------------------------
+
+
+def test_band_consensus_takes_median_of_localizations():
+    locs = [
+        ScorebarLocalization(238, 1678, 18, 63, 0.8),
+        ScorebarLocalization(240, 1680, 18, 63, 0.9),
+        ScorebarLocalization(242, 1682, 20, 65, 0.7),
+        None,
+    ]
+    calls = iter(locs)
+    region = detect_scorebar_band_region(
+        duration=400.0,
+        probe_w=1920,
+        probe_h=1080,
+        localize_fn=lambda _t: next(calls),
+        num_samples=4,
+    )
+    assert abs(region.x - 240 / 1920) < 1e-3
+    assert region.source == "band"
+    assert region.confidence > 0.0
+
+
+def test_band_consensus_all_miss_falls_back_full_frame():
+    region = detect_scorebar_band_region(
+        duration=400.0,
+        probe_w=1920,
+        probe_h=1080,
+        localize_fn=lambda _t: None,
+        num_samples=4,
+    )
+    assert region.is_full_frame()
+
+
+def test_band_consensus_below_min_hits_falls_back_full_frame():
+    locs = [ScorebarLocalization(240, 1680, 18, 63, 0.9), None, None, None]
+    calls = iter(locs)
+    region = detect_scorebar_band_region(
+        duration=400.0,
+        probe_w=1920,
+        probe_h=1080,
+        localize_fn=lambda _t: next(calls),
+        num_samples=4,
+        min_hits=2,
+    )
+    assert region.is_full_frame()

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -526,3 +526,57 @@ def test_band_consensus_below_min_hits_falls_back_full_frame():
         min_hits=2,
     )
     assert region.is_full_frame()
+
+
+def test_band_consensus_rejects_noise_and_picks_dominant_cluster():
+    from allaganeye.video.capture_region import (
+        ScorebarLocalization,
+        detect_scorebar_band_region,
+    )
+
+    # 4 true (y~0, high conf) + 3 noise (y~540-582, varied conf incl one 0.69)
+    locs = [
+        ScorebarLocalization(600, 1315, 0, 45, 1.0),
+        ScorebarLocalization(600, 1315, 0, 45, 1.0),
+        ScorebarLocalization(604, 1311, 12, 57, 0.52),
+        ScorebarLocalization(600, 1315, 0, 45, 1.0),
+        ScorebarLocalization(1116, 1919, 540, 585, 0.21),
+        ScorebarLocalization(508, 1288, 582, 627, 0.28),
+        ScorebarLocalization(0, 778, 558, 603, 0.69),
+    ]
+    calls = iter(locs)
+    region = detect_scorebar_band_region(
+        duration=400.0,
+        probe_w=1920,
+        probe_h=1080,
+        localize_fn=lambda _t: next(calls),
+        num_samples=7,
+    )
+    # must converge on the true cluster (y~0), NOT the noise-mixed median (y~0.24)
+    assert region.y < 0.05, f"expected true cluster y~0, got {region.y}"
+    assert abs(region.x - 600 / 1920) < 0.05
+
+
+def test_band_consensus_balanced_split_median_falls_between_clusters():
+    # 3 true (y~0-12, high conf) vs 3 noise (y~540-582, low conf): an exact
+    # count tie where a plain median of y_top lands in the gap (~276px / y~0.26),
+    # producing a between-clusters garbage band. Dominant-cluster selection breaks
+    # the tie by mean confidence (true 0.84 > noise 0.39) and recovers y~0.
+    locs = [
+        ScorebarLocalization(600, 1315, 0, 45, 1.0),
+        ScorebarLocalization(600, 1315, 0, 45, 1.0),
+        ScorebarLocalization(604, 1311, 12, 57, 0.52),
+        ScorebarLocalization(1116, 1919, 540, 585, 0.21),
+        ScorebarLocalization(508, 1288, 582, 627, 0.28),
+        ScorebarLocalization(0, 778, 558, 603, 0.69),
+    ]
+    calls = iter(locs)
+    region = detect_scorebar_band_region(
+        duration=400.0,
+        probe_w=1920,
+        probe_h=1080,
+        localize_fn=lambda _t: next(calls),
+        num_samples=6,
+    )
+    assert region.y < 0.05, f"expected true cluster y~0, got {region.y}"
+    assert abs(region.x - 600 / 1920) < 0.05

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -8,6 +8,7 @@ from allaganeye.video.capture_region import (
     _emblem_and_margin,
     _maybe_snap_full_frame,
     _scorebar_saturated_runs,
+    band_region_from_localization,
     detect_region_blackout_overlap,
     detect_region_variance,
     iou,
@@ -446,3 +447,31 @@ def test_region_mean_empty_crop_clamps_to_1px():
     frame = np.full((10, 10), 50, dtype=np.uint8)
     degenerate = CaptureRegion(0.999, 0.999, 0.0001, 0.0001)
     assert region_mean(frame, degenerate) == 50.0
+
+
+# ---------------------------------------------------------------------------
+# Task A2: band_region_from_localization
+# ---------------------------------------------------------------------------
+
+
+def test_band_region_normalizes_probe_px_to_unit_rect():
+    loc = ScorebarLocalization(
+        x_left=240, x_right=1680, y_top=18, y_bottom=63, confidence=0.9
+    )
+    region = band_region_from_localization(loc, probe_w=1920, probe_h=1080)
+    assert abs(region.x - 240 / 1920) < 1e-6
+    assert abs(region.y - 18 / 1080) < 1e-6
+    assert abs(region.w - (1680 - 240) / 1920) < 1e-6
+    assert abs(region.h - (63 - 18) / 1080) < 1e-6
+    assert region.confidence == 0.9
+    assert region.source == "band"
+
+
+def test_band_region_clamps_into_unit_square():
+    loc = ScorebarLocalization(
+        x_left=-5, x_right=1925, y_top=-2, y_bottom=70, confidence=0.5
+    )
+    region = band_region_from_localization(loc, probe_w=1920, probe_h=1080)
+    assert region.x >= 0.0 and region.y >= 0.0
+    assert region.x + region.w <= 1.0 + 1e-9
+    assert region.y + region.h <= 1.0 + 1e-9

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -12,6 +12,7 @@ from allaganeye.video.capture_region import (
     detect_region_variance,
     iou,
     localize_scorebar,
+    region_mean,
     top_edge_error_px,
 )
 
@@ -415,3 +416,33 @@ def test_localize_agrees_with_has_scorebar_v2_non_match():
     f = np.full((H, W, 3), 40, dtype=np.uint8)
     assert localize_scorebar(f) is None
     assert _has_scorebar_v2(f.tobytes()) is False
+
+
+# ---------------------------------------------------------------------------
+# Task A1: is_full_frame + region_mean
+# ---------------------------------------------------------------------------
+
+
+def test_is_full_frame_true_only_for_unit_rect():
+    assert FULL_FRAME.is_full_frame() is True
+    assert CaptureRegion(0.0, 0.0, 1.0, 1.0).is_full_frame() is True
+    assert CaptureRegion(0.1, 0.0, 0.9, 1.0).is_full_frame() is False
+    assert CaptureRegion(0.0, 0.0, 1.0, 0.5).is_full_frame() is False
+
+
+def test_region_mean_full_frame_equals_frame_mean():
+    frame = np.arange(12, dtype=np.uint8).reshape(3, 4)
+    assert region_mean(frame, FULL_FRAME) == float(frame.mean())
+
+
+def test_region_mean_crops_to_band():
+    frame = np.zeros((10, 10), dtype=np.uint8)
+    frame[0:2, :] = 200  # bright top band
+    band = CaptureRegion(0.0, 0.0, 1.0, 0.2)
+    assert region_mean(frame, band) == 200.0
+
+
+def test_region_mean_empty_crop_clamps_to_1px():
+    frame = np.full((10, 10), 50, dtype=np.uint8)
+    degenerate = CaptureRegion(0.999, 0.999, 0.0001, 0.0001)
+    assert region_mean(frame, degenerate) == 50.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,6 +294,20 @@ def test_split_vtuber_default_false(mock_run_split, fake_video):
     assert config.vtuber is False
 
 
+def test_split_vtuber_hidden_from_help():
+    """--vtuber は split --help に出ない (hidden、PR #823 R1 で A6 から前倒し)."""
+    result = runner.invoke(app, ["split", "--help"])
+    assert result.exit_code == 0
+    assert "--vtuber" not in result.stdout
+
+
+def test_detect_vtuber_hidden_from_help():
+    """--vtuber は detect --help に出ない (hidden、PR #823 R1 で A6 から前倒し)."""
+    result = runner.invoke(app, ["detect", "--help"])
+    assert result.exit_code == 0
+    assert "--vtuber" not in result.stdout
+
+
 @patch(MODULE)
 def test_split_verbose_short(mock_run_split, fake_video):
     """-v flag sets verbose=True."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -275,6 +275,26 @@ def test_split_no_gpu_flag(mock_run_split, fake_video):
 
 
 @patch(MODULE)
+def test_split_vtuber_flag(mock_run_split, fake_video):
+    """--vtuber sets config.vtuber=True on split (L3 B6)."""
+    result = runner.invoke(app, ["split", str(fake_video), "--vtuber"])
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.vtuber is True
+
+
+@patch(MODULE)
+def test_split_vtuber_default_false(mock_run_split, fake_video):
+    """Omitting --vtuber keeps config.vtuber=False (OBS full-frame, L3 B6)."""
+    result = runner.invoke(app, ["split", str(fake_video)])
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.vtuber is False
+
+
+@patch(MODULE)
 def test_split_verbose_short(mock_run_split, fake_video):
     """-v flag sets verbose=True."""
     result = runner.invoke(app, ["split", str(fake_video), "-v"])
@@ -1000,6 +1020,24 @@ def test_detect_invokes_run_detect(mock_run_detect, fake_video):
     mock_run_detect.assert_called_once()
     args, _kwargs = mock_run_detect.call_args
     assert args[0] == fake_video
+
+
+@patch("allaganeye.commands.detect.run_detect")
+def test_detect_vtuber_flag(mock_run_detect, fake_video):
+    """--vtuber sets config.vtuber=True on detect (L3 B6)."""
+    result = runner.invoke(app, ["detect", str(fake_video), "--vtuber"])
+    assert result.exit_code == 0, result.stdout
+    config = mock_run_detect.call_args[0][1]
+    assert config.vtuber is True
+
+
+@patch("allaganeye.commands.detect.run_detect")
+def test_detect_vtuber_default_false(mock_run_detect, fake_video):
+    """Omitting --vtuber keeps config.vtuber=False on detect (L3 B6)."""
+    result = runner.invoke(app, ["detect", str(fake_video)])
+    assert result.exit_code == 0, result.stdout
+    config = mock_run_detect.call_args[0][1]
+    assert config.vtuber is False
 
 
 @patch("allaganeye.commands.detect.run_detect")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,3 +83,11 @@ class TestSplitConfigValidation:
         with pytest.raises(ConfigValidationError) as exc_info:
             SplitConfig(sample_interval=-1.0)
         assert exc_info.value.exit_code == 5
+
+    def test_vtuber_default_false(self):
+        """vtuber defaults False so OBS full-frame behavior is unchanged (L3 B6)."""
+        assert SplitConfig().vtuber is False
+
+    def test_vtuber_true_is_valid(self):
+        """vtuber=True is accepted (game-inset scorebar-band anchor path)."""
+        assert SplitConfig(vtuber=True).vtuber is True

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -138,6 +138,36 @@ def test_detect_uses_cache_when_present(tmp_path):
     assert (tmp_path / "metadata.json").exists()
 
 
+def test_detect_verbose_cache_miss_summary_includes_vtuber_token(tmp_path, capsys):
+    """detect の cache-miss verbose summary に vtuber token が出る (PR #823 R2).
+
+    run_split 側の Detecting summary (R1 fix) と同形。初回 (cache-miss) 実行でも
+    検出 mode の provenance が stdout に残ることを pin する。
+    """
+    config = SplitConfig(
+        output_dir=tmp_path, min_match_duration=60.0, no_cache=True, vtuber=True
+    )
+    with (
+        patch(f"{MODULE_DETECT}.probe_video", return_value=PROBE_RESULT),
+        patch(f"{MODULE_DETECT}._run_detection", return_value=BOUNDARIES),
+    ):
+        run_detect(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "Detecting match boundaries" in out
+    assert "vtuber=on" in out
+
+    config_off = SplitConfig(
+        output_dir=tmp_path, min_match_duration=60.0, no_cache=True
+    )
+    with (
+        patch(f"{MODULE_DETECT}.probe_video", return_value=PROBE_RESULT),
+        patch(f"{MODULE_DETECT}._run_detection", return_value=BOUNDARIES),
+    ):
+        run_detect(Path("input.mp4"), config_off, verbose=True)
+    out = capsys.readouterr().out
+    assert "vtuber=off" in out
+
+
 def test_detect_writes_system_info_to_metadata(tmp_path, monkeypatch):
     """#591 -- detect で書き出した metadata.json に system_info が含まれる."""
     monkeypatch.setattr(

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1166,6 +1166,8 @@ class TestDetectMatchBoundaries:
                 height,
                 workers,
                 *,
+                band_region=FULL_FRAME,
+                vtuber=False,
                 audio_hits,
                 stats,
                 progress_callback=None,
@@ -2609,3 +2611,27 @@ def test_detect_has_vtuber_param_defaulting_false():
     sig = inspect.signature(det.detect_match_boundaries)
     assert "vtuber" in sig.parameters
     assert sig.parameters["vtuber"].default is False
+
+
+# ============================================================
+# Task D1: band_region/vtuber threading + trailing-drop VTuber gate (Phase 2)
+# ============================================================
+
+
+def test_filter_call_receives_band_region_and_vtuber():
+    # static check: detect threads detect_region + vtuber into the scorebar filter.
+    import inspect
+    from allaganeye.video import detector as det
+
+    src = inspect.getsource(det.detect_match_boundaries)
+    assert "band_region=detect_region" in src
+    assert "vtuber=vtuber" in src
+
+
+def test_trailing_drop_gated_off_for_vtuber():
+    import inspect
+    from allaganeye.video import detector as det
+
+    src = inspect.getsource(det.detect_match_boundaries)
+    # the trailing-drop call must be guarded so it never runs on the VTuber path.
+    assert "if src_resolution is not None and not vtuber:" in src

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -203,7 +203,7 @@ class TestRefineBlackoutRegions:
     def test_2s_blackout_detected(self, mock_probe):
         """A 2.0s blackout is precisely measured and retained."""
 
-        def side_effect(path, t):
+        def side_effect(path, t, region=FULL_FRAME):
             # Blackout from 100.0 to 102.0
             return 5.0 if 100.0 <= t < 102.0 else 128.0
 
@@ -223,7 +223,7 @@ class TestRefineBlackoutRegions:
     def test_1s_respawn_stays_short(self, mock_probe):
         """A 1.0s respawn blackout remains short after refinement."""
 
-        def side_effect(path, t):
+        def side_effect(path, t, region=FULL_FRAME):
             return 5.0 if 100.0 <= t < 101.0 else 128.0
 
         mock_probe.side_effect = side_effect
@@ -314,7 +314,7 @@ class TestRefineBlackoutRegions:
 
         call_count = 0
 
-        def side_effect(video_path, t):
+        def side_effect(video_path, t, region=FULL_FRAME):
             nonlocal call_count
             call_count += 1
             # Every 3rd probe fails
@@ -408,7 +408,7 @@ class TestRefineBlackoutRegions:
 
         call_count = 0
 
-        def side_effect(video_path, t):
+        def side_effect(video_path, t, region=FULL_FRAME):
             nonlocal call_count
             call_count += 1
             if call_count % 3 == 0:
@@ -1036,7 +1036,9 @@ class TestDetectMatchBoundaries:
             return {t: 5.0 if 598.0 <= t <= 602.0 else 128.0 for t in ts}
 
         mock_chunk.side_effect = chunk_side_effect
-        mock_probe.side_effect = lambda path, t: 5.0 if 593.0 <= t <= 607.0 else 128.0
+        mock_probe.side_effect = lambda path, t, region=FULL_FRAME: (
+            5.0 if 593.0 <= t <= 607.0 else 128.0
+        )
         result = detect_match_boundaries(
             Path("test.mp4"),
             duration_hint=1800.0,
@@ -1150,7 +1152,9 @@ class TestDetectMatchBoundaries:
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 5.0 if 598.0 <= t <= 602.0 else 128.0 for t in ts
         }
-        mock_probe.side_effect = lambda path, t: 5.0 if 593.0 <= t <= 607.0 else 128.0
+        mock_probe.side_effect = lambda path, t, region=FULL_FRAME: (
+            5.0 if 593.0 <= t <= 607.0 else 128.0
+        )
         with patch(
             "allaganeye.video.scorebar.filter_blackouts_with_scorebar"
         ) as mock_filter:
@@ -1599,7 +1603,9 @@ class TestPass1HysteresisIntegration:
 
         mock_chunk.side_effect = chunk_side_effect
         # Pass 2 confirms blackout (<15.0 strict) in the same span
-        mock_probe.side_effect = lambda p, t: 5.0 if 599.0 <= t <= 610.0 else 128.0
+        mock_probe.side_effect = lambda p, t, region=FULL_FRAME: (
+            5.0 if 599.0 <= t <= 610.0 else 128.0
+        )
 
         result = detect_match_boundaries(
             Path("test.mp4"),
@@ -1638,7 +1644,9 @@ class TestPass1HysteresisIntegration:
 
         mock_chunk.side_effect = chunk_side_effect
         # Pass 2 at 0.25s finds real blackout 8137.25-8139.75
-        mock_probe.side_effect = lambda p, t: 2.0 if 8137.25 <= t <= 8139.75 else 128.0
+        mock_probe.side_effect = lambda p, t, region=FULL_FRAME: (
+            2.0 if 8137.25 <= t <= 8139.75 else 128.0
+        )
 
         detect_match_boundaries(
             Path("test.mp4"),
@@ -2479,3 +2487,14 @@ def test_frame_brightness_band_reshapes_and_crops():
     frame2d[0:9, :] = 100  # top 5% rows bright
     band = CaptureRegion(0.0, 0.0, 1.0, 0.05)
     assert det._frame_brightness(buf.reshape(-1), band) == 100.0
+
+
+def test_refine_accepts_region_kwarg_default_full_frame():
+    # Pass2 (_refine_blackout_regions) must accept a region kwarg defaulting to
+    # FULL_FRAME so existing callers (detect_match_boundaries) stay bit-exact.
+    # Signature-level pin: Pass2 needs a real video to run end-to-end (B2).
+    import inspect
+
+    sig = inspect.signature(det._refine_blackout_regions)
+    assert "region" in sig.parameters
+    assert sig.parameters["region"].default is FULL_FRAME

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2543,6 +2543,23 @@ def test_resolve_detect_region_swallows_exceptions_to_full_frame(monkeypatch, ca
     assert any("band anchor" in r.message for r in caplog.records)
 
 
+def test_resolve_detect_region_warns_on_consensus_miss_full_frame(monkeypatch, caplog):
+    # consensus-miss (非例外縮退) も silent にしない (R5): --vtuber 明示 run が
+    # FULL_FRAME (汚染 path) で続行することを warning で痕跡に残す。
+    import logging
+
+    from pathlib import Path
+
+    from allaganeye.video import capture_region as cr
+    from allaganeye.video import detector as det
+
+    monkeypatch.setattr(cr, "detect_scorebar_band_region", lambda **kw: cr.FULL_FRAME)
+    with caplog.at_level(logging.WARNING, logger="allaganeye.video.detector"):
+        region = det._resolve_detect_region(Path("dummy.mp4"), 400.0)
+    assert region.is_full_frame()
+    assert any("consensus" in r.message for r in caplog.records)
+
+
 def test_detect_match_boundaries_passes_region_to_all_three_call_sites(monkeypatch):
     # Keystone wiring guard: the region resolved by Stage 0 must reach Pass1
     # (_scan_cpu), GPU (scan_gpu), and Pass2 (_refine_blackout_regions).  On a

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2569,6 +2569,9 @@ def test_detect_match_boundaries_passes_region_to_all_three_call_sites(monkeypat
     monkeypatch.setattr(gpu_detector, "scan_gpu", fake_scan_gpu)
     monkeypatch.setattr(det, "_refine_blackout_regions", fake_refine)
 
+    # vtuber=True is required so Stage 0 resolves the band anchor; without it
+    # the gate (B4-rev) keeps detect_region=FULL_FRAME and the sentinel from
+    # the monkeypatched _resolve_detect_region would not reach the call sites.
     # CPU path
     det.detect_match_boundaries(
         Path("test.mp4"),
@@ -2576,6 +2579,7 @@ def test_detect_match_boundaries_passes_region_to_all_three_call_sites(monkeypat
         sample_interval=1.0,
         min_match_duration=0.5,
         use_gpu=False,
+        vtuber=True,
     )
     # GPU path
     det.detect_match_boundaries(
@@ -2584,9 +2588,24 @@ def test_detect_match_boundaries_passes_region_to_all_three_call_sites(monkeypat
         sample_interval=1.0,
         min_match_duration=0.5,
         use_gpu=True,
+        vtuber=True,
     )
 
     assert cpu_calls == [sentinel]
     assert gpu_calls == [sentinel]
     # Pass2 runs in both invocations.
     assert refine_calls == [sentinel, sentinel]
+
+
+# ============================================================
+# Task B4-rev: --vtuber gate on Stage 0 anchor (OBS bit-exact fix)
+# ============================================================
+
+
+def test_detect_has_vtuber_param_defaulting_false():
+    from allaganeye.video import detector as det
+    import inspect
+
+    sig = inspect.signature(det.detect_match_boundaries)
+    assert "vtuber" in sig.parameters
+    assert sig.parameters["vtuber"].default is False

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -5,10 +5,13 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from allaganeye.audio.matcher import BgmHit
 from allaganeye.exceptions import VideoProcessingError
+from allaganeye.video import detector as det
+from allaganeye.video.capture_region import FULL_FRAME, CaptureRegion
 from allaganeye.video.detector import (
     MatchBoundary,
     _BLACKOUT_PADDING,
@@ -2460,3 +2463,19 @@ class TestDropPostMatchTrailing:
         """Empty input returns empty, no exception."""
         result = _drop_post_match_trailing([], Path("v.mp4"), 1800.0, None)
         assert result == []
+
+
+def test_frame_brightness_full_frame_is_1d_mean_bitexact():
+    # CPU scan passes a 1-D grayscale buffer (320*180,). FULL_FRAME must
+    # equal float(buf.mean()) EXACTLY (no reshape) for OBS bit-exact.
+    buf = np.arange(det._FRAME_SIZE, dtype=np.uint8)  # 1-D, length 320*180
+    assert det._frame_brightness(buf, FULL_FRAME) == float(buf.mean())
+
+
+def test_frame_brightness_band_reshapes_and_crops():
+    # band branch must reshape the 1-D buffer to (180,320) then crop.
+    buf = np.zeros(det._FRAME_SIZE, dtype=np.uint8)
+    frame2d = buf.reshape(det._SAMPLE_HEIGHT, det._SAMPLE_WIDTH)
+    frame2d[0:9, :] = 100  # top 5% rows bright
+    band = CaptureRegion(0.0, 0.0, 1.0, 0.05)
+    assert det._frame_brightness(buf.reshape(-1), band) == 100.0

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2618,20 +2618,119 @@ def test_detect_has_vtuber_param_defaulting_false():
 # ============================================================
 
 
-def test_filter_call_receives_band_region_and_vtuber():
-    # static check: detect threads detect_region + vtuber into the scorebar filter.
-    import inspect
-    from allaganeye.video import detector as det
+def _vtuber_filter_capture(seen: dict):
+    """Build a filter_blackouts_with_scorebar stand-in that records kwargs.
 
-    src = inspect.getsource(det.detect_match_boundaries)
-    assert "band_region=detect_region" in src
-    assert "vtuber=vtuber" in src
+    Mirrors the real signature (allaganeye/video/scorebar.py) so the
+    keyword-only block (band_region / vtuber / audio_hits / stats /
+    progress_callback) binds exactly as the production call site passes it.
+    Returns every region classified as ``match_boundary`` so segments survive
+    into the trailing-drop stage.
+    """
+
+    def filter_side_effect(
+        video_path,
+        regions,
+        duration,
+        height,
+        workers=None,
+        *,
+        band_region=FULL_FRAME,
+        vtuber=False,
+        audio_hits=None,
+        stats=None,
+        progress_callback=None,
+    ):
+        seen["band_region"] = band_region
+        seen["vtuber"] = vtuber
+        return regions, ["match_boundary"] * len(regions)
+
+    return filter_side_effect
 
 
-def test_trailing_drop_gated_off_for_vtuber():
-    import inspect
-    from allaganeye.video import detector as det
+@patch("allaganeye.video.detector._resolve_detect_region")
+@patch("allaganeye.video.detector._drop_post_match_trailing")
+@patch("allaganeye.video.detector._probe_single_frame")
+@patch("allaganeye.video.detector._decode_chunk_cpu")
+def test_vtuber_threads_filter_kwargs_and_gates_trailing_drop(
+    mock_chunk, mock_probe, mock_trailing, mock_resolve
+):
+    """Behavioral: vtuber=True threads band_region/vtuber into the scorebar
+    filter at runtime and skips the irreversible trailing-drop (#797 gate).
 
-    src = inspect.getsource(det.detect_match_boundaries)
-    # the trailing-drop call must be guarded so it never runs on the VTuber path.
-    assert "if src_resolution is not None and not vtuber:" in src
+    Replaces the prior inspect.getsource static checks: this exercises the
+    real call path so an early return or refactor that breaks the gate fails
+    here (the static substring tests would still pass).
+    """
+    # One blackout region around t=600 (single match boundary).
+    mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kw: {
+        t: 5.0 if 598.0 <= t <= 602.0 else 128.0 for t in ts
+    }
+    mock_probe.side_effect = lambda p, t, region=FULL_FRAME: (
+        5.0 if 593.0 <= t <= 607.0 else 128.0
+    )
+    # Passthrough so the assertion is "was it called", independent of segments.
+    mock_trailing.side_effect = lambda segs, *a, **k: segs
+    # Isolate from real ffmpeg/localize I/O; return a distinct (non-FULL_FRAME)
+    # region so band_region threading is observable, not a degraded default.
+    band = CaptureRegion(0.1, 0.1, 0.8, 0.2, confidence=0.9, source="tierB")
+    mock_resolve.return_value = band
+
+    seen: dict = {}
+    with patch(
+        "allaganeye.video.scorebar.filter_blackouts_with_scorebar",
+        side_effect=_vtuber_filter_capture(seen),
+    ):
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+            src_resolution=(1920, 1080),
+            vtuber=True,
+        )
+
+    # filter received the resolved band region and the vtuber flag at runtime.
+    assert seen["vtuber"] is True
+    assert seen["band_region"] is not None
+    assert seen["band_region"] is band
+    # VTuber path must NOT run the irreversible trailing-drop (#797 / #805).
+    mock_trailing.assert_not_called()
+
+
+@patch("allaganeye.video.detector._drop_post_match_trailing")
+@patch("allaganeye.video.detector._probe_single_frame")
+@patch("allaganeye.video.detector._decode_chunk_cpu")
+def test_obs_runs_trailing_drop_and_filter_sees_vtuber_false(
+    mock_chunk, mock_probe, mock_trailing
+):
+    """Behavioral OBS regression guard: vtuber=False (default OBS path) keeps
+    running the trailing-drop and reports vtuber=False to the scorebar filter.
+
+    Pairs with the vtuber=True test to pin the gate from both sides so a
+    regression that drops the ``not vtuber`` guard is caught.
+    """
+    mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kw: {
+        t: 5.0 if 598.0 <= t <= 602.0 else 128.0 for t in ts
+    }
+    mock_probe.side_effect = lambda p, t, region=FULL_FRAME: (
+        5.0 if 593.0 <= t <= 607.0 else 128.0
+    )
+    mock_trailing.side_effect = lambda segs, *a, **k: segs
+
+    seen: dict = {}
+    with patch(
+        "allaganeye.video.scorebar.filter_blackouts_with_scorebar",
+        side_effect=_vtuber_filter_capture(seen),
+    ):
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+            src_resolution=(1920, 1080),
+        )
+
+    assert seen["vtuber"] is False
+    # OBS path runs the trailing-drop exactly once.
+    mock_trailing.assert_called_once()

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2498,3 +2498,95 @@ def test_refine_accepts_region_kwarg_default_full_frame():
     sig = inspect.signature(det._refine_blackout_regions)
     assert "region" in sig.parameters
     assert sig.parameters["region"].default is FULL_FRAME
+
+
+# ============================================================
+# Task B4: Stage 0 band anchor resolution (_resolve_detect_region)
+# ============================================================
+
+
+def test_resolve_detect_region_exists():
+    from allaganeye.video import detector as det
+
+    assert hasattr(det, "_resolve_detect_region")
+
+
+def test_resolve_detect_region_falls_back_full_frame_on_probe_failure(monkeypatch):
+    from allaganeye.video import detector as det
+    from allaganeye.video.capture_region import FULL_FRAME  # noqa: F401
+    from pathlib import Path
+
+    # all hi-res probes fail -> localize_fn always None -> band consensus FULL_FRAME
+    monkeypatch.setattr(det, "_probe_frame_rgb_hires", lambda vp, t: None)
+    region = det._resolve_detect_region(Path("dummy.mp4"), 400.0)
+    assert region.is_full_frame()
+
+
+def test_resolve_detect_region_swallows_exceptions_to_full_frame(monkeypatch):
+    # Anchor failure must NEVER break detect: any exception inside the probe
+    # path is swallowed to FULL_FRAME (OBS-safe degrade, bit-exact preserved).
+    from allaganeye.video import detector as det
+    from pathlib import Path
+
+    def _boom(vp, t):
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(det, "_probe_frame_rgb_hires", _boom)
+    region = det._resolve_detect_region(Path("dummy.mp4"), 400.0)
+    assert region.is_full_frame()
+
+
+def test_detect_match_boundaries_passes_region_to_all_three_call_sites(monkeypatch):
+    # Keystone wiring guard: the region resolved by Stage 0 must reach Pass1
+    # (_scan_cpu), GPU (scan_gpu), and Pass2 (_refine_blackout_regions).  On a
+    # probe failure the resolved region is FULL_FRAME, but the kwarg must still
+    # be threaded through every call so VTuber band ROIs propagate.
+    from allaganeye.video import detector as det
+    from allaganeye.video import gpu_detector
+    from allaganeye.video.capture_region import FULL_FRAME
+    from pathlib import Path
+
+    sentinel = CaptureRegion(0.0, 0.10, 1.0, 0.18, confidence=0.9, source="band")
+    monkeypatch.setattr(det, "_resolve_detect_region", lambda vp, dh: sentinel)
+
+    cpu_calls: list[CaptureRegion] = []
+    gpu_calls: list[CaptureRegion] = []
+    refine_calls: list[CaptureRegion] = []
+
+    def fake_scan_cpu(*args, **kwargs):
+        cpu_calls.append(kwargs.get("region", FULL_FRAME))
+        return {0.0: 100.0, 1.0: 100.0}
+
+    def fake_scan_gpu(*args, **kwargs):
+        gpu_calls.append(kwargs.get("region", FULL_FRAME))
+        return {0.0: 100.0, 1.0: 100.0}
+
+    def fake_refine(*args, **kwargs):
+        refine_calls.append(kwargs.get("region", FULL_FRAME))
+        return []
+
+    monkeypatch.setattr(det, "_scan_cpu", fake_scan_cpu)
+    monkeypatch.setattr(gpu_detector, "scan_gpu", fake_scan_gpu)
+    monkeypatch.setattr(det, "_refine_blackout_regions", fake_refine)
+
+    # CPU path
+    det.detect_match_boundaries(
+        Path("test.mp4"),
+        duration_hint=2.0,
+        sample_interval=1.0,
+        min_match_duration=0.5,
+        use_gpu=False,
+    )
+    # GPU path
+    det.detect_match_boundaries(
+        Path("test.mp4"),
+        duration_hint=2.0,
+        sample_interval=1.0,
+        min_match_duration=0.5,
+        use_gpu=True,
+    )
+
+    assert cpu_calls == [sentinel]
+    assert gpu_calls == [sentinel]
+    # Pass2 runs in both invocations.
+    assert refine_calls == [sentinel, sentinel]

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2524,9 +2524,12 @@ def test_resolve_detect_region_falls_back_full_frame_on_probe_failure(monkeypatc
     assert region.is_full_frame()
 
 
-def test_resolve_detect_region_swallows_exceptions_to_full_frame(monkeypatch):
+def test_resolve_detect_region_swallows_exceptions_to_full_frame(monkeypatch, caplog):
     # Anchor failure must NEVER break detect: any exception inside the probe
     # path is swallowed to FULL_FRAME (OBS-safe degrade, bit-exact preserved).
+    # R4: 縮退は silent にせず warning を 1 行残す (診断性のみ、挙動不変)。
+    import logging
+
     from allaganeye.video import detector as det
     from pathlib import Path
 
@@ -2534,8 +2537,10 @@ def test_resolve_detect_region_swallows_exceptions_to_full_frame(monkeypatch):
         raise RuntimeError("probe exploded")
 
     monkeypatch.setattr(det, "_probe_frame_rgb_hires", _boom)
-    region = det._resolve_detect_region(Path("dummy.mp4"), 400.0)
+    with caplog.at_level(logging.WARNING, logger="allaganeye.video.detector"):
+        region = det._resolve_detect_region(Path("dummy.mp4"), 400.0)
     assert region.is_full_frame()
+    assert any("band anchor" in r.message for r in caplog.records)
 
 
 def test_detect_match_boundaries_passes_region_to_all_three_call_sites(monkeypatch):

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -1000,3 +1000,28 @@ class TestGpuFallbackIntegration:
         mock_gpu.assert_called_once()
         mock_cpu.assert_called_once()
         assert len(result) >= 1
+
+
+class TestGpuBrightnessParity:
+    """GPU Pass1 brightness must route through detector._frame_brightness so
+    CPU and GPU compute brightness identically (Phase 1 B3, Codex #8)."""
+
+    def test_gpu_brightness_shares_frame_brightness_helper(self):
+        # GPU path must use the same _frame_brightness so CPU/GPU parity holds.
+        import numpy as np
+
+        from allaganeye.video import detector as det
+        from allaganeye.video.capture_region import FULL_FRAME
+
+        frame = np.arange(det._FRAME_SIZE, dtype=np.uint8)
+        assert det._frame_brightness(frame, FULL_FRAME) == float(frame.mean())
+
+    def test_scan_gpu_accepts_region_kwarg_default_full_frame(self):
+        import inspect
+
+        from allaganeye.video import gpu_detector as gpu
+        from allaganeye.video.capture_region import FULL_FRAME
+
+        sig = inspect.signature(gpu.scan_gpu)
+        assert "region" in sig.parameters
+        assert sig.parameters["region"].default is FULL_FRAME

--- a/tests/test_l3_phase2_parity.py
+++ b/tests/test_l3_phase2_parity.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.slow
 
 def _vtuber_sample() -> Path | None:
     base = (
-        os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER") or r"E:\allaganeye-samples"
+        os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER") or r"E:/allaganeye-samples"
     )
     cands = list(Path(base).glob("*オンサル*")) if Path(base).exists() else []
     return cands[0] if cands else None

--- a/tests/test_l3_phase2_parity.py
+++ b/tests/test_l3_phase2_parity.py
@@ -1,0 +1,100 @@
+"""Phase 2 受け入れ (slow / sample-gated): VTuber 過分割解消 + OBS v2/localize parity.
+
+実機データ依存 (Idios verify、PYTHONUTF8=1)。CI では sample 未設定で skip。
+parity は production に入れない harness 計測 (spec section 8.1 P2-b)。
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+
+def _vtuber_sample() -> Path | None:
+    base = (
+        os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER") or r"E:\allaganeye-samples"
+    )
+    cands = list(Path(base).glob("*オンサル*")) if Path(base).exists() else []
+    return cands[0] if cands else None
+
+
+@pytest.mark.skipif(_vtuber_sample() is None, reason="VTuber sample not available")
+def test_vtuber_split_removes_in_match_overspilt():
+    from allaganeye.video.probe import probe_video
+    from allaganeye.video import detector as det
+
+    video = _vtuber_sample()
+    assert video is not None  # guaranteed by skipif; narrows Path | None -> Path
+    meta = probe_video(video)
+    res = (meta["width"], meta["height"])
+    # vtuber=True path: classifier removes in-match band-crop blackouts.
+    matches_vtuber = det.detect_match_boundaries(
+        video, duration_hint=meta["duration"], src_resolution=res, vtuber=True
+    )
+    # Phase 1 over-split baseline (vtuber=True without Phase 2 classify) split far
+    # more; here we assert the classified result is a sane, small match count.
+    assert 0 < len(matches_vtuber) <= 12, (
+        f"VTuber split should be practical, got {len(matches_vtuber)} matches"
+    )
+
+
+def _obs_sample() -> Path | None:
+    base = os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR")
+    if not base or not Path(base).exists():
+        return None
+    cands = list(Path(base).glob("*.mkv"))
+    return cands[0] if cands else None
+
+
+@pytest.mark.skipif(_obs_sample() is None, reason="OBS sample not available")
+def test_obs_v2_vs_localize_presence_parity(caplog):
+    """v2 (authoritative) と localize の scorebar-present を時間グリッドで突合。
+
+    production には入れない harness 専用計測 (spec section 8.1 P2-b)。一様グリッドで
+    v2-present と localize-present を比較し、不一致を per-sample ログ化する。long
+    非試合区間 (lobby/result) を含む全域で v2/localize の FP/FN 差を可観測にする
+    (Codex #3)。assert は緩く「不一致が極端でない」のみ (閾値校正は Phase 3)。
+    """
+    import logging
+
+    from allaganeye.video.probe import probe_video
+    from allaganeye.video import detector as det
+    from allaganeye.video import scorebar as sb
+
+    video = _obs_sample()
+    assert video is not None  # guaranteed by skipif; narrows Path | None -> Path
+    meta = probe_video(video)
+    duration = meta["duration"]
+
+    # Uniform interior grid (avoid the very edges).
+    n = 40
+    times = [duration * (i + 1) / (n + 1) for i in range(n)]
+
+    agree = 0
+    disagree = 0
+    with caplog.at_level(logging.INFO):
+        for t in times:
+            raw = det._probe_frame_rgb_hires(video, t)
+            v2 = det._has_scorebar_v2(raw)
+            loc = sb._localize_present_from_raw(raw)
+            if v2 is None or loc is None:
+                continue
+            if v2 == loc:
+                agree += 1
+            else:
+                disagree += 1
+                logging.getLogger(__name__).info(
+                    "PARITY_DIFF t=%.1f v2=%s localize=%s", t, v2, loc
+                )
+        total = agree + disagree
+        logging.getLogger(__name__).info(
+            "PARITY summary: %d/%d agree (%d diffs)", agree, total, disagree
+        )
+
+    assert total > 0, "no valid probes -- check sample video / opencv"
+    # localize should broadly agree with v2 on OBS (the position-independent
+    # localizer finds the same full-screen scorebar). A wildly low agreement
+    # signals a regression worth Idios investigating; calibration is Phase 3.
+    assert agree / total >= 0.6, f"v2/localize parity too low: {agree}/{total}"

--- a/tests/test_l3_phase2_parity.py
+++ b/tests/test_l3_phase2_parity.py
@@ -20,6 +20,7 @@ def _vtuber_sample() -> Path | None:
     return cands[0] if cands else None
 
 
+@pytest.mark.slow_detect
 @pytest.mark.skipif(_vtuber_sample() is None, reason="VTuber sample not available")
 def test_vtuber_split_removes_in_match_overspilt():
     from allaganeye.video.probe import probe_video

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -1,0 +1,18 @@
+"""Unit tests for presence-based match detection (no video required)."""
+
+from __future__ import annotations
+
+from allaganeye.video.presence import PresenceMatch, PresenceSample
+
+
+def test_presence_sample_fields():
+    s = PresenceSample(time=12.0, present=True, confidence=0.9)
+    assert s.time == 12.0
+    assert s.present is True
+    assert s.confidence == 0.9
+
+
+def test_presence_match_fields():
+    m = PresenceMatch(start=10.0, end=900.0)
+    assert m.start == 10.0
+    assert m.end == 900.0

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -6,8 +6,13 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
+import pytest
 
-from allaganeye.video.capture_region import ScorebarLocalization
+from allaganeye.exceptions import VideoProcessingError
+from allaganeye.video.capture_region import (
+    ScorebarLocalization,
+    localize_from_rgb_bytes,
+)
 from allaganeye.video.presence import (
     PresenceMatch,
     PresenceSample,
@@ -113,8 +118,8 @@ def test_localize_present_at_present(monkeypatch):
     )
     monkeypatch.setattr(
         presence,
-        "localize_scorebar",
-        lambda frame: ScorebarLocalization(
+        "localize_from_rgb_bytes",
+        lambda raw, *, height, width: ScorebarLocalization(
             x_left=600, x_right=1300, y_top=20, y_bottom=65, confidence=0.8
         ),
     )
@@ -131,7 +136,9 @@ def test_localize_present_at_absent(monkeypatch):
     monkeypatch.setattr(
         presence, "_probe_frame_rgb_hires", lambda vp, t: fake_frame_bytes
     )
-    monkeypatch.setattr(presence, "localize_scorebar", lambda frame: None)
+    monkeypatch.setattr(
+        presence, "localize_from_rgb_bytes", lambda raw, *, height, width: None
+    )
     sample = presence.localize_present_at(Path("dummy.mkv"), 50.0)
     assert sample.present is False
     assert sample.confidence == 0.0
@@ -214,3 +221,42 @@ def test_detect_matches_present_at_video_edges(monkeypatch):
         workers=2,
     )
     assert matches == [PresenceMatch(start=0.0, end=500.0)]
+
+
+def test_scan_presence_isolates_single_probe_failure():
+    """1 probe の VideoProcessingError で全 scan が abort しない (PR #823 R3).
+
+    production の同型 pool (_probe_scorebar_context / _refine_blackout_regions)
+    と同じ per-future 縮退。失敗 probe は safe absent になる。
+    """
+
+    def fn(t: float) -> PresenceSample:
+        if t == 2.0:
+            raise VideoProcessingError("probe failed")
+        return PresenceSample(time=t, present=True, confidence=1.0)
+
+    samples = scan_presence(Path("v.mp4"), 4.0, stride=2.0, workers=2, sample_fn=fn)
+
+    assert [s.time for s in samples] == [0.0, 2.0, 4.0]
+    assert samples[0].present is True
+    assert samples[1].present is False
+    assert samples[1].confidence == 0.0
+    assert samples[2].present is True
+
+
+def test_scan_presence_all_probe_failures_raise():
+    """全 probe 失敗 (ffmpeg 不在等の系統故障) は silent all-absent にせず fail-loud."""
+
+    def fn(t: float) -> PresenceSample:
+        raise VideoProcessingError("ffmpeg not found")
+
+    with pytest.raises(VideoProcessingError):
+        scan_presence(Path("v.mp4"), 4.0, stride=2.0, workers=2, sample_fn=fn)
+
+
+def test_localize_from_rgb_bytes_none_passthrough_and_decode():
+    """共有 helper (R3 dedup): raw None -> None / 正常 bytes は decode して localizer へ."""
+    assert localize_from_rgb_bytes(None, height=4, width=4) is None
+    # 4x4 RGB の全黒 frame: decode は成功し、localizer は scorebar なし -> None
+    raw = bytes(4 * 4 * 3)
+    assert localize_from_rgb_bytes(raw, height=4, width=4) is None

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -11,6 +11,7 @@ from allaganeye.video.capture_region import ScorebarLocalization
 from allaganeye.video.presence import (
     PresenceMatch,
     PresenceSample,
+    detect_matches_by_presence,
     refine_boundary,
     scan_presence,
     segment_presence,
@@ -164,3 +165,52 @@ def test_scan_presence_grid_and_order():
         False,
         False,
     ]
+
+
+def test_detect_matches_by_presence_end_to_end(monkeypatch):
+    import allaganeye.video.presence as presence
+
+    # Ground physics: scorebar present for 250 <= t < 740.
+    def present_phys(t: float) -> bool:
+        return 250.0 <= t < 740.0
+
+    monkeypatch.setattr(
+        presence,
+        "localize_present_at",
+        lambda vp, t: PresenceSample(time=t, present=present_phys(t), confidence=1.0),
+    )
+
+    matches = detect_matches_by_presence(
+        Path("dummy.mkv"),
+        duration=1000.0,
+        stride=100.0,
+        t_gap=120.0,
+        t_min_match=60.0,
+        tol=1.0,
+        workers=2,
+    )
+    assert len(matches) == 1
+    # coarse run is 300..700 (grid); refine pulls start->250, end->740
+    assert abs(matches[0].start - 250.0) <= 1.0
+    assert abs(matches[0].end - 740.0) <= 1.0
+
+
+def test_detect_matches_present_at_video_edges(monkeypatch):
+    import allaganeye.video.presence as presence
+
+    # present for the entire video -> match spans [0, duration], no refine
+    monkeypatch.setattr(
+        presence,
+        "localize_present_at",
+        lambda vp, t: PresenceSample(time=t, present=True, confidence=1.0),
+    )
+    matches = detect_matches_by_presence(
+        Path("dummy.mkv"),
+        duration=500.0,
+        stride=100.0,
+        t_gap=120.0,
+        t_min_match=60.0,
+        tol=1.0,
+        workers=2,
+    )
+    assert matches == [PresenceMatch(start=0.0, end=500.0)]

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
 
+import numpy as np
+
+from allaganeye.video.capture_region import ScorebarLocalization
 from allaganeye.video.presence import (
     PresenceMatch,
     PresenceSample,
@@ -96,3 +100,45 @@ def test_refine_boundary_respects_tolerance():
 
     edge = refine_boundary(480.0, 520.0, present_at, tol=0.1)
     assert abs(edge - 500.0) <= 0.1
+
+
+def test_localize_present_at_present(monkeypatch):
+    import allaganeye.video.presence as presence
+
+    fake_frame_bytes = (np.zeros((1080, 1920, 3), dtype=np.uint8)).tobytes()
+    monkeypatch.setattr(
+        presence, "_probe_frame_rgb_hires", lambda vp, t: fake_frame_bytes
+    )
+    monkeypatch.setattr(
+        presence,
+        "localize_scorebar",
+        lambda frame: ScorebarLocalization(
+            x_left=600, x_right=1300, y_top=20, y_bottom=65, confidence=0.8
+        ),
+    )
+    sample = presence.localize_present_at(Path("dummy.mkv"), 123.0)
+    assert sample.time == 123.0
+    assert sample.present is True
+    assert sample.confidence == 0.8
+
+
+def test_localize_present_at_absent(monkeypatch):
+    import allaganeye.video.presence as presence
+
+    fake_frame_bytes = (np.zeros((1080, 1920, 3), dtype=np.uint8)).tobytes()
+    monkeypatch.setattr(
+        presence, "_probe_frame_rgb_hires", lambda vp, t: fake_frame_bytes
+    )
+    monkeypatch.setattr(presence, "localize_scorebar", lambda frame: None)
+    sample = presence.localize_present_at(Path("dummy.mkv"), 50.0)
+    assert sample.present is False
+    assert sample.confidence == 0.0
+
+
+def test_localize_present_at_probe_failure(monkeypatch):
+    import allaganeye.video.presence as presence
+
+    monkeypatch.setattr(presence, "_probe_frame_rgb_hires", lambda vp, t: None)
+    sample = presence.localize_present_at(Path("dummy.mkv"), 7.0)
+    assert sample.present is False
+    assert sample.confidence == 0.0

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from allaganeye.video.presence import PresenceMatch, PresenceSample, segment_presence
+from allaganeye.video.presence import (
+    PresenceMatch,
+    PresenceSample,
+    refine_boundary,
+    segment_presence,
+)
 
 
 def test_presence_sample_fields():
@@ -63,3 +68,31 @@ def test_segment_drops_short_present_spike():
 
 def test_segment_empty_input():
     assert segment_presence([], t_gap=30.0, t_min_match=60.0) == []
+
+
+def test_refine_boundary_finds_transition_forward():
+    # scorebar present for t < 500, absent for t >= 500 (match end)
+    def present_at(t: float) -> bool:
+        return t < 500.0
+
+    # bracket: t_true=480 (present), t_false=520 (absent)
+    edge = refine_boundary(480.0, 520.0, present_at, tol=1.0)
+    assert abs(edge - 500.0) <= 1.0
+
+
+def test_refine_boundary_finds_transition_backward():
+    # scorebar absent for t < 300, present for t >= 300 (match start)
+    def present_at(t: float) -> bool:
+        return t >= 300.0
+
+    # bracket: t_true=320 (present), t_false=280 (absent)
+    edge = refine_boundary(320.0, 280.0, present_at, tol=1.0)
+    assert abs(edge - 300.0) <= 1.0
+
+
+def test_refine_boundary_respects_tolerance():
+    def present_at(t: float) -> bool:
+        return t < 500.0
+
+    edge = refine_boundary(480.0, 520.0, present_at, tol=0.1)
+    assert abs(edge - 500.0) <= 0.1

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -12,6 +12,7 @@ from allaganeye.video.presence import (
     PresenceMatch,
     PresenceSample,
     refine_boundary,
+    scan_presence,
     segment_presence,
 )
 
@@ -142,3 +143,24 @@ def test_localize_present_at_probe_failure(monkeypatch):
     sample = presence.localize_present_at(Path("dummy.mkv"), 7.0)
     assert sample.present is False
     assert sample.confidence == 0.0
+
+
+def test_scan_presence_grid_and_order():
+    # synthetic sample_fn: present for 200 <= t < 500
+    def sample_fn(t: float) -> PresenceSample:
+        return PresenceSample(time=t, present=(200.0 <= t < 500.0), confidence=1.0)
+
+    samples = scan_presence(
+        Path("dummy.mkv"), duration=600.0, stride=100.0, workers=2, sample_fn=sample_fn
+    )
+    # times must be sorted and cover 0,100,...,600
+    assert [s.time for s in samples] == [0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0]
+    assert [s.present for s in samples] == [
+        False,
+        False,
+        True,
+        True,
+        True,
+        False,
+        False,
+    ]

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -287,6 +287,55 @@ def test_scan_presence_default_sampler_mixed_probe_none_stays_absent(monkeypatch
     assert samples[1].confidence == 0.0
 
 
+def test_scan_presence_partial_failures_logged(caplog):
+    """部分故障 (全滅未満) は absent 化しつつ warning で痕跡を残す (R5 可視化)."""
+    import logging
+
+    def fn(t: float) -> PresenceSample:
+        if t == 2.0:
+            raise VideoProcessingError("probe failed")
+        return PresenceSample(time=t, present=True, confidence=1.0)
+
+    with caplog.at_level(logging.WARNING, logger="allaganeye.video.presence"):
+        samples = scan_presence(Path("v.mp4"), 4.0, stride=2.0, workers=2, sample_fn=fn)
+    assert [s.present for s in samples] == [True, False, True]
+    assert any("presence probes failed" in r.message for r in caplog.records)
+
+
+def test_refine_probe_failure_warns_and_treats_absent(monkeypatch, caplog):
+    """refine 中の probe 失敗は absent 続行 + warning で痕跡を残す (R5 可視化).
+
+    境界が最大 1 stride ずれうる縮退なので silent にしない (semantics 統一は
+    設計 issue で後続)。
+    """
+    import logging
+
+    import allaganeye.video.presence as presence
+
+    grid = {0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0}
+
+    def fake_localize(vp, t, *, raise_on_probe_failure=False):
+        if t not in grid:
+            if raise_on_probe_failure:
+                raise VideoProcessingError("probe failed mid-refine")
+            return PresenceSample(time=t, present=False, confidence=0.0)
+        return PresenceSample(time=t, present=(200.0 <= t < 500.0), confidence=1.0)
+
+    monkeypatch.setattr(presence, "localize_present_at", fake_localize)
+    with caplog.at_level(logging.WARNING, logger="allaganeye.video.presence"):
+        matches = presence.detect_matches_by_presence(
+            Path("dummy.mkv"),
+            duration=600.0,
+            stride=100.0,
+            t_gap=120.0,
+            t_min_match=60.0,
+            tol=50.0,
+            workers=2,
+        )
+    assert len(matches) == 1
+    assert any("refine" in r.message for r in caplog.records)
+
+
 def test_localize_from_rgb_bytes_none_passthrough_and_decode():
     """共有 helper (R3 dedup): raw None -> None / 正常 bytes は decode して localizer へ."""
     assert localize_from_rgb_bytes(None, height=4, width=4) is None

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -184,7 +184,9 @@ def test_detect_matches_by_presence_end_to_end(monkeypatch):
     monkeypatch.setattr(
         presence,
         "localize_present_at",
-        lambda vp, t: PresenceSample(time=t, present=present_phys(t), confidence=1.0),
+        lambda vp, t, **_kw: PresenceSample(
+            time=t, present=present_phys(t), confidence=1.0
+        ),
     )
 
     matches = detect_matches_by_presence(
@@ -209,7 +211,7 @@ def test_detect_matches_present_at_video_edges(monkeypatch):
     monkeypatch.setattr(
         presence,
         "localize_present_at",
-        lambda vp, t: PresenceSample(time=t, present=True, confidence=1.0),
+        lambda vp, t, **_kw: PresenceSample(time=t, present=True, confidence=1.0),
     )
     matches = detect_matches_by_presence(
         Path("dummy.mkv"),
@@ -252,6 +254,37 @@ def test_scan_presence_all_probe_failures_raise():
 
     with pytest.raises(VideoProcessingError):
         scan_presence(Path("v.mp4"), 4.0, stride=2.0, workers=2, sample_fn=fn)
+
+
+def test_scan_presence_default_sampler_all_probe_none_fails_loud(monkeypatch):
+    """default sampler 経由: 全 probe が raw None (decode 系統故障) でも fail-loud (R4).
+
+    R3 の fail-loud guard は VideoProcessingError raise しか数えず、raw None ->
+    safe absent 変換で decode 系統故障が silent 全 absent になる穴があった。
+    """
+    import allaganeye.video.presence as presence
+
+    monkeypatch.setattr(presence, "_probe_frame_rgb_hires", lambda vp, t: None)
+    with pytest.raises(VideoProcessingError):
+        scan_presence(Path("v.mp4"), 4.0, stride=2.0, workers=2)
+
+
+def test_scan_presence_default_sampler_mixed_probe_none_stays_absent(monkeypatch):
+    """default sampler 経由: 一部 probe のみ raw None なら scan は完走し absent 化 (R4)."""
+    import allaganeye.video.presence as presence
+
+    loc = ScorebarLocalization(
+        x_left=600, x_right=1300, y_top=20, y_bottom=65, confidence=0.8
+    )
+    monkeypatch.setattr(
+        presence, "_probe_frame_rgb_hires", lambda vp, t: None if t == 2.0 else b"x"
+    )
+    monkeypatch.setattr(
+        presence, "localize_from_rgb_bytes", lambda raw, *, height, width: loc
+    )
+    samples = scan_presence(Path("v.mp4"), 4.0, stride=2.0, workers=2)
+    assert [s.present for s in samples] == [True, False, True]
+    assert samples[1].confidence == 0.0
 
 
 def test_localize_from_rgb_bytes_none_passthrough_and_decode():

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from allaganeye.video.presence import PresenceMatch, PresenceSample
+from collections.abc import Sequence
+
+from allaganeye.video.presence import PresenceMatch, PresenceSample, segment_presence
 
 
 def test_presence_sample_fields():
@@ -16,3 +18,48 @@ def test_presence_match_fields():
     m = PresenceMatch(start=10.0, end=900.0)
     assert m.start == 10.0
     assert m.end == 900.0
+
+
+def _samples(spec: Sequence[tuple[float, bool]]) -> list[PresenceSample]:
+    return [PresenceSample(time=t, present=p, confidence=1.0) for t, p in spec]
+
+
+def test_segment_single_match():
+    # present 0..900 (stride 100) -> one match
+    samples = _samples([(t, True) for t in range(0, 1000, 100)])
+    matches = segment_presence(samples, t_gap=30.0, t_min_match=60.0)
+    assert matches == [PresenceMatch(start=0.0, end=900.0)]
+
+
+def test_segment_two_matches_split_by_long_gap():
+    # match A 0..200, absent 300..600 (gap 400 >= t_gap), match B 700..900
+    spec = [(t, True) for t in (0, 100, 200)]
+    spec += [(t, False) for t in (300, 400, 500, 600)]
+    spec += [(t, True) for t in (700, 800, 900)]
+    matches = segment_presence(_samples(spec), t_gap=120.0, t_min_match=60.0)
+    assert matches == [
+        PresenceMatch(start=0.0, end=200.0),
+        PresenceMatch(start=700.0, end=900.0),
+    ]
+
+
+def test_segment_absorbs_short_absent_gap():
+    # short absent at 300 only (gap from 200 to 400 = 200 < t_gap=300) -> merged
+    spec = [(t, True) for t in (0, 100, 200)]
+    spec += [(300, False)]
+    spec += [(t, True) for t in (400, 500, 600)]
+    matches = segment_presence(_samples(spec), t_gap=300.0, t_min_match=60.0)
+    assert matches == [PresenceMatch(start=0.0, end=600.0)]
+
+
+def test_segment_drops_short_present_spike():
+    # isolated present spike 400..450 (duration 50 < t_min_match=60) -> dropped
+    spec = [(t, False) for t in (0, 100, 200, 300)]
+    spec += [(400, True), (450, True)]
+    spec += [(t, False) for t in (600, 700, 800)]
+    matches = segment_presence(_samples(spec), t_gap=120.0, t_min_match=60.0)
+    assert matches == []
+
+
+def test_segment_empty_input():
+    assert segment_presence([], t_gap=30.0, t_min_match=60.0) == []

--- a/tests/test_presence_harness.py
+++ b/tests/test_presence_harness.py
@@ -10,6 +10,7 @@ from tests.presence_harness import (
     ComparisonResult,
     GroundTruth,
     GroundTruthMatch,
+    build_arg_parser,
     compare_segments,
     load_ground_truth,
 )
@@ -81,3 +82,42 @@ def test_compare_boundary_outside_tolerance_is_not_matched():
     assert res.matched == 0
     assert res.missed == 1
     assert res.spurious == 1
+
+
+def test_build_arg_parser_defaults():
+    parser = build_arg_parser()
+    args = parser.parse_args(["--video", "v.mkv", "--ground-truth", "gt.json"])
+    assert args.video == "v.mkv"
+    assert args.ground_truth == "gt.json"
+    assert args.stride == 4.0
+    assert args.t_gap == 30.0
+    assert args.t_min_match == 120.0
+    assert args.tol == 1.0
+    assert args.workers == 8
+
+
+def test_build_arg_parser_overrides():
+    parser = build_arg_parser()
+    args = parser.parse_args(
+        [
+            "--video",
+            "v.mkv",
+            "--ground-truth",
+            "gt.json",
+            "--stride",
+            "3",
+            "--t-gap",
+            "45",
+            "--t-min-match",
+            "90",
+            "--tol",
+            "0.5",
+            "--workers",
+            "16",
+        ]
+    )
+    assert args.stride == 3.0
+    assert args.t_gap == 45.0
+    assert args.t_min_match == 90.0
+    assert args.tol == 0.5
+    assert args.workers == 16

--- a/tests/test_presence_harness.py
+++ b/tests/test_presence_harness.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from tests.presence_harness import GroundTruth, GroundTruthMatch, load_ground_truth
+from allaganeye.video.presence import PresenceMatch
+from tests.presence_harness import (
+    ComparisonResult,
+    GroundTruth,
+    GroundTruthMatch,
+    compare_segments,
+    load_ground_truth,
+)
 
 
 def test_load_ground_truth(tmp_path: Path):
@@ -31,3 +38,46 @@ def test_load_ground_truth(tmp_path: Path):
         GroundTruthMatch(start=49.0, end=1054.0),
         GroundTruthMatch(start=1256.0, end=2178.0),
     ]
+
+
+def _gt(pairs: list[tuple[float, float]]) -> list[GroundTruthMatch]:
+    return [GroundTruthMatch(start=a, end=b) for a, b in pairs]
+
+
+def test_compare_all_matched_within_tolerance():
+    detected = [PresenceMatch(50.0, 1056.0), PresenceMatch(1257.0, 2176.0)]
+    gt = _gt([(49.0, 1054.0), (1256.0, 2178.0)])
+    res = compare_segments(detected, gt, tolerance=5.0)
+    assert isinstance(res, ComparisonResult)
+    assert res.matched == 2
+    assert res.missed == 0
+    assert res.spurious == 0
+    assert res.max_boundary_error <= 2.0
+
+
+def test_compare_missed_match():
+    detected = [PresenceMatch(50.0, 1056.0)]
+    gt = _gt([(49.0, 1054.0), (1256.0, 2178.0)])
+    res = compare_segments(detected, gt, tolerance=5.0)
+    assert res.matched == 1
+    assert res.missed == 1
+    assert res.spurious == 0
+
+
+def test_compare_spurious_match():
+    detected = [PresenceMatch(50.0, 1056.0), PresenceMatch(4000.0, 4500.0)]
+    gt = _gt([(49.0, 1054.0)])
+    res = compare_segments(detected, gt, tolerance=5.0)
+    assert res.matched == 1
+    assert res.missed == 0
+    assert res.spurious == 1
+
+
+def test_compare_boundary_outside_tolerance_is_not_matched():
+    # end off by 40s (> tol) -> not a match -> missed + spurious
+    detected = [PresenceMatch(50.0, 1100.0)]
+    gt = _gt([(49.0, 1054.0)])
+    res = compare_segments(detected, gt, tolerance=5.0)
+    assert res.matched == 0
+    assert res.missed == 1
+    assert res.spurious == 1

--- a/tests/test_presence_harness.py
+++ b/tests/test_presence_harness.py
@@ -1,0 +1,33 @@
+"""Unit tests for the presence validation harness (no video required)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.presence_harness import GroundTruth, GroundTruthMatch, load_ground_truth
+
+
+def test_load_ground_truth(tmp_path: Path):
+    gt_file = tmp_path / "gt.json"
+    gt_file.write_text(
+        json.dumps(
+            {
+                "source_file": "20260116/rec.mkv",
+                "tolerance_sec": 5,
+                "matches": [
+                    {"index": 1, "start_time": 49, "end_time": 1054},
+                    {"index": 2, "start_time": 1256, "end_time": 2178},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    gt = load_ground_truth(gt_file)
+    assert isinstance(gt, GroundTruth)
+    assert gt.source_file == "20260116/rec.mkv"
+    assert gt.tolerance_sec == 5.0
+    assert gt.matches == [
+        GroundTruthMatch(start=49.0, end=1054.0),
+        GroundTruthMatch(start=1256.0, end=2178.0),
+    ]

--- a/tests/test_presence_validation.py
+++ b/tests/test_presence_validation.py
@@ -1,0 +1,58 @@
+"""Slow, sample-gated OBS validation for presence detection (Phase 1 gate).
+
+Runs the presence detector on each OBS source that has a manual ground-truth
+file and asserts the GT-accuracy gate: zero missed, zero spurious, and all
+boundary errors within the GT tolerance.  Requires ALLAGANEYE_SAMPLE_VIDEO_DIR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from allaganeye.video.presence import detect_matches_by_presence
+from allaganeye.video.probe import probe_video
+from tests.presence_harness import compare_segments, load_ground_truth
+
+_GT_DIR = Path(__file__).parent / "baselines" / "v0.3.0" / "ground-truth"
+
+# Provisional thresholds (spec section 4.6). Calibrate with Idios if a gate
+# fails on real footage during Phase 1 sign-off.
+_STRIDE = 4.0
+_T_GAP = 30.0
+_T_MIN_MATCH = 120.0
+_TOL = 1.0
+_WORKERS = 8
+
+
+def _obs_gt_files() -> list[Path]:
+    return sorted(_GT_DIR.glob("obs-*.json"))
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("gt_file", _obs_gt_files(), ids=lambda p: p.stem)
+def test_obs_presence_gt_accuracy(gt_file: Path, sample_video_dir: Path) -> None:
+    gt = load_ground_truth(gt_file)
+    video = sample_video_dir / gt.source_file
+    if not video.exists():
+        pytest.skip(f"sample video not found: {video}")
+
+    duration = float(probe_video(video)["duration"])
+    detected = detect_matches_by_presence(
+        video,
+        duration,
+        stride=_STRIDE,
+        t_gap=_T_GAP,
+        t_min_match=_T_MIN_MATCH,
+        tol=_TOL,
+        workers=_WORKERS,
+    )
+    res = compare_segments(detected, gt.matches, tolerance=gt.tolerance_sec)
+
+    assert res.missed == 0, f"{gt_file.stem}: missed {res.missed} matches"
+    assert res.spurious == 0, f"{gt_file.stem}: {res.spurious} spurious matches"
+    assert res.max_boundary_error <= gt.tolerance_sec, (
+        f"{gt_file.stem}: boundary error {res.max_boundary_error:.1f}s "
+        f"> tol {gt.tolerance_sec}s"
+    )

--- a/tests/test_regression_330.py
+++ b/tests/test_regression_330.py
@@ -122,12 +122,14 @@ def _assert_match_6_end_within_tolerance(boundaries: list[MatchBoundary]) -> Non
 class TestMatch6BoundaryRegression:
     """Regression: #330 Match 6 end 35s shift resolved by #361 A3/A4."""
 
+    @pytest.mark.slow_detect
     def test_match_6_boundary_2015_within_tolerance_cpu(
         self, primary_video: Path, primary_metadata: ProbeResult
     ) -> None:
         boundaries = _run_detection(primary_video, primary_metadata, use_gpu=False)
         _assert_match_6_end_within_tolerance(boundaries)
 
+    @pytest.mark.slow_detect
     @gpu_available
     def test_match_6_boundary_2015_within_tolerance_gpu(
         self, primary_video: Path, primary_metadata: ProbeResult

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1458,6 +1458,55 @@ def test_classify_localize_both_absent_is_non_fl(monkeypatch):
     assert cls == "non_fl"
 
 
+def test_classify_localize_reprobe_rescues_to_boundary(monkeypatch):
+    # Pins the #524 re-probe rescue: the initial +1/2/3s probes both land
+    # absent (e.g. inside a fade), but the region_width-offset re-probe finds
+    # the scorebar on the pre side -> rescued from non_fl to match_boundary.
+    # Call ordering inside _classify_blackout_localize: pre (1), post (2),
+    # then pre_re (3), post_re (4) since both initial sides are not-True.
+    from allaganeye.video import scorebar as sb
+
+    calls = {"n": 0}
+    # call 1 pre absent, call 2 post absent, call 3 pre_re present, call 4 post_re absent
+    per_call_present = {1: False, 2: False, 3: True, 4: False}
+
+    def fake_probe(video, ts, height, workers, *, with_localize=False):
+        calls["n"] += 1
+        present = per_call_present[calls["n"]]
+        return ([None] * len(ts), [b"f"] * len(ts), [present] * len(ts))
+
+    monkeypatch.setattr(sb, "_probe_scorebar_context", fake_probe)
+    monkeypatch.setattr(sb, "_band_mad_min", lambda *a, **k: 1.23)
+    cls = sb._classify_blackout_localize(
+        Path("x.mp4"), (100.0, 103.0), duration=400.0, height=180, workers=1
+    )
+    # Without the re-probe block this region would be non_fl (both initial
+    # sides absent); the pre-side re-probe rescues it to match_boundary.
+    assert calls["n"] == 4  # all four probe sets were consulted
+    assert cls == "match_boundary"
+
+
+def test_classify_localize_all_none_is_unknown(monkeypatch):
+    # All probes (including the re-probe) return localize None -> the re-probe
+    # majority is None and must NOT override, leaving the side None -> unknown.
+    from allaganeye.video import scorebar as sb
+
+    monkeypatch.setattr(
+        sb,
+        "_probe_scorebar_context",
+        lambda v, ts, h, w, *, with_localize=False: (
+            [None] * len(ts),
+            [b"f"] * len(ts),
+            [None] * len(ts),
+        ),
+    )
+    monkeypatch.setattr(sb, "_band_mad_min", lambda *a, **k: 1.23)
+    cls = sb._classify_blackout_localize(
+        Path("x.mp4"), (100.0, 103.0), duration=400.0, height=180, workers=1
+    )
+    assert cls == "unknown"
+
+
 # ---------------------------------------------------------------------------
 # classify_blackout vtuber gate unit tests (Phase 2 B3)
 # ---------------------------------------------------------------------------

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1551,3 +1551,24 @@ def test_classify_blackout_obs_does_not_call_localize(monkeypatch):
     )
     out = sb.classify_blackout(Path("x.mp4"), (10.0, 12.0), 400.0, 180)
     assert out == "non_fl"
+
+
+def test_filter_threads_vtuber_to_classify(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    from allaganeye.video.capture_region import CaptureRegion
+
+    seen = []
+
+    def fake_classify(
+        video, region, duration, height, workers=None, *, band_region, vtuber
+    ):
+        seen.append((vtuber, band_region.source))
+        return "match_boundary"
+
+    monkeypatch.setattr(sb, "classify_blackout", fake_classify)
+    monkeypatch.setattr(sb, "_merge_boundary_pairs", lambda *a, **k: (a[1], a[2]))
+    band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
+    sb.filter_blackouts_with_scorebar(
+        Path("x.mp4"), [(10.0, 12.0)], 400.0, 180, band_region=band, vtuber=True
+    )
+    assert seen == [(True, "band")]

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from allaganeye.audio.matcher import BgmHit
+from allaganeye.video.capture_region import CaptureRegion
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
     _SCOREBAR_CHANNEL_STD_THRESHOLD,
@@ -1258,3 +1259,47 @@ class TestProbeScorebarContext:
         )
         assert results == [None, None]
         assert frames == [None, None]
+
+
+_W = 320
+
+
+def _solid_frame(height, fill):
+    return np.full((height, _W, 3), fill, dtype=np.uint8).tobytes()
+
+
+def test_is_static_default_uses_absolute_roi_unchanged():
+    h = 180
+    # two identical frames -> static (MAD 0) under default absolute ROI
+    frames = [_solid_frame(h, 50), _solid_frame(h, 50)]
+    assert _is_static_from_frames(frames, h) is True
+
+
+def test_is_static_band_region_argument_accepted():
+    import inspect
+
+    sig = inspect.signature(_is_static_from_frames)
+    assert "region" in sig.parameters
+    assert sig.parameters["region"].default is None
+
+
+def test_is_static_band_region_derives_from_normalized_region():
+    h = 180
+    # Build frames where the absolute scorebar ROI is identical (static) but
+    # a band region elsewhere differs between frames. With region given, the
+    # band-derived ROI must drive the MAD -> not static.
+    a = np.full((h, _W, 3), 50, dtype=np.uint8)
+    b = np.full((h, _W, 3), 50, dtype=np.uint8)
+    # Region = top-left quadrant (away from the bottom scorebar ROI).
+    region = CaptureRegion(0.0, 0.0, 0.25, 0.25)
+    bx1 = max(0, int(region.x * _W))
+    bx2 = min(_W, int((region.x + region.w) * _W))
+    by1 = max(0, int(region.y * h))
+    by2 = min(h, int((region.y + region.h) * h))
+    b[by1:by2, bx1:bx2, :] = 200  # large diff inside the band region only
+    frames = [a.tobytes(), b.tobytes()]
+
+    # Default absolute ROI sees no change -> static.
+    assert _is_static_from_frames(frames, h) is True
+    # Band region sees the change -> not static.
+    assert _is_static_from_frames(frames, h, region=region) is False

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1572,3 +1572,25 @@ def test_filter_threads_vtuber_to_classify(monkeypatch):
         Path("x.mp4"), [(10.0, 12.0)], 400.0, 180, band_region=band, vtuber=True
     )
     assert seen == [(True, "band")]
+
+
+def test_merge_gap_probe_uses_localize_when_vtuber(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    from allaganeye.video.capture_region import CaptureRegion
+
+    captured = {}
+
+    def fake_probe(video, points, height, workers, *, with_localize=False):
+        captured["with_localize"] = with_localize
+        # gap shows no scorebar by either signal -> eligible to merge.
+        return ([None] * len(points), [b"f"] * len(points), [False] * len(points))
+
+    monkeypatch.setattr(sb, "_probe_scorebar_context", fake_probe)
+    regions = [(10.0, 12.0), (30.0, 32.0)]
+    cls = ["match_boundary", "match_boundary"]
+    band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
+    merged, _merged_cls = sb._merge_boundary_pairs(
+        Path("x.mp4"), regions, cls, 400.0, 180, None, band_region=band, vtuber=True
+    )
+    assert captured["with_localize"] is True
+    assert merged == [(10.0, 32.0)]  # localize-absent gap -> merged

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -17,6 +17,7 @@ from allaganeye.video.detector import (
     _has_scorebar,
     _scaled_height,
 )
+from allaganeye.video import scorebar as sb
 from allaganeye.video.scorebar import (
     _is_static_from_frames,
     _majority_scorebar,
@@ -222,8 +223,8 @@ class TestClassifyBlackout:
         """Both sides have scorebar, not static -> in_match."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([True, True, True], [f, f, f]),  # pre
-            ([True, True, True], [f, f, f]),  # post
+            ([True, True, True], [f, f, f], [None, None, None]),  # pre
+            ([True, True, True], [f, f, f], [None, None, None]),  # post
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "in_match"
@@ -234,8 +235,8 @@ class TestClassifyBlackout:
         """Both sides scorebar, but post is static -> match_boundary."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([True, True, True], [f, f, f]),  # pre
-            ([True, True, True], [f, f, f]),  # post
+            ([True, True, True], [f, f, f], [None, None, None]),  # pre
+            ([True, True, True], [f, f, f], [None, None, None]),  # post
         ]
         mock_static.return_value = True  # post side is static screen
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
@@ -248,8 +249,8 @@ class TestClassifyBlackout:
         """Both sides scorebar, post not static but pre is -> match_boundary."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([True, True, True], [f, f, f]),  # pre
-            ([True, True, True], [f, f, f]),  # post
+            ([True, True, True], [f, f, f], [None, None, None]),  # pre
+            ([True, True, True], [f, f, f], [None, None, None]),  # post
         ]
         mock_static.side_effect = [False, True]  # post=not static, pre=static
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
@@ -261,8 +262,8 @@ class TestClassifyBlackout:
         """Pre=False, Post=True -> match_boundary (match start)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False, False, False], [f, f, f]),  # pre
-            ([True, True, True], [f, f, f]),  # post
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre
+            ([True, True, True], [f, f, f], [None, None, None]),  # post
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "match_boundary"
@@ -272,8 +273,8 @@ class TestClassifyBlackout:
         """Pre=True, Post=False -> match_boundary (match end)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([True, True, True], [f, f, f]),  # pre
-            ([False, False, False], [f, f, f]),  # post
+            ([True, True, True], [f, f, f], [None, None, None]),  # pre
+            ([False, False, False], [f, f, f], [None, None, None]),  # post
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "match_boundary"
@@ -283,10 +284,10 @@ class TestClassifyBlackout:
         """Neither side has scorebar -> non_fl (re-probe also confirms)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False, False, False], [f, f, f]),  # pre initial
-            ([False, False, False], [f, f, f]),  # post initial
-            ([False, False], [f, f]),  # pre re-probe (#524)
-            ([False, False], [f, f]),  # post re-probe (#524)
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre initial
+            ([False, False, False], [f, f, f], [None, None, None]),  # post initial
+            ([False, False], [f, f], [None, None]),  # pre re-probe (#524)
+            ([False, False], [f, f], [None, None]),  # post re-probe (#524)
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "non_fl"
@@ -295,10 +296,14 @@ class TestClassifyBlackout:
     def test_all_probes_failed(self, mock_probe):
         """All probes failed (initial+re-probe) -> unknown."""
         mock_probe.side_effect = [
-            ([None, None, None], [None, None, None]),  # pre initial
-            ([None, None, None], [None, None, None]),  # post initial
-            ([None, None], [None, None]),  # pre re-probe (#524)
-            ([None, None], [None, None]),  # post re-probe (#524)
+            ([None, None, None], [None, None, None], [None, None, None]),  # pre initial
+            (
+                [None, None, None],
+                [None, None, None],
+                [None, None, None],
+            ),  # post initial
+            ([None, None], [None, None], [None, None]),  # pre re-probe (#524)
+            ([None, None], [None, None], [None, None]),  # post re-probe (#524)
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "unknown"
@@ -308,8 +313,8 @@ class TestClassifyBlackout:
         """Pre all failed, post has scorebar -> unknown (safe side)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([None, None, None], [None, None, None]),  # pre
-            ([True, True, True], [f, f, f]),  # post
+            ([None, None, None], [None, None, None], [None, None, None]),  # pre
+            ([True, True, True], [f, f, f], [None, None, None]),  # post
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "unknown"
@@ -319,8 +324,12 @@ class TestClassifyBlackout:
         """Partial failures with majority vote."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([True, True, None], [f, f, None]),  # pre: 2/2 True
-            ([False, None, None], [f, None, None]),  # post: 1/1 False
+            ([True, True, None], [f, f, None], [None, None, None]),  # pre: 2/2 True
+            (
+                [False, None, None],
+                [f, None, None],
+                [None, None, None],
+            ),  # post: 1/1 False
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 102.0), 300.0, _HEIGHT)
         assert result == "match_boundary"
@@ -842,8 +851,8 @@ class TestClassifyBlackoutBoundary:
         """Region near start (0.5s) -> pre timestamps clamp to 0.0."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([True], [f]),  # pre: only 1 unique timestamp after dedup
-            ([True, True, True], [f, f, f]),  # post: 3 timestamps
+            ([True], [f], [None]),  # pre: only 1 unique timestamp after dedup
+            ([True, True, True], [f, f, f], [None, None, None]),  # post: 3 timestamps
         ]
         result = classify_blackout(Path("v.mp4"), (0.5, 3.0), 300.0, _HEIGHT)
         assert result == "in_match"
@@ -863,9 +872,9 @@ class TestClassifyBlackoutBoundary:
         """
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False, False, False], [f, f, f]),  # pre initial
-            ([False], [f]),  # post initial: collapsed
-            ([False, False, False], [f, f, f]),  # pre re-probe
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre initial
+            ([False], [f], [None]),  # post initial: collapsed
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre re-probe
         ]
         result = classify_blackout(Path("v.mp4"), (297.0, 299.5), 300.0, _HEIGHT)
         assert result == "non_fl"
@@ -885,10 +894,10 @@ class TestClassifyBlackoutReProbe:
         """Both pre/post initial=False -> re-probe finds post=True -> match_boundary."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False, False, False], [f, f, f]),  # pre initial
-            ([False, False, False], [f, f, f]),  # post initial
-            ([False, False, False], [f, f, f]),  # pre re-probe
-            ([True, True, True], [f, f, f]),  # post re-probe
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre initial
+            ([False, False, False], [f, f, f], [None, None, None]),  # post initial
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre re-probe
+            ([True, True, True], [f, f, f], [None, None, None]),  # post re-probe
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
         assert result == "match_boundary"
@@ -910,10 +919,18 @@ class TestClassifyBlackoutReProbe:
         """
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([None, None, None], [None, None, None]),  # pre initial
-            ([None, None, None], [None, None, None]),  # post initial
-            ([True, True, True], [f, f, f]),  # pre re-probe
-            ([False, False, False], [f, f, f]),  # post re-probe success False
+            ([None, None, None], [None, None, None], [None, None, None]),  # pre initial
+            (
+                [None, None, None],
+                [None, None, None],
+                [None, None, None],
+            ),  # post initial
+            ([True, True, True], [f, f, f], [None, None, None]),  # pre re-probe
+            (
+                [False, False, False],
+                [f, f, f],
+                [None, None, None],
+            ),  # post re-probe success False
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
         assert result == "match_boundary"
@@ -929,8 +946,8 @@ class TestClassifyBlackoutReProbe:
         """Initial pre=True (any-side True) -> re-probe skipped."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([True, True, True], [f, f, f]),  # pre initial
-            ([False, False, False], [f, f, f]),  # post initial
+            ([True, True, True], [f, f, f], [None, None, None]),  # pre initial
+            ([False, False, False], [f, f, f], [None, None, None]),  # post initial
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
         assert result == "match_boundary"
@@ -942,8 +959,8 @@ class TestClassifyBlackoutReProbe:
         """Initial post=True -> re-probe skipped."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False, False, False], [f, f, f]),  # pre initial
-            ([True, True, True], [f, f, f]),  # post initial
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre initial
+            ([True, True, True], [f, f, f], [None, None, None]),  # post initial
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
         assert result == "match_boundary"
@@ -955,10 +972,10 @@ class TestClassifyBlackoutReProbe:
         """Initial both False + re-probe both False -> non_fl preserved."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False, False, False], [f, f, f]),  # pre initial
-            ([False, False, False], [f, f, f]),  # post initial
-            ([False, False, False], [f, f, f]),  # pre re-probe
-            ([False, False, False], [f, f, f]),  # post re-probe
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre initial
+            ([False, False, False], [f, f, f], [None, None, None]),  # post initial
+            ([False, False, False], [f, f, f], [None, None, None]),  # pre re-probe
+            ([False, False, False], [f, f, f], [None, None, None]),  # post re-probe
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
         assert result == "non_fl"
@@ -970,10 +987,22 @@ class TestClassifyBlackoutReProbe:
         """Initial both None + re-probe both False -> non_fl (unknown -> non_fl)."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([None, None, None], [None, None, None]),  # pre initial
-            ([None, None, None], [None, None, None]),  # post initial
-            ([False, False, False], [f, f, f]),  # pre re-probe success False
-            ([False, False, False], [f, f, f]),  # post re-probe success False
+            ([None, None, None], [None, None, None], [None, None, None]),  # pre initial
+            (
+                [None, None, None],
+                [None, None, None],
+                [None, None, None],
+            ),  # post initial
+            (
+                [False, False, False],
+                [f, f, f],
+                [None, None, None],
+            ),  # pre re-probe success False
+            (
+                [False, False, False],
+                [f, f, f],
+                [None, None, None],
+            ),  # post re-probe success False
         ]
         result = classify_blackout(Path("v.mp4"), (100.0, 108.0), 300.0, _HEIGHT)
         assert result == "non_fl"
@@ -984,11 +1013,11 @@ class TestClassifyBlackoutReProbe:
         """Pre re-probe collapses to existing 0.0 -> skipped; post re-probe runs."""
         f = _FAKE_FRAME
         mock_probe.side_effect = [
-            ([False], [f]),  # pre initial (all 3 collapse to 0.0)
-            ([False, False, False], [f, f, f]),  # post initial
+            ([False], [f], [None]),  # pre initial (all 3 collapse to 0.0)
+            ([False, False, False], [f, f, f], [None, None, None]),  # post initial
             # pre re-probe: max(0, 0-(5+3/2/1)) = 0.0 -> dedupe vs {0.0} -> empty
             # post re-probe: 5+(5+1/2/3) = 11/12/13
-            ([True, True, True], [f, f, f]),  # post re-probe
+            ([True, True, True], [f, f, f], [None, None, None]),  # post re-probe
         ]
         # region (0.0, 5.0), duration=15, region_width=5.0
         result = classify_blackout(Path("v.mp4"), (0.0, 5.0), 15.0, _HEIGHT)
@@ -1185,7 +1214,7 @@ class TestProbeScorebarContext:
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=_FAKE_FRAME)
     def test_duplicate_timestamps_probed_once(self, mock_probe, mock_has):
         """Duplicate timestamps should be deduplicated -- probe called once."""
-        results, frames = _probe_scorebar_context(
+        results, frames, _loc = _probe_scorebar_context(
             Path("dummy.mp4"), [1.0, 1.0, 1.0], _HEIGHT, workers=1
         )
         assert mock_probe.call_count == 1
@@ -1200,7 +1229,7 @@ class TestProbeScorebarContext:
     def test_results_aligned_with_input_order(self, mock_probe, mock_has):
         """Returned lists must follow the original timestamps order."""
         ts = [3.0, 1.0, 2.0]
-        results, frames = _probe_scorebar_context(
+        results, frames, _loc = _probe_scorebar_context(
             Path("dummy.mp4"), ts, _HEIGHT, workers=2
         )
         assert len(results) == len(ts)
@@ -1212,7 +1241,7 @@ class TestProbeScorebarContext:
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=None)
     def test_probe_failure_returns_none(self, mock_probe, mock_has):
         """When _probe_frame_rgb returns None, results propagate None."""
-        results, frames = _probe_scorebar_context(
+        results, frames, _loc = _probe_scorebar_context(
             Path("dummy.mp4"), [1.0, 2.0], _HEIGHT, workers=1
         )
         assert results == [None, None]
@@ -1225,7 +1254,7 @@ class TestProbeScorebarContext:
         mock_probe.side_effect = lambda _path, t, _h: _FAKE_FRAME if t == 1.0 else None
         mock_has.side_effect = lambda raw, _h: True if raw is not None else None
 
-        results, frames = _probe_scorebar_context(
+        results, frames, _loc = _probe_scorebar_context(
             Path("dummy.mp4"), [1.0, 2.0, 1.0], _HEIGHT, workers=1
         )
         # ts=1.0 succeeds (True), ts=2.0 fails (None), ts=1.0 reuses result
@@ -1238,7 +1267,7 @@ class TestProbeScorebarContext:
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=_FAKE_FRAME)
     def test_empty_timestamps(self, mock_probe, mock_has):
         """Empty timestamps list returns empty results."""
-        results, frames = _probe_scorebar_context(
+        results, frames, _loc = _probe_scorebar_context(
             Path("dummy.mp4"), [], _HEIGHT, workers=1
         )
         assert results == []
@@ -1254,7 +1283,7 @@ class TestProbeScorebarContext:
         mock_probe.side_effect = VideoProcessingError("ffmpeg not found")
         mock_has.side_effect = lambda raw, _h: True if raw is not None else None
 
-        results, frames = _probe_scorebar_context(
+        results, frames, _loc = _probe_scorebar_context(
             Path("dummy.mp4"), [1.0, 2.0], _HEIGHT, workers=1
         )
         assert results == [None, None]
@@ -1303,3 +1332,33 @@ def test_is_static_band_region_derives_from_normalized_region():
     assert _is_static_from_frames(frames, h) is True
     # Band region sees the change -> not static.
     assert _is_static_from_frames(frames, h, region=region) is False
+
+
+def test_probe_context_3tuple_localize_none_by_default(monkeypatch):
+    # with_localize omitted -> 3rd element all None, scorebar/raw unchanged.
+    monkeypatch.setattr(sb, "_probe_frame_rgb", lambda v, t, h: f"lo{t}".encode())
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", lambda v, t: f"hi{t}".encode())
+    monkeypatch.setattr(sb, "_has_scorebar_v2", lambda raw: True)
+    # _localize_present_from_raw must NOT be called when with_localize is False.
+    monkeypatch.setattr(
+        sb,
+        "_localize_present_from_raw",
+        lambda raw: (_ for _ in ()).throw(AssertionError("must not localize")),
+    )
+    scorebar, raw, loc = sb._probe_scorebar_context(
+        Path("x.mp4"), [1.0, 2.0], height=180, workers=1
+    )
+    assert scorebar == [True, True]
+    assert raw == [b"lo1.0", b"lo2.0"]
+    assert loc == [None, None]
+
+
+def test_probe_context_with_localize_populates_3rd(monkeypatch):
+    monkeypatch.setattr(sb, "_probe_frame_rgb", lambda v, t, h: b"lo")
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", lambda v, t: f"hi{t}".encode())
+    monkeypatch.setattr(sb, "_has_scorebar_v2", lambda raw: False)
+    monkeypatch.setattr(sb, "_localize_present_from_raw", lambda raw: raw == b"hi1.0")
+    _scorebar, _raw, loc = sb._probe_scorebar_context(
+        Path("x.mp4"), [1.0, 2.0], height=180, workers=1, with_localize=True
+    )
+    assert loc == [True, False]

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1392,3 +1392,67 @@ def test_band_mad_min_returns_none_for_degenerate_band():
 
 def test_band_mad_min_none_for_under_two_frames():
     assert _band_mad_min([_rgb(180, 50)], 180) is None
+
+
+# ---------------------------------------------------------------------------
+# _classify_blackout_localize unit tests (Phase 2 B2)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_localize_truth_table(monkeypatch):
+    # Inject localize-present per probe set; assert the present-only labels.
+    from allaganeye.video import scorebar as sb
+
+    calls = {"n": 0}
+
+    def fake_probe(video, ts, height, workers, *, with_localize=False):
+        # pre call first, post call second (region_width re-probe not triggered
+        # unless both not-True).
+        calls["n"] += 1
+        present = calls["n"] == 1  # pre present, post absent -> match_boundary
+        return ([None] * len(ts), [b"f"] * len(ts), [present] * len(ts))
+
+    monkeypatch.setattr(sb, "_probe_scorebar_context", fake_probe)
+    monkeypatch.setattr(sb, "_band_mad_min", lambda *a, **k: 1.23)
+    cls = sb._classify_blackout_localize(
+        Path("x.mp4"), (100.0, 103.0), duration=400.0, height=180, workers=1
+    )
+    assert cls == "match_boundary"
+
+
+def test_classify_localize_both_present_is_in_match(monkeypatch):
+    from allaganeye.video import scorebar as sb
+
+    monkeypatch.setattr(
+        sb,
+        "_probe_scorebar_context",
+        lambda v, ts, h, w, *, with_localize=False: (
+            [None] * len(ts),
+            [b"f"] * len(ts),
+            [True] * len(ts),
+        ),
+    )
+    monkeypatch.setattr(sb, "_band_mad_min", lambda *a, **k: 5.0)
+    cls = sb._classify_blackout_localize(
+        Path("x.mp4"), (100.0, 101.0), duration=400.0, height=180, workers=1
+    )
+    assert cls == "in_match"
+
+
+def test_classify_localize_both_absent_is_non_fl(monkeypatch):
+    from allaganeye.video import scorebar as sb
+
+    monkeypatch.setattr(
+        sb,
+        "_probe_scorebar_context",
+        lambda v, ts, h, w, *, with_localize=False: (
+            [None] * len(ts),
+            [b"f"] * len(ts),
+            [False] * len(ts),
+        ),
+    )
+    monkeypatch.setattr(sb, "_band_mad_min", lambda *a, **k: 0.1)
+    cls = sb._classify_blackout_localize(
+        Path("x.mp4"), (100.0, 102.0), duration=400.0, height=180, workers=1
+    )
+    assert cls == "non_fl"

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -19,6 +19,7 @@ from allaganeye.video.detector import (
 )
 from allaganeye.video import scorebar as sb
 from allaganeye.video.scorebar import (
+    _band_mad_min,
     _is_static_from_frames,
     _majority_scorebar,
     _probe_scorebar_context,
@@ -1362,3 +1363,32 @@ def test_probe_context_with_localize_populates_3rd(monkeypatch):
         Path("x.mp4"), [1.0, 2.0], height=180, workers=1, with_localize=True
     )
     assert loc == [True, False]
+
+
+# ---------------------------------------------------------------------------
+# _band_mad_min unit tests (Phase 2 B1)
+# ---------------------------------------------------------------------------
+
+
+def _rgb(height, fill):
+    return np.full((height, _W, 3), fill, dtype=np.uint8).tobytes()
+
+
+def test_band_mad_min_absolute_roi_matches_is_static():
+    # region=None path must stay bit-exact: identical frames -> MAD 0 -> static.
+    frames = [_rgb(180, 50), _rgb(180, 50)]
+    assert _band_mad_min(frames, 180) == 0.0
+    assert _is_static_from_frames(frames, 180) is True
+
+
+def test_band_mad_min_returns_none_for_degenerate_band():
+    # a band so thin it collapses to an empty crop -> None (not nan, not 0).
+    frames = [_rgb(180, 50), _rgb(180, 90)]
+    degenerate = CaptureRegion(0.5, 0.5, 0.0, 0.0)
+    assert _band_mad_min(frames, 180, degenerate) is None
+    # _is_static_from_frames must not raise / must be False for degenerate band.
+    assert _is_static_from_frames(frames, 180, degenerate) is False
+
+
+def test_band_mad_min_none_for_under_two_frames():
+    assert _band_mad_min([_rgb(180, 50)], 180) is None

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1456,3 +1456,49 @@ def test_classify_localize_both_absent_is_non_fl(monkeypatch):
         Path("x.mp4"), (100.0, 102.0), duration=400.0, height=180, workers=1
     )
     assert cls == "non_fl"
+
+
+# ---------------------------------------------------------------------------
+# classify_blackout vtuber gate unit tests (Phase 2 B3)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_blackout_vtuber_delegates_to_localize(monkeypatch):
+    from allaganeye.video import scorebar as sb
+    from allaganeye.video.capture_region import CaptureRegion
+
+    seen = {}
+
+    def fake_localize(video, region, duration, height, workers=None, *, band_region):
+        seen["band"] = band_region
+        return "in_match"
+
+    monkeypatch.setattr(sb, "_classify_blackout_localize", fake_localize)
+    band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
+    out = sb.classify_blackout(
+        Path("x.mp4"), (10.0, 11.0), 400.0, 180, vtuber=True, band_region=band
+    )
+    assert out == "in_match"
+    assert seen["band"] is band
+
+
+def test_classify_blackout_obs_does_not_call_localize(monkeypatch):
+    from allaganeye.video import scorebar as sb
+
+    monkeypatch.setattr(
+        sb,
+        "_classify_blackout_localize",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("OBS must not localize")),
+    )
+    # vtuber defaults False -> must take the v2 path (probe returns absent here).
+    monkeypatch.setattr(
+        sb,
+        "_probe_scorebar_context",
+        lambda v, ts, h, w, *, with_localize=False: (
+            [False] * len(ts),
+            [b"f"] * len(ts),
+            [None] * len(ts),
+        ),
+    )
+    out = sb.classify_blackout(Path("x.mp4"), (10.0, 12.0), 400.0, 180)
+    assert out == "non_fl"

--- a/tests/test_scorebar_v2.py
+++ b/tests/test_scorebar_v2.py
@@ -543,7 +543,9 @@ class TestProbeScorebarContextV2:
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=b"lo")
     def test_v2_true_returns_true(self, _lo, _hi, mock_v1, _mock_v2):
         """V2 True -> True; V1 not consulted."""
-        results, frames = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
+        results, frames, _ = _probe_scorebar_context(
+            Path("v.mp4"), [1.0], 180, workers=1
+        )
         assert results == [True]
         # frames returned are LOW-RES (used for static-screen detection)
         assert frames == [b"lo"]
@@ -561,7 +563,7 @@ class TestProbeScorebarContextV2:
         frame, V2 False wins, because V1 has known FP on lobby backgrounds
         that block correct merging of match_boundary pairs (PR #313 rationale).
         """
-        results, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
+        results, _, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
         assert results == [False]
         mock_v1.assert_not_called()
 
@@ -572,7 +574,7 @@ class TestProbeScorebarContextV2:
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=b"lo")
     def test_v2_none_falls_back_to_v1(self, _lo, _hi, mock_v1, _mock_v2):
         """V2 None (e.g. opencv missing or hi-res probe failed) -> V1 result."""
-        results, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
+        results, _, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
         assert results == [True]
         mock_v1.assert_called_once()
 
@@ -583,7 +585,7 @@ class TestProbeScorebarContextV2:
     @patch(f"{SCOREBAR_MODULE}._probe_frame_rgb", return_value=b"lo")
     def test_v1_method_skips_hires_probe(self, _lo, mock_hi, _mock_v1_fn, mock_v2):
         """When METHOD=v1, no high-res probe and no V2 call."""
-        results, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
+        results, _, _ = _probe_scorebar_context(Path("v.mp4"), [1.0], 180, workers=1)
         assert results == [True]
         mock_hi.assert_not_called()
         mock_v2.assert_not_called()

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1295,6 +1295,7 @@ class TestRefineProgressBar:
             workers,
             *,
             progress_callback=None,
+            region=None,
         ):
             # Mimic Pass 2: publish total then advance per probe (#366)
             total_probes = 4
@@ -1349,6 +1350,7 @@ class TestRefineProgressBar:
             workers,
             *,
             progress_callback=None,
+            region=None,
         ):
             # Mimic Pass 2: publish total then advance per probe (#366)
             total_probes = 6

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -128,6 +128,40 @@ def test_pipeline_happy_path(mock_probe, mock_detect, mock_split, tmp_path):
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.detect_match_boundaries")
 @patch(f"{MODULE}.probe_video")
+def test_pipeline_threads_vtuber_default_false(
+    mock_probe, mock_detect, mock_split, tmp_path
+):
+    """config.vtuber=False (default) reaches detect_match_boundaries (L3 B6)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+
+    run_split(Path("input.mp4"), config)
+
+    _, detect_kwargs = mock_detect.call_args
+    assert detect_kwargs["vtuber"] is False
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
+def test_pipeline_threads_vtuber_true(mock_probe, mock_detect, mock_split, tmp_path):
+    """config.vtuber=True is threaded into detect_kwargs (L3 B6)."""
+    mock_probe.return_value = PROBE_RESULT
+    mock_detect.return_value = BOUNDARIES
+    mock_split.return_value = _output_files(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, vtuber=True)
+
+    run_split(Path("input.mp4"), config)
+
+    _, detect_kwargs = mock_detect.call_args
+    assert detect_kwargs["vtuber"] is True
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.detect_match_boundaries")
+@patch(f"{MODULE}.probe_video")
 def test_pipeline_metadata_json_content(mock_probe, mock_detect, mock_split, tmp_path):
     """metadata.json contains correct structure and values."""
     mock_probe.return_value = PROBE_RESULT

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -3584,6 +3584,8 @@ def test_verbose_cache_hit_prints_detection_params(
     # (#384 contract: audio display is driven by the helper, not
     # config.no_audio directly).
     assert "audio=frozen" in out
+    # vtuber provenance token (PR #823 R1): 検出 mode を表示に含める。
+    assert "vtuber=off" in out
 
 
 @patch(f"{MODULE}.split_video")
@@ -3636,6 +3638,53 @@ def test_verbose_cache_hit_audio_line_matches_cache_miss_path(
     tail = out[header_idx:]
     # When AUDIO_FROZEN=False and no_audio=False, audio=on.
     assert "audio=on" in tail, f"expected audio=on in cache hit summary: {tail[:400]!r}"
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_hit_prints_vtuber_on_token(
+    mock_probe, mock_split, tmp_path, capsys
+):
+    """vtuber=True で生成した cache の hit 表示は vtuber=on (provenance 可視化).
+
+    cache key fix (PR #823) で mode 混在 hit は不可能になったが、表示にも
+    provenance を出して troubleshoot 報告から検出 mode を判別可能にする。
+    """
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, vtuber=True)
+    _seed_cache(source, tmp_path, config)
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    run_split(source, config, verbose=True)
+    out = capsys.readouterr().out
+
+    header_idx = out.find("Cache hit:")
+    assert header_idx >= 0
+    assert "vtuber=on" in out[header_idx:]
+
+
+@patch(f"{MODULE}._run_detection")
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_miss_summary_includes_vtuber_token(
+    mock_probe, mock_split, mock_run_detection, tmp_path, capsys
+):
+    """cache-miss の Detecting summary に vtuber token が出る (provenance 可視化)."""
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+    mock_run_detection.return_value = BOUNDARIES
+
+    config = SplitConfig(output_dir=tmp_path, no_cache=True, vtuber=True)
+    run_split(source, config, verbose=True)
+    assert "vtuber=on" in capsys.readouterr().out
+
+    config_off = SplitConfig(output_dir=tmp_path, no_cache=True)
+    run_split(source, config_off, verbose=True)
+    assert "vtuber=off" in capsys.readouterr().out
 
 
 def test_display_cache_hit_params_malformed_json_emits_unavailable(tmp_path, capsys):

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1420,6 +1420,8 @@ class TestRefineProgressBar:
                 h,
                 w,
                 *,
+                band_region=None,
+                vtuber=False,
                 audio_hits=None,
                 stats=None,
                 progress_callback=None,

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1127,6 +1127,43 @@ class TestCacheRoundTrip:
         different_config = SplitConfig(output_dir=tmp_path / "output", no_audio=True)
         assert _load_cache(cache_path, cache_video, 1.0, different_config) is None
 
+    def test_param_mismatch_vtuber(self, cache_video, cache_config, tmp_path):
+        """標準 run の cache を vtuber run が再利用しない -> None (gate の cache bypass 防止)."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        vtuber_config = SplitConfig(output_dir=tmp_path / "output", vtuber=True)
+        assert _load_cache(cache_path, cache_video, 1.0, vtuber_config) is None
+
+    def test_param_mismatch_vtuber_reverse(self, cache_video, cache_config, tmp_path):
+        """vtuber run の cache を標準 run が再利用しない -> None (released path 保護)."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        vtuber_config = SplitConfig(output_dir=tmp_path / "output", vtuber=True)
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, vtuber_config, CACHE_BOUNDARIES
+        )
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
+
+    def test_legacy_cache_without_vtuber_key(self, cache_video, cache_config, tmp_path):
+        """vtuber key なし legacy cache: 標準 run は有効 (後方互換)、vtuber run は無効。
+
+        --vtuber 導入前の cache はすべて標準 path の結果なので missing = False と
+        同値に扱う (既存ユーザーの cache を無駄に invalidate しない)。
+        """
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        data["params"].pop("vtuber", None)
+        cache_path.write_text(json.dumps(data), encoding="utf-8")
+        assert (
+            _load_cache(cache_path, cache_video, 1.0, cache_config) == CACHE_BOUNDARIES
+        )
+        vtuber_config = SplitConfig(output_dir=tmp_path / "output", vtuber=True)
+        assert _load_cache(cache_path, cache_video, 1.0, vtuber_config) is None
+
     def test_version_mismatch(self, cache_video, cache_config, tmp_path):
         """cache_version mismatch -> None."""
         cache_path = tmp_path / "output" / ".detection_cache.json"

--- a/tests/test_vtuber_region_e2e.py
+++ b/tests/test_vtuber_region_e2e.py
@@ -1,0 +1,111 @@
+"""VTuber scorebar 帯 anchor + 帯 crop の end-to-end 受け入れ (L3 Phase 1 D2).
+
+slow_detect マーカー: 実 VTuber VOD 必須、CI default deselect。
+VTuber サンプルは ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER (既定 E:/allaganeye-samples)。
+
+本テストは Phase 1 の *wiring* (Stage 0 帯 anchor -> Stage 1 帯 crop brightness)
+が実 VTuber VOD でクラッシュせず成立することを示す demonstrated-level 検証。
+band anchor が localize できるか自体は Phase 2/3 の calibration 課題なので、
+どの VOD でも localize しない場合は skip する (Phase 1 の wiring bug ではない)。
+guard verify は大容量 VTuber VOD を FP で弾くため owner override 運用、PYTHONUTF8=1。
+"""
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from allaganeye.video.capture_region import CaptureRegion
+
+pytestmark = pytest.mark.slow_detect
+
+_VTUBER_DIR = Path(
+    os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER", r"E:/allaganeye-samples")
+)
+
+
+def _vtuber_vods() -> list[Path]:
+    if not _VTUBER_DIR.exists():
+        return []
+    return sorted(_VTUBER_DIR.glob("*.mp4"))
+
+
+def _first_localizable_vod() -> "tuple[Path, CaptureRegion] | None":
+    """band anchor が non-FULL_FRAME を返す最初の VOD と region を探す。
+
+    見つからなければ None (全 VOD で localize 不成立 -> Phase 2/3 課題)。
+    """
+    from allaganeye.video import detector as det
+    from allaganeye.video.probe import probe_video
+
+    for vod in _vtuber_vods():
+        try:
+            meta = probe_video(vod)
+            region = det._resolve_detect_region(vod, meta["duration"])
+        except Exception:  # noqa: S112 - best-effort discovery; a bad VOD just skips
+            continue
+        if not region.is_full_frame():
+            return vod, region
+    return None
+
+
+@pytest.mark.skipif(not _vtuber_vods(), reason="VTuber sample VOD not available")
+def test_band_anchor_resolves_or_degrades_safely():
+    """全 VTuber VOD で _resolve_detect_region がクラッシュせず CaptureRegion を返す。
+
+    band anchor は (a) inset 帯を localize して non-FULL_FRAME を返すか、
+    (b) localize 不成立で FULL_FRAME に安全縮退する。どちらでもクラッシュは不可。
+    """
+    from allaganeye.video import detector as det
+    from allaganeye.video.capture_region import CaptureRegion
+    from allaganeye.video.probe import probe_video
+
+    vods = _vtuber_vods()
+    for vod in vods:
+        meta = probe_video(vod)
+        region = det._resolve_detect_region(vod, meta["duration"])
+        assert isinstance(region, CaptureRegion)
+        # 帯 ROI なら source="band"、縮退なら FULL_FRAME (source="fallback")
+        assert region.source in ("band", "fallback")
+
+
+def test_band_crop_brightness_differs_from_full_frame_when_localized():
+    """band anchor が localize できた VOD で、帯 crop 輝度と full-frame 輝度が
+    実際に異なる ROI を測っていることを示す (帯限定が効いている証拠)。
+
+    どの VOD でも localize しない場合は skip (Phase 2/3 calibration へ)。
+    """
+    found = _first_localizable_vod()
+    if found is None:
+        pytest.skip(
+            "no VTuber VOD localized a scorebar band (Phase 2/3 calibration); "
+            "Phase 1 wiring is exercised by test_band_anchor_resolves_or_degrades_safely"
+        )
+    vod, region = found
+    from allaganeye.video import detector as det
+    from allaganeye.video.capture_region import region_mean
+
+    # probe one hi-res in-match frame at the VOD midpoint
+    from allaganeye.video.probe import probe_video
+
+    meta = probe_video(vod)
+    raw = det._probe_frame_rgb_hires(vod, meta["duration"] / 2.0)
+    assert raw is not None, "midpoint hi-res probe failed"
+
+    import numpy as np
+
+    frame = np.frombuffer(raw, dtype=np.uint8).reshape(
+        det._SCOREBAR_V2_PROBE_HEIGHT, det._SCOREBAR_V2_PROBE_WIDTH, 3
+    )
+    # grayscale for brightness comparison (same as detector's gray decode intent)
+    gray = frame.mean(axis=2)
+    full = float(gray.mean())
+    band = region_mean(gray, region)
+    # band ROI is a thin top strip; on an in-match frame it should measure a
+    # different mean than the whole frame (proves the crop targets a sub-region).
+    assert band != full, (
+        f"band crop ({band:.2f}) equals full-frame mean ({full:.2f}); "
+        f"crop may not be targeting the scorebar band (region={region})"
+    )

--- a/tests/test_vtuber_region_e2e.py
+++ b/tests/test_vtuber_region_e2e.py
@@ -1,6 +1,6 @@
 """VTuber scorebar 帯 anchor + 帯 crop の end-to-end 受け入れ (L3 Phase 1 D2).
 
-slow_detect マーカー: 実 VTuber VOD 必須、CI default deselect。
+slow + slow_detect マーカー: 実 VTuber VOD 必須、CI default deselect。
 VTuber サンプルは ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER (既定 E:/allaganeye-samples)。
 
 本テストは Phase 1 の *wiring* (Stage 0 帯 anchor -> Stage 1 帯 crop brightness)
@@ -19,7 +19,7 @@ import pytest
 if TYPE_CHECKING:
     from allaganeye.video.capture_region import CaptureRegion
 
-pytestmark = pytest.mark.slow_detect
+pytestmark = [pytest.mark.slow, pytest.mark.slow_detect]
 
 _VTUBER_DIR = Path(
     os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER", r"E:/allaganeye-samples")

--- a/tests/test_vtuber_region_e2e.py
+++ b/tests/test_vtuber_region_e2e.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 pytestmark = [pytest.mark.slow, pytest.mark.slow_detect]
 
 _VTUBER_DIR = Path(
-    os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER", r"E:/allaganeye-samples")
+    os.environ.get("ALLAGANEYE_SAMPLE_VIDEO_DIR_VTUBER") or r"E:/allaganeye-samples"
 )
 
 


### PR DESCRIPTION
## 概要

masked-OBS 検出対応 (#821) の Phase 分割 PR (a)/(b) のうち **(a) 土台**。VTuber/masked 共有の検出土台 Phase 0/1/2 を develop-0.3.0 に提出する。masked-OBS 本体 (spec/plan + A1-A8) は本 PR land 後に PR (b) として提出する。

- **Phase 0**: 検出 subsystem 現状 map (`docs/detection-map.md`: layer インベントリ / git 考古学 / load-bearing 判定 / coupling 図)
- **Phase 1**: presence 検出エンジン (`video/presence.py` + GT 検証ハーネス) と scorebar 帯 anchor/crop (`video/capture_region.py`、Pass1/Pass2/GPU brightness の region 経由化)
- **Phase 2**: localize 分類器 (`_classify_blackout_localize`、filter / merge gap probe / trailing-drop の vtuber gate 配線)
- 設計 spec: presence ベース検出エンジン / 2 信号 fusion 再アーキ (presence 全置換見直しの経緯含む)

59 commits / 37 files / +7713 −134 (単一 PR 閾値超過のため #821 を 2 PR に Phase 分割)。

## OBS 標準 path の bit-exact 保証 (設計の核)

- 新機構はすべて**明示 `--vtuber` gate 内** (Phase 1 B4-rev で確定)。gate なし = 現行 path を構造保証
- Pass1/Pass2/GPU の brightness region 経由化は FULL_FRAME 既定で bit-exact (B1/B2/B3)
- `--vtuber` flag は **hidden** (/iterate-review Round 1 で PR (b) A6 から前倒し)。PR (b) (A6) は `--masked` との排他のみを追加する

## Pre-flight (Iron Law 6) 記録

- Step 0/4: #821 の open/all PR 重複なし (作成直前に再確認済み)
- Step 1: origin/develop-0.3.0 (30b2ccb #819) へ rebase 済み (52 commits clean replay)
- Step 2/3: base 先行 commit = #819 のみ。**file 交差ゼロだが機能交差 1 件検出**: #819 の slow superset guard が `test_vtuber_region_e2e.py` の `slow_detect` 単独 marker を collection exit 4 で reject → PR 内 fix (0731d2d、slow superset 追加)
- Step 5: `/codex:adversarial-review` 実施 → verdict needs-attention / **HIGH 1 件を PR 内修正** (aef8fce):
  - **Detection cache が vtuber mode を key に含めず、`--vtuber` cache を標準 run が再利用しうる (明示 gate の cache bypass)** → `_save_cache`/`_load_cache` に vtuber を配線 + mode-switch / legacy 後方互換テスト 3 件 (TDD RED→GREEN)。key なし legacy cache は `--vtuber` 導入前 = 標準 path の結果なので False と同値に扱い、既存ユーザーの cache を invalidate しない
  - 同型の穴は PR (b) の `masked` にもある → PR (b) で `masked` を cache key に追加予定 (実機検証時に手動 `--no-cache` で回避していた運用の構造的解消)
- /iterate-review Round 1: (A) 5 件 (うち 2 件は (A)* user gate で対応単位を確定) を PR 内修正 (e9de049)。vtuber provenance の metadata schema 拡張のみ PR (b) 一括に deferred (下記 Deferred Findings)
- /iterate-review Round 2: (A) 3 件を PR 内修正 (7da1518): detect 側 cache-miss にも Detecting summary を mirror (vtuber token) / slow_detect under-marking 3 件追補 (-m slow_detect 27 → 30) / detection-map.md の hard line refs を symbol 参照化
- /iterate-review Round 3: (A) 2 件を PR 内修正 (d8cffe0): scan_presence の per-probe 例外隔離 (1 probe 失敗で全 scan abort しない + 全 probe 失敗は fail-loud) / RGB→localize boilerplate 3 箇所を localize_from_rgb_bytes helper に dedup
- /iterate-review Round 4: (A) 3 件を PR 内修正 (5cdd8f5): raw-None decode 系統故障も fail-loud 判定に乗せる (raise_on_probe_failure seam) / anchor 縮退の logging (warning + debug、挙動不変) / verbose 出力例の doc 追従 (cli-spec ×2 + output-spec ×1、workers=auto 既存 drift 含む)。bit-exact 再実機は「全修正が検出計算非接触」の論証維持で省略 (Idios 判断 2026-06-12)
- /iterate-review Round 5 (cap): 縮退×silent/loud 契約クラスの 3 周収斂を検知 (whack-a-mole 早期停止)。Idios 判断 (2026-06-13) = 最小可視化 patch 3 件 (95fc2d1: consensus-miss warning / refine probe 失敗 warning / 部分故障集計 warning) + 設計 issue #824 起票 (probe-failure semantics 統一契約)。doc 空白 drift 1 件も同 commit で修正

## Self-Test Report

machine-verified (本 PR tree で実施):

- [x] `python -m pytest` → **1388 passed**, 1 skipped, 60 deselected (exit 0、#819 guard 含む。Round 5 後に再実行)
- [x] `python -m ruff check .` → All checks passed
- [x] `python -m ruff format --check .` → 131 files already formatted
- [x] `python -m pyright` → 0 errors, 0 warnings
- [x] `bash scripts/check-markdownlint.sh` → 0 errors
- [x] `python -m pytest -m slow_detect --collect-only` → 30 selected (slow 配線健全、R2 で under-marking 3 件追補)
- [x] `git diff 142906e 0731d2d -- allaganeye/` → empty (rebase + marker fix は production code 無変更)

machine-verified (実機 @ RTX 5090、branch tip b516792 = 本 PR 内容 + masked A1-A8 stack で実施。詳細は #821):

- [x] OBS baseline bit-exact: `test_v030_baseline_regression::test_class_a_bit_exact` 4/4 PASS
- [x] masked 3 サンプル実機 detect (13/8/25 matches、全滅なし — PR (b) 機能の先行 evidence)

machine-unverifiable:

- verified lineage (b516792) との production code 差分は cache key fix (aef8fce) + Round 1/2 の verbose token / hidden 化 (e9de049, 7da1518) + Round 3 の presence 例外隔離 / localize_from_rgb_bytes dedup (d8cffe0) + Round 4 の raw-None fail-loud / anchor 縮退 logging (5cdd8f5) + Round 5 の縮退可視化 warning 3 件 (95fc2d1)。いずれも検出アルゴリズムの計算内容に非接触 (cache 再利用判定・verbose 表示・CLI help・例外経路・等価 refactor) で、bit-exact 計測 (cache 不使用の tmp 環境で実行) に影響しない。dedup の等価性は既存 unit (capture_region 46 / presence 19 / scorebar / detector) で担保

## 関連

- Refs #821 (masked-OBS feature、Phase 分割 (a))
- Refs #753 (L3 配信形式対応 parent、re-plan)
- 後続: PR (b) = masked-OBS 本体 (8a0498b..b516792 の rebase + masked cache key + vtuber/masked metadata schema 一括 bump + A6 排他) / follow-up #822 (localize 過分割精緻化)

session: l3-p2-region-detection

<!-- iterate-review:deferred:start -->
## Deferred Findings (managed by /iterate-review)

- [A]* Round 1: vtuber/masked provenance の metadata schema 拡張 (detection_params + codegen + GUI zod + metadata-spec の 4 層連鎖) → deferred-to: #821 PR (b) で vtuber/masked 一括 bump (Idios 判断 2026-06-12)
- [A]* Round 5: probe-failure semantics の統一契約 (presence/anchor 縮退の tri-state 化等、R3-R5 で 3 周収斂した設計クラス) → deferred-to: #824 (新規設計 issue、Idios 判断 2026-06-13。R5 では最小可視化 patch のみ実施)

<!-- iterate-review:deferred:end -->