### PR TITLE
ci: sh test 配線 + branch pin の develop-* 化 (Refs #816)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,8 @@
 gui/src/types/metadata.generated.ts text eol=lf
 allaganeye/metadata_types.py text eol=lf
 schemas/metadata.schema.json text eol=lf
+
+# error-hints fixtures are byte-compared test vectors: tests/scripts/test_extract_*.sh
+# diff awk output (always LF) against expected-*.tsv. Force LF so a Windows
+# autocrlf=true checkout does not produce false drift FAILs (#816).
+tests/fixtures/error-hints/* text eol=lf

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -113,7 +113,7 @@ validate-checklist は plain bullet `-` を無視するため未実施でもブ�
 ## 関連
 
 - Refs #
-- Base branch: `develop-0.2.0`
+- Base branch: `develop-x.y.z` <!-- 現行の開発 branch に置換 -->
 - Session: <!-- 例: relaxed-mestorf-9807da -->
 
 ## 備考 (任意)

--- a/.github/workflows/check-pr-checklist-test.yml
+++ b/.github/workflows/check-pr-checklist-test.yml
@@ -7,10 +7,11 @@ on:
       - '.github/scripts/check-pr-checklist.test.js'
       - '.github/workflows/check-pr-checklist-test.yml'
   push:
-    branches: [develop-0.2.0, main]
+    branches: [main, "develop-*"]
     paths:
       - '.github/scripts/check-pr-checklist.js'
       - '.github/scripts/check-pr-checklist.test.js'
+      - '.github/workflows/check-pr-checklist-test.yml'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,25 @@ jobs:
       - name: Hook tests
         run: pytest tests/hooks/ -v --tb=short
 
+      # tests/scripts/test_*.sh は .github/scripts/ の error-hint-drift 検査
+      # (check-error-hint-drift.sh / extract-*.awk) の test harness。
+      # audit 2026-06-10 P3「CI 参照ゼロ」対応 (#816)。glob 配線にして
+      # 将来の test_*.sh 追加忘れを防ぎ、空 glob は配線退行として fail させる。
+      - name: Shell test harness (tests/scripts/test_*.sh)
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tests=(tests/scripts/test_*.sh)
+          if (( ${#tests[@]} == 0 )); then
+            echo "::error::tests/scripts/test_*.sh matched no files (wiring regression, audit 2026-06-10 P3 / #816)"
+            exit 1
+          fi
+          for t in "${tests[@]}"; do
+            echo "=== ${t} ==="
+            bash "$t"
+          done
+
   gui-frontend:
     runs-on: ubuntu-latest
     steps:

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -679,14 +679,14 @@ Claude Code のセッション用 worktree はセッション終了時に `git w
 
 `scripts/cleanup-claude-branches.sh --apply` が `git branch -D` で削除する条件 (#708):
 
-- **AND 1 (merged)**: いずれかの `origin/develop-*` または `origin/main` の祖先 (`git merge-base --is-ancestor`。#816 で develop-0.2.0 固定から一般化)
+- **AND 1 (merged)**: 最新 (`sort -V`) の `origin/develop-*` または `origin/main` の祖先 (`git merge-base --is-ancestor`。#816 で develop-0.2.0 固定から一般化。stale な旧 develop ref を merge 根拠にしないため最新のみを採用)
 - **AND 2 (active 参照なし)**: `git worktree list --porcelain` の `branch refs/heads/...` 集合に含まれない
 - **AND 3 (24h cooldown)**: 最終 commit (`git log -1 --format=%ct`) が 24h 以上前
 - **prefix 限定**: `claude/` のみ (= `feature/xxx` 等の手動 branch は対象外)
 
 **評価順序**: AND 2 → AND 1 → AND 3 (cost-efficient: AND 2 は local hash lookup で安価、AND 1 / AND 3 は git subprocess を spawn するため後回し)。最初に fail した条件が `kept <branch> (reason: not-merged | active | cooldown)` の reason として記録される。
 
-`origin/develop-*` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。`git fetch` は hook 内で実行せず、user の通常運用 (`git pull`) を前提とする。
+最新の `origin/develop-*` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。`git fetch` は hook 内で実行せず、user の通常運用 (`git pull`) を前提とする。
 
 ### 手動実行
 
@@ -727,7 +727,7 @@ Stop hook は**自セッションのディレクトリを sweep しない**。�
 
 `rmdir` のみを使用するため、アクティブな worktree や何らかのファイルが残っているディレクトリは**削除されない**。想定外のファイルが残っているディレクトリは出力で明示されるため、必要に応じて手動で確認する。Stop hook が起動中のセッションのアクティブ worktree は `.git` 参照で保護されるため安全に skip される。Windows のディレクトリハンドル保持問題 (#477 コメント) は上記 2 段階設計により回避している。
 
-`cleanup-claude-branches.sh` も同様に明示的に安全な AND 3 条件 (merged + active 参照なし + 24h cooldown) + `claude/` prefix 限定下でのみ `git branch -D` を実行し、merged 保証により data loss しない。`origin/develop-*` / `origin/main` が未 fetch なら `is-ancestor` false に倒れて keep する設計のため、fetch されていない開発環境でも安全に動作する。
+`cleanup-claude-branches.sh` も同様に明示的に安全な AND 3 条件 (merged + active 参照なし + 24h cooldown) + `claude/` prefix 限定下でのみ `git branch -D` を実行し、merged 保証により data loss しない。最新の `origin/develop-*` / `origin/main` が未 fetch なら `is-ancestor` false に倒れて keep する設計のため、fetch されていない開発環境でも安全に動作する。
 
 ## brainstorming sweep 規約 (#746 教訓)
 

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -679,14 +679,14 @@ Claude Code のセッション用 worktree はセッション終了時に `git w
 
 `scripts/cleanup-claude-branches.sh --apply` が `git branch -D` で削除する条件 (#708):
 
-- **AND 1 (merged)**: `origin/develop-0.2.0` または `origin/main` の祖先 (`git merge-base --is-ancestor`)
+- **AND 1 (merged)**: いずれかの `origin/develop-*` または `origin/main` の祖先 (`git merge-base --is-ancestor`。#816 で develop-0.2.0 固定から一般化)
 - **AND 2 (active 参照なし)**: `git worktree list --porcelain` の `branch refs/heads/...` 集合に含まれない
 - **AND 3 (24h cooldown)**: 最終 commit (`git log -1 --format=%ct`) が 24h 以上前
 - **prefix 限定**: `claude/` のみ (= `feature/xxx` 等の手動 branch は対象外)
 
 **評価順序**: AND 2 → AND 1 → AND 3 (cost-efficient: AND 2 は local hash lookup で安価、AND 1 / AND 3 は git subprocess を spawn するため後回し)。最初に fail した条件が `kept <branch> (reason: not-merged | active | cooldown)` の reason として記録される。
 
-`origin/develop-0.2.0` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。`git fetch` は hook 内で実行せず、user の通常運用 (`git pull`) を前提とする。
+`origin/develop-*` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。`git fetch` は hook 内で実行せず、user の通常運用 (`git pull`) を前提とする。
 
 ### 手動実行
 
@@ -727,7 +727,7 @@ Stop hook は**自セッションのディレクトリを sweep しない**。�
 
 `rmdir` のみを使用するため、アクティブな worktree や何らかのファイルが残っているディレクトリは**削除されない**。想定外のファイルが残っているディレクトリは出力で明示されるため、必要に応じて手動で確認する。Stop hook が起動中のセッションのアクティブ worktree は `.git` 参照で保護されるため安全に skip される。Windows のディレクトリハンドル保持問題 (#477 コメント) は上記 2 段階設計により回避している。
 
-`cleanup-claude-branches.sh` も同様に明示的に安全な AND 3 条件 (merged + active 参照なし + 24h cooldown) + `claude/` prefix 限定下でのみ `git branch -D` を実行し、merged 保証により data loss しない。`origin/develop-0.2.0` / `origin/main` が未 fetch なら `is-ancestor` false に倒れて keep する設計のため、fetch されていない開発環境でも安全に動作する。
+`cleanup-claude-branches.sh` も同様に明示的に安全な AND 3 条件 (merged + active 参照なし + 24h cooldown) + `claude/` prefix 限定下でのみ `git branch -D` を実行し、merged 保証により data loss しない。`origin/develop-*` / `origin/main` が未 fetch なら `is-ancestor` false に倒れて keep する設計のため、fetch されていない開発環境でも安全に動作する。
 
 ## brainstorming sweep 規約 (#746 教訓)
 

--- a/docs/superpowers/plans/2026-06-12-audit-w1-n1.md
+++ b/docs/superpowers/plans/2026-06-12-audit-w1-n1.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**注記 (2026-06-13 Pre-flight Step 5)**: 本 plan は point-in-time の実行 artifact。Codex adversarial-review の HIGH finding (stale な旧 `origin/develop-*` remote-tracking ref を merge 根拠に誤削除しうる) を受け、merge base は plan 記載の「全 `origin/develop-*`」から「**sort -V 最新の `origin/develop-*` + `origin/main`**」へ変更した (Idios 承認 2026-06-13)。実装確定の正は `scripts/cleanup-claude-branches.sh` と `tests/hooks/test_cleanup_claude_branches.py` (Scenario 6-10) を参照。
+**注記 (2026-06-13 Pre-flight Step 5)**: 本 plan は point-in-time の実行 artifact。Codex adversarial-review の HIGH finding (stale な旧 `origin/develop-*` remote-tracking ref を merge 根拠に誤削除しうる) を受け、merge base は plan 記載の「全 `origin/develop-*`」から「**sort -V 最新の `origin/develop-*` + `origin/main`**」へ変更した (Idios 承認 2026-06-13)。実装確定の正は `scripts/cleanup-claude-branches.sh` と `tests/hooks/test_cleanup_claude_branches.py` (Scenario 6-11) を参照。
 
 **Goal:** CI 未配線の sh test harness 3 本を ci.yml に配線し、develop-0.2.0 固定 pin (cleanup script / checklist-test workflow / PR template) を develop-\* 一般化または placeholder 化する。あわせて Windows checkout で sh test が偽 FAIL する CRLF 問題を .gitattributes で恒久解消する。
 

--- a/docs/superpowers/plans/2026-06-12-audit-w1-n1.md
+++ b/docs/superpowers/plans/2026-06-12-audit-w1-n1.md
@@ -1,0 +1,559 @@
+# Audit Remediation Wave 1 — N1 (#816) CI guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** CI 未配線の sh test harness 3 本を ci.yml に配線し、develop-0.2.0 固定 pin (cleanup script / checklist-test workflow / PR template) を develop-\* 一般化または placeholder 化する。あわせて Windows checkout で sh test が偽 FAIL する CRLF 問題を .gitattributes で恒久解消する。
+
+**Architecture:** (1) `cleanup-claude-branches.sh` の merged 判定を「`origin/develop-*` 列挙 + `origin/main`」に一般化 (TDD: 新 pin test の red を旧 script で実証 → 修正 → green)。(2) ci.yml `hook-test` job に glob ベースの sh test 実行 step を追加 (空 glob guard 付き、発火側の red をローカル simulation で実証)。(3) `check-pr-checklist-test.yml` push trigger を `develop-*` 化 + workflow 自身を push paths に追加 (AC「develop-0.3.0 への push で走る」をマージ後に機械観測可能にする)。挙動を明文化している `docs/l2-workflow.md` 3 箇所を同 PR で同期する。
+
+**Tech Stack:** GitHub Actions (ubuntu-latest bash) / bash (Git Bash, mapfile / for-each-ref) / pytest (tests/hooks/ の subprocess fixture) / .gitattributes (eol=lf)
+
+**元 issue:** #816。受け入れ条件は spec [`docs/superpowers/specs/2026-06-10-audit-remediation-design.md`](../specs/2026-06-10-audit-remediation-design.md) §N1「受け入れ条件案」を正式 AC として逐条検証する (#812/#815 で確立した運用):
+
+1. CI green
+2. sh test 3 本が CI ログに出る
+3. develop-0.3.0 への push で checklist-test が走る
+
+**スコープ追加 2 件 (2026-06-12 Idios 承認済み、AskUserQuestion 実施)**: (a) `.gitattributes` に error-hints fixture の `eol=lf` 追加 (CRLF 偽 FAIL 恒久対策)、(b) `.github/pull_request_template.md:116` の `Base branch: develop-0.2.0` を `develop-x.y.z` placeholder 化 (audit 未記載の同類 stale pin 3 件目)。
+
+**前提条件 / 事実 (2026-06-12 実測):**
+
+- main worktree = `develop-0.3.0` @ b80e71d (clean)。session-id: `audit-w1-n1-20260612`、branch: `claude/audit-w1-n1`
+- `origin/develop-0.2.0` は**既に origin から消失** (`git for-each-ref 'refs/remotes/origin/develop-*'` → `origin/develop-0.3.0` のみ)。現行 script の AND 1 は origin/main 経由でしか成立しない
+- sh test 3 本は **LF コンテンツでは 3 本とも PASS** (git blob を process substitution で食わせる CI 相当実験で確認済み)。working tree (autocrlf=true, CRLF) では `test_extract_doc_hints.sh` / `test_extract_rust_hints.sh` の 2 本が偽 FAIL (expected-\*.tsv の CRLF vs awk 出力の LF)
+- `python -m pytest tests/hooks/ -q` → 40 passed (ローカル green baseline)
+- `tests/hooks/conftest.py` の tmp_repo は develop-0.2.0 ベースで構築 + `refs/remotes/origin/develop-0.2.0` を mirror → 一般化後も既存 40 テストはそのまま green (develop-0.2.0 は develop-\* にマッチ)
+- shellcheck はローカル未導入 → `pip install shellcheck-py` で検証 (pyproject には追加しない)。CI には shellcheck job (severity warning) あり
+- `check-pr-checklist.js` は PR 本文の `Base branch:` 行を検証しない (placeholder 化は表示のみの変更)
+- lint/型チェックは `python -m ruff` / `python -m pyright allaganeye gui tests scripts` (PATH に直接ない + stale worktree noise 回避)。markdownlint は `bash scripts/check-markdownlint.sh` の出力を変更ファイル名で grep して判定
+- lint と commit を `;` / `&&` で同一行連結しない (運用ルール)
+
+---
+
+## File Structure
+
+| 区分 | path | 責務 |
+| --- | --- | --- |
+| Create | `docs/superpowers/plans/2026-06-12-audit-w1-n1.md` | 本 plan (PR 先頭 commit に同梱) |
+| Modify | `scripts/cleanup-claude-branches.sh:7,92-98` | merged 判定の develop-\* 一般化 + header comment |
+| Modify | `tests/hooks/test_cleanup_claude_branches.py` (末尾追記) | 一般化 pin test (Scenario 6) + 安全側 fallback test (Scenario 7) |
+| Modify | `docs/l2-workflow.md:682,689,730` | AND 1 条件記述の同期 |
+| Modify | `.github/workflows/ci.yml` (hook-test job 末尾) | sh test harness 実行 step (glob + 空 glob guard) |
+| Modify | `.gitattributes` (末尾追記) | error-hints fixture の eol=lf 固定 |
+| Modify | `.github/workflows/check-pr-checklist-test.yml:9-13` | push trigger の develop-\* 化 + 自己 path 追加 |
+| Modify | `.github/pull_request_template.md:116` | Base branch 行の placeholder 化 |
+
+---
+
+## Task 1: branch 作成 + plan 同梱 commit (controller 実行)
+
+**Files:**
+
+- Add: `docs/superpowers/plans/2026-06-12-audit-w1-n1.md` (本 plan、作成済み・未コミット)
+
+- [ ] **Step 1: clean 確認と branch 作成**
+
+```bash
+cd /e/projects/kobutachan-tools/kobutachan-allaganeye
+pwd && git branch --show-current   # develop-0.3.0 であること
+git status --short                 # untracked が本 plan のみであること
+git fetch origin develop-0.3.0
+git checkout -b claude/audit-w1-n1 origin/develop-0.3.0
+```
+
+Expected: branch `claude/audit-w1-n1` が最新 base から作成される。
+
+- [ ] **Step 2: plan を commit**
+
+```bash
+git add docs/superpowers/plans/2026-06-12-audit-w1-n1.md
+git commit -F - <<'EOF'
+doc: N1 CI guard の実装 plan を追加 (Refs #816)
+
+audit remediation Wave 1 N1。spec §N1 の just-in-time plan
+(対象ファイル実測 2026-06-12 + スコープ追加 2 件の Idios 承認を反映)。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+Expected: commit 成功 (docs のみの単一 scope)。
+
+## Task 2: cleanup-claude-branches.sh の develop-\* 一般化 (TDD)
+
+**Files:**
+
+- Modify: `tests/hooks/test_cleanup_claude_branches.py` (末尾に Scenario 6/7 追記)
+- Modify: `scripts/cleanup-claude-branches.sh:7,92-98`
+- Modify: `docs/l2-workflow.md:682,689,730`
+
+- [ ] **Step 1: failing pin test を書く (Scenario 6) + 安全側 fallback test (Scenario 7)**
+
+`tests/hooks/test_cleanup_claude_branches.py` の末尾 (`test_empty_branch_list_emits_zero_summary` の後) に追加:
+
+```python
+# ---------- Scenario 6: origin/develop-0.3.0 のみ存在 (develop-* 一般化, #816) ----------
+
+
+def test_merged_to_newer_develop_branch_deleted(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+) -> None:
+    """develop-0.2.0 が origin から消えても現行 origin/develop-* で merged 判定できる (#816).
+
+    実環境の再現: origin/develop-0.2.0 は v0.2.x 期の後に削除済みで、
+    origin/develop-0.3.0 のみが存在する。旧実装 (develop-0.2.0 固定) では
+    not-merged 扱いで永遠に kept になる (audit 2026-06-10 P3)。
+    """
+    import subprocess
+
+    make_claude_branch("scenario6", merged=True, age_seconds=86400 * 2)
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/develop-0.3.0", "HEAD"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "-d", "refs/remotes/origin/develop-0.2.0"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    deleted = _of_event(result.ndjson, "deleted")
+    assert any(e["name"] == "claude/scenario6" for e in deleted), result.stdout
+
+
+# ---------- Scenario 7: origin/develop-* も origin/main も無い -> 安全側 keep ----------
+
+
+def test_no_develop_remote_refs_keeps_branch(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+) -> None:
+    """origin/develop-* が 1 本も無く origin/main も無い場合は not-merged で keep (安全側)."""
+    import subprocess
+
+    make_claude_branch("scenario7", merged=True, age_seconds=86400 * 2)
+    subprocess.run(
+        ["git", "update-ref", "-d", "refs/remotes/origin/develop-0.2.0"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    kept = _of_event(result.ndjson, "kept")
+    assert any(
+        e["name"] == "claude/scenario7" and e["reason"] == "not-merged" for e in kept
+    ), result.stdout
+```
+
+- [ ] **Step 2: red を確認 (Scenario 6 のみ fail、Scenario 7 は旧実装でも pass)**
+
+```bash
+python -m pytest tests/hooks/test_cleanup_claude_branches.py -q
+```
+
+Expected: `1 failed, 9 passed` — fail は `test_merged_to_newer_develop_branch_deleted` (旧実装は origin/develop-0.2.0 固定のため kept reason=not-merged になる)。これが一般化の red 実証。
+
+- [ ] **Step 3: script を一般化**
+
+`scripts/cleanup-claude-branches.sh` line 7 の header comment を変更:
+
+```text
+#   1. merged: ancestor of any origin/develop-* branch or origin/main
+```
+
+line 82 (`done < <(git -C "$REPO_ROOT" worktree list --porcelain)`) の直後・`for branch in` ループの前に追加:
+
+```bash
+# AND 1 merge bases: 全 origin/develop-* (現行/将来の開発 branch) + origin/main (#816)。
+# 固定 pin (develop-0.2.0) だと release 後に新 develop branch へ merge された
+# branch が永遠に not-merged 扱いになる (audit 2026-06-10 P3)。
+mapfile -t MERGE_BASES < <(git -C "$REPO_ROOT" for-each-ref --format='%(refname:short)' 'refs/remotes/origin/develop-*')
+MERGE_BASES+=("origin/main")
+```
+
+既存の AND 1 ブロック (lines 92-98):
+
+```bash
+  # AND 1: merged 判定
+  merged=0
+  if git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "origin/develop-0.2.0" 2>/dev/null; then
+    merged=1
+  elif git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "origin/main" 2>/dev/null; then
+    merged=1
+  fi
+```
+
+を以下に置換:
+
+```bash
+  # AND 1: merged 判定 (いずれかの origin/develop-* or origin/main の祖先)
+  merged=0
+  for base in "${MERGE_BASES[@]}"; do
+    if git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "$base" 2>/dev/null; then
+      merged=1
+      break
+    fi
+  done
+```
+
+ref が存在しない場合は `merge-base --is-ancestor` が fail → `2>/dev/null` → `merged=0` のまま、という旧実装と同じ安全側挙動を維持する。`MERGE_BASES` は `origin/main` を必ず含むため `set -u` の空配列展開問題はない (bash 4.4+ では空でも安全)。
+
+- [ ] **Step 4: green を確認 (全 hook test)**
+
+```bash
+python -m pytest tests/hooks/ -q
+```
+
+Expected: `42 passed` (既存 40 + 新 2)。
+
+- [ ] **Step 5: shellcheck (ローカル導入 + 実行)**
+
+```bash
+pip install shellcheck-py
+shellcheck --severity=warning scripts/cleanup-claude-branches.sh
+echo "shellcheck exit=$?"
+```
+
+Expected: 出力なし / `shellcheck exit=0` (CI shellcheck job と同 severity)。
+
+- [ ] **Step 6: docs/l2-workflow.md の挙動記述 3 箇所を同期**
+
+line 682:
+
+```text
+- **AND 1 (merged)**: いずれかの `origin/develop-*` または `origin/main` の祖先 (`git merge-base --is-ancestor`。#816 で develop-0.2.0 固定から一般化)
+```
+
+line 689 の先頭部:
+
+```text
+`origin/develop-*` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。
+```
+
+line 730 の該当部 (`origin/develop-0.2.0` / `origin/main` が未 fetch なら → 同様に置換):
+
+```text
+`origin/develop-*` / `origin/main` が未 fetch なら `is-ancestor` false に倒れて keep する設計のため、fetch されていない開発環境でも安全に動作する。
+```
+
+- [ ] **Step 7: markdownlint (変更ファイルのみ判定)**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | grep -E "l2-workflow" || echo LINT_OK_L2WORKFLOW
+```
+
+Expected: `LINT_OK_L2WORKFLOW` (stale worktree noise は変更ファイル名 grep で除外して判定)。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/cleanup-claude-branches.sh tests/hooks/test_cleanup_claude_branches.py docs/l2-workflow.md
+git commit -F - <<'EOF'
+fix(hooks): cleanup-claude-branches の merged 判定を origin/develop-* に一般化 (Refs #816)
+
+origin/develop-0.2.0 は origin から削除済みで、固定 pin のままだと
+develop-0.3.0 以降に merge された claude/* branch が永遠に掃除されない
+(audit 2026-06-10 P3)。for-each-ref で origin/develop-* を列挙 +
+origin/main を加えた集合に対して is-ancestor 判定するよう一般化。
+旧実装で fail する pin test (Scenario 6) と安全側 fallback test
+(Scenario 7) を追加し、docs/l2-workflow.md の挙動記述 3 箇所を同期。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task 3: .gitattributes (fixture eol=lf) + ci.yml sh test 配線
+
+**Files:**
+
+- Modify: `.gitattributes` (末尾追記)
+- Modify: `.github/workflows/ci.yml` (hook-test job の `Hook tests` step 直後)
+
+- [ ] **Step 1: .gitattributes に fixture の eol=lf を追加**
+
+`.gitattributes` 末尾に追記:
+
+```text
+
+# error-hints fixtures are byte-compared test vectors: tests/scripts/test_extract_*.sh
+# diff awk output (always LF) against expected-*.tsv. Force LF so a Windows
+# autocrlf=true checkout does not produce false drift FAILs (#816).
+tests/fixtures/error-hints/* text eol=lf
+```
+
+- [ ] **Step 2: working tree を LF に更新し、偽 FAIL していた sh test の green 化を確認**
+
+```bash
+rm tests/fixtures/error-hints/*
+git checkout -- tests/fixtures/error-hints/
+git ls-files --eol tests/fixtures/error-hints/
+for t in tests/scripts/test_*.sh; do echo "=== $t ==="; bash "$t"; done
+```
+
+Expected: `git ls-files --eol` の 4 ファイルが `w/lf` になる。sh test 3 本がすべて PASS (CRLF checkout で偽 FAIL していた 2 本が green 化 = 修正の実証)。`git status` で fixture は modified にならない (index は元から LF)。
+
+- [ ] **Step 3: ci.yml hook-test job に sh test step を追加**
+
+`.github/workflows/ci.yml` の hook-test job、`Hook tests` step (line 116-117) の直後に追加:
+
+```yaml
+      # tests/scripts/test_*.sh は .github/scripts/ の error-hint-drift 検査
+      # (check-error-hint-drift.sh / extract-*.awk) の test harness。
+      # audit 2026-06-10 P3「CI 参照ゼロ」対応 (#816)。glob 配線にして
+      # 将来の test_*.sh 追加忘れを防ぎ、空 glob は配線退行として fail させる。
+      - name: Shell test harness (tests/scripts/test_*.sh)
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tests=(tests/scripts/test_*.sh)
+          if (( ${#tests[@]} == 0 )); then
+            echo "::error::tests/scripts/test_*.sh matched no files (wiring regression, audit 2026-06-10 P3 / #816)"
+            exit 1
+          fi
+          for t in "${tests[@]}"; do
+            echo "=== ${t} ==="
+            bash "$t"
+          done
+```
+
+- [ ] **Step 4: step body の発火側 red 実証 (ローカル simulation)**
+
+保護機構 (CI gate) は green だけでなく「違反時に非ゼロで fail する」side を実証する (memory `feedback_protective_mechanism_red_verification`):
+
+```bash
+# (a) green: step body をそのまま実行
+bash -c 'set -euo pipefail; shopt -s nullglob; tests=(tests/scripts/test_*.sh); if (( ${#tests[@]} == 0 )); then echo "::error::no files"; exit 1; fi; for t in "${tests[@]}"; do echo "=== ${t} ==="; bash "$t"; done'
+echo "green exit=$?"
+
+# (b) red 1: 空 glob guard — tests/ が無いディレクトリから同 body を実行
+(cd /tmp && bash -c 'set -euo pipefail; shopt -s nullglob; tests=(tests/scripts/test_*.sh); if (( ${#tests[@]} == 0 )); then echo "::error::no files"; exit 1; fi; for t in "${tests[@]}"; do bash "$t"; done')
+echo "red1 exit=$?"
+
+# (c) red 2: fixture 違反注入 — expected-doc.tsv に bogus 行を追加して fail を観測後、復元
+printf 'bogus.code\tbogus hint\n' >> tests/fixtures/error-hints/expected-doc.tsv
+bash tests/scripts/test_extract_doc_hints.sh
+echo "red2 exit=$?"
+git checkout -- tests/fixtures/error-hints/expected-doc.tsv
+```
+
+Expected: green exit=0 (3 本 PASS が echo される) / red1 exit=1 (`::error::` 出力) / red2 exit=1 (`FAIL: drift detected`)。復元後に `git status --short` で fixture が clean なこと。
+
+- [ ] **Step 5: ci.yml の YAML 構文 sanity check**
+
+```bash
+python -c "import yaml, io; yaml.safe_load(io.open('.github/workflows/ci.yml', encoding='utf-8')); print('YAML_OK')"
+```
+
+Expected: `YAML_OK`。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .gitattributes .github/workflows/ci.yml
+git commit -F - <<'EOF'
+ci: tests/scripts/test_*.sh を hook-test job に配線 + fixture を eol=lf 固定 (Refs #816)
+
+audit 2026-06-10 P3「sh test 3 本が CI 参照ゼロ」対応。glob 配線
+(空 glob は配線退行として fail) で将来の test_*.sh も自動配線する。
+error-hints fixture は byte 比較の test vector のため eol=lf を強制し、
+Windows autocrlf=true checkout での偽 FAIL を恒久解消 (#612 と同型)。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task 4: check-pr-checklist-test.yml push trigger の develop-\* 化
+
+**Files:**
+
+- Modify: `.github/workflows/check-pr-checklist-test.yml:9-13`
+
+- [ ] **Step 1: push trigger を変更**
+
+現状 (lines 9-13):
+
+```yaml
+  push:
+    branches: [develop-0.2.0, main]
+    paths:
+      - '.github/scripts/check-pr-checklist.js'
+      - '.github/scripts/check-pr-checklist.test.js'
+```
+
+を以下に置換 (branches を ci.yml と同形式の `[main, "develop-*"]` に、paths へ workflow 自身を追加して pull_request 側 paths (lines 5-8) と対称化):
+
+```yaml
+  push:
+    branches: [main, "develop-*"]
+    paths:
+      - '.github/scripts/check-pr-checklist.js'
+      - '.github/scripts/check-pr-checklist.test.js'
+      - '.github/workflows/check-pr-checklist-test.yml'
+```
+
+paths への自己追加は AC 3「develop-0.3.0 への push で checklist-test が走る」をマージ後に機械観測可能にするため (本 PR は workflow file のみ touch するので、自己 path が無いとマージ push でトリガーされず AC を実測できない)。
+
+- [ ] **Step 2: YAML 構文 sanity check**
+
+```bash
+python -c "import yaml, io; yaml.safe_load(io.open('.github/workflows/check-pr-checklist-test.yml', encoding='utf-8')); print('YAML_OK')"
+```
+
+Expected: `YAML_OK`。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/check-pr-checklist-test.yml
+git commit -F - <<'EOF'
+ci: check-pr-checklist-test の push trigger を develop-* 化 (Refs #816)
+
+develop-0.2.0 固定 pin のため develop-0.3.0 への push で unit test が
+走らなかった (audit 2026-06-10 P3)。branches を ci.yml と同形式の
+[main, "develop-*"] に変更。paths に workflow 自身を追加して
+pull_request 側と対称化し、AC「develop-* push で走る」をマージ後に
+観測可能にする。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task 5: PR template の Base branch placeholder 化
+
+**Files:**
+
+- Modify: `.github/pull_request_template.md:116`
+
+- [ ] **Step 1: placeholder 化**
+
+line 116:
+
+```text
+- Base branch: `develop-0.2.0`
+```
+
+を以下に置換 (バージョン更新のたびに stale 化する構造を根絶):
+
+```text
+- Base branch: `develop-x.y.z` <!-- 現行の開発 branch に置換 -->
+```
+
+- [ ] **Step 2: markdownlint (変更ファイルのみ判定)**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | grep -E "pull_request_template" || echo LINT_OK_TEMPLATE
+```
+
+Expected: `LINT_OK_TEMPLATE`。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/pull_request_template.md
+git commit -F - <<'EOF'
+doc: PR template の Base branch を develop-x.y.z placeholder 化 (Refs #816)
+
+develop-0.2.0 固定の同類 stale pin (audit 未記載の 3 件目、#816 実測で
+検出、2026-06-12 Idios 承認でスコープ追加)。check-pr-checklist.js は
+本行を検証しないため表示のみの変更。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task 6: 全体検証 (Iron Law 6 path 別チェック、controller 実行)
+
+**Files:** なし
+
+- [ ] **Step 1: Python 系 (tests/hooks/ 変更のため)**
+
+```bash
+python -m ruff check .
+python -m ruff format --check .
+python -m pyright allaganeye gui tests scripts
+python -m pytest
+```
+
+Expected: すべて pass (pytest は fast suite。tests/hooks/ 42 passed を含む)。
+
+- [ ] **Step 2: shell 系 (CI shellcheck job 相当)**
+
+```bash
+shellcheck --severity=warning scripts/cleanup-claude-branches.sh tests/scripts/test_check_error_hint_drift.sh tests/scripts/test_extract_doc_hints.sh tests/scripts/test_extract_rust_hints.sh
+echo "exit=$?"
+```
+
+Expected: `exit=0`。
+
+- [ ] **Step 3: markdownlint (変更 .md 全件)**
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | grep -E "2026-06-12-audit-w1-n1|l2-workflow|pull_request_template" || echo LINT_OK_ALL
+```
+
+Expected: `LINT_OK_ALL`。
+
+- [ ] **Step 4: AC 逐条の事前確認 (マージ前に検証可能な範囲)**
+
+| AC (spec §N1) | 検証手段 | タイミング |
+| --- | --- | --- |
+| 1. CI green | PR の CI 実走 (python / hook-test / gui / shellcheck / 全 job) | PR 作成後 |
+| 2. sh test 3 本が CI ログに出る | PR CI の hook-test job ログに `=== tests/scripts/test_*.sh ===` 3 行 + PASS | PR 作成後 |
+| 3. develop-0.3.0 push で checklist-test が走る | (i) 本 PR で workflow 自身が pull_request paths に含まれ job が PR 上で走る (構文/job green の実証)、(ii) マージ push での実走観測 (Task 4 の自己 path 追加で観測可能) | (i) PR 作成後 / (ii) マージ後 (/close-issue で実測) |
+
+## Task 7: Iron Law 6 Pre-flight Step 0-5 + PR 作成 (controller 実行)
+
+**Files:** なし
+
+- [ ] **Step 0: ハードゲート**
+
+```bash
+gh pr list --repo Idios/kobutachan-allaganeye --search "816" --state open
+```
+
+Expected: 0 件 (既存 PR があれば STOP して Idios に確認)。
+
+- [ ] **Step 1-3: base 同期 + 交差判定**
+
+```bash
+git fetch origin develop-0.3.0
+git log HEAD..origin/develop-0.3.0 --oneline
+```
+
+Expected: 0 行。出力がある場合は取り込み commit の touched files と本 PR の交差を確認し、交差すれば rebase + 再検証。
+
+- [ ] **Step 4: 並行 PR 重複再確認**
+
+```bash
+gh pr list --repo Idios/kobutachan-allaganeye --search "816" --state all
+```
+
+Expected: 本 PR 関連以外 0 件。
+
+- [ ] **Step 5: codex adversarial-review**
+
+memory `project_codex_adversarial_review_direct_invocation.md` の方法で companion script の `adversarial-review` subcommand を直接呼ぶ (--background + run_in_background、focus は ASCII: 「CI workflow trigger semantics (push paths self-reference), bash glob/mapfile edge cases under set -u, cleanup script deletes branches via Stop hook after merge - safety AND conditions preserved?, Iron Law 3 scope (gitattributes/template additions approved 2026-06-12), CRLF rationale」)。不可なら CLAUDE.md §C6 fallback (superpowers requesting-code-review subagent) + PR 本文に Codex fallback notice。
+
+- [ ] **Step 6: push + PR 作成**
+
+PR 本文の Self-Test Report は machine-verified を `[x]`、machine-unverifiable を plain bullet で書き分ける。実機検証 trigger 表対象 path (gpu_detector / audio / detector.py / gui) の変更なし → 「該当なし」を明記。base `develop-0.3.0`、`Refs #816` (Closes 禁止)、session-id `audit-w1-n1-20260612` を記載。
+
+## Task 8: /iterate-review 自走 (controller 実行)
+
+- [ ] PR 作成後に `/iterate-review <PR#>` を invoke。1 round = 1 commit (`fix(round-N): <要約> (Refs #816)`)、round gate / ambiguous は AskUserQuestion、divergence cap Round 5。
+- [ ] 収束後、Idios にマージを依頼 (merge は Idios)。
+
+## マージ後 (本 plan のスコープ外、忘れ防止の記録のみ)
+
+1. AC 3 の実測: develop-0.3.0 への merge push で checklist-test workflow の実走を確認 (`gh run list --workflow=check-pr-checklist-test.yml`)
+2. spec §N1 マージ後アクション: stale worktree 掃除 (branches → worktrees の 2 段、各 dry-run → **Iron Law 2 AskUserQuestion** → apply)。注意: 9 本の stale worktree は「active」protection で branch cleanup から保護されるため、`git worktree remove` (dirty なら既定で拒否) を先行させる必要がある。origin 残存の merged branch (claude/audit-w1-g1 / -g5) の remote 削除も同ゲートで判断
+3. #816 のレビュー由来追記コメント対応: 掃除後にローカル lint noise (markdownlint 3,410 件 / pyright 197 errors) の解消確認 + `.claude/worktrees/**` の lint ignore glob 追加要否の検討
+4. `/close-issue 816` (spec §N1 AC 逐条 + issue checkbox 逐条のマージ後 base 実測検証)

--- a/docs/superpowers/plans/2026-06-12-audit-w1-n1.md
+++ b/docs/superpowers/plans/2026-06-12-audit-w1-n1.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+**注記 (2026-06-13 Pre-flight Step 5)**: 本 plan は point-in-time の実行 artifact。Codex adversarial-review の HIGH finding (stale な旧 `origin/develop-*` remote-tracking ref を merge 根拠に誤削除しうる) を受け、merge base は plan 記載の「全 `origin/develop-*`」から「**sort -V 最新の `origin/develop-*` + `origin/main`**」へ変更した (Idios 承認 2026-06-13)。実装確定の正は `scripts/cleanup-claude-branches.sh` と `tests/hooks/test_cleanup_claude_branches.py` (Scenario 6-10) を参照。
+
 **Goal:** CI 未配線の sh test harness 3 本を ci.yml に配線し、develop-0.2.0 固定 pin (cleanup script / checklist-test workflow / PR template) を develop-\* 一般化または placeholder 化する。あわせて Windows checkout で sh test が偽 FAIL する CRLF 問題を .gitattributes で恒久解消する。
 
 **Architecture:** (1) `cleanup-claude-branches.sh` の merged 判定を「`origin/develop-*` 列挙 + `origin/main`」に一般化 (TDD: 新 pin test の red を旧 script で実証 → 修正 → green)。(2) ci.yml `hook-test` job に glob ベースの sh test 実行 step を追加 (空 glob guard 付き、発火側の red をローカル simulation で実証)。(3) `check-pr-checklist-test.yml` push trigger を `develop-*` 化 + workflow 自身を push paths に追加 (AC「develop-0.3.0 への push で走る」をマージ後に機械観測可能にする)。挙動を明文化している `docs/l2-workflow.md` 3 箇所を同 PR で同期する。

--- a/scripts/cleanup-claude-branches.sh
+++ b/scripts/cleanup-claude-branches.sh
@@ -87,6 +87,10 @@ done < <(git -C "$REPO_ROOT" worktree list --porcelain)
 # develop-* を信用すると fetch --prune されず残った stale な旧 develop ref
 # だけに merged な branch を誤削除しうる (Codex adversarial-review HIGH) ため、
 # 現行 = version 最大の develop のみを merge base に採用する (no-network 維持)。
+# 注: no-network 設計のため「最新 develop ref 自体の鮮度」は原理的に保証できない
+# (stale と fresh はローカルでは識別不能)。残余リスクは fetch 済み -> release なし
+# 廃棄 -> 再 fetch なし、の 3 連鎖が条件で本 repo の release flow では非発生、
+# かつ commit は当該 ref から reachable で GC されない (2026-06-13 Idios 受容確定)。
 mapfile -t DEVELOP_REFS < <(git -C "$REPO_ROOT" for-each-ref --format='%(refname:short)' 'refs/remotes/origin/develop-*' | sort -V)
 MERGE_BASES=()
 if (( ${#DEVELOP_REFS[@]} > 0 )); then

--- a/scripts/cleanup-claude-branches.sh
+++ b/scripts/cleanup-claude-branches.sh
@@ -4,7 +4,7 @@
 # Output: stdout NDJSON (one JSON object per line). Schema: schemas/cleanup-output.schema.json.
 #
 # Safety AND conditions (unchanged from pre-#710):
-#   1. merged: ancestor of origin/develop-0.2.0 or origin/main
+#   1. merged: ancestor of any origin/develop-* branch or origin/main
 #   2. active 不在: not referenced by any active worktree
 #   3. cooldown: last commit ≥ 24h ago
 #   (prefix filter: claude/* only is listed)
@@ -81,6 +81,12 @@ while IFS= read -r line; do
   fi
 done < <(git -C "$REPO_ROOT" worktree list --porcelain)
 
+# AND 1 merge bases: 全 origin/develop-* (現行/将来の開発 branch) + origin/main (#816)。
+# 固定 pin (develop-0.2.0) だと release 後に新 develop branch へ merge された
+# branch が永遠に not-merged 扱いになる (audit 2026-06-10 P3)。
+mapfile -t MERGE_BASES < <(git -C "$REPO_ROOT" for-each-ref --format='%(refname:short)' 'refs/remotes/origin/develop-*')
+MERGE_BASES+=("origin/main")
+
 for branch in "${BRANCHES[@]}"; do
   # AND 2: active 不在判定
   if [[ -n "${ACTIVE_BRANCHES[$branch]:-}" ]]; then
@@ -89,13 +95,14 @@ for branch in "${BRANCHES[@]}"; do
     continue
   fi
 
-  # AND 1: merged 判定
+  # AND 1: merged 判定 (いずれかの origin/develop-* or origin/main の祖先)
   merged=0
-  if git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "origin/develop-0.2.0" 2>/dev/null; then
-    merged=1
-  elif git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "origin/main" 2>/dev/null; then
-    merged=1
-  fi
+  for base in "${MERGE_BASES[@]}"; do
+    if git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "$base" 2>/dev/null; then
+      merged=1
+      break
+    fi
+  done
   if [[ "$merged" -eq 0 ]]; then
     _emit kept name="$branch" reason=not-merged
     kept=$((kept + 1))

--- a/scripts/cleanup-claude-branches.sh
+++ b/scripts/cleanup-claude-branches.sh
@@ -3,7 +3,7 @@
 #
 # Output: stdout NDJSON (one JSON object per line). Schema: schemas/cleanup-output.schema.json.
 #
-# Safety AND conditions (unchanged from pre-#710):
+# Safety AND conditions (3-condition structure unchanged from pre-#710; AND 1 bases generalized in #816):
 #   1. merged: ancestor of any origin/develop-* branch or origin/main
 #   2. active 不在: not referenced by any active worktree
 #   3. cooldown: last commit ≥ 24h ago

--- a/scripts/cleanup-claude-branches.sh
+++ b/scripts/cleanup-claude-branches.sh
@@ -4,7 +4,7 @@
 # Output: stdout NDJSON (one JSON object per line). Schema: schemas/cleanup-output.schema.json.
 #
 # Safety AND conditions (3-condition structure unchanged from pre-#710; AND 1 bases generalized in #816):
-#   1. merged: ancestor of any origin/develop-* branch or origin/main
+#   1. merged: ancestor of the latest (sort -V) origin/develop-* or origin/main
 #   2. active 不在: not referenced by any active worktree
 #   3. cooldown: last commit ≥ 24h ago
 #   (prefix filter: claude/* only is listed)
@@ -81,10 +81,17 @@ while IFS= read -r line; do
   fi
 done < <(git -C "$REPO_ROOT" worktree list --porcelain)
 
-# AND 1 merge bases: 全 origin/develop-* (現行/将来の開発 branch) + origin/main (#816)。
+# AND 1 merge bases: sort -V 最新の origin/develop-* + origin/main (#816)。
 # 固定 pin (develop-0.2.0) だと release 後に新 develop branch へ merge された
-# branch が永遠に not-merged 扱いになる (audit 2026-06-10 P3)。
-mapfile -t MERGE_BASES < <(git -C "$REPO_ROOT" for-each-ref --format='%(refname:short)' 'refs/remotes/origin/develop-*')
+# branch が永遠に not-merged 扱いになる (audit 2026-06-10 P3)。一方、全
+# develop-* を信用すると fetch --prune されず残った stale な旧 develop ref
+# だけに merged な branch を誤削除しうる (Codex adversarial-review HIGH) ため、
+# 現行 = version 最大の develop のみを merge base に採用する (no-network 維持)。
+mapfile -t DEVELOP_REFS < <(git -C "$REPO_ROOT" for-each-ref --format='%(refname:short)' 'refs/remotes/origin/develop-*' | sort -V)
+MERGE_BASES=()
+if (( ${#DEVELOP_REFS[@]} > 0 )); then
+  MERGE_BASES+=("${DEVELOP_REFS[-1]}")
+fi
 MERGE_BASES+=("origin/main")
 
 for branch in "${BRANCHES[@]}"; do

--- a/scripts/cleanup-claude-branches.sh
+++ b/scripts/cleanup-claude-branches.sh
@@ -106,7 +106,7 @@ for branch in "${BRANCHES[@]}"; do
     continue
   fi
 
-  # AND 1: merged 判定 (いずれかの origin/develop-* or origin/main の祖先)
+  # AND 1: merged 判定 (sort -V 最新の origin/develop-* or origin/main の祖先)
   merged=0
   for base in "${MERGE_BASES[@]}"; do
     if git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "$base" 2>/dev/null; then

--- a/tests/hooks/conftest.py
+++ b/tests/hooks/conftest.py
@@ -48,9 +48,10 @@ def _symlink_or_copy(src: Path, dst: Path) -> None:
 def tmp_repo(tmp_path: Path) -> Path:
     """Isolated git repo with .claude/ and scripts/ wired from project root.
 
-    The repo has an initial commit on `develop-0.2.0` (the project's default
-    base branch). cleanup-claude-branches.sh's merge-base logic resolves
-    correctly against this branch.
+    The repo has an initial commit on `develop-0.2.0` (a fixture-internal
+    branch name kept for historical continuity; it matches the develop-*
+    glob, so cleanup-claude-branches.sh's merge-base logic resolves
+    correctly against it regardless of the project's current base branch).
     """
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/hooks/test_cleanup_claude_branches.py
+++ b/tests/hooks/test_cleanup_claude_branches.py
@@ -175,6 +175,8 @@ def test_merged_to_newer_develop_branch_deleted(
     import subprocess
 
     make_claude_branch("scenario6", merged=True, age_seconds=86400 * 2)
+    # NOTE: make_claude_branch は呼び出しごとに origin/develop-0.2.0 を HEAD へ
+    # 再 mirror するため (conftest)、ref の削除/付け替えは最後の呼び出しの後で行う。
     subprocess.run(
         ["git", "update-ref", "refs/remotes/origin/develop-0.3.0", "HEAD"],
         cwd=tmp_repo,
@@ -204,6 +206,8 @@ def test_no_develop_remote_refs_keeps_branch(
     import subprocess
 
     make_claude_branch("scenario7", merged=True, age_seconds=86400 * 2)
+    # NOTE: make_claude_branch は呼び出しごとに origin/develop-0.2.0 を HEAD へ
+    # 再 mirror するため (conftest)、ref の削除/付け替えは最後の呼び出しの後で行う。
     subprocess.run(
         ["git", "update-ref", "-d", "refs/remotes/origin/develop-0.2.0"],
         cwd=tmp_repo,
@@ -215,3 +219,41 @@ def test_no_develop_remote_refs_keeps_branch(
     assert any(
         e["name"] == "claude/scenario7" and e["reason"] == "not-merged" for e in kept
     ), result.stdout
+
+
+# ---------- Scenario 8: 複数 origin/develop-* 共存、新しい方にのみ merged ----------
+
+
+def test_merged_to_one_of_multiple_develop_refs_deleted(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+) -> None:
+    """branch を含まない develop-* ref があってもループが次の base へ継続する (#816).
+
+    origin/develop-0.2.0 (stale、branch を含まない) と origin/develop-0.3.0
+    (branch を含む) が共存するとき、最初の base の is-ancestor 失敗で
+    keep に倒れず、後続 base で merged 判定されることを pin する。
+    """
+    import subprocess
+
+    make_claude_branch("scenario8", merged=True, age_seconds=86400 * 2)
+    # NOTE: make_claude_branch は呼び出しごとに origin/develop-0.2.0 を HEAD へ
+    # 再 mirror するため (conftest)、ref の付け替えは最後の呼び出しの後で行う。
+    # HEAD は merge commit。第 1 親 (HEAD^1) = merge 前の develop tip で
+    # scenario8 の commit を含まない = stale な旧 develop ref を再現する。
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/develop-0.2.0", "HEAD^1"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/develop-0.3.0", "HEAD"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    deleted = _of_event(result.ndjson, "deleted")
+    assert any(e["name"] == "claude/scenario8" for e in deleted), result.stdout

--- a/tests/hooks/test_cleanup_claude_branches.py
+++ b/tests/hooks/test_cleanup_claude_branches.py
@@ -324,3 +324,44 @@ def test_merged_to_main_but_not_latest_develop_deleted(
     assert_valid_ndjson(result.ndjson)
     deleted = _of_event(result.ndjson, "deleted")
     assert any(e["name"] == "claude/scenario10" for e in deleted), result.stdout
+
+
+# ---------- Scenario 11: double-digit version は sort -V でのみ正しく最新判定 ----------
+
+
+def test_latest_develop_uses_version_sort_for_double_digits(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+) -> None:
+    """develop-0.10.0 vs 0.9.0 で version sort が最新を選ぶことを pin (#816).
+
+    `sort -V` が lexical `sort` に退行すると 0.9.0 > 0.10.0 と誤判定し、
+    branch を含まない旧 develop が merge base になって kept に倒れる
+    (v0.10.0 到達時に silent 再発する bug class)。本テストはその退行で fail する。
+    """
+    import subprocess
+
+    make_claude_branch("scenario11", merged=True, age_seconds=86400 * 2)
+    # NOTE: make_claude_branch は呼び出しごとに origin/develop-0.2.0 を HEAD へ
+    # 再 mirror するため (conftest)、ref の削除/付け替えは最後の呼び出しの後で行う。
+    subprocess.run(
+        ["git", "update-ref", "-d", "refs/remotes/origin/develop-0.2.0"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/develop-0.9.0", "HEAD^1"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/develop-0.10.0", "HEAD"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    deleted = _of_event(result.ndjson, "deleted")
+    assert any(e["name"] == "claude/scenario11" for e in deleted), result.stdout

--- a/tests/hooks/test_cleanup_claude_branches.py
+++ b/tests/hooks/test_cleanup_claude_branches.py
@@ -221,28 +221,28 @@ def test_no_develop_remote_refs_keeps_branch(
     ), result.stdout
 
 
-# ---------- Scenario 8: 複数 origin/develop-* 共存、新しい方にのみ merged ----------
+# ---------- Scenario 8: 複数 origin/develop-* 共存時は sort -V 最新が選ばれる ----------
 
 
-def test_merged_to_one_of_multiple_develop_refs_deleted(
+def test_latest_develop_selected_among_multiple(
     tmp_repo: Path,
     make_claude_branch,
     run_hook,
     assert_valid_ndjson,
 ) -> None:
-    """branch を含まない develop-* ref があってもループが次の base へ継続する (#816).
+    """複数 origin/develop-* 共存時、sort -V 最新のみが merge base になる (#816).
 
-    origin/develop-0.2.0 (stale、branch を含まない) と origin/develop-0.3.0
-    (branch を含む) が共存するとき、最初の base の is-ancestor 失敗で
-    keep に倒れず、後続 base で merged 判定されることを pin する。
+    旧 origin/develop-0.2.0 (branch を含まない) と新 origin/develop-0.3.0
+    (branch を含む) が共存するとき、最新の 0.3.0 が選ばれて deleted になる。
+    選択を誤って 0.2.0 を使うと kept になるため、version 選択を pin する。
     """
     import subprocess
 
     make_claude_branch("scenario8", merged=True, age_seconds=86400 * 2)
     # NOTE: make_claude_branch は呼び出しごとに origin/develop-0.2.0 を HEAD へ
     # 再 mirror するため (conftest)、ref の付け替えは最後の呼び出しの後で行う。
-    # HEAD は merge commit。第 1 親 (HEAD^1) = merge 前の develop tip で
-    # scenario8 の commit を含まない = stale な旧 develop ref を再現する。
+    # origin/develop-0.2.0 (旧、branch を含まない) と origin/develop-0.3.0
+    # (新、branch を含む) を共存させる。最新 = 0.3.0 が選ばれれば deleted になる。
     subprocess.run(
         ["git", "update-ref", "refs/remotes/origin/develop-0.2.0", "HEAD^1"],
         cwd=tmp_repo,
@@ -257,3 +257,70 @@ def test_merged_to_one_of_multiple_develop_refs_deleted(
     assert_valid_ndjson(result.ndjson)
     deleted = _of_event(result.ndjson, "deleted")
     assert any(e["name"] == "claude/scenario8" for e in deleted), result.stdout
+
+
+# ---------- Scenario 9: stale な旧 develop にのみ merged -> 安全側 keep (Codex HIGH) ----------
+
+
+def test_merged_only_to_stale_older_develop_kept(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+) -> None:
+    """stale な旧 origin/develop-* にのみ merged な branch は削除しない (#816 Codex HIGH).
+
+    Stop hook は fetch/prune しないため、origin 側で削除済みの旧 develop の
+    remote-tracking ref がローカルに残存しうる。merge base を sort -V 最新の
+    develop に限定することで、旧 ref だけを根拠にした削除を防ぐ。
+    """
+    import subprocess
+
+    make_claude_branch("scenario9", merged=True, age_seconds=86400 * 2)
+    # NOTE: make_claude_branch は呼び出しごとに origin/develop-0.2.0 を HEAD へ
+    # 再 mirror するため (conftest)、ref の付け替えは最後の呼び出しの後で行う。
+    # origin/develop-0.2.0 (= HEAD、branch を含む stale 旧 ref) はそのまま残し、
+    # 現行 develop に相当する origin/develop-0.3.0 を HEAD^1 (branch を含まない)
+    # に置く = 「旧にのみ merged、現行には未 merged」を再現する。
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/develop-0.3.0", "HEAD^1"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    kept = _of_event(result.ndjson, "kept")
+    assert any(
+        e["name"] == "claude/scenario9" and e["reason"] == "not-merged" for e in kept
+    ), result.stdout
+
+
+# ---------- Scenario 10: 最新 develop に未 merged でも origin/main に merged -> deleted ----------
+
+
+def test_merged_to_main_but_not_latest_develop_deleted(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+) -> None:
+    """origin/main fallback の pin: 最新 develop が含まなくても main に merged なら削除可."""
+    import subprocess
+
+    make_claude_branch("scenario10", merged=True, age_seconds=86400 * 2)
+    # NOTE: make_claude_branch は呼び出しごとに origin/develop-0.2.0 を HEAD へ
+    # 再 mirror するため (conftest)、ref の付け替えは最後の呼び出しの後で行う。
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/develop-0.2.0", "HEAD^1"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    deleted = _of_event(result.ndjson, "deleted")
+    assert any(e["name"] == "claude/scenario10" for e in deleted), result.stdout

--- a/tests/hooks/test_cleanup_claude_branches.py
+++ b/tests/hooks/test_cleanup_claude_branches.py
@@ -155,3 +155,63 @@ def test_empty_branch_list_emits_zero_summary(
     summaries = _of_event(result.ndjson, "summary")
     assert len(summaries) == 1
     assert summaries[0]["total"] == 0
+
+
+# ---------- Scenario 6: origin/develop-0.3.0 のみ存在 (develop-* 一般化, #816) ----------
+
+
+def test_merged_to_newer_develop_branch_deleted(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+) -> None:
+    """develop-0.2.0 が origin から消えても現行 origin/develop-* で merged 判定できる (#816).
+
+    実環境の再現: origin/develop-0.2.0 は v0.2.x 期の後に削除済みで、
+    origin/develop-0.3.0 のみが存在する。旧実装 (develop-0.2.0 固定) では
+    not-merged 扱いで永遠に kept になる (audit 2026-06-10 P3)。
+    """
+    import subprocess
+
+    make_claude_branch("scenario6", merged=True, age_seconds=86400 * 2)
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/develop-0.3.0", "HEAD"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "-d", "refs/remotes/origin/develop-0.2.0"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    deleted = _of_event(result.ndjson, "deleted")
+    assert any(e["name"] == "claude/scenario6" for e in deleted), result.stdout
+
+
+# ---------- Scenario 7: origin/develop-* も origin/main も無い -> 安全側 keep ----------
+
+
+def test_no_develop_remote_refs_keeps_branch(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+) -> None:
+    """origin/develop-* が 1 本も無く origin/main も無い場合は not-merged で keep (安全側)."""
+    import subprocess
+
+    make_claude_branch("scenario7", merged=True, age_seconds=86400 * 2)
+    subprocess.run(
+        ["git", "update-ref", "-d", "refs/remotes/origin/develop-0.2.0"],
+        cwd=tmp_repo,
+        check=True,
+    )
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    kept = _of_event(result.ndjson, "kept")
+    assert any(
+        e["name"] == "claude/scenario7" and e["reason"] == "not-merged" for e in kept
+    ), result.stdout


### PR DESCRIPTION
## 概要

audit P3 対応の CI/インフラ guard (Refs #816)。spec: docs/superpowers/specs/2026-06-10-audit-remediation-design.md §N1。実装 plan (docs/superpowers/plans/2026-06-12-audit-w1-n1.md) を先頭 commit で同梱。

受け入れ条件は確立済み運用どおり **spec §N1「受け入れ条件案」を正式 AC** として扱う (#812/#815 と同じ): (1) CI green / (2) sh test 3 本が CI ログに出る / (3) develop-0.3.0 への push で checklist-test が走る。

スコープ追加 2 件 (.gitattributes / PR template) と Codex HIGH 対応 (semver-latest 化 → 残余リスク受容) は、いずれも AskUserQuestion で Idios 承認済み (2026-06-12 / 2026-06-13)。

## 変更内容

- `scripts/cleanup-claude-branches.sh`: merged 判定 (AND 1) を `origin/develop-0.2.0` 固定から「**sort -V 最新の `origin/develop-*` + `origin/main`**」へ一般化 (実環境では origin/develop-0.2.0 が既に消失しており、develop-0.3.0 に merged な branch が永遠に掃除されない実害を実測確認)。安全 AND 条件の構造 (merged / active / cooldown / claude prefix) と no-network 設計は不変
- `tests/hooks/test_cleanup_claude_branches.py`: Scenario 6 (一般化の pin、**旧実装で red 実証**: 1 failed, 9 passed) / 7 (develop-* も main も無い → 安全側 keep) / 8 (複数 develop 共存時の sort -V 選択 pin) / 9 (**stale 旧 develop にのみ merged → kept**、Codex HIGH の red→green) / 10 (main fallback の pin) / 11 (sort -V double-digit の退行 pin、round-2 で追加) を追加 — hooks 計 46 passed
- `docs/l2-workflow.md`: AND 1 挙動記述 3 箇所を同期
- `.github/workflows/ci.yml` hook-test job: `tests/scripts/test_*.sh` を glob 配線する step を追加 (**空 glob は配線退行として fail**。audit 根本原因「存在するが配線されず silent」の再発防止)
- `.gitattributes`: `tests/fixtures/error-hints/*` を `eol=lf` 固定 (byte 比較 test vector が Windows autocrlf=true checkout で偽 FAIL する問題の恒久対策、#612 と同型。スコープ追加 a)
- `.github/workflows/check-pr-checklist-test.yml`: push trigger を `[main, "develop-*"]` 化 + paths に workflow 自身を追加 (AC 3 をマージ後 push で機械観測可能にする)
- `.github/pull_request_template.md`: `Base branch: develop-0.2.0` → `develop-x.y.z` placeholder (audit 未記載の同類 stale pin 3 件目を実測で検出。スコープ追加 b)

## Self-Test Report

- [x] `python -m ruff check .` / `python -m ruff format --check .` 全 pass
- [x] `python -m pyright allaganeye gui tests scripts` → 0 errors, 0 warnings
- [x] `python -m pytest` → 1307 passed, 1 skipped, 51 deselected (round-2 の Scenario 11 追加後の再実測。tests/hooks/ 46 passed を含む。1 warning は pre-existing の pytest-asyncio deprecation で本 PR 無関係)
- [x] shellcheck --severity=warning (CI job と同等): cleanup-claude-branches.sh + 配線対象 test_*.sh 3 本すべて exit 0
- [x] TDD red 実証 ×2: Scenario 6 が一般化前実装で fail (1 failed, 9 passed) / Scenario 9 が semver-latest 化前実装で fail (1 failed, 12 passed) をそれぞれ観測してから実装
- [x] CI step body の発火側実証: green exit=0 (3 本 PASS 表示) / 空 glob guard exit=1 (`::error::` 出力) / fixture 違反注入 exit=1 (`FAIL: drift detected`、注入は復元済み)
- [x] sh test 3 本がローカル PASS (eol=lf 適用後。適用前は CRLF 起因で 2 本偽 FAIL = 修正の red→green)
- [x] YAML parse OK (ci.yml / check-pr-checklist-test.yml)
- [x] markdownlint: 変更 .md (plan / l2-workflow / pull_request_template) violation ゼロ (.claude/worktrees/ の既知 noise 3,410 件は除外判定。#816 マージ後掃除で解消予定)
- AC 1 (CI green) / AC 2 (sh test 3 本がログに出る) は本 PR の CI 実走で確認する。AC 3 は (i) 本 PR で workflow 自身の pull_request paths により job が走る + (ii) マージ push での実走 (/close-issue で実測) の 2 段
- 実機検証: 該当なし (gpu_detector.py / audio/ / video/detector.py / gui/ 変更なし)

## Codex adversarial-review (Pre-flight Step 5)

companion script の adversarial-review subcommand で 2 回実施 (focus: trigger semantics / bash edge cases / Stop hook 削除安全性 / Iron Law 3 scope)。

- **Round 1**: HIGH 摘出「全 origin/develop-* を merge base にすると stale な旧 develop ref だけに merged な branch を誤削除しうる」→ **本 PR 内対応** (13244a2): merge base を sort -V 最新に制限 + Scenario 9 red→green (Idios 承認)
- **Round 2 (再確認)**: verdict **needs-attention** 継続「最新 develop ref 自体も stale でありうる」。これは no-network 設計 (#708 確定、fetch は user 運用前提) の下で**原理的に解消不能な設計トレードオフ**と判断: stale/fresh はローカルで bit-identical のため Codex が要求する regression test も書けない。残余リスクの成立条件 (fetch 済み → release なし廃棄 → 再 fetch なし、の 3 連鎖) は本 repo の release flow (develop tip → main merge → branch 削除) で非発生、かつ commit は当該 ref から reachable で GC されない。**2026-06-13 Idios が受容を確定** (代替案 main-only / fetch--prune 導入は提示の上で不採用)。根拠は script comment にも記録済み (4ced76c)。adversarial-review もぐら叩き早期停止の運用 (memory 既録) に従い、同一クラス 2 周目で設計判断に切替えた

## Pre-flight (Iron Law 6)

- PR 作成時の base HEAD: b80e71d (`git rev-parse origin/develop-0.3.0`)
- PR head の base 取り込み: 取り込み不要 (base 進行なし、push 直前再確認で behind 0)
- 直近マージ PR の影響: なし (#820 = docs のみ、touched files 交差なし)
- 並行 PR 確認 (`gh pr list --search "816" --state all`): 重複なし (hit は #820 (G5, merged) のみで別 issue)

## 備考

- quality review の情報提供 3 件 (対応不要と判定、記録): (a) .gitattributes glob は非再帰 — 現状 flat dir、subdir 追加時は `**` 化 / (b) sh test step は Hook tests の後段 fail-fast — repo の job 内 step 連鎖慣行と一致 / (c) template placeholder は無検証 — 表示のみの欄のため受容
- docs/l2-workflow.md には cleanup 節以外に era 記述としての develop-0.2.0 言及が残存 (例: L2 統合先の記述)。W6 (doc 一括再同期、spec §W6) の SSoT 適用でまとめて精査予定
- マージ後アクション (spec §N1): stale worktree 掃除 (branches → worktrees の 2 段、各 dry-run → Iron Law 2 AskUserQuestion → apply) は本 PR 外で実施。#816 のレビュー由来コメント (lint noise 解消確認 + .claude/worktrees/** ignore glob 検討) も掃除時に対応

## 関連

- Refs #816
- Base branch: `develop-0.3.0`
- Session: audit-w1-n1-20260612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- iterate-review:deferred:start -->
## Deferred Findings (managed by /iterate-review)

- [W6-deferral] Round 1: era 記述としての develop-0.2.0 残存 (docs/l2-workflow.md:38,42,51,53,155,396 / scope-guard SKILL.md:39 / docs/release-process.md:53 (Round 2 開示分追記)) → W6 (doc 一括再同期, spec §新規 issue 起票一覧 row 13) 起票時に消化 (Idios 確定 2026-06-13、audit P2 catalog 済み)

<!-- iterate-review:deferred:end -->


