### PR TITLE
feat(l3): masked OBS 検出対応 本体 - mask-free 領域 fallback + provenance (Refs #821)

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -153,9 +153,18 @@ def split(
         bool,
         typer.Option(
             "--vtuber",
+            help="(experimental) VTuber recording (game inset): scorebar-band "
+            "anchor detection. Under-detects irregular transitions; deferred (#480).",
             hidden=True,
-            help="VTuber recording (game inset): use scorebar-band anchor for "
-            "detection. Omit for OBS full-frame (default).",
+        ),
+    ] = False,
+    masked: Annotated[
+        bool,
+        typer.Option(
+            "--masked",
+            help="Masked recording: a chat-hiding image is composited over the "
+            "full screen. Auto-detects a mask-free region and re-detects; this "
+            "flag forces that path even when some blackouts are found.",
         ),
     ] = False,
     verbose: Annotated[
@@ -180,6 +189,8 @@ def split(
             raise ConfigValidationError("--quiet and --verbose are mutually exclusive")
         if gpu and no_gpu:
             raise ConfigValidationError("--gpu and --no-gpu are mutually exclusive")
+        if vtuber and masked:
+            raise ConfigValidationError("--vtuber and --masked are mutually exclusive")
         if video_path is not None and from_metadata is not None:
             raise ConfigValidationError(
                 "VIDEO_PATH and --from-metadata are mutually exclusive"
@@ -221,6 +232,7 @@ def split(
                 no_cache=no_cache,
                 no_audio=no_audio,
                 vtuber=vtuber,
+                masked=masked,
             )
             from allaganeye.commands.split_matches import run_split_from_metadata
 
@@ -250,6 +262,7 @@ def split(
             no_cache=no_cache,
             no_audio=no_audio,
             vtuber=vtuber,
+            masked=masked,
         )
 
         from allaganeye.commands.split_matches import run_split
@@ -334,9 +347,18 @@ def detect(
         bool,
         typer.Option(
             "--vtuber",
+            help="(experimental) VTuber recording (game inset): scorebar-band "
+            "anchor detection. Under-detects irregular transitions; deferred (#480).",
             hidden=True,
-            help="VTuber recording (game inset): use scorebar-band anchor for "
-            "detection. Omit for OBS full-frame (default).",
+        ),
+    ] = False,
+    masked: Annotated[
+        bool,
+        typer.Option(
+            "--masked",
+            help="Masked recording: a chat-hiding image is composited over the "
+            "full screen. Auto-detects a mask-free region and re-detects; this "
+            "flag forces that path even when some blackouts are found.",
         ),
     ] = False,
     verbose: Annotated[
@@ -373,6 +395,8 @@ def detect(
             raise ConfigValidationError("--quiet and --verbose are mutually exclusive")
         if gpu and no_gpu:
             raise ConfigValidationError("--gpu and --no-gpu are mutually exclusive")
+        if vtuber and masked:
+            raise ConfigValidationError("--vtuber and --masked are mutually exclusive")
         if progress_format not in ("text", "json"):
             raise ConfigValidationError(
                 f"Invalid --progress-format: {progress_format!r}. "
@@ -409,6 +433,7 @@ def detect(
             no_cache=no_cache,
             no_audio=no_audio,
             vtuber=vtuber,
+            masked=masked,
         )
 
         from allaganeye.commands.detect import run_detect

--- a/allaganeye/commands/detect.py
+++ b/allaganeye/commands/detect.py
@@ -33,6 +33,7 @@ from allaganeye.commands.split_matches import (
     _format_duration,
     _iso_utc_now,
     _load_cache,
+    _read_cached_masked_fallback,
     _print_environment_header,
     _print_detection_stats,
     _resolve_gpu_mode_with_probe,
@@ -125,12 +126,16 @@ def run_detect(
 
     cache_path = config.output_dir / ".detection_cache.json"
     boundaries = None
+    # #821 -- resolved masked fallback。cache-hit は cache 記録値を引き継ぎ、
+    # cache-miss は detection callback で捕捉する。
+    masked_fallback_used = False
     use_gpu = False
     gpu_vendor: str | None = None
     available_vendors: list[str] = []
     if not config.no_cache:
         boundaries = _load_cache(cache_path, video_path, effective_interval, config)
         if boundaries is not None:
+            masked_fallback_used = _read_cached_masked_fallback(cache_path)
             if show and verbose:
                 _display_cache_hit_params(cache_path, config)
             if show:
@@ -177,6 +182,10 @@ def run_detect(
 
         detect_stats: DetectionStats | None = {} if verbose else None
 
+        def _on_masked_fallback() -> None:
+            nonlocal masked_fallback_used
+            masked_fallback_used = True
+
         boundaries = _run_detection(
             video_path,
             metadata,
@@ -189,6 +198,7 @@ def run_detect(
             gpu_vendor=gpu_vendor,
             progress_emitter=progress_emitter,
             brightness_callback=on_brightness,
+            masked_fallback_callback=_on_masked_fallback,
         )
 
         if not boundaries:
@@ -212,7 +222,13 @@ def run_detect(
             _display_results(boundaries, metadata, video_path, verbose)
 
         _save_cache(
-            cache_path, video_path, metadata, effective_interval, config, boundaries
+            cache_path,
+            video_path,
+            metadata,
+            effective_interval,
+            config,
+            boundaries,
+            masked_fallback_used=masked_fallback_used,
         )
 
     gaps = _find_gaps(boundaries, metadata["duration"], min_gap=300.0)
@@ -275,6 +291,7 @@ def run_detect(
         gaps=gaps,
         system_info=system_info,
         brightness_samples=brightness_samples,
+        masked_fallback_used=masked_fallback_used,
     )
     metadata_path = config.output_dir / "metadata.json"
     write_metadata_atomic(metadata_path, payload)

--- a/allaganeye/commands/detect.py
+++ b/allaganeye/commands/detect.py
@@ -171,7 +171,8 @@ def run_detect(
                 f"min_match={config.min_match_duration}s, "
                 f"min_blackout={config.min_blackout_duration}s, "
                 f"audio={_audio_status_str(config.no_audio)}, "
-                f"vtuber={'on' if config.vtuber else 'off'})"
+                f"vtuber={'on' if config.vtuber else 'off'}, "
+                f"masked={'on' if config.masked else 'off'})"
             )
 
         detect_stats: DetectionStats | None = {} if verbose else None

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -48,7 +48,11 @@ class Gap(TypedDict):
 
 logger = logging.getLogger(__name__)
 
-_CACHE_VERSION = 2
+# v3 (#821): masked auto-fallback (flag なしでも 0-blackout で発火) の導入で
+# 「missing masked = 標準 path と同一挙動」が成立しなくなったため、pre-#821
+# cache を全面 invalidate する (v2 cache が hit し続けると masked 動画の誤結果
+# が再利用され、新 detector が走らない)。
+_CACHE_VERSION = 3
 
 
 def run_split(
@@ -139,6 +143,9 @@ def run_split(
                 effective_interval=effective_interval,
                 detected_at=detected_at,
                 system_info=cached_system_info,
+                # cache-hit: resolved path は当該 boundaries を生成した検出の
+                # 記録値 (cache top-level) を引き継ぐ。
+                masked_fallback_used=_read_cached_masked_fallback(cache_path),
                 quiet=quiet,
             )
             _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -193,6 +200,13 @@ def run_split(
     def _on_brightness(samples: dict[float, float]) -> None:
         captured_brightness.update(samples)
 
+    # #821 -- masked fallback の resolved path を捕捉 (request flag と分離)。
+    masked_fallback_used = False
+
+    def _on_masked_fallback() -> None:
+        nonlocal masked_fallback_used
+        masked_fallback_used = True
+
     boundaries = _run_detection(
         video_path,
         metadata,
@@ -204,6 +218,7 @@ def run_split(
         use_gpu=use_gpu,
         gpu_vendor=gpu_vendor,
         brightness_callback=_on_brightness,
+        masked_fallback_callback=_on_masked_fallback,
     )
 
     if not boundaries:
@@ -235,7 +250,13 @@ def run_split(
 
     # Save detection cache
     _save_cache(
-        cache_path, video_path, metadata, effective_interval, config, boundaries
+        cache_path,
+        video_path,
+        metadata,
+        effective_interval,
+        config,
+        boundaries,
+        masked_fallback_used=masked_fallback_used,
     )
 
     # Step 3: Split (unless dry-run)
@@ -270,6 +291,7 @@ def run_split(
         detected_at=detected_at,
         system_info=detected_system_info,
         brightness_samples=brightness_samples,
+        masked_fallback_used=masked_fallback_used,
         quiet=quiet,
     )
     _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -427,6 +449,11 @@ def run_split_from_metadata(
         detection_completed_at=preserve_completed_at,
         system_info=split_only_system_info,
         brightness_samples=preserve_brightness_samples,
+        # from-metadata: 入力 metadata に記録された resolved path を引き継ぐ
+        # (本ランは detect しないため)。
+        masked_fallback_used=bool(
+            (detection_params or {}).get("masked_fallback_used", False)
+        ),
         quiet=quiet,
     )
     _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -519,6 +546,9 @@ def _display_cache_hit_params(cache_path: Path, config: SplitConfig) -> None:
     # 表示は cache 記録値を正とする (legacy cache は key なし = False)。
     cached_vtuber = bool(params.get("vtuber", False))
     cached_masked = bool(params.get("masked", False))
+    # resolved path (top-level、key 非対象)。auto-fallback 時は masked=off でも
+    # masked_fallback=on になる (#821)。
+    cached_fallback = bool(data.get("masked_fallback_used", False))
 
     typer.echo(header)
     typer.echo(
@@ -529,7 +559,8 @@ def _display_cache_hit_params(cache_path: Path, config: SplitConfig) -> None:
         f"min_blackout={params.get('min_blackout_duration', '?')}s, "
         f"audio={_audio_status_str(cached_no_audio)}, "
         f"vtuber={'on' if cached_vtuber else 'off'}, "
-        f"masked={'on' if cached_masked else 'off'}"
+        f"masked={'on' if cached_masked else 'off'}, "
+        f"masked_fallback={'on' if cached_fallback else 'off'}"
     )
 
 
@@ -741,6 +772,7 @@ def _run_detection(
     gpu_vendor: str | None = None,
     progress_emitter: ProgressEmitter | None = None,
     brightness_callback: Callable[[dict[float, float]], None] | None = None,
+    masked_fallback_callback: Callable[[], None] | None = None,
 ) -> list[MatchBoundary]:
     """Run detection with progress bars for each phase (#328, #329, #331).
 
@@ -774,6 +806,7 @@ def _run_detection(
         "audio_hits": audio_hits,
         "stats": stats,
         "brightness_callback": brightness_callback,
+        "masked_fallback_callback": masked_fallback_callback,
         # #576: rational fps propagation (probe -> detector).
         "source_fps": metadata.get("fps"),
         "source_fps_num": metadata.get("fps_num"),
@@ -1220,6 +1253,7 @@ def _split_and_write_metadata(
     detection_completed_at: str | None = None,
     system_info: SystemInfo,
     brightness_samples: BrightnessSamples | None = None,
+    masked_fallback_used: bool = False,
     quiet: bool = False,
 ) -> None:
     """Split video and write metadata.json (#591: system_info required).
@@ -1281,6 +1315,7 @@ def _split_and_write_metadata(
         gaps=gaps,
         system_info=system_info,
         brightness_samples=brightness_samples,
+        masked_fallback_used=masked_fallback_used,
     )
     metadata_path = config.output_dir / "metadata.json"
     write_metadata_atomic(metadata_path, result)
@@ -1306,6 +1341,7 @@ def _build_metadata_payload(
     gaps: list[Gap],
     system_info: SystemInfo,
     brightness_samples: BrightnessSamples | None = None,
+    masked_fallback_used: bool = False,
 ) -> Metadata:
     """Build the ``metadata.json`` payload dict (schema v1, #463 / #569 / #586 / #591).
 
@@ -1363,9 +1399,12 @@ def _build_metadata_payload(
             "use_gpu": config.use_gpu,
             "workers": config.workers,
             # vtuber/masked は検出 path の provenance (PR #823 R1 deferred 分)。
-            # schema 上は optional (導入前 metadata との後方互換)。
+            # schema 上は optional (導入前 metadata との後方互換)。masked は
+            # request flag、masked_fallback_used は resolved path (auto-fallback
+            # 含む) で、両者は 0-blackout auto-trigger 時に乖離する (#821)。
             "vtuber": config.vtuber,
             "masked": config.masked,
+            "masked_fallback_used": masked_fallback_used,
         },
         "system_info": system_info,
         "matches": [
@@ -1734,6 +1773,8 @@ def _save_cache(
     effective_interval: float,
     config: SplitConfig,
     boundaries: list[MatchBoundary],
+    *,
+    masked_fallback_used: bool = False,
 ) -> None:
     """Save detection results to cache file."""
     resolved = video_path.resolve()
@@ -1763,6 +1804,10 @@ def _save_cache(
             "vtuber": config.vtuber,
             "masked": config.masked,
         },
+        # resolved path は key (params) ではなく top-level に記録する: auto-masked
+        # 動画の cache 再利用は request flag の一致で正しく機能させ、provenance
+        # は表示/metadata 引き継ぎ用に保持する (#821)。
+        "masked_fallback_used": masked_fallback_used,
         "boundaries": boundaries,
     }
     try:
@@ -1772,6 +1817,19 @@ def _save_cache(
         )
     except OSError:
         logger.debug("Failed to write detection cache to %s", cache_path)
+
+
+def _read_cached_masked_fallback(cache_path: Path) -> bool:
+    """cache-hit 経路用: cache に記録された resolved masked fallback を読む。
+
+    読めない / 欠落時は False (標準 path 扱い)。cache key の一部ではないため
+    `_load_cache` とは独立に読む (#821)。
+    """
+    try:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(data.get("masked_fallback_used", False))
 
 
 def _load_cache(

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -177,7 +177,8 @@ def run_split(
             f"min_match={config.min_match_duration}s, "
             f"min_blackout={config.min_blackout_duration}s, "
             f"audio={_audio_status_str(config.no_audio)}, "
-            f"vtuber={'on' if config.vtuber else 'off'})"
+            f"vtuber={'on' if config.vtuber else 'off'}, "
+            f"masked={'on' if config.masked else 'off'})"
         )
 
     detect_stats: DetectionStats | None = {} if verbose else None
@@ -514,9 +515,10 @@ def _display_cache_hit_params(cache_path: Path, config: SplitConfig) -> None:
     # Live-probe AUDIO_FROZEN so the verbose line mirrors `_run_audio_scan`
     # behaviour for the current run, same as the cache-miss summary.
     cached_no_audio = bool(params.get("no_audio", config.no_audio))
-    # vtuber は cache key (PR #823) に含まれるため hit 時は config と一致するが、
+    # vtuber / masked は cache key に含まれるため hit 時は config と一致するが、
     # 表示は cache 記録値を正とする (legacy cache は key なし = False)。
     cached_vtuber = bool(params.get("vtuber", False))
+    cached_masked = bool(params.get("masked", False))
 
     typer.echo(header)
     typer.echo(
@@ -526,7 +528,8 @@ def _display_cache_hit_params(cache_path: Path, config: SplitConfig) -> None:
         f"min_match={params.get('min_match_duration', '?')}s, "
         f"min_blackout={params.get('min_blackout_duration', '?')}s, "
         f"audio={_audio_status_str(cached_no_audio)}, "
-        f"vtuber={'on' if cached_vtuber else 'off'}"
+        f"vtuber={'on' if cached_vtuber else 'off'}, "
+        f"masked={'on' if cached_masked else 'off'}"
     )
 
 
@@ -1359,6 +1362,10 @@ def _build_metadata_payload(
             "no_audio": config.no_audio,
             "use_gpu": config.use_gpu,
             "workers": config.workers,
+            # vtuber/masked は検出 path の provenance (PR #823 R1 deferred 分)。
+            # schema 上は optional (導入前 metadata との後方互換)。
+            "vtuber": config.vtuber,
+            "masked": config.masked,
         },
         "system_info": system_info,
         "matches": [
@@ -1754,6 +1761,7 @@ def _save_cache(
             "min_blackout_duration": config.min_blackout_duration,
             "no_audio": config.no_audio,
             "vtuber": config.vtuber,
+            "masked": config.masked,
         },
         "boundaries": boundaries,
     }
@@ -1805,9 +1813,9 @@ def _load_cache(
         return None
 
     params = data.get("params", {})
-    # vtuber は detection path を切り替えるため cache key に含める (gate の cache
-    # bypass 防止)。key なし legacy cache は --vtuber 導入前 = 標準 path の結果
-    # なので False と同値に扱う。
+    # vtuber / masked は detection path を切り替えるため cache key に含める (gate
+    # の cache bypass 防止)。key なし legacy cache は両 flag 導入前 = 標準 path の
+    # 結果なので False と同値に扱う。
     if (
         params.get("sample_interval") != effective_interval
         or params.get("blackout_threshold") != config.blackout_threshold
@@ -1815,6 +1823,7 @@ def _load_cache(
         or params.get("min_blackout_duration") != config.min_blackout_duration
         or params.get("no_audio") != config.no_audio
         or params.get("vtuber", False) != config.vtuber
+        or params.get("masked", False) != config.masked
     ):
         logger.debug("Cache parameter mismatch")
         return None

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -762,6 +762,9 @@ def _run_detection(
         # L3 B6: VTuber game-inset recording -> scorebar-band anchor region.
         # False (default) keeps FULL_FRAME = OBS bit-exact behavior.
         "vtuber": config.vtuber,
+        # L3 masked-OBS (#753): chat-mask overlay -> mask-free region fallback.
+        # False (default) only auto-triggers on 0-blackout; True forces it.
+        "masked": config.masked,
         "workers": config.workers,
         "src_resolution": (metadata["width"], metadata["height"]),
         "codec": metadata.get("codec"),

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -22,6 +22,7 @@ class SplitConfig:
     no_cache: bool = False
     no_audio: bool = False
     vtuber: bool = False
+    masked: bool = False
 
     def __post_init__(self) -> None:
         if self.workers is not None and self.workers < 1:

--- a/allaganeye/metadata_types.py
+++ b/allaganeye/metadata_types.py
@@ -21,6 +21,7 @@ class DetectionParams(TypedDict):
     workers: float | None
     vtuber: NotRequired[bool]
     masked: NotRequired[bool]
+    masked_fallback_used: NotRequired[bool]
 
 
 class Match(TypedDict):

--- a/allaganeye/metadata_types.py
+++ b/allaganeye/metadata_types.py
@@ -19,6 +19,8 @@ class DetectionParams(TypedDict):
     no_audio: bool
     use_gpu: float | bool | None
     workers: float | None
+    vtuber: NotRequired[bool]
+    masked: NotRequired[bool]
 
 
 class Match(TypedDict):

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -444,6 +444,85 @@ def detect_region_blackout_overlap(
     )
 
 
+def _maximal_ones_rectangle(mask: np.ndarray) -> tuple[int, int, int, int] | None:
+    """Largest all-ones axis-aligned rectangle in a binary mask (histogram stack).
+
+    Returns ``(x0, y0, x1, y1)`` half-open (x1/y1 exclusive) of the maximum-area
+    all-ones rectangle, or ``None`` when the mask has no set pixels.  O(H*W):
+    per-row histogram heights + largest-rectangle-in-histogram with a sentinel.
+    """
+    h, w = mask.shape
+    heights = np.zeros(w, dtype=np.int32)
+    best_area = 0
+    best: tuple[int, int, int, int] | None = None
+    for y in range(h):
+        heights = np.where(mask[y] > 0, heights + 1, 0)
+        hh = heights.tolist()
+        stack: list[int] = []
+        x = 0
+        while x <= w:
+            cur = hh[x] if x < w else 0
+            if not stack or hh[stack[-1]] <= cur:
+                stack.append(x)
+                x += 1
+            else:
+                top = stack.pop()
+                height = hh[top]
+                left = 0 if not stack else stack[-1] + 1
+                width = x - left
+                area = height * width
+                if area > best_area:
+                    best_area = area
+                    best = (left, y - height + 1, left + width, y + 1)
+    return best
+
+
+def detect_mask_free_region(
+    frames: list[np.ndarray],
+    *,
+    bright_thresh: float = _OVERLAP_BRIGHT,
+    dark_thresh: float = _OVERLAP_DARK,
+    min_area_frac: float = _MIN_REGION_AREA_FRAC,
+) -> CaptureRegion:
+    """Largest hole-free game rectangle for masked recordings (#753 masked-OBS).
+
+    Refines S3 (``detect_region_blackout_overlap``): instead of the largest game
+    *component bbox* (which can contain mask holes), returns the largest solid
+    all-game *rectangle* (maximal all-ones rectangle over the game mask), so the
+    measurement region excludes bright static masks composited over gameplay.
+
+    game pixel = max brightness > ``bright_thresh`` AND min brightness <
+    ``dark_thresh`` (brightens during play, darkens during a blackout).  Bright
+    static masks never darken (min stays high) -> excluded.  Always-dark bars
+    never brighten -> excluded.  Unmasked full-frame game -> every pixel is game
+    -> snaps to FULL_FRAME.  Fewer than 2 frames, no game pixels, or a max
+    rectangle below ``min_area_frac`` of the frame -> FULL_FRAME (safe degenerate:
+    the masked-fallback caller treats FULL_FRAME as "no mask region found").
+    """
+    if len(frames) < 2:
+        return FULL_FRAME
+    stack = np.stack(frames).astype(np.float32)
+    pmax = stack.max(axis=0)
+    pmin = stack.min(axis=0)
+    game_mask = ((pmax > bright_thresh) & (pmin < dark_thresh)).astype(np.uint8)
+    rect = _maximal_ones_rectangle(game_mask)
+    if rect is None:
+        return FULL_FRAME
+    x0, y0, x1, y1 = rect
+    h, w = game_mask.shape
+    if (x1 - x0) * (y1 - y0) < min_area_frac * w * h:
+        return FULL_FRAME
+    region = CaptureRegion(
+        x0 / w,
+        y0 / h,
+        (x1 - x0) / w,
+        (y1 - y0) / h,
+        confidence=0.8,
+        source="tierA",
+    ).clamp()
+    return _maybe_snap_full_frame(region)
+
+
 _BAND_CONSENSUS_MIN_HITS = 2
 """帯 consensus に必要な最小局在化成功数。これ未満は FULL_FRAME 縮退。"""
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -303,6 +303,7 @@ def detect_match_boundaries(
     min_blackout_duration: float = 3.0,
     use_gpu: bool = False,
     vtuber: bool = False,
+    masked: bool = False,
     workers: int | None = None,
     src_resolution: tuple[int, int] | None = None,
     codec: str | None = None,
@@ -329,6 +330,9 @@ def detect_match_boundaries(
             to generate the list of sample timestamps.
         use_gpu: If True, use chunked parallel GPU decode instead of
             per-frame -ss probes.  Falls back to CPU on failure.
+        masked: If True (or when standard full-frame Pass 1 finds no
+            blackout), re-detect on a mask-free region with position-
+            independent classification (#753 masked-OBS).  OBS bit-exact.
         src_resolution: (width, height) from probe.  When provided,
             scorebar-based filtering is applied to remove in-match
             blackouts and non-FL blackouts.
@@ -446,6 +450,35 @@ def detect_match_boundaries(
         t for t, b in results.items() if b < pass1_blackout_threshold
     )
 
+    # Masked fallback (#753 masked-OBS): when standard full-frame Pass 1 finds no
+    # blackout (bright chat-mask overlays hold the average above threshold), OR
+    # --masked forces it, re-detect on a mask-free region with position-
+    # independent classification.  Gated by `not vtuber and (masked or not
+    # blackout_times)`: OBS baselines always have >=1 blackout so `not
+    # blackout_times` is False -> the standard path below runs unchanged
+    # (bit-exact; spec section 3 / R1).  VTuber uses its own path.
+    if not vtuber and (masked or not blackout_times):
+        masked_segments = _detect_masked_fallback(
+            video_path,
+            duration_hint=duration_hint,
+            sample_interval=sample_interval,
+            blackout_threshold=blackout_threshold,
+            min_match_duration=min_match_duration,
+            min_blackout_duration=min_blackout_duration,
+            use_gpu=use_gpu,
+            workers=workers,
+            src_resolution=src_resolution,
+            codec=codec,
+            gpu_vendor=gpu_vendor,
+            source_fps_num=source_fps_num,
+            source_fps_den=source_fps_den,
+            source_fps=source_fps,
+            audio_hits=audio_hits,
+            stats=stats,
+        )
+        if masked_segments is not None:
+            return masked_segments
+
     # Group into regions and expand with transition frames (#71)
     blackout_regions = _group_blackout_regions(blackout_times, sample_interval)
     blackout_regions = _expand_regions_with_transitions(
@@ -532,6 +565,139 @@ def detect_match_boundaries(
             min_match_duration=min_match_duration,
         )
     return segments
+
+
+def _detect_masked_fallback(
+    video_path: Path,
+    *,
+    duration_hint: float,
+    sample_interval: float,
+    blackout_threshold: float,
+    min_match_duration: float,
+    min_blackout_duration: float,
+    use_gpu: bool,
+    workers: int | None,
+    src_resolution: tuple[int, int] | None,
+    codec: str | None,
+    gpu_vendor: str | None,
+    source_fps_num: int | None,
+    source_fps_den: int | None,
+    source_fps: float | None,
+    audio_hits: Sequence[BgmHit] | None,
+    stats: DetectionStats | None,
+) -> list[MatchBoundary] | None:
+    """Masked-OBS detection: region-aware Pass 1/2 + localize classification.
+
+    Returns segments, or ``None`` when no mask-free region is found (caller falls
+    through to the standard single-segment result).  Deliberately duplicates the
+    standard Pass1/Pass2/classify sequence (calling the same factored helpers)
+    rather than sharing a core, so the standard OBS path is structurally
+    unchanged (bit-exact mandate; spec section 3 / R1).  Uses ``band_region=
+    FULL_FRAME`` + ``localize=True`` (full-frame position-independent scorebar;
+    v2 absolute coords FN on ultrawide, spec section 5).  No trailing-drop:
+    ``_drop_post_match_trailing`` probes v2 absolute coords which FN on
+    ultrawide (same rationale as the VTuber gate in detect_match_boundaries).
+    """
+    region = _resolve_masked_region(video_path, duration_hint, workers)
+    if region.is_full_frame():
+        return None  # no mask region found -> defer to the standard result
+
+    if use_gpu:
+        from allaganeye.video.gpu_detector import scan_gpu
+
+        try:
+            results = scan_gpu(
+                video_path,
+                duration_hint,
+                sample_interval,
+                blackout_threshold,
+                None,
+                codec=codec,
+                vendor=gpu_vendor,
+                source_fps_num=source_fps_num,
+                source_fps_den=source_fps_den,
+                source_fps=source_fps,
+                region=region,
+            )
+        except VideoProcessingError:
+            results = _scan_cpu(
+                video_path,
+                duration_hint,
+                sample_interval,
+                blackout_threshold,
+                workers,
+                None,
+                source_fps_num=source_fps_num,
+                source_fps_den=source_fps_den,
+                source_fps=source_fps,
+                region=region,
+            )
+    else:
+        results = _scan_cpu(
+            video_path,
+            duration_hint,
+            sample_interval,
+            blackout_threshold,
+            workers,
+            None,
+            source_fps_num=source_fps_num,
+            source_fps_den=source_fps_den,
+            source_fps=source_fps,
+            region=region,
+        )
+
+    pass1_blackout_threshold = blackout_threshold + _BLACKOUT_THRESHOLD_UPPER_MARGIN
+    blackout_times = sorted(
+        t for t, b in results.items() if b < pass1_blackout_threshold
+    )
+    blackout_regions = _group_blackout_regions(blackout_times, sample_interval)
+    blackout_regions = _expand_regions_with_transitions(
+        blackout_regions, results, sample_interval, _TRANSITION_THRESHOLD
+    )
+    if _ENABLE_BORDERLINE_REFINEMENT:
+        borderline_regions = _borderline_pseudo_regions(
+            results, blackout_threshold, duration_hint
+        )
+        if borderline_regions:
+            blackout_regions = _merge_regions(
+                blackout_regions + borderline_regions, sample_interval
+            )
+
+    refined_regions = _refine_blackout_regions(
+        video_path,
+        blackout_regions,
+        blackout_threshold,
+        duration_hint,
+        workers,
+        region=region,
+    )
+
+    classifications: list[str] | None = None
+    if src_resolution is not None:
+        from allaganeye.video.scorebar import filter_blackouts_with_scorebar
+
+        height = _scaled_height(src_resolution[0], src_resolution[1])
+        refined_regions, classifications = filter_blackouts_with_scorebar(
+            video_path,
+            refined_regions,
+            duration_hint,
+            height,
+            workers,
+            band_region=FULL_FRAME,
+            localize=True,
+            audio_hits=audio_hits,
+            stats=stats,
+        )
+
+    effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)
+    return _filter_and_extract_segments(
+        refined_regions,
+        duration_hint,
+        min_match_duration,
+        effective_min,
+        classifications=classifications,
+        stats=stats,
+    )
 
 
 def _decode_chunk_cpu(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -867,23 +867,13 @@ def _generate_timestamps(duration: float, interval: float) -> list[float]:
     return timestamps
 
 
-def _probe_single_frame(
-    video_path: Path,
-    timestamp: float,
-    region: CaptureRegion = FULL_FRAME,
-) -> float:
-    """Probe a single frame's mean brightness using ffmpeg -ss seek.
+def _decode_gray_raw(video_path: Path, timestamp: float) -> bytes | None:
+    """Decode exactly one 320x180 grayscale frame to raw bytes via ffmpeg -ss.
 
-    Uses input seeking (``-ss`` before ``-i``) for fast keyframe-based
-    access, then decodes exactly one frame at 320x180 grayscale.
-
-    Brightness is computed via :func:`_frame_brightness`, so *region*
-    defaults to ``FULL_FRAME`` (the 1-D ``float(frame.mean())`` path is
-    byte-identical to the pre-region behavior; a band region reshapes the
-    raw buffer to ``(_SAMPLE_HEIGHT, _SAMPLE_WIDTH)`` and crops).
-
-    Returns the mean brightness (0-255).  Returns 255.0 on probe failure
-    (treated as non-blackout to avoid false positives).
+    Shared by :func:`_probe_single_frame` (brightness) and
+    :func:`_probe_frame_gray2d` (2D array).  Returns the first ``_FRAME_SIZE``
+    bytes, or ``None`` on timeout / ffmpeg error / short read.  Raises
+    ``VideoProcessingError`` only when ffmpeg is missing.
     """
     cmd = [
         find_ffmpeg(),
@@ -903,7 +893,6 @@ def _probe_single_frame(
         "gray",
         "pipe:1",
     ]
-
     try:
         result = subprocess.run(cmd, capture_output=True, timeout=30)
     except FileNotFoundError as e:
@@ -911,16 +900,44 @@ def _probe_single_frame(
             "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
         ) from e
     except subprocess.TimeoutExpired:
-        return 255.0  # treat timeout as non-blackout
-
+        return None
     if result.returncode != 0:
-        return 255.0  # ffmpeg error, treat as non-blackout
-
+        return None
     if len(result.stdout) < _FRAME_SIZE:
-        return 255.0  # incomplete frame, treat as non-blackout
+        return None
+    return result.stdout[:_FRAME_SIZE]
 
-    frame = np.frombuffer(result.stdout[:_FRAME_SIZE], dtype=np.uint8)
+
+def _probe_single_frame(
+    video_path: Path,
+    timestamp: float,
+    region: CaptureRegion = FULL_FRAME,
+) -> float:
+    """Probe a single frame's mean brightness using ffmpeg -ss seek.
+
+    Returns the mean brightness (0-255).  Returns 255.0 on probe failure
+    (treated as non-blackout to avoid false positives).  Brightness is computed
+    via :func:`_frame_brightness`, so *region* defaults to ``FULL_FRAME`` (the
+    1-D ``float(frame.mean())`` path is byte-identical to the pre-region
+    behavior; a band region reshapes the raw buffer and crops).
+    """
+    raw = _decode_gray_raw(video_path, timestamp)
+    if raw is None:
+        return 255.0
+    frame = np.frombuffer(raw, dtype=np.uint8)
     return _frame_brightness(frame, region)
+
+
+def _probe_frame_gray2d(video_path: Path, timestamp: float) -> np.ndarray | None:
+    """Probe one 320x180 grayscale frame as a 2D ``(H, W)`` uint8 array.
+
+    Returns ``None`` on probe failure.  Used by :func:`_resolve_masked_region`
+    for static-overlay mask-free region detection (#753 masked-OBS).
+    """
+    raw = _decode_gray_raw(video_path, timestamp)
+    if raw is None:
+        return None
+    return np.frombuffer(raw, dtype=np.uint8).reshape(_SAMPLE_HEIGHT, _SAMPLE_WIDTH)
 
 
 def _probe_frame_rgb(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -345,6 +345,10 @@ def detect_match_boundaries(
     chunk_dispatch_callback: Callable[[int], None] | None = None,
     gpu_vendor: str | None = None,
     brightness_callback: Callable[[dict[float, float]], None] | None = None,
+    # #821: masked fallback の結果が採用されたとき (明示 --masked / 0-blackout
+    # auto-trigger とも) に一度だけ呼ばれる。request flag と resolved path を
+    # 分離して記録するための通知 seam (brightness_callback と同型)。
+    masked_fallback_callback: Callable[[], None] | None = None,
     # #576: rational fps propagation (preferred over float source_fps).
     # Either pair (num+den) takes precedence; float source_fps is the
     # backward-compatible fallback (Fraction.limit_denominator path).
@@ -507,6 +511,8 @@ def detect_match_boundaries(
             brightness_results=results,
         )
         if masked_segments is not None:
+            if masked_fallback_callback is not None:
+                masked_fallback_callback()
             return masked_segments
 
     # Group into regions and expand with transition frames (#71)

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -500,7 +500,7 @@ def detect_match_boundaries(
             height,
             workers,
             band_region=detect_region,
-            vtuber=vtuber,
+            localize=vtuber,
             audio_hits=audio_hits,
             stats=stats,
             progress_callback=scorebar_progress_callback,

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -264,22 +264,51 @@ Must span multiple blackouts so game pixels register a dark ``min``; 48 over a
 multi-hour FL recording covers many match boundaries (spec section 5).
 """
 
+_MASKED_REGION_DARK = 32
+"""Darkest-brightness frames sampled for masked region detection when a Pass-1
+brightness hint is available.  These land on the masked blackouts (game region
+dark) so ``detect_mask_free_region`` can see game pixels reach a dark min."""
+
+_MASKED_REGION_EVEN = 32
+"""Evenly-spaced frames sampled alongside ``_MASKED_REGION_DARK`` (gameplay:
+game region bright) so each game pixel is bright in some frame AND dark in
+another (#753: even-only sampling missed brief blackouts on shorter recordings)."""
+
 
 def _resolve_masked_region(
-    video_path: Path, duration_hint: float, workers: int | None
+    video_path: Path,
+    duration_hint: float,
+    workers: int | None,
+    *,
+    brightness_hint: dict[float, float] | None = None,
 ) -> CaptureRegion:
     """Detect the mask-free game rectangle for masked recordings (#753).
 
-    Samples ``_MASKED_REGION_SAMPLES`` sparse grayscale frames and runs
-    ``detect_mask_free_region``.  Any failure (decode, opencv, empty) degrades to
-    FULL_FRAME so the masked-fallback caller can treat FULL_FRAME as "no mask
-    region found" and defer to the standard result.  Never raises.
+    Samples grayscale frames and runs ``detect_mask_free_region``.  When a
+    ``brightness_hint`` (the standard full-frame Pass-1 ``{timestamp: brightness}``
+    map) is provided, samples the ``_MASKED_REGION_DARK`` darkest timestamps (the
+    masked blackouts, where the game region goes dark) plus ``_MASKED_REGION_EVEN``
+    evenly-spaced timestamps (gameplay, where it is bright) -- both are required
+    so each game pixel is bright in some frame AND dark in another.  Without a
+    hint, falls back to ``_MASKED_REGION_SAMPLES`` even samples.  Any failure
+    (decode, opencv, empty) degrades to FULL_FRAME so the caller can treat
+    FULL_FRAME as "no mask region found".  Never raises.
     """
     from allaganeye.video.capture_region import detect_mask_free_region
 
     try:
-        n = _MASKED_REGION_SAMPLES
-        times = [duration_hint * (i + 1) / (n + 1) for i in range(n)]
+        if brightness_hint:
+            dark_ts = sorted(brightness_hint, key=lambda t: brightness_hint[t])[
+                :_MASKED_REGION_DARK
+            ]
+            even_ts = [
+                duration_hint * (i + 1) / (_MASKED_REGION_EVEN + 1)
+                for i in range(_MASKED_REGION_EVEN)
+            ]
+            times = sorted(set(dark_ts) | set(even_ts))
+        else:
+            n = _MASKED_REGION_SAMPLES
+            times = [duration_hint * (i + 1) / (n + 1) for i in range(n)]
         max_workers = max(1, min(len(times), workers or os.cpu_count() or 4))
         frames: list[np.ndarray] = []
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
@@ -475,6 +504,7 @@ def detect_match_boundaries(
             source_fps=source_fps,
             audio_hits=audio_hits,
             stats=stats,
+            brightness_results=results,
         )
         if masked_segments is not None:
             return masked_segments
@@ -585,6 +615,7 @@ def _detect_masked_fallback(
     source_fps: float | None,
     audio_hits: Sequence[BgmHit] | None,
     stats: DetectionStats | None,
+    brightness_results: dict[float, float] | None = None,
 ) -> list[MatchBoundary] | None:
     """Masked-OBS detection: region-aware Pass 1/2 + localize classification.
 
@@ -598,7 +629,9 @@ def _detect_masked_fallback(
     ``_drop_post_match_trailing`` probes v2 absolute coords which FN on
     ultrawide (same rationale as the VTuber gate in detect_match_boundaries).
     """
-    region = _resolve_masked_region(video_path, duration_hint, workers)
+    region = _resolve_masked_region(
+        video_path, duration_hint, workers, brightness_hint=brightness_results
+    )
     if region.is_full_frame():
         return None  # no mask region found -> defer to the standard result
 

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -257,6 +257,42 @@ def _resolve_detect_region(video_path: Path, duration_hint: float) -> CaptureReg
     return region
 
 
+_MASKED_REGION_SAMPLES = 48
+"""Sparse frames sampled across the video for mask-free region detection.
+
+Must span multiple blackouts so game pixels register a dark ``min``; 48 over a
+multi-hour FL recording covers many match boundaries (spec section 5).
+"""
+
+
+def _resolve_masked_region(
+    video_path: Path, duration_hint: float, workers: int | None
+) -> CaptureRegion:
+    """Detect the mask-free game rectangle for masked recordings (#753).
+
+    Samples ``_MASKED_REGION_SAMPLES`` sparse grayscale frames and runs
+    ``detect_mask_free_region``.  Any failure (decode, opencv, empty) degrades to
+    FULL_FRAME so the masked-fallback caller can treat FULL_FRAME as "no mask
+    region found" and defer to the standard result.  Never raises.
+    """
+    from allaganeye.video.capture_region import detect_mask_free_region
+
+    try:
+        n = _MASKED_REGION_SAMPLES
+        times = [duration_hint * (i + 1) / (n + 1) for i in range(n)]
+        max_workers = max(1, min(len(times), workers or os.cpu_count() or 4))
+        frames: list[np.ndarray] = []
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            for frame in pool.map(lambda t: _probe_frame_gray2d(video_path, t), times):
+                if frame is not None:
+                    frames.append(frame)
+        if len(frames) < 2:
+            return FULL_FRAME
+        return detect_mask_free_region(frames)
+    except Exception:
+        return FULL_FRAME
+
+
 def detect_match_boundaries(
     video_path: Path,
     *,

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -420,7 +420,7 @@ def classify_blackout(
     - ``"unknown"``: all probes failed on either side -> keep boundary (safe)
     """
     if localize:
-        # position-independent: VTuber / masked path — uses the localize
+        # position-independent: VTuber / masked path - uses the localize
         # classifier as the sole signal (spec section 8.1 P2-a).
         # The OBS v2 body below is left untouched.
         return _classify_blackout_localize(

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -389,7 +389,7 @@ def classify_blackout(
     workers: int | None = None,
     *,
     band_region: CaptureRegion = FULL_FRAME,
-    vtuber: bool = False,
+    localize: bool = False,
 ) -> str:
     """Classify a blackout region by scorebar context.
 
@@ -419,9 +419,10 @@ def classify_blackout(
     - ``"non_fl"``: neither side has scorebar -> non-FL blackout (#109)
     - ``"unknown"``: all probes failed on either side -> keep boundary (safe)
     """
-    if vtuber:
-        # VTuber path: position-independent localize as the sole signal
-        # (spec section 8.1 P2-a). The OBS v2 body below is left untouched.
+    if localize:
+        # position-independent: VTuber / masked path — uses the localize
+        # classifier as the sole signal (spec section 8.1 P2-a).
+        # The OBS v2 body below is left untouched.
         return _classify_blackout_localize(
             video_path,
             region,
@@ -575,7 +576,7 @@ def filter_blackouts_with_scorebar(
     workers: int | None = None,
     *,
     band_region: CaptureRegion = FULL_FRAME,
-    vtuber: bool = False,
+    localize: bool = False,
     audio_hits: Sequence[BgmHit] | None = None,
     stats: DetectionStats | None = None,
     progress_callback: Callable[[int, int], None] | None = None,
@@ -623,7 +624,7 @@ def filter_blackouts_with_scorebar(
             height,
             workers,
             band_region=band_region,
-            vtuber=vtuber,
+            localize=localize,
         )
         if progress_callback is not None:
             progress_callback(idx + 1, total_regions)
@@ -689,7 +690,7 @@ def filter_blackouts_with_scorebar(
         height,
         workers,
         band_region=band_region,
-        vtuber=vtuber,
+        localize=localize,
     )
 
 
@@ -702,7 +703,7 @@ def _merge_boundary_pairs(
     workers: int | None,
     *,
     band_region: CaptureRegion = FULL_FRAME,
-    vtuber: bool = False,
+    localize: bool = False,
 ) -> tuple[list[tuple[float, float]], list[str]]:
     """Merge consecutive match_boundary pairs separated by non-FL content.
 
@@ -737,7 +738,7 @@ def _merge_boundary_pairs(
                 probe_points = [
                     gap_start + (gap_end - gap_start) * k / 10 for k in range(1, 10)
                 ]
-                if vtuber:
+                if localize:
                     _, _, probe_signal = _probe_scorebar_context(
                         video_path,
                         probe_points,

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -129,7 +129,7 @@ allaganeye 0.1.1 (ffmpeg 8.1, Python 3.12.10, Windows 11)
 Probing: recording.mkv
   Duration: 10228.7s, Resolution: 1920x1080, FPS: 60.00, Codec: h264
 Cache hit: detection params from .detection_cache.json
-  sample_interval=3.0s, threshold=15.0, min_match=300.0s, min_blackout=3.0s, audio=frozen, vtuber=off, masked=off
+  sample_interval=3.0s, threshold=15.0, min_match=300.0s, min_blackout=3.0s, audio=frozen, vtuber=off, masked=off, masked_fallback=off
 Detected 8 match(es) in recording.mkv (2:50:28) (cached)
   Match 1:   00:00 -   15:17  (15m17s)  [unknown]
   ...

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -78,7 +78,7 @@ allaganeye 0.1.1 (ffmpeg 8.1, Python 3.12.10, Windows 11)
   Disk: 1359.5 / 3726.0 GB free on E:
 Probing: recording.mkv
   Duration: 10228.7s, Resolution: 1920x1080, FPS: 60.00, Codec: h264
-Detecting match boundaries (interval=3.0s, threshold=15.0, workers=auto (24), min_match=300.0s, min_blackout=3.0s, audio=frozen, vtuber=off)
+Detecting match boundaries (interval=3.0s, threshold=15.0, workers=auto (24), min_match=300.0s, min_blackout=3.0s, audio=frozen, vtuber=off, masked=off)
 Detecting  #################################### 100%
 Refining   #################################### 100%
 Scorebar   #################################### 100%
@@ -129,7 +129,7 @@ allaganeye 0.1.1 (ffmpeg 8.1, Python 3.12.10, Windows 11)
 Probing: recording.mkv
   Duration: 10228.7s, Resolution: 1920x1080, FPS: 60.00, Codec: h264
 Cache hit: detection params from .detection_cache.json
-  sample_interval=3.0s, threshold=15.0, min_match=300.0s, min_blackout=3.0s, audio=frozen, vtuber=off
+  sample_interval=3.0s, threshold=15.0, min_match=300.0s, min_blackout=3.0s, audio=frozen, vtuber=off, masked=off
 Detected 8 match(es) in recording.mkv (2:50:28) (cached)
   Match 1:   00:00 -   15:17  (15m17s)  [unknown]
   ...

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -81,6 +81,8 @@ JSON Schema は writer 契約として strict (additional properties は受け�
 | `no_audio` | boolean | 音声昇格無効化フラグ |
 | `use_gpu` | number \| boolean \| null | GPU モード (null = auto 判定) |
 | `workers` | number \| null | 並列ワーカー数 (null = auto) |
+| `vtuber` | boolean | VTuber 帯 anchor path で検出したか (#821)。新規書き込みは常に出力 / 読み込み時は欠落許容 (欠落 = false、#821 導入前の出力) |
+| `masked` | boolean | masked (チャット隠しマスク) fallback path で検出したか (#821)。新規書き込みは常に出力 / 読み込み時は欠落許容 (欠落 = false) |
 
 ### `Match` オブジェクト (`matches[]`)
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -81,8 +81,9 @@ JSON Schema は writer 契約として strict (additional properties は受け�
 | `no_audio` | boolean | 音声昇格無効化フラグ |
 | `use_gpu` | number \| boolean \| null | GPU モード (null = auto 判定) |
 | `workers` | number \| null | 並列ワーカー数 (null = auto) |
-| `vtuber` | boolean | VTuber 帯 anchor path で検出したか (#821)。新規書き込みは常に出力 / 読み込み時は欠落許容 (欠落 = false、#821 導入前の出力) |
-| `masked` | boolean | masked (チャット隠しマスク) fallback path で検出したか (#821)。新規書き込みは常に出力 / 読み込み時は欠落許容 (欠落 = false) |
+| `vtuber` | boolean | `--vtuber` flag の値 (#821。VTuber path は auto-trigger しないため request = resolved)。新規書き込みは常に出力 / 読み込み時は欠落許容 (欠落 = false、#821 導入前の出力) |
+| `masked` | boolean | `--masked` flag の値 (request、#821)。fallback は 0-blackout で auto-trigger もするため、resolved path は `masked_fallback_used` を参照。新規書き込みは常に出力 / 読み込み時は欠落許容 (欠落 = false) |
+| `masked_fallback_used` | boolean | mask-free 領域 fallback が実際にこの結果を生成したか (明示 `--masked` / 0-blackout auto-trigger とも true、#821)。新規書き込みは常に出力 / 読み込み時は欠落許容 (欠落 = false) |
 
 ### `Match` オブジェクト (`matches[]`)
 

--- a/docs/output-spec.md
+++ b/docs/output-spec.md
@@ -57,7 +57,7 @@ Error: --quiet and --verbose are mutually exclusive
 | 6 | Dry-run 通知 (`[dry-run] Detect only...` / `Dry run: skipping split`) | [#418](https://github.com/Idios/kobutachan-allaganeye/issues/418) | - | - | - | ◯ | ◯ | × | ❌ |
 | 7 | Cache hit 検知パラメータ (`Cache hit: detection params from ...`) | [#380](https://github.com/Idios/kobutachan-allaganeye/issues/380) | × | ◯ (cache hit 時のみ) | × | × | ◯ | × | ❌ |
 | 8 | Auto-selected / Forced GPU/CPU mode | - | × | ◯ | × | × | ◯ | × | ❌ |
-| 9 | 検知パラメータ summary (`interval=..., threshold=..., workers=auto (N), audio=frozen, vtuber=off`) | [#384](https://github.com/Idios/kobutachan-allaganeye/issues/384), [#389](https://github.com/Idios/kobutachan-allaganeye/issues/389) | × | ◯ | × | × | ◯ | × | ❌ |
+| 9 | 検知パラメータ summary (`interval=..., threshold=..., workers=auto (N), audio=frozen, vtuber=off, masked=off`) | [#384](https://github.com/Idios/kobutachan-allaganeye/issues/384), [#389](https://github.com/Idios/kobutachan-allaganeye/issues/389) | × | ◯ | × | × | ◯ | × | ❌ |
 | 10 | 進捗バー `Detecting` / `Refining` / `Scorebar` | [#368](https://github.com/Idios/kobutachan-allaganeye/issues/368), [#393](https://github.com/Idios/kobutachan-allaganeye/issues/393) | ◯ | ◯ | × | ◯ | ◯ | × | ❌ |
 | 11 | 検知統計 (`Pass 1`, `Pass 2`, `Scorebar`, `Splitting` elapsed 含) | [#386](https://github.com/Idios/kobutachan-allaganeye/issues/386), [#387](https://github.com/Idios/kobutachan-allaganeye/issues/387) | × | ◯ | × | × | ◯ | × | ❌ |
 | 12 | Filter drop 内訳 + unknown match 行 (`Filter: N candidates -> M matches` + `+ N unknown match (録画途中試合)`) | [#388](https://github.com/Idios/kobutachan-allaganeye/issues/388), [#433](https://github.com/Idios/kobutachan-allaganeye/issues/433) | × | ◯ | × | × | ◯ | × | ❌ |

--- a/docs/superpowers/plans/2026-06-05-masked-obs-detection-subproject-a.md
+++ b/docs/superpowers/plans/2026-06-05-masked-obs-detection-subproject-a.md
@@ -1,0 +1,1094 @@
+# masked + ultrawide OBS 検出 (Sub-project A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** チャット隠しマスク画像を重ねた全画面 OBS 録画 (ultrawide 含む) を、標準 detect が 0 blackout で全滅したとき mask-free 領域の輝度で再検出し、position-independent な localize 分類で試合分割できるようにする。
+
+**Architecture:** 標準 full-frame Pass 1 が 0 blackout を返したとき (または `--masked` 強制時) のみ走る純粋な追加経路 `_detect_masked_fallback` を `detect_match_boundaries` 内の明示 gate (`not vtuber and (masked or not blackout_times)`) で起動する。fallback は (1) static-overlay で mask-free 矩形を検出 → (2) parked Phase 1 region 機構 (`region=`) で Pass1/Pass2 を再実行 → (3) parked Phase 2 localize 分類器 (`localize=True`) で試合境界を分類 → (4) 既存 segment 抽出。OBS 5 baseline は full-frame で必ず blackout を拾うため gate が False のまま = 標準 path のコードは構造的に不変 (bit-exact)。
+
+**Tech Stack:** Python 3.12 / numpy / opencv-python-headless / ffmpeg / Typer。既存 `allaganeye.video.{detector,scorebar,gpu_detector,capture_region}` の parked Phase 0/1/2 機構を土台に再利用する。
+
+---
+
+## 設計不変条件 (全タスク共通、違反したら STOP)
+
+- **bit-exact mandate**: `vtuber=False` かつ標準 Pass1 が blackout を 1 つでも返す録画では、`detect_match_boundaries` の実行 path は現行と完全一致しなければならない。masked 経路は gate (`not vtuber and (masked or not blackout_times)`) の内側のみ。OBS 5 baseline (Task 7) で必ず構造確認する。
+- **隔離 > DRY**: `_detect_masked_fallback` は標準 path の scan/refine/classify を共有関数に抽出せず**意図的に複製**する (既存 factored helper は呼ぶ)。標準 path body を触る refactor は bit-exact を 2 度壊した教訓 (spec §10 R1) のため禁止。複製箇所には cross-reference コメントを付ける。
+- **localize 分類器のみ共有**: VTuber 固有 (band-anchor `_resolve_detect_region` / `--vtuber` user flag) は再利用しない。共有するのは position-independent 分類器のみ。その選択子をこの plan で `vtuber` → `localize` に正名化する (Task 4)。
+
+## 再利用する既存機構 (再実装禁止)
+
+| シンボル | 場所 | 役割 |
+| --- | --- | --- |
+| `CaptureRegion` / `FULL_FRAME` / `region_mean` / `_maybe_snap_full_frame` | `capture_region.py` | 正規化矩形 + 縮退 snap |
+| `detect_region_blackout_overlap` (S3) / `_OVERLAP_BRIGHT=60` / `_OVERLAP_DARK=20` / `_MIN_REGION_AREA_FRAC=0.08` | `capture_region.py` | Task 1 の発想の土台 + 共有定数 |
+| `_scan_cpu(region=)` / `scan_gpu(region=)` / `_refine_blackout_regions(region=)` / `_frame_brightness(region=)` | `detector.py` / `gpu_detector.py` | Phase 1 region threading |
+| `_group_blackout_regions` / `_expand_regions_with_transitions` / `_borderline_pseudo_regions` / `_merge_regions` / `_filter_and_extract_segments` | `detector.py` | 検出パイプライン部品 |
+| `_scaled_height` / `_BLACKOUT_THRESHOLD_UPPER_MARGIN` / `_TRANSITION_THRESHOLD` / `_ENABLE_BORDERLINE_REFINEMENT` / `_REFINED_MIN_BLACKOUT` | `detector.py` | 共有定数・ヘルパ |
+| `filter_blackouts_with_scorebar` / `classify_blackout` / `_classify_blackout_localize` / `_merge_boundary_pairs` / `_probe_scorebar_context(with_localize=)` / `_localize_present_from_raw` | `scorebar.py` | Phase 2 localize 分類 |
+| `SplitConfig` / `_run_detection` の `detect_kwargs` / CLI `--vtuber` flag | `config.py` / `commands/split_matches.py` / `cli.py` | CLI plumbing |
+
+## File Structure
+
+- Modify: `allaganeye/video/capture_region.py` — `detect_mask_free_region` + `_maximal_ones_rectangle` を追加 (S3 を hole-free 矩形に精緻化)。
+- Modify: `allaganeye/video/detector.py` — `_decode_gray_raw` 抽出 + `_probe_frame_gray2d` / `_resolve_masked_region` / `_detect_masked_fallback` 追加 + `detect_match_boundaries` に `masked` param と gate branch、`filter_blackouts_with_scorebar` 呼び出しを `localize=` に追従。
+- Modify: `allaganeye/video/scorebar.py` — 分類器選択子 `vtuber` → `localize` 正名化 (`classify_blackout` / `filter_blackouts_with_scorebar` / `_merge_boundary_pairs`)。
+- Modify: `allaganeye/config.py` — `SplitConfig.masked: bool = False`。
+- Modify: `allaganeye/cli.py` — `--masked` option (split + detect)、`--vtuber` を `hidden=True` 化、`--vtuber`/`--masked` 排他。
+- Modify: `allaganeye/commands/split_matches.py` — `detect_kwargs` に `"masked": config.masked`。
+- Test: `tests/test_capture_region.py` / `tests/test_detector.py` / `tests/test_scorebar.py` / `tests/test_config.py` / `tests/test_cli.py` / `tests/test_l3_phase2_parity.py` / `tests/test_split_matches.py` / `tests/test_scorebar_v2.py`。
+
+---
+
+## Task 1: mask-free 矩形検出 (`detect_mask_free_region`)
+
+S3 (`detect_region_blackout_overlap`) は game の最大連結成分**bbox** を返すためマスク穴を含みうる。本タスクは game mask 上の**最大 all-ones 矩形** (hole-free) を返す形に精緻化する。
+
+**Files:**
+
+- Modify: `allaganeye/video/capture_region.py`
+- Test: `tests/test_capture_region.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_capture_region.py` の末尾に追加:
+
+```python
+import numpy as np
+
+from allaganeye.video.capture_region import (
+    FULL_FRAME,
+    detect_mask_free_region,
+    _maximal_ones_rectangle,
+)
+
+
+def _rect_overlaps(rect_px, block_px) -> bool:
+    ax0, ay0, ax1, ay1 = rect_px
+    bx0, by0, bx1, by1 = block_px
+    return ax0 < bx1 and bx0 < ax1 and ay0 < by1 and by0 < ay1
+
+
+def _frames_with_mask(h, w, mask_block, values=(5, 200, 5, 200)):
+    """Game pixels cycle bright/dark across frames; mask_block stays bright (200)."""
+    bx0, by0, bx1, by1 = mask_block
+    frames = []
+    for v in values:
+        f = np.full((h, w), v, dtype=np.uint8)
+        f[by0:by1, bx0:bx1] = 200  # static bright mask -> min never < dark
+        frames.append(f)
+    return frames
+
+
+def test_maximal_ones_rectangle_simple_block():
+    mask = np.zeros((4, 5), dtype=np.uint8)
+    mask[1:4, 1:4] = 1  # 3x3 block of ones at (x=1..3, y=1..3)
+    assert _maximal_ones_rectangle(mask) == (1, 1, 4, 4)
+
+
+def test_maximal_ones_rectangle_empty_is_none():
+    assert _maximal_ones_rectangle(np.zeros((4, 4), dtype=np.uint8)) is None
+
+
+def test_detect_mask_free_region_excludes_bright_mask():
+    # 20x20, bright static mask at bottom-left (cols 0..10, rows 10..20).
+    frames = _frames_with_mask(20, 20, (0, 10, 10, 20))
+    region = detect_mask_free_region(frames)
+    assert not region.is_full_frame()
+    # Returned rectangle must not intersect the mask block.
+    px = (
+        round(region.x * 20),
+        round(region.y * 20),
+        round((region.x + region.w) * 20),
+        round((region.y + region.h) * 20),
+    )
+    assert not _rect_overlaps(px, (0, 10, 10, 20))
+
+
+def test_detect_mask_free_region_full_game_snaps_full_frame():
+    # Every pixel cycles bright/dark -> game everywhere -> FULL_FRAME.
+    frames = [np.full((20, 20), v, dtype=np.uint8) for v in (5, 200, 5, 200)]
+    assert detect_mask_free_region(frames).is_full_frame()
+
+
+def test_detect_mask_free_region_tiny_game_is_full_frame():
+    # Only a 2x2 game patch (rest stays bright) -> below min_area_frac -> FULL_FRAME.
+    frames = []
+    for v in (5, 200):
+        f = np.full((20, 20), 200, dtype=np.uint8)
+        f[0:2, 0:2] = v
+        frames.append(f)
+    assert detect_mask_free_region(frames).is_full_frame()
+
+
+def test_detect_mask_free_region_single_frame_is_full_frame():
+    assert detect_mask_free_region([np.zeros((20, 20), dtype=np.uint8)]).is_full_frame()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_capture_region.py -k "mask_free or maximal_ones" -v`
+Expected: FAIL with `ImportError: cannot import name 'detect_mask_free_region'`.
+
+- [ ] **Step 3: Implement `_maximal_ones_rectangle` + `detect_mask_free_region`**
+
+`allaganeye/video/capture_region.py` の `detect_region_blackout_overlap` 直後に追加:
+
+```python
+def _maximal_ones_rectangle(mask: np.ndarray) -> tuple[int, int, int, int] | None:
+    """Largest all-ones axis-aligned rectangle in a binary mask (histogram stack).
+
+    Returns ``(x0, y0, x1, y1)`` half-open (x1/y1 exclusive) of the maximum-area
+    all-ones rectangle, or ``None`` when the mask has no set pixels.  O(H*W):
+    per-row histogram heights + largest-rectangle-in-histogram with a sentinel.
+    """
+    h, w = mask.shape
+    heights = np.zeros(w, dtype=np.int32)
+    best_area = 0
+    best: tuple[int, int, int, int] | None = None
+    for y in range(h):
+        heights = np.where(mask[y] > 0, heights + 1, 0)
+        hh = heights.tolist()
+        stack: list[int] = []
+        x = 0
+        while x <= w:
+            cur = hh[x] if x < w else 0
+            if not stack or hh[stack[-1]] <= cur:
+                stack.append(x)
+                x += 1
+            else:
+                top = stack.pop()
+                height = hh[top]
+                left = 0 if not stack else stack[-1] + 1
+                width = x - left
+                area = height * width
+                if area > best_area:
+                    best_area = area
+                    best = (left, y - height + 1, left + width, y + 1)
+    return best
+
+
+def detect_mask_free_region(
+    frames: list[np.ndarray],
+    *,
+    bright_thresh: float = _OVERLAP_BRIGHT,
+    dark_thresh: float = _OVERLAP_DARK,
+    min_area_frac: float = _MIN_REGION_AREA_FRAC,
+) -> CaptureRegion:
+    """Largest hole-free game rectangle for masked recordings (#753 masked-OBS).
+
+    Refines S3 (``detect_region_blackout_overlap``): instead of the largest game
+    *component bbox* (which can contain mask holes), returns the largest solid
+    all-game *rectangle* (maximal all-ones rectangle over the game mask), so the
+    measurement region excludes bright static masks composited over gameplay.
+
+    game pixel = max brightness > ``bright_thresh`` AND min brightness <
+    ``dark_thresh`` (brightens during play, darkens during a blackout).  Bright
+    static masks never darken (min stays high) -> excluded.  Always-dark bars
+    never brighten -> excluded.  Unmasked full-frame game -> every pixel is game
+    -> snaps to FULL_FRAME.  Fewer than 2 frames, no game pixels, or a max
+    rectangle below ``min_area_frac`` of the frame -> FULL_FRAME (safe degenerate:
+    the masked-fallback caller treats FULL_FRAME as "no mask region found").
+    """
+    if len(frames) < 2:
+        return FULL_FRAME
+    stack = np.stack(frames).astype(np.float32)
+    pmax = stack.max(axis=0)
+    pmin = stack.min(axis=0)
+    game_mask = ((pmax > bright_thresh) & (pmin < dark_thresh)).astype(np.uint8)
+    rect = _maximal_ones_rectangle(game_mask)
+    if rect is None:
+        return FULL_FRAME
+    x0, y0, x1, y1 = rect
+    h, w = game_mask.shape
+    if (x1 - x0) * (y1 - y0) < min_area_frac * w * h:
+        return FULL_FRAME
+    region = CaptureRegion(
+        x0 / w,
+        y0 / h,
+        (x1 - x0) / w,
+        (y1 - y0) / h,
+        confidence=0.8,
+        source="tierA",
+    ).clamp()
+    return _maybe_snap_full_frame(region)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_capture_region.py -k "mask_free or maximal_ones" -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/video/capture_region.py tests/test_capture_region.py
+git commit -m "feat(l3): mask-free 矩形検出 detect_mask_free_region (S3 を hole-free 化, masked-OBS A1)"
+```
+
+---
+
+## Task 2: 単一フレーム grayscale 2D デコード (`_probe_frame_gray2d`)
+
+mask-free 領域検出 (Task 3) には輝度スカラーではなく 2D フレーム配列が要る。`_probe_single_frame` の ffmpeg デコードを behavior-preserving に `_decode_gray_raw` へ抽出し、2D 版を追加する。
+
+**Files:**
+
+- Modify: `allaganeye/video/detector.py:858-911` (`_probe_single_frame`)
+- Test: `tests/test_detector.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_detector.py` の末尾に追加:
+
+```python
+import numpy as np
+
+from allaganeye.video import detector as _det
+
+
+def test_probe_frame_gray2d_returns_2d(monkeypatch):
+    buf = bytes(range(256)) * (_det._FRAME_SIZE // 256 + 1)
+    monkeypatch.setattr(_det, "_decode_gray_raw", lambda v, t: buf[: _det._FRAME_SIZE])
+    frame = _det._probe_frame_gray2d(_det.Path("x.mp4"), 1.0)
+    assert frame is not None
+    assert frame.shape == (_det._SAMPLE_HEIGHT, _det._SAMPLE_WIDTH)
+    assert frame.dtype == np.uint8
+
+
+def test_probe_frame_gray2d_none_on_decode_failure(monkeypatch):
+    monkeypatch.setattr(_det, "_decode_gray_raw", lambda v, t: None)
+    assert _det._probe_frame_gray2d(_det.Path("x.mp4"), 1.0) is None
+
+
+def test_probe_single_frame_regression_via_shared_decoder(monkeypatch):
+    # Extraction must preserve _probe_single_frame brightness exactly.
+    buf = bytes([10]) * _det._FRAME_SIZE
+    monkeypatch.setattr(_det, "_decode_gray_raw", lambda v, t: buf)
+    assert _det._probe_single_frame(_det.Path("x.mp4"), 1.0) == 10.0
+    monkeypatch.setattr(_det, "_decode_gray_raw", lambda v, t: None)
+    assert _det._probe_single_frame(_det.Path("x.mp4"), 1.0) == 255.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_detector.py -k "probe_frame_gray2d or regression_via_shared" -v`
+Expected: FAIL with `AttributeError: ... has no attribute '_decode_gray_raw'`.
+
+- [ ] **Step 3: Extract `_decode_gray_raw` and add `_probe_frame_gray2d`**
+
+`allaganeye/video/detector.py`、現行 `_probe_single_frame` (lines 858-911) を以下で置換:
+
+```python
+def _decode_gray_raw(video_path: Path, timestamp: float) -> bytes | None:
+    """Decode exactly one 320x180 grayscale frame to raw bytes via ffmpeg -ss.
+
+    Shared by :func:`_probe_single_frame` (brightness) and
+    :func:`_probe_frame_gray2d` (2D array).  Returns the first ``_FRAME_SIZE``
+    bytes, or ``None`` on timeout / ffmpeg error / short read.  Raises
+    ``VideoProcessingError`` only when ffmpeg is missing.
+    """
+    cmd = [
+        find_ffmpeg(),
+        "-threads",
+        "1",
+        "-ss",
+        str(timestamp),
+        "-i",
+        str(video_path),
+        "-frames:v",
+        "1",
+        "-s",
+        f"{_SAMPLE_WIDTH}x{_SAMPLE_HEIGHT}",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "gray",
+        "pipe:1",
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, timeout=30)
+    except FileNotFoundError as e:
+        raise VideoProcessingError(
+            "ffmpeg not found. Please install ffmpeg and ensure it is in PATH."
+        ) from e
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0:
+        return None
+    if len(result.stdout) < _FRAME_SIZE:
+        return None
+    return result.stdout[:_FRAME_SIZE]
+
+
+def _probe_single_frame(
+    video_path: Path,
+    timestamp: float,
+    region: CaptureRegion = FULL_FRAME,
+) -> float:
+    """Probe a single frame's mean brightness using ffmpeg -ss seek.
+
+    Returns the mean brightness (0-255).  Returns 255.0 on probe failure
+    (treated as non-blackout to avoid false positives).  Brightness is computed
+    via :func:`_frame_brightness`, so *region* defaults to ``FULL_FRAME`` (the
+    1-D ``float(frame.mean())`` path is byte-identical to the pre-region
+    behavior; a band region reshapes the raw buffer and crops).
+    """
+    raw = _decode_gray_raw(video_path, timestamp)
+    if raw is None:
+        return 255.0
+    frame = np.frombuffer(raw, dtype=np.uint8)
+    return _frame_brightness(frame, region)
+
+
+def _probe_frame_gray2d(video_path: Path, timestamp: float) -> np.ndarray | None:
+    """Probe one 320x180 grayscale frame as a 2D ``(H, W)`` uint8 array.
+
+    Returns ``None`` on probe failure.  Used by :func:`_resolve_masked_region`
+    for static-overlay mask-free region detection (#753 masked-OBS).
+    """
+    raw = _decode_gray_raw(video_path, timestamp)
+    if raw is None:
+        return None
+    return np.frombuffer(raw, dtype=np.uint8).reshape(_SAMPLE_HEIGHT, _SAMPLE_WIDTH)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_detector.py -k "probe_frame_gray2d or regression_via_shared or probe_single_frame" -v`
+Expected: PASS (新規 3 + 既存 `_probe_single_frame` テスト全て green = 抽出が behavior-preserving)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/video/detector.py tests/test_detector.py
+git commit -m "refactor(l3): grayscale decode を _decode_gray_raw に抽出 + _probe_frame_gray2d 追加 (masked-OBS A2)"
+```
+
+---
+
+## Task 3: mask-free 領域解決 (`_resolve_masked_region`)
+
+疎サンプルした 2D フレーム群を `detect_mask_free_region` に渡し、例外は FULL_FRAME に握り潰す orchestration。
+
+**Files:**
+
+- Modify: `allaganeye/video/detector.py` (import 群と `_resolve_detect_region` 近傍に追加)
+- Test: `tests/test_detector.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_detector.py` に追加:
+
+```python
+def _masked_frames():
+    out = []
+    for v in (5, 200, 5, 200):
+        f = np.full((_det._SAMPLE_HEIGHT, _det._SAMPLE_WIDTH), v, dtype=np.uint8)
+        f[120:180, 0:120] = 200  # static bright mask, bottom-left
+        out.append(f)
+    return out
+
+
+def test_resolve_masked_region_finds_mask_free_rect(monkeypatch):
+    seq = iter(_masked_frames() * 20)
+    monkeypatch.setattr(_det, "_probe_frame_gray2d", lambda v, t: next(seq, _masked_frames()[0]))
+    region = _det._resolve_masked_region(_det.Path("x.mp4"), 600.0, None)
+    assert not region.is_full_frame()
+
+
+def test_resolve_masked_region_full_frame_when_no_frames(monkeypatch):
+    monkeypatch.setattr(_det, "_probe_frame_gray2d", lambda v, t: None)
+    assert _det._resolve_masked_region(_det.Path("x.mp4"), 600.0, None).is_full_frame()
+
+
+def test_resolve_masked_region_swallows_exceptions(monkeypatch):
+    def boom(v, t):
+        raise RuntimeError("decode blew up")
+
+    monkeypatch.setattr(_det, "_probe_frame_gray2d", boom)
+    assert _det._resolve_masked_region(_det.Path("x.mp4"), 600.0, None).is_full_frame()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_detector.py -k resolve_masked_region -v`
+Expected: FAIL with `AttributeError: ... has no attribute '_resolve_masked_region'`.
+
+- [ ] **Step 3: Implement `_resolve_masked_region`**
+
+`allaganeye/video/detector.py`、`_resolve_detect_region` の直後に追加 (`ThreadPoolExecutor` は既に import 済 / `os` も import 済であることを確認: ファイル冒頭に無ければ `import os` を追加):
+
+```python
+_MASKED_REGION_SAMPLES = 48
+"""Sparse frames sampled across the video for mask-free region detection.
+
+Must span multiple blackouts so game pixels register a dark ``min``; 48 over a
+multi-hour FL recording covers many match boundaries (spec section 5).
+"""
+
+
+def _resolve_masked_region(
+    video_path: Path, duration_hint: float, workers: int | None
+) -> CaptureRegion:
+    """Detect the mask-free game rectangle for masked recordings (#753).
+
+    Samples ``_MASKED_REGION_SAMPLES`` sparse grayscale frames and runs
+    ``detect_mask_free_region``.  Any failure (decode, opencv, empty) degrades to
+    FULL_FRAME so the masked-fallback caller can treat FULL_FRAME as "no mask
+    region found" and defer to the standard result.  Never raises.
+    """
+    from allaganeye.video.capture_region import detect_mask_free_region
+
+    try:
+        n = _MASKED_REGION_SAMPLES
+        times = [duration_hint * (i + 1) / (n + 1) for i in range(n)]
+        max_workers = max(1, min(len(times), os.cpu_count() or 4))
+        frames: list[np.ndarray] = []
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            for frame in pool.map(lambda t: _probe_frame_gray2d(video_path, t), times):
+                if frame is not None:
+                    frames.append(frame)
+        if len(frames) < 2:
+            return FULL_FRAME
+        return detect_mask_free_region(frames)
+    except Exception:
+        return FULL_FRAME
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_detector.py -k resolve_masked_region -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/video/detector.py tests/test_detector.py
+git commit -m "feat(l3): _resolve_masked_region (疎サンプル -> mask-free 矩形, 例外は FULL_FRAME 縮退, masked-OBS A3)"
+```
+
+---
+
+## Task 4: 分類器選択子の正名化 (`vtuber` → `localize`)
+
+scorebar 層の `vtuber` boolean は実体が「position-independent localize 分類を使う」選択子。VTuber と masked が共有するため `localize` に正名化する。`detect_match_boundaries` 自身の `vtuber` param (band-anchor / trailing gate を制御) は据え置く。
+
+**Files:**
+
+- Modify: `allaganeye/video/scorebar.py` (`classify_blackout` / `filter_blackouts_with_scorebar` / `_merge_boundary_pairs`)
+- Modify: `allaganeye/video/detector.py:454` (`filter_blackouts_with_scorebar(..., vtuber=vtuber)` → `localize=vtuber`)
+- Test: `tests/test_scorebar.py` / `tests/test_l3_phase2_parity.py` / `tests/test_split_matches.py` / `tests/test_scorebar_v2.py`
+
+- [ ] **Step 1: Write the failing test (behavioral, selector routing)**
+
+`tests/test_scorebar.py` に追加:
+
+```python
+from allaganeye.video import scorebar as _sb
+
+
+def test_classify_blackout_localize_selector_routes(monkeypatch):
+    monkeypatch.setattr(_sb, "_classify_blackout_localize", lambda *a, **k: "LOCALIZED")
+    # localize=True -> position-independent path
+    assert (
+        _sb.classify_blackout(_sb.Path("x.mp4"), (10.0, 12.0), 100.0, 180, localize=True)
+        == "LOCALIZED"
+    )
+    # localize=False -> v2 path (NOT the localize sentinel; probes return real result)
+    monkeypatch.setattr(
+        _sb, "_probe_scorebar_context", lambda *a, **k: ([None], [None], [None])
+    )
+    assert (
+        _sb.classify_blackout(_sb.Path("x.mp4"), (10.0, 12.0), 100.0, 180, localize=False)
+        != "LOCALIZED"
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_scorebar.py -k localize_selector_routes -v`
+Expected: FAIL with `TypeError: classify_blackout() got an unexpected keyword argument 'localize'`.
+
+- [ ] **Step 3: Rename the selector in scorebar.py + the detector call site**
+
+`allaganeye/video/scorebar.py` で 3 関数の `vtuber: bool = False` キーワードを `localize: bool = False` に改名し、内部参照も追従:
+
+- `classify_blackout` (line 388): `vtuber: bool = False` → `localize: bool = False`。本体 `if vtuber:` (line 418) → `if localize:`。docstring の "(VTuber)" 記述は "(position-independent: VTuber / masked)" に更新。
+- `filter_blackouts_with_scorebar` (line 574): `vtuber: bool = False` → `localize: bool = False`。`classify_blackout(..., vtuber=vtuber)` (line 622) → `localize=localize`。末尾 `_merge_boundary_pairs(..., vtuber=vtuber)` (line 688) → `localize=localize`。
+- `_merge_boundary_pairs` (line 701): `vtuber: bool = False` → `localize: bool = False`。本体 `if vtuber:` (line 736) → `if localize:`。
+
+`allaganeye/video/detector.py` line 454、`filter_blackouts_with_scorebar` 呼び出しの `vtuber=vtuber,` を `localize=vtuber,` に変更 (detector の `vtuber` param 自体は据え置き)。
+
+- [ ] **Step 4: Migrate existing test call sites**
+
+scorebar 3 関数を `vtuber=` で呼ぶ既存テストを `localize=` に改名する。**`detect_match_boundaries(..., vtuber=...)` の呼び出しは改名しない** (別 param)。場所を特定:
+
+Run: `grep -rn "vtuber=" tests/ | grep -E "classify_blackout|filter_blackouts_with_scorebar|_merge_boundary_pairs"`
+
+ヒットした各行の `vtuber=` を `localize=` に置換 (主に `tests/test_scorebar.py` / `tests/test_l3_phase2_parity.py` / `tests/test_scorebar_v2.py` / `tests/test_split_matches.py`)。assertion は変更しない (挙動不変の rename)。
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_scorebar.py tests/test_scorebar_v2.py tests/test_l3_phase2_parity.py tests/test_split_matches.py -v`
+Expected: PASS (新規 selector routing test + 既存 scorebar/parity 全て green)。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add allaganeye/video/scorebar.py allaganeye/video/detector.py tests/
+git commit -m "refactor(l3): 分類器選択子を vtuber->localize に正名化 (VTuber/masked 共有, masked-OBS A4)"
+```
+
+---
+
+## Task 5: masked fallback 本体 + gate branch (`_detect_masked_fallback`)
+
+`detect_match_boundaries` に `masked` param と明示 gate branch を追加し、region 再検出 + localize 分類の隔離経路 `_detect_masked_fallback` を実装する。
+
+**Files:**
+
+- Modify: `allaganeye/video/detector.py` (`detect_match_boundaries` signature + branch、`_detect_masked_fallback` 追加)
+- Test: `tests/test_detector.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_detector.py` に追加:
+
+```python
+def _zero_blackout_results():
+    return {float(t): 200.0 for t in range(0, 600, 3)}
+
+
+def test_masked_fallback_triggers_on_zero_blackout(monkeypatch):
+    monkeypatch.setattr(_det, "_scan_cpu", lambda *a, **k: _zero_blackout_results())
+    called = {}
+
+    def fake_masked(video_path, **kw):
+        called["hit"] = True
+        return [{"start": 0.0, "end": 300.0}]
+
+    monkeypatch.setattr(_det, "_detect_masked_fallback", fake_masked)
+    out = _det.detect_match_boundaries(
+        _det.Path("x.mp4"), duration_hint=600.0, use_gpu=False, src_resolution=(1920, 1080)
+    )
+    assert called.get("hit") is True
+    assert out == [{"start": 0.0, "end": 300.0}]
+
+
+def test_masked_fallback_not_triggered_when_blackouts_present(monkeypatch):
+    # OBS bit-exact gate: blackouts present + masked=False -> fallback NOT called.
+    results = _zero_blackout_results()
+    results[300.0] = 2.0  # one blackout frame
+    monkeypatch.setattr(_det, "_scan_cpu", lambda *a, **k: results)
+    monkeypatch.setattr(_det, "_refine_blackout_regions", lambda *a, **k: [])
+    called = {}
+    monkeypatch.setattr(
+        _det, "_detect_masked_fallback", lambda *a, **k: called.setdefault("hit", True)
+    )
+    _det.detect_match_boundaries(
+        _det.Path("x.mp4"), duration_hint=600.0, use_gpu=False, src_resolution=None
+    )
+    assert "hit" not in called
+
+
+def test_masked_fallback_forced_even_with_blackouts(monkeypatch):
+    results = _zero_blackout_results()
+    results[300.0] = 2.0
+    monkeypatch.setattr(_det, "_scan_cpu", lambda *a, **k: results)
+    monkeypatch.setattr(
+        _det, "_detect_masked_fallback", lambda *a, **k: [{"start": 1.0, "end": 2.0}]
+    )
+    out = _det.detect_match_boundaries(
+        _det.Path("x.mp4"),
+        duration_hint=600.0,
+        use_gpu=False,
+        masked=True,
+        src_resolution=(1920, 1080),
+    )
+    assert out == [{"start": 1.0, "end": 2.0}]
+
+
+def test_detect_masked_fallback_returns_none_when_no_region(monkeypatch):
+    monkeypatch.setattr(_det, "_resolve_masked_region", lambda *a, **k: _det.FULL_FRAME)
+    scan_called = {}
+    monkeypatch.setattr(
+        _det, "_scan_cpu", lambda *a, **k: scan_called.setdefault("hit", True) or {}
+    )
+    out = _det._detect_masked_fallback(
+        _det.Path("x.mp4"),
+        duration_hint=600.0,
+        sample_interval=3.0,
+        blackout_threshold=15.0,
+        min_match_duration=300.0,
+        min_blackout_duration=3.0,
+        use_gpu=False,
+        workers=None,
+        src_resolution=(1920, 1080),
+        codec="h264",
+        gpu_vendor=None,
+        source_fps_num=60,
+        source_fps_den=1,
+        source_fps=None,
+        audio_hits=None,
+        stats=None,
+    )
+    assert out is None
+    assert "hit" not in scan_called  # short-circuits before scanning
+
+
+def test_detect_masked_fallback_wires_region_band_localize(monkeypatch):
+    from allaganeye.video.capture_region import CaptureRegion
+
+    fake_region = CaptureRegion(0.0, 0.0, 1.0, 0.3, source="tierA")
+    monkeypatch.setattr(_det, "_resolve_masked_region", lambda *a, **k: fake_region)
+    seen = {}
+
+    def fake_scan(video_path, dur, si, thr, workers, cb, **kw):
+        seen["scan_region"] = kw.get("region")
+        return {0.0: 2.0, 3.0: 2.0, 100.0: 200.0}
+
+    monkeypatch.setattr(_det, "_scan_cpu", fake_scan)
+
+    def fake_refine(video_path, regions, thr, dur, workers, **kw):
+        seen["refine_region"] = kw.get("region")
+        return [(0.0, 3.0)]
+
+    monkeypatch.setattr(_det, "_refine_blackout_regions", fake_refine)
+
+    def fake_filter(video_path, regions, dur, height, workers, **kw):
+        seen["band_region"] = kw.get("band_region")
+        seen["localize"] = kw.get("localize")
+        return regions, ["match_boundary"]
+
+    monkeypatch.setattr(
+        "allaganeye.video.scorebar.filter_blackouts_with_scorebar", fake_filter
+    )
+    monkeypatch.setattr(
+        _det, "_filter_and_extract_segments", lambda *a, **k: [{"start": 0.0, "end": 9.0}]
+    )
+
+    out = _det._detect_masked_fallback(
+        _det.Path("x.mp4"),
+        duration_hint=600.0,
+        sample_interval=3.0,
+        blackout_threshold=15.0,
+        min_match_duration=300.0,
+        min_blackout_duration=3.0,
+        use_gpu=False,
+        workers=None,
+        src_resolution=(1920, 1080),
+        codec="h264",
+        gpu_vendor=None,
+        source_fps_num=60,
+        source_fps_den=1,
+        source_fps=None,
+        audio_hits=None,
+        stats=None,
+    )
+    assert out == [{"start": 0.0, "end": 9.0}]
+    assert seen["scan_region"] is fake_region
+    assert seen["refine_region"] is fake_region
+    assert seen["band_region"] is _det.FULL_FRAME
+    assert seen["localize"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_detector.py -k "masked_fallback" -v`
+Expected: FAIL (`TypeError: ... unexpected keyword argument 'masked'` / `AttributeError: ... '_detect_masked_fallback'`).
+
+- [ ] **Step 3: Add `masked` param + gate branch to `detect_match_boundaries`**
+
+`allaganeye/video/detector.py`、`detect_match_boundaries` の signature に `vtuber: bool = False` の直後 (line 257 付近) へ追加:
+
+```python
+    masked: bool = False,
+```
+
+`blackout_times` を計算する箇所 (lines 397-399) の**直後**、`_group_blackout_regions` 呼び出しの**前**に gate branch を挿入:
+
+```python
+    # Masked fallback (#753 masked-OBS): when standard full-frame Pass 1 finds no
+    # blackout (bright chat-mask overlays hold the average above threshold), OR
+    # --masked forces it, re-detect on a mask-free region with position-
+    # independent classification.  Gated by `not vtuber and (masked or not
+    # blackout_times)`: OBS baselines always have >=1 blackout so `not
+    # blackout_times` is False -> the standard path below runs unchanged
+    # (bit-exact; spec section 3 / R1).  VTuber uses its own path.
+    if not vtuber and (masked or not blackout_times):
+        masked_segments = _detect_masked_fallback(
+            video_path,
+            duration_hint=duration_hint,
+            sample_interval=sample_interval,
+            blackout_threshold=blackout_threshold,
+            min_match_duration=min_match_duration,
+            min_blackout_duration=min_blackout_duration,
+            use_gpu=use_gpu,
+            workers=workers,
+            src_resolution=src_resolution,
+            codec=codec,
+            gpu_vendor=gpu_vendor,
+            source_fps_num=source_fps_num,
+            source_fps_den=source_fps_den,
+            source_fps=source_fps,
+            audio_hits=audio_hits,
+            stats=stats,
+        )
+        if masked_segments is not None:
+            return masked_segments
+```
+
+- [ ] **Step 4: Implement `_detect_masked_fallback`**
+
+`allaganeye/video/detector.py`、`detect_match_boundaries` の直後に追加 (標準 path の scan/refine/classify を**意図的に複製** — 標準 path body を触らず隔離するため。既存 factored helper は呼ぶ):
+
+```python
+def _detect_masked_fallback(
+    video_path: Path,
+    *,
+    duration_hint: float,
+    sample_interval: float,
+    blackout_threshold: float,
+    min_match_duration: float,
+    min_blackout_duration: float,
+    use_gpu: bool,
+    workers: int | None,
+    src_resolution: tuple[int, int] | None,
+    codec: str | None,
+    gpu_vendor: str | None,
+    source_fps_num: int | None,
+    source_fps_den: int | None,
+    source_fps: float | None,
+    audio_hits: Sequence[BgmHit] | None,
+    stats: DetectionStats | None,
+) -> list[MatchBoundary] | None:
+    """Masked-OBS detection: region-aware Pass 1/2 + localize classification.
+
+    Returns segments, or ``None`` when no mask-free region is found (caller falls
+    through to the standard single-segment result).  Deliberately duplicates the
+    standard Pass1/Pass2/classify sequence (calling the same factored helpers)
+    rather than sharing a core, so the standard OBS path is structurally
+    unchanged (bit-exact mandate; spec section 3 / R1).  Uses ``band_region=
+    FULL_FRAME`` + ``localize=True`` (full-frame position-independent scorebar;
+    v2 absolute coords FN on ultrawide, spec section 5).  No trailing-drop:
+    ``_drop_post_match_trailing`` probes v2 absolute coords which FN on
+    ultrawide (same rationale as the VTuber gate, line 478).
+    """
+    region = _resolve_masked_region(video_path, duration_hint, workers)
+    if region.is_full_frame():
+        return None  # no mask region found -> defer to the standard result
+
+    if use_gpu:
+        from allaganeye.video.gpu_detector import scan_gpu
+
+        try:
+            results = scan_gpu(
+                video_path,
+                duration_hint,
+                sample_interval,
+                blackout_threshold,
+                None,
+                codec=codec,
+                vendor=gpu_vendor,
+                source_fps_num=source_fps_num,
+                source_fps_den=source_fps_den,
+                source_fps=source_fps,
+                region=region,
+            )
+        except VideoProcessingError:
+            results = _scan_cpu(
+                video_path,
+                duration_hint,
+                sample_interval,
+                blackout_threshold,
+                workers,
+                None,
+                source_fps_num=source_fps_num,
+                source_fps_den=source_fps_den,
+                source_fps=source_fps,
+                region=region,
+            )
+    else:
+        results = _scan_cpu(
+            video_path,
+            duration_hint,
+            sample_interval,
+            blackout_threshold,
+            workers,
+            None,
+            source_fps_num=source_fps_num,
+            source_fps_den=source_fps_den,
+            source_fps=source_fps,
+            region=region,
+        )
+
+    pass1_blackout_threshold = blackout_threshold + _BLACKOUT_THRESHOLD_UPPER_MARGIN
+    blackout_times = sorted(
+        t for t, b in results.items() if b < pass1_blackout_threshold
+    )
+    blackout_regions = _group_blackout_regions(blackout_times, sample_interval)
+    blackout_regions = _expand_regions_with_transitions(
+        blackout_regions, results, sample_interval, _TRANSITION_THRESHOLD
+    )
+    if _ENABLE_BORDERLINE_REFINEMENT:
+        borderline_regions = _borderline_pseudo_regions(
+            results, blackout_threshold, duration_hint
+        )
+        if borderline_regions:
+            blackout_regions = _merge_regions(
+                blackout_regions + borderline_regions, sample_interval
+            )
+
+    refined_regions = _refine_blackout_regions(
+        video_path,
+        blackout_regions,
+        blackout_threshold,
+        duration_hint,
+        workers,
+        region=region,
+    )
+
+    classifications: list[str] | None = None
+    if src_resolution is not None:
+        from allaganeye.video.scorebar import filter_blackouts_with_scorebar
+
+        height = _scaled_height(src_resolution[0], src_resolution[1])
+        refined_regions, classifications = filter_blackouts_with_scorebar(
+            video_path,
+            refined_regions,
+            duration_hint,
+            height,
+            workers,
+            band_region=FULL_FRAME,
+            localize=True,
+            audio_hits=audio_hits,
+            stats=stats,
+        )
+
+    effective_min = min(min_blackout_duration, _REFINED_MIN_BLACKOUT)
+    return _filter_and_extract_segments(
+        refined_regions,
+        duration_hint,
+        min_match_duration,
+        effective_min,
+        classifications=classifications,
+        stats=stats,
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_detector.py -k "masked_fallback" -v`
+Expected: PASS (5 tests)。
+
+- [ ] **Step 6: Run the full detector + scorebar suite (no regression)**
+
+Run: `pytest tests/test_detector.py tests/test_scorebar.py tests/test_l3_phase2_parity.py -q`
+Expected: PASS (既存 detect/parity の bit-exact unit が green)。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add allaganeye/video/detector.py tests/test_detector.py
+git commit -m "feat(l3): masked fallback 本体 + 0-blackout gate branch (隔離経路, masked-OBS A5)"
+```
+
+---
+
+## Task 6: CLI / config plumbing (`--masked` / `--vtuber` hidden)
+
+`SplitConfig.masked` を追加し、`--masked` CLI option (split + detect) を配線、`--vtuber` を hidden 化、両者排他にする。
+
+**Files:**
+
+- Modify: `allaganeye/config.py`
+- Modify: `allaganeye/cli.py`
+- Modify: `allaganeye/commands/split_matches.py:749-770`
+- Test: `tests/test_config.py` / `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_config.py` に追加:
+
+```python
+from allaganeye.config import SplitConfig
+
+
+def test_split_config_masked_defaults_false():
+    assert SplitConfig().masked is False
+```
+
+`tests/test_cli.py` に追加 (既存の CliRunner / `app` import パターンに合わせる):
+
+```python
+def test_split_masked_flag_sets_config(monkeypatch, tmp_path):
+    import allaganeye.commands.split_matches as sm
+
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"x")
+    captured = {}
+    monkeypatch.setattr(sm, "run_split", lambda vp, cfg, **k: captured.update(masked=cfg.masked))
+    from allaganeye.cli import app
+    from typer.testing import CliRunner
+
+    res = CliRunner().invoke(app, ["split", str(video), "--masked", "--dry-run"])
+    assert res.exit_code == 0
+    assert captured.get("masked") is True
+
+
+def test_split_vtuber_and_masked_mutually_exclusive(tmp_path):
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"x")
+    from allaganeye.cli import app
+    from typer.testing import CliRunner
+
+    res = CliRunner().invoke(app, ["split", str(video), "--vtuber", "--masked"])
+    assert res.exit_code != 0
+    assert "mutually exclusive" in res.stdout.lower() or "exclusive" in res.stdout.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_config.py -k masked tests/test_cli.py -k "masked or mutually" -v`
+Expected: FAIL (`TypeError: ... unexpected keyword argument 'masked'` / mutex 未実装)。
+
+- [ ] **Step 3: Add `SplitConfig.masked`**
+
+`allaganeye/config.py`、`vtuber: bool = False` (line 24) の直後に追加:
+
+```python
+    masked: bool = False
+```
+
+- [ ] **Step 4: Add `--masked` option + hide `--vtuber` + mutex (split command)**
+
+`allaganeye/cli.py` の `split` command で、`--vtuber` Option (lines 152-159) を `hidden=True` 付きに変更し、直後に `--masked` を追加:
+
+```python
+    vtuber: Annotated[
+        bool,
+        typer.Option(
+            "--vtuber",
+            help="(experimental) VTuber recording (game inset): scorebar-band "
+            "anchor detection. Under-detects irregular transitions; deferred (#480).",
+            hidden=True,
+        ),
+    ] = False,
+    masked: Annotated[
+        bool,
+        typer.Option(
+            "--masked",
+            help="Masked recording: a chat-hiding image is composited over the "
+            "full screen. Auto-detects a mask-free region and re-detects; this "
+            "flag forces that path even when some blackouts are found.",
+        ),
+    ] = False,
+```
+
+mutual-exclusion チェック群 (lines 178-194 付近、`if gpu and no_gpu:` の近く) に追加:
+
+```python
+        if vtuber and masked:
+            raise ConfigValidationError("--vtuber and --masked are mutually exclusive")
+```
+
+`split` の 2 つの `SplitConfig(...)` 構築 (from_metadata path line 211-223、通常 path line 239-252) それぞれの `vtuber=vtuber,` 直後に `masked=masked,` を追加。
+
+- [ ] **Step 5: Add `--masked` + hide `--vtuber` + mutex (detect command)**
+
+`allaganeye/cli.py` の `detect` command でも同様に: `--vtuber` Option (lines 332-339) に `hidden=True` を付け、直後に上記と同じ `--masked` Annotated option を追加。detect の mutex チェック箇所に `if vtuber and masked: raise ConfigValidationError(...)` を追加。`SplitConfig(...)` 構築 (line ~396-409) の `vtuber=vtuber,` 直後に `masked=masked,` を追加。
+
+- [ ] **Step 6: Thread `masked` into `detect_kwargs`**
+
+`allaganeye/commands/split_matches.py`、`_run_detection` の `detect_kwargs` (line 759 `"vtuber": config.vtuber,` の直後) に追加:
+
+```python
+        # L3 masked-OBS (#753): chat-mask overlay -> mask-free region fallback.
+        # False (default) only auto-triggers on 0-blackout; True forces it.
+        "masked": config.masked,
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pytest tests/test_config.py tests/test_cli.py -q`
+Expected: PASS (新規 + 既存 CLI/config 全て green、`--vtuber` は hidden でも機能継続)。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add allaganeye/config.py allaganeye/cli.py allaganeye/commands/split_matches.py tests/test_config.py tests/test_cli.py
+git commit -m "feat(l3): --masked CLI flag 配線 + --vtuber hidden 化 + 排他 (masked-OBS A6)"
+```
+
+---
+
+## Task 7: 検証ゲート (unit / lint / bit-exact baseline / 実機 acceptance)
+
+**Files:** (コード変更なし。ゲート実行のみ)
+
+- [ ] **Step 1: 全 unit + lint + 型チェック**
+
+Run (worktree ルートで):
+
+```bash
+ruff check .
+ruff format --check .
+pyright
+pytest -q
+```
+
+Expected: 全 PASS (slow マーカー除外、1370+ tests)。失敗があれば該当タスクに戻って修正。
+
+- [ ] **Step 2: markdownlint (新規 plan/doc)**
+
+Run: `bash scripts/check-markdownlint.sh`
+Expected: PASS (本 plan を含む全 .md)。
+
+- [ ] **Step 3: OBS bit-exact baseline gate (slow / 実機 = Idios)**
+
+`docs/testing-guide.md` §「baseline drift の判定」に従い、OBS 5 baseline の `detect` 出力が現行と一致することを確認する (masked branch が非 trigger であることの構造確認)。timestamp churn (detected_at / generated_at) は非意味的 → grep 除外で output-neutral 判定。
+
+Run: `pytest -m slow -k "baseline or detector" -q` (sample video 環境)。
+Expected: baseline diff なし (試合数・境界 timestamp が現行と一致)。
+
+- [ ] **Step 4: masked サンプル acceptance (slow / 実機 = Idios)**
+
+`E:\allaganeye-samples\20250527-29\` の 3 録画 (3440x1440 masked ultrawide) で:
+
+```bash
+allaganeye detect "E:\allaganeye-samples\20250527-29\20250527-29\2026-05-29 20-58-34.mkv" -o E:\allaganeye-samples\_masked_a_out
+```
+
+Expected: 標準 path が 0 blackout でも masked fallback が起動し、複数 match が検出される (現行の「1 match / 7h」全滅から改善)。Idios が出力動画の内容 (試合境界の妥当性) を目視確認。`--masked` 明示でも同等。CPU/GPU 双方で parity。
+
+- [ ] **Step 5: Self-Test Report をまとめ、PR Pre-flight へ**
+
+Iron Law 6 Pre-flight (Step 0 ハードゲート → base 同期 → 並行 PR 確認 → `/codex:adversarial-review`) を実施。machine-verified は `[x]`、実機検証 (Step 3/4 GPU・長時間・masked) は plain bullet で Self-Test Report に記載。ロジック変更 (`detector.py` / `scorebar.py`) を含むため Idios へ実機検証を `AskUserQuestion` で依頼。
+
+---
+
+## Self-Review (spec 突き合わせ)
+
+**1. Spec coverage:**
+
+| spec §/論点 | 実装タスク |
+| --- | --- |
+| §3 標準 path + masked fallback / §10 R1 bit-exact | Task 5 (gate branch + 隔離 `_detect_masked_fallback`) + Task 7 Step 3 baseline gate |
+| §4.1 static-overlay 領域検出 (S3 精緻化 → mask-free 矩形) | Task 1 (`detect_mask_free_region`) + Task 2/3 (frame decode + orchestration) |
+| §4.2 region-aware brightness (Phase 1 再利用) | Task 5 (`region=` を scan/refine に thread) |
+| §4.3 localize present 分類 (Phase 2 再利用) | Task 4 (`localize` 選択子) + Task 5 (`localize=True`) |
+| §4.4 起動 (0-blackout 自動 fallback + `--masked` override) | Task 5 (gate) + Task 6 (`--masked`) |
+| §6 `--vtuber` hidden/experimental 化 | Task 6 |
+| §6 やらないこと (partial mask 汎化 / per-pixel / GUI=B) | 範囲外 (本 plan は矩形 region + Sub-project A のみ) |
+| §8 検証 (unit / bit-exact / masked acceptance / CPU-GPU parity) | Task 1-6 unit + Task 7 |
+
+**2. Placeholder scan:** 各 code step に実コードを記載済。test rename (Task 4 Step 4) のみ grep ベースだが、対象関数を限定し置換ルールと検証 (Step 5 suite green) を明示。プレースホルダなし。
+
+**3. Type consistency:** `CaptureRegion` / `FULL_FRAME` / `MatchBoundary` / `BgmHit` / `DetectionStats` は detector.py で import 済を使用。`detect_mask_free_region(frames) -> CaptureRegion`、`_probe_frame_gray2d(...) -> np.ndarray | None`、`_resolve_masked_region(...) -> CaptureRegion`、`_detect_masked_fallback(...) -> list[MatchBoundary] | None` で一貫。`localize` 選択子は scorebar 3 関数で統一。`detect_match_boundaries` の `vtuber`/`masked` は別 param (前者=band-anchor/trailing gate、後者=masked fallback) で混同なし。
+
+**4. 既知の限界 (実装メモ、PR 本文に記載):**
+
+- masked auto-fallback は標準 full-frame Pass 1 (長尺は GPU でも 19min 規模) の**後**に走るため、masked 動画では Pass 1 が実質 2 回走る。masked は稀な経路のため許容。`--masked` 明示時も標準 Pass 1 を 1 度走らせる (構造単純化のトレードオフ)。
+- masked 経路では標準 `brightness_callback` が full-frame 結果で先に発火する (GUI timeline は Sub-project B が region 表示で対応)。
+- mask-free 矩形が小さすぎる / 検出不能なら FULL_FRAME → fallback は None を返し標準結果 (1 segment) に縮退。ユーザーは Sub-project B の GUI 領域調整で対応 (spec §10 R2)。

--- a/docs/superpowers/specs/2026-06-05-masked-ultrawide-obs-detection-design.md
+++ b/docs/superpowers/specs/2026-06-05-masked-ultrawide-obs-detection-design.md
@@ -1,0 +1,143 @@
+# masked + ultrawide OBS 検出対応 設計 (Sub-project A: 検出コア, 2026-06-05)
+
+> L3「配信形式対応」の再定位。VTuber inset 検出 ([2026-05-31 spec](2026-05-31-l3-detection-rearchitecture-two-signal-design.md)) が
+> 実機の不規則遷移で頭打ち・**保留** (#480) となった一方、**チャットを隠すマスク画像を全画面録画に重ねるユーザー**の動画は
+> 実証の結果 **tractable** と判明した。本 spec はその masked + ultrawide OBS 録画の検出対応 (検出コア) を設計する。
+>
+> **Status**: brainstorming 完了 / user 承認待ち (spec review gate)
+> **基づく**: 2026-06-05 実機検証 (本 § 5) + parked Phase 0/1/2 機構 (#480 branch `claude/l3-p2-region-detection`)
+> **完了基準**: GUI 統合まで (user 確定)。本 spec = **Sub-project A (検出コア・CLI)**。**Sub-project B (GUI 領域調整 UI)** は A 完了後の別サイクル (本 spec 範囲外、別 spec)。
+
+## 1. 背景: VTuber は defer、masked-OBS は直せる
+
+L3 の `配信形式対応` には 2 つの非標準フォーマットが含まれる:
+
+| | VTuber inset (defer 済 #480) | masked + ultrawide OBS (本 spec) |
+| --- | --- | --- |
+| 失敗の仕方 | under-detection (5/~11 試合) | **全滅** (0 blackout → 7h が 1 segment) |
+| 根本原因 | 遷移が暗転でない**不規則な静止画面** | **明るいマスクが暗転中も点灯** → 全画面平均が閾値を割らない |
+| game の写り方 | 小窓 inset (位置不定・脆い) | **全画面・scorebar も明瞭** |
+| 直し方 | 別アプローチ要研究 (手詰まり) | **mask-free 領域の輝度を測る** (実証済) + ultrawide は localize 分類 (実証済) |
+
+VTuber は「信号そのものが変則」で手詰まりだったが、masked-OBS は「信号はあるのに明るいマスクで平均が持ち上がっている」だけ。**game 領域 (mask 以外) を測れば本物の暗転が復活する**。
+
+## 2. 確定方針 (brainstorming 2026-06-05, user 承認)
+
+| # | 論点 | 決定 |
+| --- | --- | --- |
+| Q1 | 完了基準 | **GUI 統合まで** (v0.3.0)。A=検出コア / B=GUI に分解、A 先行 |
+| Q2 | mask-free 測定領域の決定 | **自動検出 (static-overlay) + GUI 調整**。「暗転で暗くなる=game / 常時明るい=マスク」を動画から判定 |
+| Q3 | masked mode の起動 | **自動 fallback** (標準 detect が blackout 0 → masked mode へ自動再検出)。標準 path 不変 = bit-exact 構造保証。`--masked` flag で override |
+| Q4 | 分類器 | **localize present** (Phase 2 `_classify_blackout_localize`)。v2 は ultrawide 不可、localize は可 (§5 実証) |
+| Q5 | 土台 | **parked Phase 0/1/2 の汎用機構を再利用** (region threading / `region_mean` / localize primitive / localize 分類器)。VTuber 固有 (band-anchor / `--vtuber` user flag) は再利用しない |
+
+## 3. アーキテクチャ: 標準 path + masked fallback
+
+```text
+入力動画
+  │
+  ├─[標準 detect] 全画面 brightness Pass1 (現行不変)
+  │      │
+  │      ├─ blackout > 0 → 現行どおり (Pass2 → scorebar 分類 → segment) = bit-exact
+  │      │
+  │      └─ blackout == 0 (明確な失敗) ─┐
+  │                                      ▼
+  └─[masked fallback] (または --masked override)
+         1. 自動領域検出 (static-overlay) → mask-free 測定矩形
+         2. その矩形で Pass1/Pass2 再検出 (Phase 1 region 機構)
+         3. localize present 分類 (Phase 2、ultrawide 対応)
+         4. segment 抽出 (現行 duration filter 等)
+```
+
+**bit-exact の構造保証**: 標準 path (fallback 非 trigger) のコードは一切変えない。OBS 5 baseline は必ず blackout を拾う (full-frame で暗転が見える) ため fallback に入らず、現行と byte 一致。masked fallback path は「標準 path が 0 blackout を返した後」にのみ走る純粋な追加経路。VTuber で 2 度割った「standard path 内の always-on auto 推論」とは構造的に異なる (§10 R1)。
+
+## 4. コンポーネント (Sub-project A)
+
+### 4.1 自動領域検出 (static-overlay) — parked S3 の精緻化
+
+- 疎サンプルした N フレーム (試合中＋暗転を含む) で per-pixel 判定: **最大輝度 > bright かつ 最小輝度 < dark = game** (暗転で暗くなる)。マスクは min が下がらない (常時明るい) ため除外。
+- parked `capture_region.detect_region_blackout_overlap` (S3) が発想の土台。S3 は最大連結成分の **bbox** を返すが、内側/端マスクでは bbox がマスクを含みうる → **mask-free な測定矩形**を出す形に精緻化 (例: マスク bbox を求め、それを避ける最大 clean rectangle / または game bbox からマスク列を除外)。
+- 出力 = 正規化 `CaptureRegion` (矩形)。既存 region 機構は矩形ベースのため矩形で受ける。GUI(B) がこの自動領域を表示し confirm/adjust。
+- **bit-exact 不変**: 本検出は masked fallback path 内のみ。標準 path は呼ばない。
+
+### 4.2 region-aware brightness (Phase 1 再利用)
+
+- 4.1 の矩形を Pass1 (`_scan_cpu` / `scan_gpu`) / Pass2 (`_refine_blackout_regions`) に `region=` で渡す。`region_mean` がマスクを除外した game 矩形で平均輝度を測る。§5 で 74 blackout を実証。
+- 完全に Phase 1 の実装済み機構 (region threading)。新規実装なし。
+
+### 4.3 localize present 分類 (Phase 2 再利用)
+
+- masked fallback の分類は `_classify_blackout_localize` (present 単独)。masked-OBS の遷移は**本物の暗転** (マスクで隠れていただけ) なので、in-match flank に scorebar present (localize=True) → 正しく match_boundary 分類。VTuber の under-detection (遷移が暗転でない) 問題は構造的に起きない。
+- v2 (絶対 1920x1080 座標) は ultrawide 3440x1440 の歪みリサイズで FN (§5)。localize (位置独立) は detect 成功 (§5)。よって masked/ultrawide path は localize 必須。
+
+### 4.4 起動 (fallback trigger)
+
+- 標準 Pass1 完了後、blackout フレーム数 == 0 を検出したら masked fallback へ。明確な失敗信号 (実 FL 録画は必ず暗転を持つ)。
+- `--masked` CLI flag で fallback を強制 (partial mask = full-frame で一部 blackout を拾うが under-detect するケース用の override)。GUI(B) の masked トグルも同経路。
+
+## 5. 実証データ (2026-06-05, 実機)
+
+サンプル: `E:\allaganeye-samples\20250527-29\` の 3 録画 (3440x1440 ultrawide, h264, 39-82GB, チャットを隠すキャラ立ち絵マスクを左下＋中右に静止合成)。
+
+| 検証 | 方法 | 結果 |
+| --- | --- | --- |
+| 標準 path が壊れる | `detect` (--vtuber なし, OBS path) on 2026-05-29 (7h07m) | **0 blackout / 7h が 1 match** = 全滅 |
+| 領域で暗転復活 | top 30% region で `scan_gpu` (first 2h) | **74 blackout** (full-frame は 0), region min 輝度 0.0 |
+| ultrawide scorebar | gameplay 3 frame で v2 / localize | **v2=False / localize=True** (×3) |
+
+→ masked-OBS は (a) region-aware 輝度で暗転復活 + (b) localize で ultrawide scorebar 分類、の両方が実機で成立。検証スクリプト: `_validate_masked.py` / `_validate_scorebar_uw.py` (branch、untracked)。
+
+## 6. スコープ境界
+
+**Sub-project A (本 spec) がやること**:
+
+- masked fallback (trigger + 自動領域検出 + region brightness + localize 分類)。
+- OBS 5 baseline bit-exact 維持。masked 3 サンプルの実用分割。
+- `--masked` CLI flag (override)。
+
+**やらないこと (範囲外 / 後 Phase)**:
+
+- **Sub-project B (GUI 領域調整 UI)**: A 完了後の別 spec/plan/実装サイクル。A は GUI が消費する自動領域 (`CaptureRegion`) を出すところまで。
+- **VTuber inset 検出**: defer 済 (#480、本 spec は復活させない)。`--vtuber` user-facing flag は under-detect するため hidden/experimental 化 (§9)。
+- **partial mask の頑健化 / 一般のマスク配置・解像度への汎化**: 本 spec は実証済の masked+ultrawide ケースを実用化する最小。汎化は後続。
+- **per-pixel mask 測定**: 本 spec は矩形 region (既存機構)。内側マスクで最大 clean rectangle が小さすぎる等の限界が出たら per-pixel 化を別途検討。
+
+## 7. データ構造 / API
+
+- **再利用 (parked Phase 0/1/2, branch)**: `region_mean` / region threading (`_scan_cpu`/`scan_gpu`/`_refine_blackout_regions` の `region=`) / `_probe_scorebar_context(with_localize=)` / `_localize_present_from_raw` / `_classify_blackout_localize` / `detect_region_blackout_overlap` (S3, 精緻化対象)。
+- **新規 (Sub-project A)**: masked fallback orchestration (trigger 判定 → 自動領域 → region 再検出 → localize 分類)、static-overlay 領域検出の精緻化 (S3 → mask-free 矩形)、`--masked` flag。
+- **出力**: 現行 `matches[]` / metadata.json schema 不変 (region フィールド永続化は B / 別途)。
+
+## 8. 検証戦略
+
+- **unit (動画不要)**: static-overlay 領域検出 (合成 frame: マスク=常時明るい / game=暗転で暗くなる → mask-free 矩形)。fallback trigger (0 blackout → masked mode 起動、>0 → 標準 path)。矩形 region brightness。localize 分類 (§4.3、Phase 2 既存 unit 流用)。
+- **slow・実機 (Idios)**: 3 masked サンプルで実用分割 (試合数・境界の目視)。**OBS 5 baseline bit-exact** (fallback 非 trigger を構造確認)。CPU/GPU parity。
+- **gate**: OBS bit-exact (baseline diff) + masked サンプル実用分割 (demonstrated-level)。
+
+## 9. 土台・branch 戦略 (plan で確定)
+
+parked Phase 0/1/2 (`claude/l3-p2-region-detection`、origin push 済、OBS bit-exact 実証済 §5) を土台に masked-OBS を構築する。landing 戦略は plan で確定する候補:
+
+- (a) **parked branch を継続拡張** → Phase 0/1/2 + masked-OBS を「L3 配信形式対応」1 PR で land (`--vtuber` flag は hidden 化)。
+- (b) Phase 0/1/2 (汎用機構, bit-exact, review 済) を先に develop-0.3.0 へ land → masked-OBS を別 PR で上に積む。
+- いずれも `refactor-pattern.md` の Phase 分割閾値 (touched>30 / diff>1000) を確認。
+
+`--vtuber` user-facing flag: under-detect するため masked land 時に **hidden / experimental 化** (内部 region 機構は残す)。
+
+## 10. リスク
+
+| # | リスク | 緩和 |
+| --- | --- | --- |
+| R1 | 自動領域検出が標準 OBS の bit-exact を壊す (VTuber で 2 度発生) | **masked fallback path 内に閉じ込め** (標準 path は呼ばない)。標準 path は構造的に不変。baseline は fallback 非 trigger を実機確認 |
+| R2 | static-overlay 領域検出が内側/端マスクで不正確 (S3 bbox 限界) | mask-free 矩形化で精緻化。最大 clean rectangle が小さすぎる場合は GUI(B) で調整、または per-pixel 化 (後続) |
+| R3 | fallback trigger (0 blackout) が partial mask を拾わない | `--masked` override + GUI トグル。partial mask 汎化は後続 |
+| R4 | localize が masked/ultrawide で誤検出 (位置独立ゆえの noise) | Phase 2 の present majority + 実機 GT で確認。masked-OBS は遷移が本物の暗転なので VTuber より素直 |
+| R5 | CPU/GPU/ultrawide リサイズ parity | 検証 matrix に CPU/GPU。region は正規化座標で解像度非依存 |
+
+## 11. 参照
+
+- VTuber spec (defer、土台機構の出所): [2026-05-31-l3-detection-rearchitecture-two-signal-design.md](2026-05-31-l3-detection-rearchitecture-two-signal-design.md)
+- Phase 0 map: [docs/detection-map.md](../../detection-map.md)
+- parked 実装: branch `claude/l3-p2-region-detection` (Phase 0/1/2, origin push 済)
+- 実証スクリプト: `_validate_masked.py` / `_validate_scorebar_uw.py` (branch, untracked)
+- 関連 issue: [#480](https://github.com/Idios/kobutachan-allaganeye/issues/480) (VTuber 検出, defer), [#481](https://github.com/Idios/kobutachan-allaganeye/issues/481) (minimap), [#753](https://github.com/Idios/kobutachan-allaganeye/issues/753) (配信形式対応 parent) — masked-OBS の新規 issue 起票は Iron Law 2 で起票時 AskUserQuestion

--- a/gui/src/types/metadata.generated.ts
+++ b/gui/src/types/metadata.generated.ts
@@ -88,6 +88,14 @@ export interface DetectionParams {
    * Parallel worker count. number for explicit, null for auto.
    */
   workers: number | null;
+  /**
+   * True when the VTuber scorebar-band anchor path was used (#821). Optional: absent in pre-#821 outputs and means false.
+   */
+  vtuber?: boolean;
+  /**
+   * True when the masked-recording mask-free-region fallback path was used (#821). Optional: absent in pre-#821 outputs and means false.
+   */
+  masked?: boolean;
 }
 /**
  * Single match segment. JSON Schema is the strict writer contract; reader-side passthrough for GUI-only edit fields (name / type_override / edited) is provided by zod (.passthrough() on MatchSchema) and only round-trips inside metadata.draft.json, never metadata.json proper.

--- a/gui/src/types/metadata.generated.ts
+++ b/gui/src/types/metadata.generated.ts
@@ -89,13 +89,17 @@ export interface DetectionParams {
    */
   workers: number | null;
   /**
-   * True when the VTuber scorebar-band anchor path was used (#821). Optional: absent in pre-#821 outputs and means false.
+   * True when the --vtuber flag was supplied (#821; the VTuber path never auto-triggers, so request equals resolved). Optional: absent in pre-#821 outputs and means false.
    */
   vtuber?: boolean;
   /**
-   * True when the masked-recording mask-free-region fallback path was used (#821). Optional: absent in pre-#821 outputs and means false.
+   * True when the --masked flag was supplied (request, #821). The masked fallback can also auto-trigger on zero-blackout recordings; see masked_fallback_used for the resolved path. Optional: absent in pre-#821 outputs and means false.
    */
   masked?: boolean;
+  /**
+   * True when the mask-free-region fallback actually produced this result (explicit --masked or zero-blackout auto-trigger, #821). Optional: absent in pre-#821 outputs and means false.
+   */
+  masked_fallback_used?: boolean;
 }
 /**
  * Single match segment. JSON Schema is the strict writer contract; reader-side passthrough for GUI-only edit fields (name / type_override / edited) is provided by zod (.passthrough() on MatchSchema) and only round-trips inside metadata.draft.json, never metadata.json proper.

--- a/gui/src/types/metadata.schema.ts
+++ b/gui/src/types/metadata.schema.ts
@@ -10,10 +10,13 @@ export const DetectionParamsSchema = z.object({
   workers: z.number().nullable(),
   /**
    * #821 -- detection-path provenance. Optional because pre-#821
-   * metadata.json doesn't include them; absent means false.
+   * metadata.json doesn't include them; absent means false. `masked` is
+   * the request flag; `masked_fallback_used` is the resolved path (the
+   * fallback also auto-triggers on zero-blackout recordings).
    */
   vtuber: z.boolean().optional(),
   masked: z.boolean().optional(),
+  masked_fallback_used: z.boolean().optional(),
 });
 
 export const MatchSchema = z

--- a/gui/src/types/metadata.schema.ts
+++ b/gui/src/types/metadata.schema.ts
@@ -8,6 +8,12 @@ export const DetectionParamsSchema = z.object({
   no_audio: z.boolean(),
   use_gpu: z.union([z.number(), z.boolean(), z.null()]),
   workers: z.number().nullable(),
+  /**
+   * #821 -- detection-path provenance. Optional because pre-#821
+   * metadata.json doesn't include them; absent means false.
+   */
+  vtuber: z.boolean().optional(),
+  masked: z.boolean().optional(),
 });
 
 export const MatchSchema = z

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -130,11 +130,15 @@
           "type": ["number", "null"]
         },
         "vtuber": {
-          "description": "True when the VTuber scorebar-band anchor path was used (#821). Optional: absent in pre-#821 outputs and means false.",
+          "description": "True when the --vtuber flag was supplied (#821; the VTuber path never auto-triggers, so request equals resolved). Optional: absent in pre-#821 outputs and means false.",
           "type": "boolean"
         },
         "masked": {
-          "description": "True when the masked-recording mask-free-region fallback path was used (#821). Optional: absent in pre-#821 outputs and means false.",
+          "description": "True when the --masked flag was supplied (request, #821). The masked fallback can also auto-trigger on zero-blackout recordings; see masked_fallback_used for the resolved path. Optional: absent in pre-#821 outputs and means false.",
+          "type": "boolean"
+        },
+        "masked_fallback_used": {
+          "description": "True when the mask-free-region fallback actually produced this result (explicit --masked or zero-blackout auto-trigger, #821). Optional: absent in pre-#821 outputs and means false.",
           "type": "boolean"
         }
       }

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -128,6 +128,14 @@
         "workers": {
           "description": "Parallel worker count. number for explicit, null for auto.",
           "type": ["number", "null"]
+        },
+        "vtuber": {
+          "description": "True when the VTuber scorebar-band anchor path was used (#821). Optional: absent in pre-#821 outputs and means false.",
+          "type": "boolean"
+        },
+        "masked": {
+          "description": "True when the masked-recording mask-free-region fallback path was used (#821). Optional: absent in pre-#821 outputs and means false.",
+          "type": "boolean"
         }
       }
     },

--- a/tests/test_capture_region.py
+++ b/tests/test_capture_region.py
@@ -6,9 +6,11 @@ from allaganeye.video.capture_region import (
     RegionTimeline,
     ScorebarLocalization,
     _emblem_and_margin,
+    _maximal_ones_rectangle,
     _maybe_snap_full_frame,
     _scorebar_saturated_runs,
     band_region_from_localization,
+    detect_mask_free_region,
     detect_region_blackout_overlap,
     detect_region_variance,
     detect_scorebar_band_region,
@@ -580,3 +582,70 @@ def test_band_consensus_balanced_split_median_falls_between_clusters():
     )
     assert region.y < 0.05, f"expected true cluster y~0, got {region.y}"
     assert abs(region.x - 600 / 1920) < 0.05
+
+
+# ---------------------------------------------------------------------------
+# A-Task 1: detect_mask_free_region + _maximal_ones_rectangle
+# ---------------------------------------------------------------------------
+
+
+def _rect_overlaps(rect_px, block_px) -> bool:
+    ax0, ay0, ax1, ay1 = rect_px
+    bx0, by0, bx1, by1 = block_px
+    return ax0 < bx1 and bx0 < ax1 and ay0 < by1 and by0 < ay1
+
+
+def _frames_with_mask(h, w, mask_block, values=(5, 200, 5, 200)):
+    """Game pixels cycle bright/dark across frames; mask_block stays bright (200)."""
+    bx0, by0, bx1, by1 = mask_block
+    frames = []
+    for v in values:
+        f = np.full((h, w), v, dtype=np.uint8)
+        f[by0:by1, bx0:bx1] = 200  # static bright mask -> min never < dark
+        frames.append(f)
+    return frames
+
+
+def test_maximal_ones_rectangle_simple_block():
+    mask = np.zeros((4, 5), dtype=np.uint8)
+    mask[1:4, 1:4] = 1  # 3x3 block of ones at (x=1..3, y=1..3)
+    assert _maximal_ones_rectangle(mask) == (1, 1, 4, 4)
+
+
+def test_maximal_ones_rectangle_empty_is_none():
+    assert _maximal_ones_rectangle(np.zeros((4, 4), dtype=np.uint8)) is None
+
+
+def test_detect_mask_free_region_excludes_bright_mask():
+    # 20x20, bright static mask at bottom-left (cols 0..10, rows 10..20).
+    frames = _frames_with_mask(20, 20, (0, 10, 10, 20))
+    region = detect_mask_free_region(frames)
+    assert not region.is_full_frame()
+    # Returned rectangle must not intersect the mask block.
+    px = (
+        round(region.x * 20),
+        round(region.y * 20),
+        round((region.x + region.w) * 20),
+        round((region.y + region.h) * 20),
+    )
+    assert not _rect_overlaps(px, (0, 10, 10, 20))
+
+
+def test_detect_mask_free_region_full_game_snaps_full_frame():
+    # Every pixel cycles bright/dark -> game everywhere -> FULL_FRAME.
+    frames = [np.full((20, 20), v, dtype=np.uint8) for v in (5, 200, 5, 200)]
+    assert detect_mask_free_region(frames).is_full_frame()
+
+
+def test_detect_mask_free_region_tiny_game_is_full_frame():
+    # Only a 2x2 game patch (rest stays bright) -> below min_area_frac -> FULL_FRAME.
+    frames = []
+    for v in (5, 200):
+        f = np.full((20, 20), 200, dtype=np.uint8)
+        f[0:2, 0:2] = v
+        frames.append(f)
+    assert detect_mask_free_region(frames).is_full_frame()
+
+
+def test_detect_mask_free_region_single_frame_is_full_frame():
+    assert detect_mask_free_region([np.zeros((20, 20), dtype=np.uint8)]).is_full_frame()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1110,6 +1110,30 @@ def test_split_from_metadata_missing_file_exits_with_input_file_error(tmp_path):
     assert result.exit_code == 2  # InputFileError
 
 
+# --- masked flag and vtuber/masked mutex (L3 A6) ---
+
+
+@patch(MODULE)
+def test_split_masked_flag_sets_config(mock_run_split, tmp_path):
+    """--masked sets config.masked=True and is threaded through to SplitConfig."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"x")
+    result = runner.invoke(app, ["split", str(video), "--masked"])
+    assert result.exit_code == 0, result.stdout
+    config = mock_run_split.call_args[0][1]
+    assert config.masked is True
+
+
+def test_split_vtuber_and_masked_mutually_exclusive(tmp_path):
+    """--vtuber and --masked together should exit non-zero with 'exclusive' in output."""
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"x")
+    result = runner.invoke(app, ["split", str(video), "--vtuber", "--masked"])
+    assert result.exit_code != 0
+    combined = result.stdout + (result.stderr or "")
+    assert "exclusive" in combined.lower()
+
+
 # --- single-dash long-option hint (#440) ---
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1114,24 +1114,34 @@ def test_split_from_metadata_missing_file_exits_with_input_file_error(tmp_path):
 
 
 @patch(MODULE)
-def test_split_masked_flag_sets_config(mock_run_split, tmp_path):
+def test_split_masked_flag_sets_config(mock_run_split, fake_video):
     """--masked sets config.masked=True and is threaded through to SplitConfig."""
-    video = tmp_path / "v.mp4"
-    video.write_bytes(b"x")
-    result = runner.invoke(app, ["split", str(video), "--masked"])
+    result = runner.invoke(app, ["split", str(fake_video), "--masked"])
     assert result.exit_code == 0, result.stdout
     config = mock_run_split.call_args[0][1]
     assert config.masked is True
 
 
-def test_split_vtuber_and_masked_mutually_exclusive(tmp_path):
-    """--vtuber and --masked together should exit non-zero with 'exclusive' in output."""
-    video = tmp_path / "v.mp4"
-    video.write_bytes(b"x")
-    result = runner.invoke(app, ["split", str(video), "--vtuber", "--masked"])
-    assert result.exit_code != 0
+@patch(MODULE)
+def test_split_vtuber_and_masked_mutually_exclusive(mock_run_split, fake_video):
+    """--vtuber and --masked together exit 5 without calling run_split."""
+    result = runner.invoke(app, ["split", str(fake_video), "--vtuber", "--masked"])
+    assert result.exit_code == 5
+    mock_run_split.assert_not_called()
     combined = result.stdout + (result.stderr or "")
-    assert "exclusive" in combined.lower()
+    assert "--vtuber and --masked are mutually exclusive" in combined
+    assert result.stdout == "", f"stdout must be empty: {result.stdout!r}"
+
+
+@patch("allaganeye.commands.detect.run_detect")
+def test_detect_vtuber_and_masked_mutually_exclusive(mock_run_detect, fake_video):
+    """--vtuber and --masked together exit 5 on detect without calling run_detect."""
+    result = runner.invoke(app, ["detect", str(fake_video), "--vtuber", "--masked"])
+    assert result.exit_code == 5
+    mock_run_detect.assert_not_called()
+    combined = result.stdout + (result.stderr or "")
+    assert "--vtuber and --masked are mutually exclusive" in combined
+    assert result.stdout == "", f"stdout must be empty: {result.stdout!r}"
 
 
 # --- single-dash long-option hint (#440) ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,3 +91,7 @@ class TestSplitConfigValidation:
     def test_vtuber_true_is_valid(self):
         """vtuber=True is accepted (game-inset scorebar-band anchor path)."""
         assert SplitConfig(vtuber=True).vtuber is True
+
+    def test_split_config_masked_defaults_false(self):
+        """masked defaults False so OBS full-frame behavior is unchanged (L3 A6)."""
+        assert SplitConfig().masked is False

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -193,6 +193,29 @@ def test_detect_verbose_cache_miss_summary_includes_masked_token(tmp_path, capsy
     assert "masked=off" in out
 
 
+def test_detect_records_masked_fallback_used(tmp_path):
+    """detect 経路でも resolved path が metadata に記録される (run_split と同型)."""
+
+    def fake_run_detection(*args, **kwargs):
+        cb = kwargs.get("masked_fallback_callback")
+        assert cb is not None, (
+            "run_detect must pass masked_fallback_callback to _run_detection"
+        )
+        cb()
+        return BOUNDARIES
+
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, no_cache=True)
+    with (
+        patch(f"{MODULE_DETECT}.probe_video", return_value=PROBE_RESULT),
+        patch(f"{MODULE_DETECT}._run_detection", side_effect=fake_run_detection),
+    ):
+        run_detect(Path("input.mp4"), config, quiet=True)
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    assert payload["detection_params"]["masked"] is False
+    assert payload["detection_params"]["masked_fallback_used"] is True
+
+
 def test_detect_writes_system_info_to_metadata(tmp_path, monkeypatch):
     """#591 -- detect で書き出した metadata.json に system_info が含まれる."""
     monkeypatch.setattr(

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -168,6 +168,31 @@ def test_detect_verbose_cache_miss_summary_includes_vtuber_token(tmp_path, capsy
     assert "vtuber=off" in out
 
 
+def test_detect_verbose_cache_miss_summary_includes_masked_token(tmp_path, capsys):
+    """detect の cache-miss verbose summary に masked token が出る (vtuber と同型)."""
+    config = SplitConfig(
+        output_dir=tmp_path, min_match_duration=60.0, no_cache=True, masked=True
+    )
+    with (
+        patch(f"{MODULE_DETECT}.probe_video", return_value=PROBE_RESULT),
+        patch(f"{MODULE_DETECT}._run_detection", return_value=BOUNDARIES),
+    ):
+        run_detect(Path("input.mp4"), config, verbose=True)
+    out = capsys.readouterr().out
+    assert "masked=on" in out
+
+    config_off = SplitConfig(
+        output_dir=tmp_path, min_match_duration=60.0, no_cache=True
+    )
+    with (
+        patch(f"{MODULE_DETECT}.probe_video", return_value=PROBE_RESULT),
+        patch(f"{MODULE_DETECT}._run_detection", return_value=BOUNDARIES),
+    ):
+        run_detect(Path("input.mp4"), config_off, verbose=True)
+    out = capsys.readouterr().out
+    assert "masked=off" in out
+
+
 def test_detect_writes_system_info_to_metadata(tmp_path, monkeypatch):
     """#591 -- detect で書き出した metadata.json に system_info が含まれる."""
     monkeypatch.setattr(

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2784,3 +2784,39 @@ def test_probe_single_frame_regression_via_shared_decoder(monkeypatch):
     assert det._probe_single_frame(det.Path("x.mp4"), 1.0) == 10.0
     monkeypatch.setattr(det, "_decode_gray_raw", lambda v, t: None)
     assert det._probe_single_frame(det.Path("x.mp4"), 1.0) == 255.0
+
+
+# ============================================================
+# TestResolveMaskedRegion (masked-OBS A3)
+# ============================================================
+
+
+def _masked_frames():
+    out = []
+    for v in (5, 200, 5, 200):
+        f = np.full((det._SAMPLE_HEIGHT, det._SAMPLE_WIDTH), v, dtype=np.uint8)
+        f[120:180, 0:120] = 200  # static bright mask, bottom-left
+        out.append(f)
+    return out
+
+
+def test_resolve_masked_region_finds_mask_free_rect(monkeypatch):
+    seq = iter(_masked_frames() * 20)
+    monkeypatch.setattr(
+        det, "_probe_frame_gray2d", lambda v, t: next(seq, _masked_frames()[0])
+    )
+    region = det._resolve_masked_region(det.Path("x.mp4"), 600.0, None)
+    assert not region.is_full_frame()
+
+
+def test_resolve_masked_region_full_frame_when_no_frames(monkeypatch):
+    monkeypatch.setattr(det, "_probe_frame_gray2d", lambda v, t: None)
+    assert det._resolve_masked_region(det.Path("x.mp4"), 600.0, None).is_full_frame()
+
+
+def test_resolve_masked_region_swallows_exceptions(monkeypatch):
+    def boom(v, t):
+        raise RuntimeError("decode blew up")
+
+    monkeypatch.setattr(det, "_probe_frame_gray2d", boom)
+    assert det._resolve_masked_region(det.Path("x.mp4"), 600.0, None).is_full_frame()

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1167,7 +1167,7 @@ class TestDetectMatchBoundaries:
                 workers,
                 *,
                 band_region=FULL_FRAME,
-                vtuber=False,
+                localize=False,
                 audio_hits,
                 stats,
                 progress_callback=None,
@@ -2644,7 +2644,7 @@ def _vtuber_filter_capture(seen: dict):
     """Build a filter_blackouts_with_scorebar stand-in that records kwargs.
 
     Mirrors the real signature (allaganeye/video/scorebar.py) so the
-    keyword-only block (band_region / vtuber / audio_hits / stats /
+    keyword-only block (band_region / localize / audio_hits / stats /
     progress_callback) binds exactly as the production call site passes it.
     Returns every region classified as ``match_boundary`` so segments survive
     into the trailing-drop stage.
@@ -2658,13 +2658,13 @@ def _vtuber_filter_capture(seen: dict):
         workers=None,
         *,
         band_region=FULL_FRAME,
-        vtuber=False,
+        localize=False,
         audio_hits=None,
         stats=None,
         progress_callback=None,
     ):
         seen["band_region"] = band_region
-        seen["vtuber"] = vtuber
+        seen["localize"] = localize
         return regions, ["match_boundary"] * len(regions)
 
     return filter_side_effect
@@ -2712,8 +2712,8 @@ def test_vtuber_threads_filter_kwargs_and_gates_trailing_drop(
             vtuber=True,
         )
 
-    # filter received the resolved band region and the vtuber flag at runtime.
-    assert seen["vtuber"] is True
+    # filter received the resolved band region and the localize flag at runtime.
+    assert seen["localize"] is True
     assert seen["band_region"] is not None
     assert seen["band_region"] is band
     # VTuber path must NOT run the irreversible trailing-drop (#797 / #805).
@@ -2753,7 +2753,7 @@ def test_obs_runs_trailing_drop_and_filter_sees_vtuber_false(
             src_resolution=(1920, 1080),
         )
 
-    assert seen["vtuber"] is False
+    assert seen["localize"] is False
     # OBS path runs the trailing-drop exactly once.
     mock_trailing.assert_called_once()
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1132,6 +1132,53 @@ class TestDetectMatchBoundaries:
         )
         assert isinstance(result, list)
 
+    @patch("allaganeye.video.detector._detect_masked_fallback")
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_masked_fallback_callback_fires_when_result_used(
+        self, mock_chunk, mock_fallback
+    ):
+        """fallback の結果が採用されたときのみ callback が発火 (resolved provenance).
+
+        request flag (masked) と resolved path を分離するための通知 seam。
+        brightness_callback (#569/#644) と同型の配線。
+        """
+        # zero-blackout -> gate (not vtuber and not blackout_times) が fallback へ
+        mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
+            t: 100.0 for t in ts
+        }
+        fallback_result = [{"start": 0.0, "end": 9.0, "type": "fl_match"}]
+        mock_fallback.return_value = fallback_result
+        fired: list[bool] = []
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=10.0,
+            sample_interval=1.0,
+            min_match_duration=1.0,
+            masked_fallback_callback=lambda: fired.append(True),
+        )
+        assert result == fallback_result
+        assert fired == [True]
+
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
+    @patch("allaganeye.video.detector._decode_chunk_cpu")
+    def test_masked_fallback_callback_not_fired_when_fallback_gives_up(
+        self, mock_chunk, _mock_region
+    ):
+        """fallback が None (縮退) で標準 path に落ちた場合は callback 不発."""
+        mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
+            t: 100.0 for t in ts
+        }
+        fired: list[bool] = []
+        result = detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=10.0,
+            sample_interval=1.0,
+            min_match_duration=1.0,
+            masked_fallback_callback=lambda: fired.append(True),
+        )
+        assert isinstance(result, list)
+        assert fired == []
+
     @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
     def test_stats_populated_cpu(self, mock_chunk, _mock_region):

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2756,3 +2756,31 @@ def test_obs_runs_trailing_drop_and_filter_sees_vtuber_false(
     assert seen["vtuber"] is False
     # OBS path runs the trailing-drop exactly once.
     mock_trailing.assert_called_once()
+
+
+# ============================================================
+# TestDecodeGrayRaw / TestProbeFrameGray2d (masked-OBS A2)
+# ============================================================
+
+
+def test_probe_frame_gray2d_returns_2d(monkeypatch):
+    buf = bytes(range(256)) * (det._FRAME_SIZE // 256 + 1)
+    monkeypatch.setattr(det, "_decode_gray_raw", lambda v, t: buf[: det._FRAME_SIZE])
+    frame = det._probe_frame_gray2d(det.Path("x.mp4"), 1.0)
+    assert frame is not None
+    assert frame.shape == (det._SAMPLE_HEIGHT, det._SAMPLE_WIDTH)
+    assert frame.dtype == np.uint8
+
+
+def test_probe_frame_gray2d_none_on_decode_failure(monkeypatch):
+    monkeypatch.setattr(det, "_decode_gray_raw", lambda v, t: None)
+    assert det._probe_frame_gray2d(det.Path("x.mp4"), 1.0) is None
+
+
+def test_probe_single_frame_regression_via_shared_decoder(monkeypatch):
+    # Extraction must preserve _probe_single_frame brightness exactly.
+    buf = bytes([10]) * det._FRAME_SIZE
+    monkeypatch.setattr(det, "_decode_gray_raw", lambda v, t: buf)
+    assert det._probe_single_frame(det.Path("x.mp4"), 1.0) == 10.0
+    monkeypatch.setattr(det, "_decode_gray_raw", lambda v, t: None)
+    assert det._probe_single_frame(det.Path("x.mp4"), 1.0) == 255.0

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -3029,3 +3029,84 @@ def test_detect_masked_fallback_wires_region_band_localize(monkeypatch):
     assert seen["refine_region"] is fake_region
     assert seen["band_region"] is det.FULL_FRAME
     assert seen["localize"] is True
+
+
+# ============================================================
+# A-Task 8: brightness-hint dark+even sampling
+# ============================================================
+
+
+def test_resolve_masked_region_hint_samples_darkest(monkeypatch):
+    # brightness_hint marks 3 very-dark timestamps (the masked blackouts).
+    DUR = 1000.0
+    hint = {
+        float(t): (5.0 if t in (100, 300, 700) else 200.0) for t in range(0, 1000, 10)
+    }
+    sampled = []
+
+    def fake(v, t):
+        sampled.append(round(t, 3))
+        return np.zeros((det._SAMPLE_HEIGHT, det._SAMPLE_WIDTH), dtype=np.uint8)
+
+    monkeypatch.setattr(det, "_probe_frame_gray2d", fake)
+    det._resolve_masked_region(det.Path("x.mp4"), DUR, None, brightness_hint=hint)
+    # The 3 darkest timestamps must be among those decoded (dark-moment sampling).
+    assert {100.0, 300.0, 700.0}.issubset(set(sampled))
+
+
+def test_resolve_masked_region_hint_finds_region(monkeypatch):
+    DUR = 1000.0
+    dark = {100.0, 300.0, 700.0}
+    hint = {float(t): (5.0 if t in dark else 200.0) for t in range(0, 1000, 10)}
+
+    def fake(v, t):
+        # dark timestamps -> game region dark (5); others -> game bright (200).
+        base = 5 if t in dark else 200
+        f = np.full((det._SAMPLE_HEIGHT, det._SAMPLE_WIDTH), base, dtype=np.uint8)
+        f[120:180, 0:120] = 200  # static bright mask, bottom-left
+        return f
+
+    monkeypatch.setattr(det, "_probe_frame_gray2d", fake)
+    r = det._resolve_masked_region(det.Path("x.mp4"), DUR, None, brightness_hint=hint)
+    assert not r.is_full_frame()  # dark+even sampling recovers the region
+
+
+def test_resolve_masked_region_no_hint_unchanged(monkeypatch):
+    # Without a hint, behavior is the prior even-only sampling (backward compat).
+    seq = iter(_masked_frames() * 40)
+    monkeypatch.setattr(
+        det, "_probe_frame_gray2d", lambda v, t: next(seq, _masked_frames()[0])
+    )
+    r = det._resolve_masked_region(det.Path("x.mp4"), 600.0, None)
+    assert not r.is_full_frame()
+
+
+def test_detect_masked_fallback_threads_brightness_hint(monkeypatch):
+    seen = {}
+
+    def fake_resolve(video_path, duration_hint, workers, *, brightness_hint=None):
+        seen["hint"] = brightness_hint
+        return det.FULL_FRAME  # short-circuit (returns None) -- we only check wiring
+
+    monkeypatch.setattr(det, "_resolve_masked_region", fake_resolve)
+    out = det._detect_masked_fallback(
+        det.Path("x.mp4"),
+        duration_hint=600.0,
+        sample_interval=3.0,
+        blackout_threshold=15.0,
+        min_match_duration=300.0,
+        min_blackout_duration=3.0,
+        use_gpu=False,
+        workers=None,
+        src_resolution=(1920, 1080),
+        codec="h264",
+        gpu_vendor=None,
+        source_fps_num=60,
+        source_fps_den=1,
+        source_fps=None,
+        audio_hits=None,
+        stats=None,
+        brightness_results={1.0: 5.0, 2.0: 200.0},
+    )
+    assert out is None
+    assert seen["hint"] == {1.0: 5.0, 2.0: 200.0}

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1007,8 +1007,13 @@ class TestProbeSingleFrame:
 
 
 class TestDetectMatchBoundaries:
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._probe_single_frame")
-    def test_all_bright(self, mock_probe):
+    def test_all_bright(self, mock_probe, _mock_region):
+        # _mock_region: zero-blackout Pass 1 now routes through the masked
+        # fallback gate (#753 A5); stub the region resolver to FULL_FRAME so the
+        # masked path returns None and falls through to the standard result
+        # without spawning real ffmpeg probes (kept fast/deterministic).
         mock_probe.return_value = 128.0
         result = detect_match_boundaries(
             Path("test.mp4"), duration_hint=300.0, min_match_duration=100.0
@@ -1049,8 +1054,11 @@ class TestDetectMatchBoundaries:
         assert result[0]["start"] == 0.0
         assert result[1]["end"] == pytest.approx(1800.0)
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_custom_threshold(self, mock_chunk):
+    def test_custom_threshold(self, mock_chunk, _mock_region):
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub
+        # falls through to standard result (no real ffmpeg probes).
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 20.0 for t in ts
         }
@@ -1083,9 +1091,11 @@ class TestDetectMatchBoundaries:
         ):
             detect_match_boundaries(Path("test.mp4"), min_match_duration=100.0)
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_brightness_callback_receives_pass1_results(self, mock_chunk):
+    def test_brightness_callback_receives_pass1_results(self, mock_chunk, _mock_region):
         """#569 -- brightness_callback fires once with full Pass 1 map."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 50.0 + t for t in ts
         }
@@ -1105,9 +1115,11 @@ class TestDetectMatchBoundaries:
         assert results[0.0] == pytest.approx(50.0)
         assert results[5.0] == pytest.approx(55.0)
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_brightness_callback_optional_default(self, mock_chunk):
+    def test_brightness_callback_optional_default(self, mock_chunk, _mock_region):
         """Omitting the callback is a no-op (preserves pre-#569 callers)."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 100.0 for t in ts
         }
@@ -1120,9 +1132,11 @@ class TestDetectMatchBoundaries:
         )
         assert isinstance(result, list)
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_stats_populated_cpu(self, mock_chunk):
+    def test_stats_populated_cpu(self, mock_chunk, _mock_region):
         """Verbose callers receive pipeline statistics (issue #336 Phase 1)."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         from allaganeye.video.detector import DetectionStats
 
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
@@ -1195,8 +1209,10 @@ class TestDetectMatchBoundaries:
         assert stats.get("scorebar_non_fl") == 3
         assert stats.get("audio_promotions") == 1
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_progress_callback(self, mock_chunk):
+    def test_progress_callback(self, mock_chunk, _mock_region):
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 128.0 for t in ts
         }
@@ -1296,8 +1312,10 @@ class TestDetectMatchBoundaries:
             "no intermediate progress was published; callbacks appear batched"
         )
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_progress_callback_none(self, mock_chunk):
+    def test_progress_callback_none(self, mock_chunk, _mock_region):
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 128.0 for t in ts
         }
@@ -1306,9 +1324,11 @@ class TestDetectMatchBoundaries:
         )
         assert len(result) == 1
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_sample_count(self, mock_chunk):
+    def test_sample_count(self, mock_chunk, _mock_region):
         """All timestamps are processed across chunks."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         call_timestamps = []
 
         def side_effect(vp, ts, cs, ce, si, **kwargs):
@@ -1324,9 +1344,11 @@ class TestDetectMatchBoundaries:
         )
         assert len(set(call_timestamps)) == 150
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_chunked_execution(self, mock_chunk):
+    def test_chunked_execution(self, mock_chunk, _mock_region):
         """Multiple chunks are created for parallel execution."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 128.0 for t in ts
         }
@@ -1339,10 +1361,16 @@ class TestDetectMatchBoundaries:
         assert len(result) == 1
         assert mock_chunk.call_count >= 1
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_scorebar_filtering_called_with_resolution(self, mock_chunk, mock_filter):
+    def test_scorebar_filtering_called_with_resolution(
+        self, mock_chunk, mock_filter, _mock_region
+    ):
         """Scorebar filtering is invoked when src_resolution is provided."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub
+        # so the masked path returns None and the standard scorebar call still
+        # fires exactly once (assertion below unchanged).
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 128.0 for t in ts
         }
@@ -1358,12 +1386,16 @@ class TestDetectMatchBoundaries:
         )
         mock_filter.assert_called_once()
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
     @patch("allaganeye.video.detector._decode_chunk_cpu")
     def test_scorebar_filtering_skipped_without_resolution(
-        self, mock_chunk, mock_filter
+        self, mock_chunk, mock_filter, _mock_region
     ):
         """Scorebar filtering is NOT invoked when src_resolution is None."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub
+        # -> masked path returns None before its own scorebar call, so
+        # assert_not_called() still holds.
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 128.0 for t in ts
         }
@@ -1374,10 +1406,14 @@ class TestDetectMatchBoundaries:
         )
         mock_filter.assert_not_called()
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_audio_hits_forwarded_to_scorebar_filter(self, mock_chunk, mock_filter):
+    def test_audio_hits_forwarded_to_scorebar_filter(
+        self, mock_chunk, mock_filter, _mock_region
+    ):
         """audio_hits parameter is passed through to scorebar filtering (#288)."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 128.0 for t in ts
         }
@@ -1396,10 +1432,14 @@ class TestDetectMatchBoundaries:
         mock_filter.assert_called_once()
         assert mock_filter.call_args.kwargs["audio_hits"] == hits
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.scorebar.filter_blackouts_with_scorebar")
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_audio_hits_default_none_forwarded_as_none(self, mock_chunk, mock_filter):
+    def test_audio_hits_default_none_forwarded_as_none(
+        self, mock_chunk, mock_filter, _mock_region
+    ):
         """Omitted audio_hits reaches the scorebar filter as None."""
+        # _mock_region: zero-blackout -> masked gate (#753 A5); FULL_FRAME stub.
         mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kwargs: {
             t: 128.0 for t in ts
         }
@@ -1620,10 +1660,11 @@ class TestPass1HysteresisIntegration:
         # the blackout and splits the video into two matches.
         assert len(result) == 2
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._probe_single_frame")
     @patch("allaganeye.video.detector._decode_chunk_cpu")
     def test_borderline_triggers_refinement_around_missed_blackout(
-        self, mock_chunk, mock_probe
+        self, mock_chunk, mock_probe, _mock_region
     ):
         """A3: Pass 1 borderline frames trigger Pass 2 +-3s refinement.
 
@@ -1650,6 +1691,9 @@ class TestPass1HysteresisIntegration:
             2.0 if 8137.25 <= t <= 8139.75 else 128.0
         )
 
+        # _mock_region: borderline-only Pass 1 has 0 strict blackouts -> masked
+        # gate (#753 A5); FULL_FRAME stub returns None so the standard A3
+        # pseudo-region path still runs and probes around t=8139.
         detect_match_boundaries(
             Path("test.mp4"),
             duration_hint=10000.0,
@@ -1665,12 +1709,16 @@ class TestPass1HysteresisIntegration:
             f"but probed: {sorted(set(probed))[:10]}..."
         )
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._probe_single_frame")
     @patch("allaganeye.video.detector._decode_chunk_cpu")
     def test_borderline_refinement_disabled_skips_pseudo_regions(
-        self, mock_chunk, mock_probe
+        self, mock_chunk, mock_probe, _mock_region
     ):
         """With _ENABLE_BORDERLINE_REFINEMENT=False, no pseudo regions added."""
+        # _mock_region: borderline-only Pass 1 has 0 strict blackouts -> masked
+        # gate (#753 A5); FULL_FRAME stub returns None so the standard path runs
+        # and (with A3 disabled) probes no region near 8139.
 
         def chunk_side_effect(vp, ts, cs, ce, si, **kwargs):
             return {t: 20.0 if t == 8139.0 else 128.0 for t in ts}
@@ -1691,10 +1739,16 @@ class TestPass1HysteresisIntegration:
         near_borderline = [t for t in probed if 8136.0 <= t <= 8142.0]
         assert not near_borderline
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._probe_single_frame")
     @patch("allaganeye.video.detector._decode_chunk_cpu")
-    def test_upper_margin_zero_restores_strict_threshold(self, mock_chunk, mock_probe):
+    def test_upper_margin_zero_restores_strict_threshold(
+        self, mock_chunk, mock_probe, _mock_region
+    ):
         """With _BLACKOUT_THRESHOLD_UPPER_MARGIN=0.0, only b<threshold is blackout."""
+        # _mock_region: with margin 0, the 15.5 frame is not blackout -> 0
+        # blackouts -> masked gate (#753 A5); FULL_FRAME stub falls through to
+        # the standard single-match result.
 
         def chunk_side_effect(vp, ts, cs, ce, si, **kwargs):
             # Make one frame borderline (15.5) but otherwise bright.
@@ -2116,8 +2170,12 @@ class TestDetectMatchBoundariesRationalFps:
     """detect_match_boundaries が source_fps_num/den を _scan_cpu / scan_gpu
     まで伝搬すること (#576 S2.3)."""
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.detector._scan_cpu")
-    def test_cpu_path_receives_rational_fps(self, mock_scan):
+    def test_cpu_path_receives_rational_fps(self, mock_scan, _mock_region):
+        # _mock_region: bright Pass 1 -> 0 blackouts -> masked gate (#753 A5);
+        # FULL_FRAME stub returns None before the masked path can call _scan_cpu
+        # again, so mock_scan.call_args remains the single standard Pass 1 call.
         mock_scan.return_value = {0.0: 100.0, 1.0: 100.0}
 
         detect_match_boundaries(
@@ -2134,9 +2192,13 @@ class TestDetectMatchBoundariesRationalFps:
         assert kwargs.get("source_fps_num") == 60000
         assert kwargs.get("source_fps_den") == 1001
 
+    @patch("allaganeye.video.detector._resolve_masked_region", return_value=FULL_FRAME)
     @patch("allaganeye.video.gpu_detector.scan_gpu")
     @patch("allaganeye.video.detector._scan_cpu")
-    def test_gpu_path_receives_rational_fps(self, _mock_cpu, mock_gpu):
+    def test_gpu_path_receives_rational_fps(self, _mock_cpu, mock_gpu, _mock_region):
+        # _mock_region: bright Pass 1 -> 0 blackouts -> masked gate (#753 A5);
+        # FULL_FRAME stub returns None before the masked path can call scan_gpu
+        # again, so mock_gpu.call_args remains the single standard Pass 1 call.
         mock_gpu.return_value = {0.0: 100.0, 1.0: 100.0}
 
         detect_match_boundaries(
@@ -2820,3 +2882,150 @@ def test_resolve_masked_region_swallows_exceptions(monkeypatch):
 
     monkeypatch.setattr(det, "_probe_frame_gray2d", boom)
     assert det._resolve_masked_region(det.Path("x.mp4"), 600.0, None).is_full_frame()
+
+
+# ============================================================
+# Masked fallback (#753 masked-OBS, A-Task 5)
+# ============================================================
+
+
+def _zero_blackout_results():
+    return {float(t): 200.0 for t in range(0, 600, 3)}
+
+
+def test_masked_fallback_triggers_on_zero_blackout(monkeypatch):
+    monkeypatch.setattr(det, "_scan_cpu", lambda *a, **k: _zero_blackout_results())
+    called = {}
+
+    def fake_masked(video_path, **kw):
+        called["hit"] = True
+        return [{"start": 0.0, "end": 300.0}]
+
+    monkeypatch.setattr(det, "_detect_masked_fallback", fake_masked)
+    out = det.detect_match_boundaries(
+        det.Path("x.mp4"),
+        duration_hint=600.0,
+        use_gpu=False,
+        src_resolution=(1920, 1080),
+    )
+    assert called.get("hit") is True
+    assert out == [{"start": 0.0, "end": 300.0}]
+
+
+def test_masked_fallback_not_triggered_when_blackouts_present(monkeypatch):
+    # OBS bit-exact gate: blackouts present + masked=False -> fallback NOT called.
+    results = _zero_blackout_results()
+    results[300.0] = 2.0  # one blackout frame
+    monkeypatch.setattr(det, "_scan_cpu", lambda *a, **k: results)
+    monkeypatch.setattr(det, "_refine_blackout_regions", lambda *a, **k: [])
+    called = {}
+    monkeypatch.setattr(
+        det, "_detect_masked_fallback", lambda *a, **k: called.setdefault("hit", True)
+    )
+    det.detect_match_boundaries(
+        det.Path("x.mp4"), duration_hint=600.0, use_gpu=False, src_resolution=None
+    )
+    assert "hit" not in called
+
+
+def test_masked_fallback_forced_even_with_blackouts(monkeypatch):
+    results = _zero_blackout_results()
+    results[300.0] = 2.0
+    monkeypatch.setattr(det, "_scan_cpu", lambda *a, **k: results)
+    monkeypatch.setattr(
+        det, "_detect_masked_fallback", lambda *a, **k: [{"start": 1.0, "end": 2.0}]
+    )
+    out = det.detect_match_boundaries(
+        det.Path("x.mp4"),
+        duration_hint=600.0,
+        use_gpu=False,
+        masked=True,
+        src_resolution=(1920, 1080),
+    )
+    assert out == [{"start": 1.0, "end": 2.0}]
+
+
+def test_detect_masked_fallback_returns_none_when_no_region(monkeypatch):
+    monkeypatch.setattr(det, "_resolve_masked_region", lambda *a, **k: det.FULL_FRAME)
+    scan_called = {}
+    monkeypatch.setattr(
+        det, "_scan_cpu", lambda *a, **k: scan_called.setdefault("hit", True) or {}
+    )
+    out = det._detect_masked_fallback(
+        det.Path("x.mp4"),
+        duration_hint=600.0,
+        sample_interval=3.0,
+        blackout_threshold=15.0,
+        min_match_duration=300.0,
+        min_blackout_duration=3.0,
+        use_gpu=False,
+        workers=None,
+        src_resolution=(1920, 1080),
+        codec="h264",
+        gpu_vendor=None,
+        source_fps_num=60,
+        source_fps_den=1,
+        source_fps=None,
+        audio_hits=None,
+        stats=None,
+    )
+    assert out is None
+    assert "hit" not in scan_called  # short-circuits before scanning
+
+
+def test_detect_masked_fallback_wires_region_band_localize(monkeypatch):
+    from allaganeye.video.capture_region import CaptureRegion
+
+    fake_region = CaptureRegion(0.0, 0.0, 1.0, 0.3, source="tierA")
+    monkeypatch.setattr(det, "_resolve_masked_region", lambda *a, **k: fake_region)
+    seen = {}
+
+    def fake_scan(video_path, dur, si, thr, workers, cb, **kw):
+        seen["scan_region"] = kw.get("region")
+        return {0.0: 2.0, 3.0: 2.0, 100.0: 200.0}
+
+    monkeypatch.setattr(det, "_scan_cpu", fake_scan)
+
+    def fake_refine(video_path, regions, thr, dur, workers, **kw):
+        seen["refine_region"] = kw.get("region")
+        return [(0.0, 3.0)]
+
+    monkeypatch.setattr(det, "_refine_blackout_regions", fake_refine)
+
+    def fake_filter(video_path, regions, dur, height, workers, **kw):
+        seen["band_region"] = kw.get("band_region")
+        seen["localize"] = kw.get("localize")
+        return regions, ["match_boundary"]
+
+    monkeypatch.setattr(
+        "allaganeye.video.scorebar.filter_blackouts_with_scorebar", fake_filter
+    )
+    monkeypatch.setattr(
+        det,
+        "_filter_and_extract_segments",
+        lambda *a, **k: [{"start": 0.0, "end": 9.0}],
+    )
+
+    out = det._detect_masked_fallback(
+        det.Path("x.mp4"),
+        duration_hint=600.0,
+        sample_interval=3.0,
+        blackout_threshold=15.0,
+        min_match_duration=300.0,
+        min_blackout_duration=3.0,
+        use_gpu=False,
+        workers=None,
+        src_resolution=(1920, 1080),
+        codec="h264",
+        gpu_vendor=None,
+        source_fps_num=60,
+        source_fps_den=1,
+        source_fps=None,
+        audio_hits=None,
+        stats=None,
+    )
+    assert out == [{"start": 0.0, "end": 9.0}]
+    assert seen["scan_region"] is fake_region
+    assert seen["refine_region"] is fake_region
+    assert seen["band_region"] is det.FULL_FRAME
+    assert seen["localize"] is True

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -39,6 +39,10 @@ def _valid_sample() -> dict[str, Any]:
             "no_audio": False,
             "use_gpu": None,
             "workers": None,
+            # optional provenance fields (#821): writer は常に出力、読み込みは
+            # 欠落許容 (pre-#821 metadata)
+            "vtuber": False,
+            "masked": False,
         },
         "matches": [
             {

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -40,9 +40,11 @@ def _valid_sample() -> dict[str, Any]:
             "use_gpu": None,
             "workers": None,
             # optional provenance fields (#821): writer は常に出力、読み込みは
-            # 欠落許容 (pre-#821 metadata)
+            # 欠落許容 (pre-#821 metadata)。masked = request flag、
+            # masked_fallback_used = resolved path (auto-fallback 含む)。
             "vtuber": False,
             "masked": False,
+            "masked_fallback_used": False,
         },
         "matches": [
             {

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1508,7 +1508,7 @@ def test_classify_localize_all_none_is_unknown(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# classify_blackout vtuber gate unit tests (Phase 2 B3)
+# classify_blackout localize selector unit tests (Phase 2 B3)
 # ---------------------------------------------------------------------------
 
 
@@ -1574,7 +1574,7 @@ def test_filter_threads_vtuber_to_classify(monkeypatch):
     assert seen == [(True, "band")]
 
 
-def test_merge_gap_probe_uses_localize_when_vtuber(monkeypatch):
+def test_merge_gap_probe_uses_localize_path(monkeypatch):
     from allaganeye.video import scorebar as sb
     from allaganeye.video.capture_region import CaptureRegion
 

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1525,7 +1525,7 @@ def test_classify_blackout_vtuber_delegates_to_localize(monkeypatch):
     monkeypatch.setattr(sb, "_classify_blackout_localize", fake_localize)
     band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
     out = sb.classify_blackout(
-        Path("x.mp4"), (10.0, 11.0), 400.0, 180, vtuber=True, band_region=band
+        Path("x.mp4"), (10.0, 11.0), 400.0, 180, localize=True, band_region=band
     )
     assert out == "in_match"
     assert seen["band"] is band
@@ -1560,16 +1560,16 @@ def test_filter_threads_vtuber_to_classify(monkeypatch):
     seen = []
 
     def fake_classify(
-        video, region, duration, height, workers=None, *, band_region, vtuber
+        video, region, duration, height, workers=None, *, band_region, localize
     ):
-        seen.append((vtuber, band_region.source))
+        seen.append((localize, band_region.source))
         return "match_boundary"
 
     monkeypatch.setattr(sb, "classify_blackout", fake_classify)
     monkeypatch.setattr(sb, "_merge_boundary_pairs", lambda *a, **k: (a[1], a[2]))
     band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
     sb.filter_blackouts_with_scorebar(
-        Path("x.mp4"), [(10.0, 12.0)], 400.0, 180, band_region=band, vtuber=True
+        Path("x.mp4"), [(10.0, 12.0)], 400.0, 180, band_region=band, localize=True
     )
     assert seen == [(True, "band")]
 
@@ -1590,7 +1590,28 @@ def test_merge_gap_probe_uses_localize_when_vtuber(monkeypatch):
     cls = ["match_boundary", "match_boundary"]
     band = CaptureRegion(0.3, 0.0, 0.37, 0.04, source="band")
     merged, _merged_cls = sb._merge_boundary_pairs(
-        Path("x.mp4"), regions, cls, 400.0, 180, None, band_region=band, vtuber=True
+        Path("x.mp4"), regions, cls, 400.0, 180, None, band_region=band, localize=True
     )
     assert captured["with_localize"] is True
     assert merged == [(10.0, 32.0)]  # localize-absent gap -> merged
+
+
+def test_classify_blackout_localize_selector_routes(monkeypatch):
+    from pathlib import Path
+
+    monkeypatch.setattr(sb, "_classify_blackout_localize", lambda *a, **k: "LOCALIZED")
+    # localize=True routes to the position-independent classifier
+    assert (
+        sb.classify_blackout(Path("x.mp4"), (10.0, 12.0), 100.0, 180, localize=True)
+        == "LOCALIZED"
+    )
+    # localize=False takes the v2 path (must NOT be the localize sentinel).
+    monkeypatch.setattr(
+        sb,
+        "_probe_scorebar_context",
+        lambda *a, **k: ([False, False, False], [None, None, None], [None, None, None]),
+    )
+    assert (
+        sb.classify_blackout(Path("x.mp4"), (10.0, 12.0), 100.0, 180, localize=False)
+        != "LOCALIZED"
+    )

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -489,6 +489,7 @@ def test_metadata_detection_params_present(
         no_audio=True,
         use_gpu=True,
         workers=8,
+        vtuber=True,
     )
 
     run_split(Path("input.mp4"), config)
@@ -505,10 +506,17 @@ def test_metadata_detection_params_present(
         "no_audio",
         "use_gpu",
         "workers",
+        "vtuber",
+        "masked",
     }
     assert set(params) == expected_keys, (
         f"detection_params keys mismatch: {set(params) ^ expected_keys}"
     )
+
+    # vtuber/masked provenance (PR #823 R1 deferred -> PR (b) で一括): metadata
+    # からどの検出 path で生成されたかを判別可能にする。
+    assert params["vtuber"] is True
+    assert params["masked"] is False
 
     # Values must reflect runtime SplitConfig.  sample_interval is the
     # effective (post-auto-adjust) value to stay in sync with
@@ -1163,6 +1171,43 @@ class TestCacheRoundTrip:
         )
         vtuber_config = SplitConfig(output_dir=tmp_path / "output", vtuber=True)
         assert _load_cache(cache_path, cache_video, 1.0, vtuber_config) is None
+
+    def test_param_mismatch_masked(self, cache_video, cache_config, tmp_path):
+        """標準 run の cache を masked run が再利用しない -> None (vtuber key と同型)."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        masked_config = SplitConfig(output_dir=tmp_path / "output", masked=True)
+        assert _load_cache(cache_path, cache_video, 1.0, masked_config) is None
+
+    def test_param_mismatch_masked_reverse(self, cache_video, cache_config, tmp_path):
+        """masked run の cache を標準 run が再利用しない -> None (released path 保護)."""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        masked_config = SplitConfig(output_dir=tmp_path / "output", masked=True)
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, masked_config, CACHE_BOUNDARIES
+        )
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
+
+    def test_legacy_cache_without_masked_key(self, cache_video, cache_config, tmp_path):
+        """masked key なし legacy cache: 標準 run は有効、masked run は無効。
+
+        --masked 導入前の cache はすべて標準 path の結果なので missing = False と
+        同値に扱う (vtuber key と同じ後方互換規約)。
+        """
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        data["params"].pop("masked", None)
+        cache_path.write_text(json.dumps(data), encoding="utf-8")
+        assert (
+            _load_cache(cache_path, cache_video, 1.0, cache_config) == CACHE_BOUNDARIES
+        )
+        masked_config = SplitConfig(output_dir=tmp_path / "output", masked=True)
+        assert _load_cache(cache_path, cache_video, 1.0, masked_config) is None
 
     def test_version_mismatch(self, cache_video, cache_config, tmp_path):
         """cache_version mismatch -> None."""
@@ -3584,8 +3629,9 @@ def test_verbose_cache_hit_prints_detection_params(
     # (#384 contract: audio display is driven by the helper, not
     # config.no_audio directly).
     assert "audio=frozen" in out
-    # vtuber provenance token (PR #823 R1): 検出 mode を表示に含める。
+    # vtuber/masked provenance token (PR #823 R1 / PR (b)): 検出 mode を表示に含める。
     assert "vtuber=off" in out
+    assert "masked=off" in out
 
 
 @patch(f"{MODULE}.split_video")
@@ -3665,6 +3711,27 @@ def test_verbose_cache_hit_prints_vtuber_on_token(
     assert "vtuber=on" in out[header_idx:]
 
 
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_hit_prints_masked_on_token(
+    mock_probe, mock_split, tmp_path, capsys
+):
+    """masked=True で生成した cache の hit 表示は masked=on (vtuber token と同型)."""
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0, masked=True)
+    _seed_cache(source, tmp_path, config)
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    run_split(source, config, verbose=True)
+    out = capsys.readouterr().out
+
+    header_idx = out.find("Cache hit:")
+    assert header_idx >= 0
+    assert "masked=on" in out[header_idx:]
+
+
 @patch(f"{MODULE}._run_detection")
 @patch(f"{MODULE}.split_video")
 @patch(f"{MODULE}.probe_video")
@@ -3685,6 +3752,28 @@ def test_verbose_cache_miss_summary_includes_vtuber_token(
     config_off = SplitConfig(output_dir=tmp_path, no_cache=True)
     run_split(source, config_off, verbose=True)
     assert "vtuber=off" in capsys.readouterr().out
+
+
+@patch(f"{MODULE}._run_detection")
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_miss_summary_includes_masked_token(
+    mock_probe, mock_split, mock_run_detection, tmp_path, capsys
+):
+    """cache-miss の Detecting summary に masked token が出る (vtuber と同型)."""
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+    mock_run_detection.return_value = BOUNDARIES
+
+    config = SplitConfig(output_dir=tmp_path, no_cache=True, masked=True)
+    run_split(source, config, verbose=True)
+    assert "masked=on" in capsys.readouterr().out
+
+    config_off = SplitConfig(output_dir=tmp_path, no_cache=True)
+    run_split(source, config_off, verbose=True)
+    assert "masked=off" in capsys.readouterr().out
 
 
 def test_display_cache_hit_params_malformed_json_emits_unavailable(tmp_path, capsys):

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -508,15 +508,18 @@ def test_metadata_detection_params_present(
         "workers",
         "vtuber",
         "masked",
+        "masked_fallback_used",
     }
     assert set(params) == expected_keys, (
         f"detection_params keys mismatch: {set(params) ^ expected_keys}"
     )
 
     # vtuber/masked provenance (PR #823 R1 deferred -> PR (b) で一括): metadata
-    # からどの検出 path で生成されたかを判別可能にする。
+    # からどの検出 path で生成されたかを判別可能にする。masked は request flag、
+    # masked_fallback_used は resolved path (auto-fallback 含む) を表す。
     assert params["vtuber"] is True
     assert params["masked"] is False
+    assert params["masked_fallback_used"] is False
 
     # Values must reflect runtime SplitConfig.  sample_interval is the
     # effective (post-auto-adjust) value to stay in sync with
@@ -1208,6 +1211,25 @@ class TestCacheRoundTrip:
         )
         masked_config = SplitConfig(output_dir=tmp_path / "output", masked=True)
         assert _load_cache(cache_path, cache_video, 1.0, masked_config) is None
+
+    def test_legacy_v2_cache_rejected(self, cache_video, cache_config, tmp_path):
+        """pre-#821 (v2) cache は version bump で全面 invalidate (Codex high finding).
+
+        masked auto-fallback (flag なしでも 0-blackout で発火) の導入により
+        「missing masked = False = 同一挙動」が成立しなくなった。v2 cache が
+        hit し続けると masked 動画の誤結果 (全滅 1-match) が再利用され、新
+        detector が永遠に走らないため、version で全面 invalidate する。
+        """
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        data["cache_version"] = 2
+        for key in ("vtuber", "masked"):
+            data["params"].pop(key, None)
+        cache_path.write_text(json.dumps(data), encoding="utf-8")
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
 
     def test_version_mismatch(self, cache_video, cache_config, tmp_path):
         """cache_version mismatch -> None."""
@@ -3774,6 +3796,71 @@ def test_verbose_cache_miss_summary_includes_masked_token(
     config_off = SplitConfig(output_dir=tmp_path, no_cache=True)
     run_split(source, config_off, verbose=True)
     assert "masked=off" in capsys.readouterr().out
+
+
+@patch(f"{MODULE}._run_detection")
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_run_split_records_masked_fallback_used(
+    mock_probe, mock_split, mock_run_detection, tmp_path
+):
+    """auto masked fallback の resolved path が metadata と cache に記録される.
+
+    Codex medium finding: gate は flag なしでも 0-blackout で fallback に入る
+    ため、request flag (masked) と resolved path (masked_fallback_used) を
+    分離して記録する。callback 配線は brightness_callback (#644) と同型。
+    """
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    def fake_run_detection(*args, **kwargs):
+        cb = kwargs.get("masked_fallback_callback")
+        assert cb is not None, (
+            "run_split must pass masked_fallback_callback to _run_detection"
+        )
+        cb()
+        return BOUNDARIES
+
+    mock_run_detection.side_effect = fake_run_detection
+    config = SplitConfig(output_dir=tmp_path, no_cache=True)
+    run_split(source, config)
+
+    data = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    assert data["detection_params"]["masked"] is False
+    assert data["detection_params"]["masked_fallback_used"] is True
+
+    cache = json.loads((tmp_path / ".detection_cache.json").read_text(encoding="utf-8"))
+    # resolved path は cache key (params) ではなく top-level に記録する
+    # (auto-masked 動画の cache 再利用は request key で正しく機能させる)。
+    assert cache["masked_fallback_used"] is True
+    assert cache["params"]["masked"] is False
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_hit_prints_masked_fallback_token(
+    mock_probe, mock_split, tmp_path, capsys
+):
+    """cache-hit 表示は resolved path (masked_fallback=on/off) も出す."""
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    _seed_cache(source, tmp_path, config)
+    cache_path = tmp_path / ".detection_cache.json"
+    data = json.loads(cache_path.read_text(encoding="utf-8"))
+    data["masked_fallback_used"] = True
+    cache_path.write_text(json.dumps(data), encoding="utf-8")
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    run_split(source, config, verbose=True)
+    out = capsys.readouterr().out
+
+    header_idx = out.find("Cache hit:")
+    assert header_idx >= 0
+    assert "masked_fallback=on" in out[header_idx:]
 
 
 def test_display_cache_hit_params_malformed_json_emits_unavailable(tmp_path, capsys):

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1458,7 +1458,7 @@ class TestRefineProgressBar:
                 w,
                 *,
                 band_region=None,
-                vtuber=False,
+                localize=False,
                 audio_hits=None,
                 stats=None,
                 progress_callback=None,


### PR DESCRIPTION
## 概要

masked-OBS 検出対応 (#821) の Phase 分割 (a)/(b) のうち **(b) 本体**。チャット隠しマスク画像を全画面合成した録画 (ultrawide 3440x1440 含む) で標準 detect が全滅する問題 (0 blackout → 7h が 1 試合) を、mask-free 領域の輝度で再検出 + position-independent localize 分類で解決する。

- **spec/plan + A1-A8 (12 commits)**: PR #823 の verified lineage (b516792) から cherry-pick で載せ替え (base が squash merge のため)。**range-diff で同一性確定: 12/12 = 内容一致 10 + context-only 1 (A3) + CLI conflict 解消 1 (A6、--vtuber hidden 重複)**
- **持ち越し対応** (b10ad13): masked cache key (vtuber key と同型) / masked provenance token (split/detect summary + cache-hit 表示) / **metadata schema 一括 bump** (PR #823 R1 deferred 分: vtuber/masked を detection_params に記録。schema → codegen → zod → metadata-spec の 4 層、optional で後方互換)
- **Codex 対応** (893987f): 下記 Pre-flight Step 5

14 commits / 24 files / +2571 −84。

## 設計の核 (OBS 標準 path 保護)

- masked fallback は gate `not vtuber and (masked or not blackout_times)` 内に隔離。OBS baseline は常に >=1 blackout のため標準 path は不変 (#823 で構造保証された土台の上)
- `--masked` は visible flag、`--vtuber` (hidden) と排他 (A6)
- **auto-fallback**: flag なしでも 0-blackout なら fallback が発火する (全滅 rescue)。この性質が Codex findings の根拠 (下記)

## Pre-flight (Iron Law 6) 記録

- Step 0/4: #821 の open PR なし (作成直前再確認、参照は merged #823 のみ)
- Step 1/2: base = #823 squash merge 後の develop-0.3.0 (61af948)、以降の移動なし
- Step 3: 並行 PR #825 (CI 系) と file 交差ゼロ
- Step 5: `/codex:adversarial-review` → needs-attention 2 件、**両方 PR 内対応** (893987f):
  - **[high] legacy cache が auto-fallback を抑止**: pre-#821 cache (masked 動画の誤結果 = 全滅 1-match) が missing-key=False 互換で hit し続け、新 detector が走らない → `_CACHE_VERSION` 2→3 で全面 invalidate (v0.3.0 未リリースのため影響限定)。PR #823 の「missing=False は意味的に正しい」論証は auto-trigger を持たない vtuber には成立するが masked では破綻する、という指摘
  - **[medium] request flag と resolved path の乖離**: cache key / Detecting 表示は request flag を維持 (auto-masked 動画の cache 再利用を正しく機能させるため resolved を key にしない)、新 optional field `masked_fallback_used` に resolved path を記録 (`masked_fallback_callback` seam、brightness_callback #644 と同型)。cache-hit / `--from-metadata` は記録値を引き継ぐ

## Self-Test Report

machine-verified (本 tree 893987f で実施):

- [x] `python -m pytest` → **1426 passed**, 1 skipped, 60 deselected (exit 0)
- [x] `python -m ruff check .` / `ruff format --check .` / `python -m pyright` → clean / 131 files / **0 errors**
- [x] `bash scripts/check-markdownlint.sh` → 0 errors
- [x] `python -m pytest -m slow_detect --collect-only` → 30 selected (#819 guard 健全)
- [x] GUI (zod/codegen 変更のため): eslint / tsc / **vitest 729 passed** (zod-schema-integrity 含む) / vite build / `cargo check` 全 pass
- [x] codegen 同期: `python scripts/codegen/generate.py` 実行後の生成物を commit (CI の `git diff --exit-code` と整合)
- [x] transplant 同一性: `git range-diff 142906e..b516792 origin/develop-0.3.0..8e8c173` = 12/12 (検出 algorithm hunks 不変)
- [x] **実機 smoke (RTX 5090、本 tree、2026-06-13)**: 28 (2h01m masked) を flag なしで detect → **8 matches、b516792 検証時と boundary 完全一致** + provenance live 実証 (`masked=false` / `masked_fallback_used=true` = auto-fallback 経路)

machine-verified (実機 @ RTX 5090、verified lineage b516792。詳細は #821):

- [x] masked 3 サンプル: 27 (3h54m)→13 / 28 (2h01m)→8 / 29 (7h07m)→25 matches (全滅なし、A8 短尺 root-cause fix 含む)
- [x] OBS baseline bit-exact: `test_class_a_bit_exact` 4/4 PASS

machine-unverifiable:

- 27/29 の本 tree 再実機は省略 (transplant 同一性 + 28 smoke 完全一致 + 新規分が cache/表示/metadata/callback のみで検出計算非接触、の論証。Idios 判断 2026-06-13)
- 既知の制限: localize 分類器の過分割 (長試合が「長 + 短 ~5.5 分」zero-gap ペアに分割) は #822 で追跡 (demonstrated-level、GUI で隣接 merge 可)

## 関連

- Refs #821 (masked-OBS feature、Phase 分割 (b)。(a) = PR #823 merged)
- Refs #753 (L3 配信形式対応 parent)
- follow-up: #822 (localize 過分割精緻化) / #824 (probe-failure semantics 統一契約 — masked fallback の縮退 site も対象)

session: l3-p2-region-detection