### PR TITLE
feat(detect): trailing drop 痕跡記録 (warnings) + --keep-trailing opt-out (#805 段階1)

### DIFF
--- a/allaganeye/cli.py
+++ b/allaganeye/cli.py
@@ -167,6 +167,14 @@ def split(
             "flag forces that path even when some blackouts are found.",
         ),
     ] = False,
+    keep_trailing: Annotated[
+        bool,
+        typer.Option(
+            "--keep-trailing",
+            help="Keep the post-match trailing segment instead of dropping it "
+            "when no scorebar is detected (disables the #797 trailing drop; #805).",
+        ),
+    ] = False,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -233,6 +241,7 @@ def split(
                 no_audio=no_audio,
                 vtuber=vtuber,
                 masked=masked,
+                keep_trailing=keep_trailing,
             )
             from allaganeye.commands.split_matches import run_split_from_metadata
 
@@ -263,6 +272,7 @@ def split(
             no_audio=no_audio,
             vtuber=vtuber,
             masked=masked,
+            keep_trailing=keep_trailing,
         )
 
         from allaganeye.commands.split_matches import run_split
@@ -361,6 +371,14 @@ def detect(
             "flag forces that path even when some blackouts are found.",
         ),
     ] = False,
+    keep_trailing: Annotated[
+        bool,
+        typer.Option(
+            "--keep-trailing",
+            help="Keep the post-match trailing segment instead of dropping it "
+            "when no scorebar is detected (disables the #797 trailing drop; #805).",
+        ),
+    ] = False,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -434,6 +452,7 @@ def detect(
             no_audio=no_audio,
             vtuber=vtuber,
             masked=masked,
+            keep_trailing=keep_trailing,
         )
 
         from allaganeye.commands.detect import run_detect

--- a/allaganeye/commands/detect.py
+++ b/allaganeye/commands/detect.py
@@ -46,6 +46,7 @@ from allaganeye.commands.split_matches import (
 from allaganeye.config import SplitConfig
 from allaganeye.detection.metadata_writer import write_metadata_atomic
 from allaganeye.detection.progress_emitter import ProgressEmitter
+from allaganeye.detection.warnings import build_warnings
 from allaganeye.exceptions import DetectionError
 from allaganeye.video.detector import DetectionStats
 from allaganeye.video.probe import probe_video
@@ -93,6 +94,16 @@ def run_detect(
         # locally so the metadata.json writer can downsample for the
         # complete-screen timeline.
         captured_brightness.update(results)
+
+    # #805 段階1 -- trailing drop の (start, end) を捕捉して metadata.json の
+    # warnings に書く。captured_brightness と同様に関数先頭で宣言し、
+    # cache-miss の detection block (callback 配線) と末尾の payload builder
+    # (warnings 変換) の両方から参照できるようにする。cache hit / drop なし
+    # では空のまま残り build_warnings(trailing_drops=()) -> []。
+    trailing_drops: list[tuple[float, float]] = []
+
+    def on_trailing_drop(start: float, end: float) -> None:
+        trailing_drops.append((start, end))
 
     total_start = time.monotonic()
     detected_at = _iso_utc_now()
@@ -199,6 +210,7 @@ def run_detect(
             progress_emitter=progress_emitter,
             brightness_callback=on_brightness,
             masked_fallback_callback=_on_masked_fallback,
+            trailing_drop_callback=on_trailing_drop,
         )
 
         if not boundaries:
@@ -292,6 +304,10 @@ def run_detect(
         system_info=system_info,
         brightness_samples=brightness_samples,
         masked_fallback_used=masked_fallback_used,
+        # #805 段階1: fresh-detection drops -> post_match_trailing_dropped
+        # warning(s). Empty when nothing dropped (incl. cache-hit, which never
+        # populates trailing_drops since _run_detection is skipped) -> [].
+        warnings=build_warnings(trailing_drops=trailing_drops),
     )
     metadata_path = config.output_dir / "metadata.json"
     write_metadata_atomic(metadata_path, payload)

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -21,7 +21,7 @@ from allaganeye.detection.metadata_writer import (
     write_metadata_atomic,
 )
 from allaganeye.detection.progress_emitter import ProgressEmitter
-from allaganeye.detection.warnings import build_warnings
+from allaganeye.detection.warnings import build_warnings, sanitize_warnings
 from allaganeye.exceptions import (
     AllaganEyeError,
     DetectionError,
@@ -435,18 +435,11 @@ def run_split_from_metadata(
     # split --from-metadata -o <same dir> が記録済み warning を silent に
     # 上書きしないよう、元 metadata の warnings を引き継ぐ (#586 timing /
     # #644 brightness と同じ preserve パターン)。本ランは再検知しないので
-    # 新たな drop 痕跡は生成されない。code を持つ dict entry のみ拾い、壊れた
-    # entry は捨てる (writer 契約を満たすため)。
-    old_warnings = payload.get("warnings")
-    preserve_warnings: list[MetadataWarning] = (
-        [
-            cast("MetadataWarning", w)
-            for w in old_warnings
-            if isinstance(w, dict) and "code" in w
-        ]
-        if isinstance(old_warnings, list)
-        else []
-    )
+    # 新たな drop 痕跡は生成されない。writer は schema 検証しないため、壊れた
+    # entry や schema 違反 optional field が freshly written metadata.json に
+    # 漏れないよう sanitize_warnings で coerce する (非 dict / code 欠落 entry の
+    # drop + 不正 field の strip)。
+    preserve_warnings = sanitize_warnings(payload.get("warnings"))
 
     detection_params = payload.get("detection_params")
     if isinstance(detection_params, dict):
@@ -580,10 +573,11 @@ def _display_cache_hit_params(cache_path: Path, config: SplitConfig) -> None:
     # Live-probe AUDIO_FROZEN so the verbose line mirrors `_run_audio_scan`
     # behaviour for the current run, same as the cache-miss summary.
     cached_no_audio = bool(params.get("no_audio", config.no_audio))
-    # vtuber / masked は cache key に含まれるため hit 時は config と一致するが、
-    # 表示は cache 記録値を正とする (legacy cache は key なし = False)。
+    # vtuber / masked / keep_trailing は cache key に含まれるため hit 時は config と
+    # 一致するが、表示は cache 記録値を正とする (legacy cache は key なし = False)。
     cached_vtuber = bool(params.get("vtuber", False))
     cached_masked = bool(params.get("masked", False))
+    cached_keep_trailing = bool(params.get("keep_trailing", False))
     # resolved path (top-level、key 非対象)。auto-fallback 時は masked=off でも
     # masked_fallback=on になる (#821)。
     cached_fallback = bool(data.get("masked_fallback_used", False))
@@ -598,6 +592,7 @@ def _display_cache_hit_params(cache_path: Path, config: SplitConfig) -> None:
         f"audio={_audio_status_str(cached_no_audio)}, "
         f"vtuber={'on' if cached_vtuber else 'off'}, "
         f"masked={'on' if cached_masked else 'off'}, "
+        f"keep_trailing={'on' if cached_keep_trailing else 'off'}, "
         f"masked_fallback={'on' if cached_fallback else 'off'}"
     )
 
@@ -1855,6 +1850,7 @@ def _save_cache(
             "no_audio": config.no_audio,
             "vtuber": config.vtuber,
             "masked": config.masked,
+            "keep_trailing": config.keep_trailing,
         },
         # resolved path は key (params) ではなく top-level に記録する: auto-masked
         # 動画の cache 再利用は request flag の一致で正しく機能させ、provenance
@@ -1923,9 +1919,11 @@ def _load_cache(
         return None
 
     params = data.get("params", {})
-    # vtuber / masked は detection path を切り替えるため cache key に含める (gate
-    # の cache bypass 防止)。key なし legacy cache は両 flag 導入前 = 標準 path の
-    # 結果なので False と同値に扱う。
+    # vtuber / masked は detection path を切り替え、keep_trailing は trailing-drop
+    # を skip して検出境界を変える (#805 段階1) ため、いずれも cache key に含める
+    # (gate / opt-out の cache bypass 防止)。key なし legacy cache は各 flag 導入前
+    # の結果 (vtuber/masked=標準 path、keep_trailing=drop ON) なので False と同値に
+    # 扱う。
     if (
         params.get("sample_interval") != effective_interval
         or params.get("blackout_threshold") != config.blackout_threshold
@@ -1934,6 +1932,7 @@ def _load_cache(
         or params.get("no_audio") != config.no_audio
         or params.get("vtuber", False) != config.vtuber
         or params.get("masked", False) != config.masked
+        or params.get("keep_trailing", False) != config.keep_trailing
     ):
         logger.debug("Cache parameter mismatch")
         return None

--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -28,7 +28,12 @@ from allaganeye.exceptions import (
     InputFileError,
     VideoProcessingError,
 )
-from allaganeye.metadata_types import BrightnessSamples, Metadata, SystemInfo
+from allaganeye.metadata_types import (
+    BrightnessSamples,
+    Metadata,
+    MetadataWarning,
+    SystemInfo,
+)
 from allaganeye.video.detector import (
     DetectionStats,
     MatchBoundary,
@@ -207,6 +212,15 @@ def run_split(
         nonlocal masked_fallback_used
         masked_fallback_used = True
 
+    # #805 段階1 -- trailing drop の (start, end) を捕捉して metadata.json の
+    # warnings に書く。brightness_callback (#644) / masked_fallback (#821) と
+    # 同じ collector パターン。callback が呼ばれない経路 (cache hit / drop なし)
+    # では trailing_drops は空のまま残り build_warnings(trailing_drops=()) -> []。
+    trailing_drops: list[tuple[float, float]] = []
+
+    def _on_trailing_drop(start: float, end: float) -> None:
+        trailing_drops.append((start, end))
+
     boundaries = _run_detection(
         video_path,
         metadata,
@@ -219,6 +233,7 @@ def run_split(
         gpu_vendor=gpu_vendor,
         brightness_callback=_on_brightness,
         masked_fallback_callback=_on_masked_fallback,
+        trailing_drop_callback=_on_trailing_drop,
     )
 
     if not boundaries:
@@ -292,6 +307,10 @@ def run_split(
         system_info=detected_system_info,
         brightness_samples=brightness_samples,
         masked_fallback_used=masked_fallback_used,
+        # #805 段階1: fresh-detection drops -> post_match_trailing_dropped
+        # warning(s). Empty when nothing dropped -> []. (cache-hit write above
+        # stays unchanged: no fresh detection = documented limitation.)
+        warnings=build_warnings(trailing_drops=trailing_drops),
         quiet=quiet,
     )
     _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -412,6 +431,23 @@ def run_split_from_metadata(
         else None
     )
 
+    # #805 段階1 -- preserve warnings across `--from-metadata`. detect ->
+    # split --from-metadata -o <same dir> が記録済み warning を silent に
+    # 上書きしないよう、元 metadata の warnings を引き継ぐ (#586 timing /
+    # #644 brightness と同じ preserve パターン)。本ランは再検知しないので
+    # 新たな drop 痕跡は生成されない。code を持つ dict entry のみ拾い、壊れた
+    # entry は捨てる (writer 契約を満たすため)。
+    old_warnings = payload.get("warnings")
+    preserve_warnings: list[MetadataWarning] = (
+        [
+            cast("MetadataWarning", w)
+            for w in old_warnings
+            if isinstance(w, dict) and "code" in w
+        ]
+        if isinstance(old_warnings, list)
+        else []
+    )
+
     detection_params = payload.get("detection_params")
     if isinstance(detection_params, dict):
         effective_interval = float(
@@ -454,6 +490,8 @@ def run_split_from_metadata(
         masked_fallback_used=bool(
             (detection_params or {}).get("masked_fallback_used", False)
         ),
+        # #805 段階1: 元 metadata の warnings を preserve (再検知しないため)。
+        warnings=preserve_warnings,
         quiet=quiet,
     )
     _emit_splitting_elapsed(split_start, len(boundaries), verbose, show)
@@ -773,6 +811,7 @@ def _run_detection(
     progress_emitter: ProgressEmitter | None = None,
     brightness_callback: Callable[[dict[float, float]], None] | None = None,
     masked_fallback_callback: Callable[[], None] | None = None,
+    trailing_drop_callback: Callable[[float, float], None] | None = None,
 ) -> list[MatchBoundary]:
     """Run detection with progress bars for each phase (#328, #329, #331).
 
@@ -807,6 +846,12 @@ def _run_detection(
         "stats": stats,
         "brightness_callback": brightness_callback,
         "masked_fallback_callback": masked_fallback_callback,
+        # #805 段階1: opt-out flag + drop-span seam. keep_trailing skips the
+        # #797 trailing drop entirely (default False = bit-exact); the callback
+        # records each dropped (start, end) so the command layer can surface
+        # it in metadata.json warnings.
+        "keep_trailing": config.keep_trailing,
+        "trailing_drop_callback": trailing_drop_callback,
         # #576: rational fps propagation (probe -> detector).
         "source_fps": metadata.get("fps"),
         "source_fps_num": metadata.get("fps_num"),
@@ -1254,6 +1299,7 @@ def _split_and_write_metadata(
     system_info: SystemInfo,
     brightness_samples: BrightnessSamples | None = None,
     masked_fallback_used: bool = False,
+    warnings: list[MetadataWarning] | None = None,
     quiet: bool = False,
 ) -> None:
     """Split video and write metadata.json (#591: system_info required).
@@ -1316,6 +1362,7 @@ def _split_and_write_metadata(
         system_info=system_info,
         brightness_samples=brightness_samples,
         masked_fallback_used=masked_fallback_used,
+        warnings=warnings,
     )
     metadata_path = config.output_dir / "metadata.json"
     write_metadata_atomic(metadata_path, result)
@@ -1342,6 +1389,7 @@ def _build_metadata_payload(
     system_info: SystemInfo,
     brightness_samples: BrightnessSamples | None = None,
     masked_fallback_used: bool = False,
+    warnings: list[MetadataWarning] | None = None,
 ) -> Metadata:
     """Build the ``metadata.json`` payload dict (schema v1, #463 / #569 / #586 / #591).
 
@@ -1436,7 +1484,11 @@ def _build_metadata_payload(
             }
             for g in gaps
         ],
-        "warnings": build_warnings(),
+        # #805 段階1: ``warnings`` defaults to None -> ``build_warnings()`` ([])
+        # so existing callers/tests stay byte-identical. Callers that capture
+        # trailing-drop spans pass a pre-built list (via build_warnings(
+        # trailing_drops=...)) which is emitted verbatim.
+        "warnings": build_warnings() if warnings is None else warnings,
     }
     if brightness_samples is not None:
         payload["brightness_samples"] = brightness_samples

--- a/allaganeye/config.py
+++ b/allaganeye/config.py
@@ -23,6 +23,7 @@ class SplitConfig:
     no_audio: bool = False
     vtuber: bool = False
     masked: bool = False
+    keep_trailing: bool = False
 
     def __post_init__(self) -> None:
         if self.workers is not None and self.workers < 1:

--- a/allaganeye/detection/warnings.py
+++ b/allaganeye/detection/warnings.py
@@ -23,6 +23,7 @@ existing emitters keep working unchanged.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Literal
 
 from allaganeye.metadata_types import MetadataWarning
@@ -40,20 +41,44 @@ emitters; the canonical literal lives inline in
 :class:`allaganeye.metadata_types.MetadataWarning`."""
 
 
-WARNING_CODES: dict[str, str] = {}
+WARNING_CODES: dict[str, str] = {
+    "post_match_trailing_dropped": (
+        "A trailing post-match segment was dropped because no scorebar was "
+        "detected in its early candidate-match window; re-run with "
+        "--keep-trailing to retain it."
+    ),
+}
 """Registry of known warning codes mapped to their default English message.
 
-Empty at introduction. Emitters should add entries here alongside the
-code they introduce so readers can look up a human-readable default even
-when the metadata payload only carries the code.
+Emitters should add entries here alongside the code they introduce so
+readers can look up a human-readable default even when the metadata
+payload only carries the code.
 """
 
 
-def build_warnings() -> list[MetadataWarning]:
+def build_warnings(
+    *,
+    trailing_drops: Sequence[tuple[float, float]] = (),
+) -> list[MetadataWarning]:
     """Build the `warnings` list for a freshly written metadata.json.
 
-    Currently unconditional: returns an empty list. Future callers may
-    pass detection / scorebar context to this helper and receive a
-    populated list back.
+    Args:
+        trailing_drops: ``(start, end)`` spans for each post-match trailing
+            segment that ``_drop_post_match_trailing`` removed (#805 段階1).
+            Each becomes a ``post_match_trailing_dropped`` warn entry so the
+            dropped match's boundaries are recoverable from metadata.json.
+
+    Returns an empty list when no context is supplied (backward compatible
+    with the #518 scaffold).
     """
-    return []
+    warnings: list[MetadataWarning] = []
+    for start, end in trailing_drops:
+        warnings.append(
+            MetadataWarning(
+                code="post_match_trailing_dropped",
+                message_en=WARNING_CODES["post_match_trailing_dropped"],
+                severity="warn",
+                context={"start": start, "end": end},
+            )
+        )
+    return warnings

--- a/allaganeye/detection/warnings.py
+++ b/allaganeye/detection/warnings.py
@@ -33,6 +33,7 @@ __all__ = [
     "MetadataWarning",
     "Severity",
     "build_warnings",
+    "sanitize_warnings",
 ]
 
 Severity = Literal["info", "warn", "error"]
@@ -82,3 +83,32 @@ def build_warnings(
             )
         )
     return warnings
+
+
+def sanitize_warnings(raw: object) -> list[MetadataWarning]:
+    """Coerce an arbitrary value (e.g. warnings read from an existing
+    metadata.json) into a list of schema-valid MetadataWarning entries.
+    Drops non-dict entries, entries without a non-empty string ``code``,
+    and any optional field whose value violates the schema; unknown keys
+    are dropped (schema is additionalProperties:false)."""
+    if not isinstance(raw, list):
+        return []
+    cleaned: list[MetadataWarning] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        code = entry.get("code")
+        if not isinstance(code, str) or not code:
+            continue
+        warning: MetadataWarning = {"code": code}
+        message_en = entry.get("message_en")
+        if isinstance(message_en, str):
+            warning["message_en"] = message_en
+        severity = entry.get("severity")
+        if severity in ("info", "warn", "error"):
+            warning["severity"] = severity
+        context = entry.get("context")
+        if isinstance(context, dict):
+            warning["context"] = context
+        cleaned.append(warning)
+    return cleaned

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -355,6 +355,11 @@ def detect_match_boundaries(
     source_fps_num: int | None = None,
     source_fps_den: int | None = None,
     source_fps: float | None = None,
+    # #805 段階1: opt out of the irreversible post-match trailing drop (#797).
+    keep_trailing: bool = False,
+    # #805 段階1: fired once with (start, end) whenever a trailing segment is
+    # actually dropped, so the lost span can be recorded in metadata.json.
+    trailing_drop_callback: Callable[[float, float], None] | None = None,
 ) -> list[MatchBoundary]:
     """Detect match boundaries by finding blackout frames.
 
@@ -391,6 +396,12 @@ def detect_match_boundaries(
             mapping covers every timestamp between 0 and ``duration_hint``
             at ``sample_interval`` spacing; non-blackout fallbacks (255.0)
             are included so consumers can plot continuous data.
+        keep_trailing: If True, skip the #797 post-match trailing drop so a
+            trailing no-scorebar segment is retained (#805 段階1 opt-out).
+        trailing_drop_callback: Optional callback invoked once with
+            ``(start, end)`` when a trailing segment is actually dropped
+            (#805 段階1); the seam used to record the lost span in
+            metadata.json.
 
     Returns list of dicts with 'start' and 'end' keys (seconds).
     """
@@ -592,13 +603,14 @@ def detect_match_boundaries(
     # (vtuber=True): _drop_post_match_trailing probes v2 (absolute coords) which
     # FNs on an inset scorebar and would silently drop a real VTuber final match
     # (spec section 8.1 P2-d / Codex #1). VTuber trailing is handled in Phase 3.
-    if src_resolution is not None and not vtuber:
+    if src_resolution is not None and not vtuber and not keep_trailing:
         segments = _drop_post_match_trailing(
             segments,
             video_path,
             duration_hint,
             stats,
             min_match_duration=min_match_duration,
+            trailing_drop_callback=trailing_drop_callback,
         )
     return segments
 
@@ -2264,6 +2276,7 @@ def _drop_post_match_trailing(
     stats: DetectionStats | None,
     *,
     min_match_duration: float = 300.0,
+    trailing_drop_callback: Callable[[float, float], None] | None = None,
 ) -> list[MatchBoundary]:
     """Drop a trailing post-match run via early-window scorebar probes (#797).
 
@@ -2349,6 +2362,11 @@ def _drop_post_match_trailing(
         unknown_count = stats.get("filter_unknown", 0)
         if unknown_count > 0:
             stats["filter_unknown"] = unknown_count - 1
+    # #805 段階1: surface the dropped span (start, end) so the command layer
+    # can record it in metadata.json. Fired only on an actual drop -- the drop
+    # decision above is unchanged (bit-exact default behavior preserved).
+    if trailing_drop_callback is not None:
+        trailing_drop_callback(start, end)
     return segments[:-1]
 
 

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -55,6 +55,7 @@ allaganeye split --from-metadata <metadata.json> [OPTIONS]
 | `--no-gpu` | `false` | GPU を無効化し CPU 検知を強制する。**`--gpu` と同時指定は排他エラー (exit 5) (#419)** |
 | `--gpu-vendor` | `auto` | 使用する GPU vendor を明示指定 (#546 / #553 / #550 / #582)。値: `auto` / `nvidia` / `amd` / `intel`。**3 vendor すべて実装済み** (`nvidia`=cuvid #546 / `amd`=d3d11va+hwdownload #553 / `intel`=QSV+hwdownload #550 h264/hevc/av1 + #582 vp9)。probe に無い vendor を要求すると exit 5。default は probe 結果から `_VENDOR_PREFERENCE` (nvidia > amd > intel) 順で選ぶ |
 | `--no-cache` | `false` | キャッシュされた検知結果を無視して再検知する |
+| `--keep-trailing` | `false` | 試合後 trailing を削除せず保持 (#797 drop 無効化、#805)。削除された場合は metadata.json の `warnings` に `post_match_trailing_dropped` を記録するが、本フラグ指定時は削除自体を抑制する |
 | `--no-audio` | `false` | 音声ベースの試合境界昇格（Fanfare スキャン）を無効化する。**現在は音声モジュールが凍結中（#327）のため、本フラグの値に関わらずスキャンは常にスキップされる。verbose 出力では `audio=frozen` と表示される (#384)** |
 | `--dry-run` | `false` | 検知のみ実行し分割しない（検知結果はキャッシュに保存される） |
 | `-v`, `--verbose` | `false` | 詳細出力（メタデータ詳細、gap 情報）。**`-q` と同時指定は排他エラー (exit 5) (#419)** |
@@ -291,6 +292,7 @@ allaganeye detect <video_path> [OPTIONS]
 | `--workers` | auto | 検知の並列ワーカー数 |
 | `--gpu` / `--no-gpu` | auto | GPU 強制 / CPU 強制 (排他) |
 | `--no-cache` | `false` | キャッシュ無視で再検知 |
+| `--keep-trailing` | `false` | 試合後 trailing を削除せず保持 (#797 drop 無効化、#805) |
 | `--no-audio` | `false` | 音声昇格無効化 (現在 frozen) |
 | `-v`, `--verbose` | `false` | 詳細出力 |
 | `-q`, `--quiet` | `false` | 進捗出力抑制 |

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -350,7 +350,7 @@ interface MetadataWarning {
 
 ### 読み書き契約
 
-- **新規書き込み**: `allaganeye detect` / `allaganeye split` は常に `warnings: []` を emit する
+- **新規書き込み**: `allaganeye detect` / `allaganeye split` は常に `warnings` 配列を emit する。通常は空配列だが、試合後 trailing が削除された場合は `post_match_trailing_dropped` エントリを含む ([#805](https://github.com/Idios/kobutachan-allaganeye/issues/805))。`--keep-trailing` 指定時は削除自体が無効化されるため空配列のまま
 - **読み込み**: `warnings` が欠落していても error にしない (pre-#518 の legacy metadata.json を許容)。GUI の zod schema は `optional`
 - **pass-through**: 未知の `code` を reader が reject してはならない (forward compat)
 - **emitter の責務** (後続 PR): `allaganeye/detection/warnings.py::WARNING_CODES` にコードキーを登録し、`build_warnings` で該当箇所から push
@@ -360,7 +360,13 @@ interface MetadataWarning {
 1. `allaganeye/detection/warnings.py::WARNING_CODES` に `"your_code": "english message"` を追加
 2. 発行箇所から `MetadataWarning(code=..., severity=..., context=...)` を生成
 3. `build_warnings` (または呼び出し経路) に集約
-4. `docs/metadata-spec.md` § warnings 一覧表 (以下 TBD) に追加
+4. `docs/metadata-spec.md` § 既知の warning コード一覧 (以下) に行を追加
+
+### 既知の warning コード一覧
+
+| code | severity | context | 意味 | 備考 |
+| --- | --- | --- | --- | --- |
+| `post_match_trailing_dropped` | `warn` | `{start, end}` (秒) | 試合後の trailing セグメント (ロビー / 市街) が、早期候補ウィンドウで scorebar を検出できなかったため削除された ([#805](https://github.com/Idios/kobutachan-allaganeye/issues/805))。`context.start` / `context.end` が削除された区間の境界 | `--keep-trailing` 指定時は削除自体が抑制されるため emit されない。`detect` → `split --from-metadata` の経路では元 metadata の本警告を preserve する |
 
 ## 将来の拡張 (Phase 1 スコープ外)
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -366,7 +366,7 @@ interface MetadataWarning {
 
 | code | severity | context | 意味 | 備考 |
 | --- | --- | --- | --- | --- |
-| `post_match_trailing_dropped` | `warn` | `{start, end}` (秒) | 試合後の trailing セグメント (ロビー / 市街) が、早期候補ウィンドウで scorebar を検出できなかったため削除された ([#805](https://github.com/Idios/kobutachan-allaganeye/issues/805))。`context.start` / `context.end` が削除された区間の境界 | `--keep-trailing` 指定時は削除自体が抑制されるため emit されない。`detect` → `split --from-metadata` の経路では元 metadata の本警告を preserve する |
+| `post_match_trailing_dropped` | `warn` | `{start, end}` (秒) | 試合後の trailing セグメント (ロビー / 市街) が、早期候補ウィンドウで scorebar を検出できなかったため削除された ([#805](https://github.com/Idios/kobutachan-allaganeye/issues/805))。`context.start` / `context.end` が削除された区間の境界 | `--keep-trailing` 指定時は削除自体が抑制されるため emit されない。`detect` → `split --from-metadata` の経路では元 metadata の本警告を preserve する。**非対称注意**: `split <video>` がキャッシュヒットした場合は `post_match_trailing_dropped` を **再構築しない** (検出キャッシュに dropped span は保持されない) ため `warnings: []` を書き出す。警告の正本は新鮮な `detect` / `split` が生成した metadata.json であり、`split --from-metadata` はそれを preserve する経路 |
 
 ## 将来の拡張 (Phase 1 スコープ外)
 

--- a/docs/metadata-spec.md
+++ b/docs/metadata-spec.md
@@ -366,7 +366,7 @@ interface MetadataWarning {
 
 | code | severity | context | 意味 | 備考 |
 | --- | --- | --- | --- | --- |
-| `post_match_trailing_dropped` | `warn` | `{start, end}` (秒) | 試合後の trailing セグメント (ロビー / 市街) が、早期候補ウィンドウで scorebar を検出できなかったため削除された ([#805](https://github.com/Idios/kobutachan-allaganeye/issues/805))。`context.start` / `context.end` が削除された区間の境界 | `--keep-trailing` 指定時は削除自体が抑制されるため emit されない。`detect` → `split --from-metadata` の経路では元 metadata の本警告を preserve する。**非対称注意**: `split <video>` がキャッシュヒットした場合は `post_match_trailing_dropped` を **再構築しない** (検出キャッシュに dropped span は保持されない) ため `warnings: []` を書き出す。警告の正本は新鮮な `detect` / `split` が生成した metadata.json であり、`split --from-metadata` はそれを preserve する経路 |
+| `post_match_trailing_dropped` | `warn` | `{start, end}` (秒) | 試合後の trailing セグメント (ロビー / 市街) が、早期候補ウィンドウで scorebar を検出できなかったため削除された ([#805](https://github.com/Idios/kobutachan-allaganeye/issues/805))。`context.start` / `context.end` が削除された区間の境界 | `--keep-trailing` 指定時は削除自体が抑制されるため emit されない。`detect` → `split --from-metadata` の経路では元 metadata の本警告を preserve する。**非対称注意 (段階1 の既知制限、[#805](https://github.com/Idios/kobutachan-allaganeye/issues/805) 段階2 で解消予定)**: `split <video>` がキャッシュヒットした場合は `post_match_trailing_dropped` を **再構築しない** (検出キャッシュに dropped span は保持されない) ため `warnings: []` を書き出す。すなわち、既に本警告を含む metadata.json と同じ出力先へ `split <video>` を cache-hit で再実行すると `[]` で上書きされる。警告の正本は新鮮な `detect` / `split` が生成した metadata.json であり、`split --from-metadata` はそれを preserve する経路。cache-hit を含む全経路での durable 化は trailing drop の非破壊化 (段階2) で対応する |
 
 ## 将来の拡張 (Phase 1 スコープ外)
 

--- a/docs/superpowers/plans/2026-06-16-audit-w1-g4.md
+++ b/docs/superpowers/plans/2026-06-16-audit-w1-g4.md
@@ -122,6 +122,7 @@ EOF
 - [ ] **Step 2 (GREEN):**
   - config.py: `SplitConfig` に `keep_trailing: bool = False` を追加 (masked の後、L25 付近)。`__post_init__` 追加検証は不要 (bool)
   - cli.py: split (masked flag L161-169 の後) と detect (masked flag L355-363 の後) に
+
     ```python
     keep_trailing: Annotated[
         bool,
@@ -132,6 +133,7 @@ EOF
         ),
     ] = False,
     ```
+
     を追加し、3 つの `SplitConfig(...)` 構築 (split 223-236 / 252-266、detect 423-437) すべてに `keep_trailing=keep_trailing` を渡す
 - [ ] **Step 3:** ruff / pyright (config.py, cli.py)
 

--- a/docs/superpowers/plans/2026-06-16-audit-w1-g4.md
+++ b/docs/superpowers/plans/2026-06-16-audit-w1-g4.md
@@ -1,0 +1,188 @@
+# Audit Remediation Wave 1 — G4 (#805 段階1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` (fresh subagent per task + spec/quality 2-stage review). TDD HARD-GATE (`superpowers:test-driven-development`): NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST. Steps use checkbox (`- [ ]`).
+
+**Goal:** `_drop_post_match_trailing` (#797) が試合後 trailing を不可逆削除しても metadata.json に痕跡を残さない (P1-4) ことと、opt-out gate が無い (P2-2) ことを「段階1 = 痕跡記録 + escape hatch」で解消する。drop 時に `warnings[]` へ `post_match_trailing_dropped` (`context: {start, end}`) を記録し、`--keep-trailing` (`SplitConfig.keep_trailing`) で drop を無効化できるようにする。**default 挙動 (drop する) は不変** = v0.3.0 baseline は bit-exact 維持。非破壊化 (drop → フラグ方式) は段階2 として #805 に残す。
+
+**Architecture (信号経路):** drop は `detect_match_boundaries` 深部の `_drop_post_match_trailing` で起こる。痕跡は **verbose 非依存**で表に出す必要がある (`stats` は detect.py:183 / split_matches.py:191 で `verbose` 時のみ `{}`、非 verbose では `None` → stats 経由だと痕跡が消える)。よって既存 `masked_fallback_callback` / `brightness_callback` と同型の **callback seam** (`trailing_drop_callback: Callable[[float, float], None]`) を新設し、command 層 (run_detect / run_split) が drop の (start, end) を収集 → `build_warnings(trailing_drops=...)` で `MetadataWarning` 化 → metadata payload へ載せる。`keep_trailing` は `detect_kwargs` 経由で `detect_match_boundaries` まで配線し、call-site gate (detector.py:595) に `and not keep_trailing` を足す (「released path を触る分岐は明示 gate に閉じ込める」教訓へ整合)。
+
+**Tech Stack:** Python 3.12 / typer / TypedDict (MetadataWarning) / jsonschema (forward-compat pin) / pytest (unit + slow_detect baseline gate)
+
+**元 issue:** #805 (P2-medium, risk)。**AC は確立済み運用どおり spec §G4「受け入れ条件案」を正式 AC として逐条検証** ([docs/superpowers/specs/2026-06-10-audit-remediation-design.md](../specs/2026-06-10-audit-remediation-design.md) §G4):
+
+1. drop 発生時に `warnings[]` へ記録される (unit)
+2. `--keep-trailing` で drop が無効化される (unit)
+3. v0.3.0 baseline 5 本の detect projection (matches+gaps) が bit-exact 維持 (`pytest -m slow_detect`)
+4. warnings field 追加が `compare-baseline.py` の projection に影響しない (確認)
+5. (spec §順序依存・リスク) `MetadataWarning` の forward-compat 規約 (unknown code 受容) を G4 のテストで pin する
+
+---
+
+## 前提条件 / 事実 (2026-06-16 実測、#823/#826 後の現状)
+
+- main worktree = `develop-0.3.0` (clean)。session-id: `audit-w1-g4-20260616`、branch: `claude/audit-w1-g4`
+- **`compare-baseline.py:24-34 normalize_metadata` は `{matches, gaps}` のみへ projection** → warnings は構造上 projection 外。AC4 は構造で満たされる (test で pin)
+- **baseline gate** = `tests/test_v030_baseline_regression.py` (`pytestmark = [slow, slow_detect]`)。Class A 4 本 + Class B 1 本を `python -m allaganeye detect <video> --no-cache` で回し compare-baseline で照合。1080p OBS のみ
+- **痕跡経路の罠**: `detect_stats` は verbose 時のみ `{}` (detect.py:183 / split_matches.py:191)。`_drop_post_match_trailing:2344-2346` の stats 記録は非 verbose で no-op。**警告は callback seam で verbose 非依存に出す** (stats はそのまま温存)
+- `WARNING_CODES` (warnings.py:43) は空 dict。`build_warnings()` (warnings.py:52-59) は無条件 `[]`。docstring が「将来 caller が context を渡し populated list を受け取る」と予告済み
+- `MetadataWarning` (metadata_types.py:56-64): `code: str` (required) / `message_en?` / `severity?: info|warn|error` / `context?: dict`。schema (`schemas/metadata.schema.json:251-277`): `code` = `type:string, minLength:1`、`context` = `object additionalProperties:true`、warning object は `additionalProperties:false` (= code/message_en/severity/context 以外のキー不可)。`post_match_trailing_dropped` + `context:{start,end}` は完全準拠
+- `_drop_post_match_trailing` (detector.py:2260-2352): drop 分岐は L2344-2352。落とす segment は `last` (= `segments[-1]`)、`start=last["start"]` (L2315) / `end=last["end"]` (L2316)、`return segments[:-1]` (L2352)。**masked path (`_detect_masked_fallback`) と vtuber は本関数を呼ばない** (detector.py:595 gate + 634-636 コメント) → callback は標準 OBS 検出でのみ発火
+- caller (detector.py:590-602): `if src_resolution is not None and not vtuber:` で `_drop_post_match_trailing(segments, video_path, duration_hint, stats, min_match_duration=...)` を呼ぶ
+- `detect_match_boundaries` (detector.py:325-358 signature, 595-603 tail) は keyword-only 引数群。新規 keyword default 付き追加は既存 caller / test 非破壊
+- `_run_detection` (split_matches.py:762-1062): `detect_kwargs` (789-814) を 3 call-site (851/1029/1062) に spread。`masked_fallback_callback` (775, 809) が callback seam の先例
+- 配線 chokepoint:
+  - `SplitConfig` (config.py:10-25) は split / detect 共通 → `keep_trailing` 1 箇所で両対応
+  - `_build_metadata_payload` (split_matches.py:1329-1443、warnings は L1439) は detect.py:280 と `_split_and_write_metadata`:1304 の 2 caller の唯一の warnings 生成点
+  - `_split_and_write_metadata` (split_matches.py:1243-1326) は run_split (137 cache-hit / 284 通常) と run_split_from_metadata (440) の共通 writer
+- run_split (split_matches.py:58-300): `_on_brightness` (200-201) / `_on_masked_fallback` (206-208) が収集 callback の先例。通常 detect は 210-222、通常 split write は 284
+- run_split_from_metadata (301+): #586 timing / #644 brightness_samples を source payload から **preserve** する確立パターンあり (preserve_brightness_samples 408-413)。warnings も同パターンで preserve する (下記スコープ判断)
+- cli.py: split flags 140-181 / SplitConfig 構築 223-236 (from_metadata) + 252-266 (通常)。detect flags 334-386 / SplitConfig 構築 423-437
+- docs: `docs/metadata-spec.md` warnings 行 L69 / §warnings L336-375 (「常に `warnings: []` を emit」L353 / code 表 TBD L363)。`docs/cli-spec.md` split flag 表 L57-58 / detect flag 表 L293-294
+- test: `tests/test_detector.py` TestDropPostMatchTrailing (2271+、既存呼びは位置引数 4 + min_match_duration kw → 新 keyword default は非破壊)。`tests/test_metadata_schema.py` (schema 検証 harness = forward-compat pin の置き場)。`tests/test_split_matches.py` / `tests/test_cli.py` (CLI flag + 配線)
+- 検証: Python path (`python -m ruff check`/`format --check`/`pyright`/`pytest`) + **`pytest -m slow_detect` baseline gate + Idios 実機 detect 検証を AskUserQuestion で依頼** (detector.py 変更 = Iron Law 6 実機 trigger)
+
+### スコープ判断 (Iron Law 3 整合)
+
+- **IN**: ① fresh 検出 (detect / split 一気通貫) で drop → warning emit、② `--keep-trailing` gate、③ docs、④ forward-compat pin、⑤ **from-metadata の warnings preserve** (#586/#644 と同じ「再 split で既存 field を消さない」確立パターン。`detect → split --from-metadata -o <同dir>` で痕跡を silent に上書き消失させる穴を塞ぐ防御。trivial = preserve_brightness_samples と同型 5 行)
+- **OUT (段階1 では非対応、既知制限として PR 本文 + #805 段階2 に記録)**: **cache-hit 経路での warning 再構成**。detection cache (`_save_cache`) は drop 痕跡を保持しないため、cache-hit re-split (`split <video>` warm cache) では warning を再現できず `warnings: []` になる (= 現状と同一、非 regression)。fresh detect の metadata.json が authoritative。段階2 (非破壊化) で drop 自体が消えるため本制限は解消される。**cache へ痕跡を足すのは段階1 scope 外** (cache schema 変更 = scope creep)
+
+---
+
+## File Structure
+
+| 区分 | path | 責務 |
+| --- | --- | --- |
+| Create | `docs/superpowers/plans/2026-06-16-audit-w1-g4.md` | 本 plan |
+| Modify | `allaganeye/detection/warnings.py` | `WARNING_CODES` に code 追加 + `build_warnings(trailing_drops=...)` |
+| Modify | `allaganeye/video/detector.py` | `detect_match_boundaries` に `keep_trailing` / `trailing_drop_callback` 追加、gate に `and not keep_trailing`、`_drop_post_match_trailing` で drop 時 callback 発火 |
+| Modify | `allaganeye/config.py` | `SplitConfig.keep_trailing: bool = False` |
+| Modify | `allaganeye/cli.py` | split / detect に `--keep-trailing` flag + 3 SplitConfig 構築へ配線 |
+| Modify | `allaganeye/commands/split_matches.py` | `_run_detection` に callback、run_split 収集 + warnings 配線、`_split_and_write_metadata` / `_build_metadata_payload` に `warnings` param、from-metadata preserve |
+| Modify | `allaganeye/commands/detect.py` | run_detect 収集 + `_build_metadata_payload(warnings=...)` |
+| Modify | `docs/metadata-spec.md` | warning code 表へ `post_match_trailing_dropped`、「常に `[]`」記述更新 |
+| Modify | `docs/cli-spec.md` | split / detect flag 表へ `--keep-trailing` 行 |
+| Modify | `tests/test_detector.py` | `_drop_post_match_trailing` callback 発火 + keep_trailing gate unit |
+| Modify | `tests/test_metadata_schema.py` | forward-compat pin (新 code が schema validate) |
+| Modify | `tests/test_split_matches.py` / `tests/test_cli.py` | flag 配線 + warnings 配線 integration |
+
+---
+
+## Task A: branch + plan commit (controller)
+
+- [ ] **Step 1:**
+
+```bash
+git branch --show-current   # develop-0.3.0
+git status --short          # 本 plan のみ untracked
+git fetch origin develop-0.3.0
+git checkout -b claude/audit-w1-g4 origin/develop-0.3.0
+git add docs/superpowers/plans/2026-06-16-audit-w1-g4.md
+git commit -F - <<'EOF'
+doc: G4 段階1 (trailing drop 痕跡記録) の実装 plan を追加 (Refs #805)
+
+audit remediation Wave 1 G4。spec §G4 の just-in-time plan。#823/#826 後の
+detector.py / scorebar.py / config.py / cli.py / split_matches.py / detect.py
+実測 + warnings callback seam + --keep-trailing gate の配線箇所確定。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task B: warnings.py — code 登録 + build_warnings 拡張 (TDD)
+
+**File:** `allaganeye/detection/warnings.py` / `tests/test_*` (warnings unit、新規 or 既存)
+
+- [ ] **Step 1 (RED):** `build_warnings(trailing_drops=[(1000.0, 1800.0)])` が 1 件の `MetadataWarning` (`code=="post_match_trailing_dropped"`, `severity=="warn"`, `context=={"start":1000.0,"end":1800.0}`, `message_en` は `WARNING_CODES` の値) を返し、`build_warnings()` が `[]` を返すことを検証する unit を追加 → fail を確認
+- [ ] **Step 2 (GREEN):** warnings.py を編集:
+  - `from collections.abc import Sequence` を追加
+  - `WARNING_CODES = {"post_match_trailing_dropped": "<英語メッセージ: A trailing post-match segment was dropped because no scorebar was detected in its early candidate-match window; re-run with --keep-trailing to retain it.>"}`
+  - `build_warnings(*, trailing_drops: Sequence[tuple[float, float]] = ()) -> list[MetadataWarning]`: 各 `(start, end)` に対し `MetadataWarning(code="post_match_trailing_dropped", message_en=WARNING_CODES["post_match_trailing_dropped"], severity="warn", context={"start": start, "end": end})` を append して返す。`trailing_drops` 空なら `[]`
+- [ ] **Step 3:** `python -m ruff check allaganeye/detection/warnings.py` / `python -m pyright allaganeye/detection/warnings.py`
+
+## Task C: detector.py — keep_trailing gate + drop callback (TDD)
+
+**File:** `allaganeye/video/detector.py` / `tests/test_detector.py`
+
+- [ ] **Step 1 (RED):** `tests/test_detector.py::TestDropPostMatchTrailing` に追加:
+  - `test_trailing_dropped_invokes_callback`: drop 条件成立時 (`_has_scorebar_v2` mock False) に `trailing_drop_callback` が `(start, end)` = 落とした segment の `(1000.0, 1800.0)` で 1 回呼ばれる
+  - `test_trailing_kept_no_callback`: scorebar present (mock True) で keep のとき callback 未発火
+  - `detect_match_boundaries` レベル: `keep_trailing=True` で `_drop_post_match_trailing` が呼ばれず最終 segment が残る (既存 2783/2832 の `@patch(... _drop_post_match_trailing)` パターンで assert_not_called)
+  - → fail を確認
+- [ ] **Step 2 (GREEN):** detector.py を編集:
+  - `_drop_post_match_trailing(... , *, min_match_duration: float = 300.0, trailing_drop_callback: Callable[[float, float], None] | None = None)`: drop 確定 (`return segments[:-1]` 直前、L2352) で `if trailing_drop_callback is not None: trailing_drop_callback(start, end)`。stats 記録 (2344-2351) は不変
+  - `detect_match_boundaries` signature に `keep_trailing: bool = False` と `trailing_drop_callback: Callable[[float, float], None] | None = None` を追加 (keyword-only 群の末尾、docstring に 1 行)
+  - caller gate (L595) を `if src_resolution is not None and not vtuber and not keep_trailing:` に変更し、`_drop_post_match_trailing(..., trailing_drop_callback=trailing_drop_callback)` を渡す
+- [ ] **Step 3:** `Callable` import 済みか確認 (typing/collections.abc)。ruff / pyright (detector.py)
+
+## Task D: config.py + cli.py — flag (TDD)
+
+**File:** `allaganeye/config.py` / `allaganeye/cli.py` / `tests/test_cli.py`
+
+- [ ] **Step 1 (RED):** `tests/test_cli.py` に `split` / `detect` の `--keep-trailing` が `SplitConfig.keep_trailing=True` を構築することを検証する unit を追加 (既存の flag→config 検証パターンに倣う) → fail
+- [ ] **Step 2 (GREEN):**
+  - config.py: `SplitConfig` に `keep_trailing: bool = False` を追加 (masked の後、L25 付近)。`__post_init__` 追加検証は不要 (bool)
+  - cli.py: split (masked flag L161-169 の後) と detect (masked flag L355-363 の後) に
+    ```python
+    keep_trailing: Annotated[
+        bool,
+        typer.Option(
+            "--keep-trailing",
+            help="Keep the post-match trailing segment instead of dropping it "
+            "when no scorebar is detected (disables the #797 trailing drop; #805).",
+        ),
+    ] = False,
+    ```
+    を追加し、3 つの `SplitConfig(...)` 構築 (split 223-236 / 252-266、detect 423-437) すべてに `keep_trailing=keep_trailing` を渡す
+- [ ] **Step 3:** ruff / pyright (config.py, cli.py)
+
+## Task E: 配線 — _run_detection / command 層 / payload builder (TDD)
+
+**File:** `allaganeye/commands/split_matches.py` / `allaganeye/commands/detect.py` / `tests/test_split_matches.py`
+
+- [ ] **Step 1 (RED):** integration unit を追加:
+  - `run_detect` / `run_split` が drop 発生時 (detector を stub し callback を 1 回発火させる、または `_run_detection` を mock) に metadata payload の `warnings` へ `post_match_trailing_dropped` を 1 件載せる
+  - `keep_trailing=True` の config で warnings が空 (drop されない)
+  - from-metadata: source metadata に warnings がある場合、出力 metadata に preserve される
+  - → fail を確認
+- [ ] **Step 2 (GREEN):**
+  - `_run_detection` (762): signature に `trailing_drop_callback: Callable[[float, float], None] | None = None` を追加、`detect_kwargs` (789-814) へ `"keep_trailing": config.keep_trailing` と `"trailing_drop_callback": trailing_drop_callback` を追加
+  - `_build_metadata_payload` (1329): keyword-only に `warnings: list[MetadataWarning] | None = None` を追加、L1439 を `"warnings": build_warnings() if warnings is None else warnings,` に変更 (default = 従来どおり `[]`、直 caller / 既存 test 非破壊)
+  - `_split_and_write_metadata` (1243): keyword-only に `warnings: list[MetadataWarning] | None = None` を追加し、1304 の `_build_metadata_payload(...)` へ `warnings=warnings` を forward
+  - run_split (58): `_on_brightness` (200-201) と同型に `trailing_drops: list[tuple[float, float]] = []` + `def _on_trailing_drop(start, end): trailing_drops.append((start, end))` を追加。`_run_detection(..., trailing_drop_callback=_on_trailing_drop)` (210)。通常 write (284) の `_split_and_write_metadata(...)` へ `warnings=build_warnings(trailing_drops=trailing_drops)` を渡す。cache-hit write (137) は変更しない (warnings 既定 `[]` = 既知制限どおり)
+  - run_detect (detect.py): 同型に `trailing_drops` + `_on_trailing_drop` を追加し `_run_detection(..., trailing_drop_callback=_on_trailing_drop)` (189)。`_build_metadata_payload(..., warnings=build_warnings(trailing_drops=trailing_drops))` (280)
+  - run_split_from_metadata (301): `preserve_brightness_samples` (408-413) と同型に `payload.get("warnings")` を list[dict]（各 dict に `code`）として検証し `preserve_warnings: list[MetadataWarning]` を作り、440 の `_split_and_write_metadata(..., warnings=preserve_warnings)` へ渡す。不正/欠落時は `[]`
+  - import: split_matches.py / detect.py で `MetadataWarning` (metadata_types) と `build_warnings` (detect.py は未 import なら追加) を解決
+- [ ] **Step 3:** ruff / pyright (split_matches.py, detect.py)
+
+## Task F: docs (metadata-spec / cli-spec)
+
+- [ ] **Step 1:** `docs/metadata-spec.md`:
+  - L353「常に `warnings: []` を emit する」を「通常は空 (`[]`)。post-match trailing が削除された場合のみ `post_match_trailing_dropped` を含む (#805)」へ更新
+  - §warnings の code 表 (L363 TBD) に `post_match_trailing_dropped` 行を追加 (code / severity=warn / context `{start, end}` / 意味 / `--keep-trailing` で抑止)
+- [ ] **Step 2:** `docs/cli-spec.md`: split flag 表 (L57-58 付近) と detect flag 表 (L293-294 付近) に `--keep-trailing | false | 試合後 trailing を削除せず保持 (#797 drop 無効化、#805)` 行を追加
+- [ ] **Step 3:** `bash scripts/check-markdownlint.sh 2>&1` を変更ファイル名 (metadata-spec / cli-spec) で grep フィルタ → 0 件
+
+## Task G: forward-compat pin (AC5)
+
+- [ ] **Step 1:** `tests/test_metadata_schema.py` に、`post_match_trailing_dropped` (+ `context:{start,end}`) を含む metadata payload が `schemas/metadata.schema.json` に対し valid であることを検証する test を追加 (既存 harness の validate 関数を使用)。「reader は unknown code を受容」契約を機械的に pin。`build_warnings(trailing_drops=...)` の出力をそのまま流すとなお良い
+- [ ] **Step 2:** `python -m pytest tests/test_metadata_schema.py tests/test_detector.py tests/test_cli.py tests/test_split_matches.py` green
+
+## Task H: Pre-flight + PR (controller)
+
+- [ ] **Step 0 (hard-gate):** `gh pr list --search "805" --state open` → G4 PR 0 件
+- [ ] **Step 1-3:** `git fetch origin develop-0.3.0` → `git log HEAD..origin/develop-0.3.0 --oneline` (取り込み未済確認) → touched files 交差判定
+- [ ] **Step 4:** `gh pr list --search "805" --state all` → 重複なし
+- [ ] **Step 5:** codex `adversarial-review` (companion script、`--background`、focus ASCII: `released OBS detect path stays bit-exact / warnings field does not change matches-gaps projection / keep_trailing gate placement / callback fires only on actual drop / from-metadata preserve correctness`)。memory `project_codex_adversarial_review_direct_invocation` の方法。不可なら CLAUDE.md §C6 fallback + PR 本文に Codex fallback notice
+- [ ] **Step 6 (machine verify):** `python -m ruff check allaganeye gui tests scripts` / `python -m ruff format --check allaganeye gui tests scripts` / `python -m pyright allaganeye gui tests scripts` / `python -m pytest` (slow 除外) を全 pass
+- [ ] **Step 7 (実機 trigger):** detector.py 変更のため **`AskUserQuestion` で Idios に (a) `pytest -m slow_detect` baseline gate (5 本 bit-exact) (b) 実機 detect での warning emit / `--keep-trailing` 動作確認 を依頼**。回答まで PR を merge 可能と扱わない
+- [ ] **Step 8:** push + PR (base `develop-0.3.0`, **Refs #805 / Closes 禁止**)。Self-Test Report: machine-verified は `[x]`、slow_detect / 実機は plain bullet `-` (Idios 依頼中)。AC 5 項目を逐条 + diff/test 引用
+
+## Task I: /iterate-review + triage comment (controller)
+
+- [ ] **Step 1:** `/iterate-review <PR#>` 自走 (1 round = 1 commit `fix(round-N): ... (Refs #805)`、divergence cap Round 5)
+- [ ] **Step 2 (#805 triage コメント, spec PR-なしアクション):** `gh issue view 805 --comments` で triage コメント未投稿を確認 → 未投稿なら「段階1 (G4 = warnings 痕跡 + `--keep-trailing`) を v0.3.0 で実施、段階2 (非破壊化: drop → フラグ方式) は本 issue で継続。audio corroboration は AUDIO_FROZEN 解除後に再評価 (#327)。cache-hit 痕跡再構成は段階2 で解消」を `gh issue comment 805 --body-file -` (HEREDOC) で投稿。優先度 label は既存 P2-medium を維持 (spec の P1-4 は内部 finding id であり issue label の昇格は別判断 → 必要なら AskUserQuestion)
+
+## マージ後 (Idios merge 後、controller)
+
+- **#805 は close しない** (段階2 継続)。`/close-issue` は呼ばず、PR を #805 に紐づけたまま open 維持
+- マージ後 worktree/branch 掃除は N1 で配線済みの仕組みに従う (本 plan では実行しない)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from allaganeye.exceptions import (
 runner = CliRunner()
 
 MODULE = "allaganeye.commands.split_matches.run_split"
+DETECT_MODULE = "allaganeye.commands.detect.run_detect"
 
 
 # --- Basic tests ---
@@ -292,6 +293,46 @@ def test_split_vtuber_default_false(mock_run_split, fake_video):
     assert result.exit_code == 0
     config = mock_run_split.call_args[0][1]
     assert config.vtuber is False
+
+
+@patch(MODULE)
+def test_split_keep_trailing_flag(mock_run_split, fake_video):
+    """--keep-trailing sets config.keep_trailing=True on split (#805 段階1)."""
+    result = runner.invoke(app, ["split", str(fake_video), "--keep-trailing"])
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.keep_trailing is True
+
+
+@patch(MODULE)
+def test_split_keep_trailing_default_false(mock_run_split, fake_video):
+    """Omitting --keep-trailing keeps config.keep_trailing=False (#797 drop on)."""
+    result = runner.invoke(app, ["split", str(fake_video)])
+
+    assert result.exit_code == 0
+    config = mock_run_split.call_args[0][1]
+    assert config.keep_trailing is False
+
+
+@patch(DETECT_MODULE)
+def test_detect_keep_trailing_flag(mock_run_detect, fake_video):
+    """--keep-trailing sets config.keep_trailing=True on detect (#805 段階1)."""
+    result = runner.invoke(app, ["detect", str(fake_video), "--keep-trailing"])
+
+    assert result.exit_code == 0
+    config = mock_run_detect.call_args[0][1]
+    assert config.keep_trailing is True
+
+
+@patch(DETECT_MODULE)
+def test_detect_keep_trailing_default_false(mock_run_detect, fake_video):
+    """Omitting --keep-trailing keeps config.keep_trailing=False on detect."""
+    result = runner.invoke(app, ["detect", str(fake_video)])
+
+    assert result.exit_code == 0
+    config = mock_run_detect.call_args[0][1]
+    assert config.keep_trailing is False
 
 
 def test_split_vtuber_hidden_from_help():

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -407,3 +407,54 @@ def test_detect_omits_brightness_samples_when_callback_silent(tmp_path):
 
     payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
     assert "brightness_samples" not in payload
+
+
+# #805 段階1 -- post_match_trailing_dropped warning wiring through run_detect
+
+
+def test_detect_records_trailing_drop_warning(tmp_path):
+    """detect 経路で trailing drop が起きたら metadata.json の warnings に
+    post_match_trailing_dropped が記録される (#805 段階1)。
+
+    `_run_detection` に渡される `trailing_drop_callback` を fake から
+    (1000.0, 1800.0) で呼び、payload の warnings に 1 件現れることを assert。
+    """
+
+    def _detect_with_trailing_drop(*args, **kwargs):
+        cb = kwargs.get("trailing_drop_callback")
+        assert cb is not None, (
+            "run_detect must pass trailing_drop_callback to _run_detection (#805)"
+        )
+        cb(1000.0, 1800.0)
+        return BOUNDARIES
+
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with (
+        patch(f"{MODULE_DETECT}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE_DETECT}._run_detection",
+            side_effect=_detect_with_trailing_drop,
+        ),
+    ):
+        run_detect(Path("input.mp4"), config, quiet=True)
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    assert payload["warnings"] == [
+        {
+            "code": "post_match_trailing_dropped",
+            "message_en": payload["warnings"][0]["message_en"],
+            "severity": "warn",
+            "context": {"start": 1000.0, "end": 1800.0},
+        }
+    ]
+
+
+def test_detect_no_trailing_drop_writes_empty_warnings(tmp_path):
+    """callback 不発 (drop なし) なら detect の warnings は [] (#805 段階1)。"""
+    probe, detect = _mock_detect_only(tmp_path)
+    config = SplitConfig(output_dir=tmp_path, min_match_duration=60.0)
+    with probe, detect:
+        run_detect(Path("input.mp4"), config, quiet=True)
+
+    payload = json.loads((tmp_path / "metadata.json").read_text("utf-8"))
+    assert payload["warnings"] == []

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -9,6 +9,7 @@ import pytest
 from allaganeye.commands.detect import run_detect
 from allaganeye.commands.split_matches import build_brightness_samples
 from allaganeye.config import SplitConfig
+from allaganeye.detection.warnings import WARNING_CODES
 from allaganeye.exceptions import DetectionError
 from allaganeye.video.detector import MatchBoundary
 from allaganeye.video.probe import ProbeResult
@@ -442,7 +443,7 @@ def test_detect_records_trailing_drop_warning(tmp_path):
     assert payload["warnings"] == [
         {
             "code": "post_match_trailing_dropped",
-            "message_en": payload["warnings"][0]["message_en"],
+            "message_en": WARNING_CODES["post_match_trailing_dropped"],
             "severity": "warn",
             "context": {"start": 1000.0, "end": 1800.0},
         }

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2293,6 +2293,48 @@ class TestDropPostMatchTrailing:
         # stays consistent after the drop (#797).
         assert stats["filter_unknown"] == 0
 
+    @patch("allaganeye.video.detector._has_scorebar_v2", return_value=False)
+    @patch("allaganeye.video.detector._probe_frame_rgb_hires", return_value=b"x")
+    def test_trailing_drop_invokes_callback_once(self, _probe, _v2):
+        """On a drop, trailing_drop_callback fires exactly once with (start, end).
+
+        #805 段階1: the callback is the seam Unit 2 uses to record the dropped
+        span in metadata.json so the lost match is recoverable.
+        """
+        segments = [
+            {"start": 100.0, "end": 1000.0, "type": "fl_match"},
+            {"start": 1000.0, "end": 1800.0, "type": "unknown"},
+        ]
+        seen: list[tuple[float, float]] = []
+        result = _drop_post_match_trailing(
+            segments,  # type: ignore[arg-type]
+            Path("v.mp4"),
+            1800.0,
+            {"filter_unknown": 1},  # type: ignore[arg-type]
+            trailing_drop_callback=lambda start, end: seen.append((start, end)),
+        )
+        assert len(result) == 1
+        assert seen == [(1000.0, 1800.0)]
+
+    @patch("allaganeye.video.detector._has_scorebar_v2", return_value=True)
+    @patch("allaganeye.video.detector._probe_frame_rgb_hires", return_value=b"x")
+    def test_trailing_keep_does_not_invoke_callback(self, _probe, _v2):
+        """When the segment is kept (scorebar present), the callback never fires."""
+        segments = [
+            {"start": 100.0, "end": 1000.0, "type": "fl_match"},
+            {"start": 1000.0, "end": 1800.0, "type": "unknown"},
+        ]
+        seen: list[tuple[float, float]] = []
+        result = _drop_post_match_trailing(
+            segments,  # type: ignore[arg-type]
+            Path("v.mp4"),
+            1800.0,
+            {},  # type: ignore[arg-type]
+            trailing_drop_callback=lambda start, end: seen.append((start, end)),
+        )
+        assert len(result) == 2
+        assert seen == []
+
     @patch("allaganeye.video.detector._has_scorebar_v2", return_value=True)
     @patch("allaganeye.video.detector._probe_frame_rgb_hires", return_value=b"x")
     def test_trailing_scorebar_present_kept(self, _probe, _v2):
@@ -2865,6 +2907,42 @@ def test_obs_runs_trailing_drop_and_filter_sees_vtuber_false(
     assert seen["localize"] is False
     # OBS path runs the trailing-drop exactly once.
     mock_trailing.assert_called_once()
+
+
+@patch("allaganeye.video.detector._drop_post_match_trailing")
+@patch("allaganeye.video.detector._probe_single_frame")
+@patch("allaganeye.video.detector._decode_chunk_cpu")
+def test_keep_trailing_gates_trailing_drop(mock_chunk, mock_probe, mock_trailing):
+    """keep_trailing=True opts out of the irreversible trailing-drop (#805 段階1).
+
+    Pairs with test_obs_runs_trailing_drop_* (which proves the default
+    keep_trailing=False path DOES drop) to pin the new gate from both sides:
+    flipping --keep-trailing must be the only thing that suppresses the call.
+    """
+    mock_chunk.side_effect = lambda vp, ts, cs, ce, si, **kw: {
+        t: 5.0 if 598.0 <= t <= 602.0 else 128.0 for t in ts
+    }
+    mock_probe.side_effect = lambda p, t, region=FULL_FRAME: (
+        5.0 if 593.0 <= t <= 607.0 else 128.0
+    )
+    mock_trailing.side_effect = lambda segs, *a, **k: segs
+
+    with patch(
+        "allaganeye.video.scorebar.filter_blackouts_with_scorebar",
+        side_effect=_vtuber_filter_capture({}),
+    ):
+        detect_match_boundaries(
+            Path("test.mp4"),
+            duration_hint=1800.0,
+            sample_interval=1.0,
+            min_match_duration=300.0,
+            src_resolution=(1920, 1080),
+            keep_trailing=True,
+        )
+
+    # --keep-trailing -> the drop helper is never invoked, so the final
+    # segment survives untouched.
+    mock_trailing.assert_not_called()
 
 
 # ============================================================

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2316,6 +2316,31 @@ class TestDropPostMatchTrailing:
         assert len(result) == 1
         assert seen == [(1000.0, 1800.0)]
 
+    @patch("allaganeye.video.detector._has_scorebar_v2", return_value=False)
+    @patch("allaganeye.video.detector._probe_frame_rgb_hires", return_value=b"x")
+    def test_trailing_drop_invokes_callback_with_stats_none(self, _probe, _v2):
+        """On a drop the callback fires even when ``stats is None``.
+
+        #805 段階1: the callback path sits intentionally outside the
+        ``if stats is not None:`` block, so non-verbose runs (stats=None)
+        still record the dropped span in metadata.json. Pin that the seam
+        is independent of stats collection.
+        """
+        segments = [
+            {"start": 100.0, "end": 1000.0, "type": "fl_match"},
+            {"start": 1000.0, "end": 1800.0, "type": "unknown"},
+        ]
+        seen: list[tuple[float, float]] = []
+        result = _drop_post_match_trailing(
+            segments,  # type: ignore[arg-type]
+            Path("v.mp4"),
+            1800.0,
+            None,
+            trailing_drop_callback=lambda start, end: seen.append((start, end)),
+        )
+        assert len(result) == 1
+        assert seen == [(1000.0, 1800.0)]
+
     @patch("allaganeye.video.detector._has_scorebar_v2", return_value=True)
     @patch("allaganeye.video.detector._probe_frame_rgb_hires", return_value=b"x")
     def test_trailing_keep_does_not_invoke_callback(self, _probe, _v2):

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -165,3 +165,31 @@ def test_warning_context_accepts_arbitrary_keys():
         }
     ]
     Draft202012Validator(schema).validate(sample)
+
+
+def test_post_match_trailing_dropped_warning_validates():
+    """A `post_match_trailing_dropped` warning (#805 段階1) must validate.
+
+    Pins the forward-compat contract: readers accept the new code because
+    the schema `code` is a free string. Feeds the real `build_warnings`
+    output so the wire shape (code / message_en / severity / context with
+    start+end) is exactly what detect/split writes.
+    """
+    from allaganeye.detection.warnings import WARNING_CODES, build_warnings
+
+    schema = _load_schema()
+    sample = _valid_sample()
+    built = build_warnings(trailing_drops=[(1000.0, 1800.0)])
+    # Sanity: the producer emitted exactly the shape we are pinning. Compare
+    # against WARNING_CODES (canonical message) rather than re-reading the
+    # NotRequired message_en key off the typed result.
+    assert built == [
+        {
+            "code": "post_match_trailing_dropped",
+            "message_en": WARNING_CODES["post_match_trailing_dropped"],
+            "severity": "warn",
+            "context": {"start": 1000.0, "end": 1800.0},
+        }
+    ]
+    sample["warnings"] = built
+    Draft202012Validator(schema).validate(sample)

--- a/tests/test_split_from_metadata.py
+++ b/tests/test_split_from_metadata.py
@@ -463,3 +463,77 @@ def test_run_split_from_metadata_omits_brightness_samples_when_source_lacks(tmp_
     assert "brightness_samples" not in fresh, (
         "元 metadata に brightness_samples が無いなら新 metadata にも書かない"
     )
+
+
+# -- #805 段階1: post_match_trailing_dropped warning preserve through --from-metadata --
+
+
+def test_run_split_from_metadata_preserves_trailing_drop_warning(tmp_path):
+    """#805 段階1 -- --from-metadata 経路で元 metadata.json の
+    post_match_trailing_dropped warning が新 metadata.json に preserve される。
+
+    detect -> split --from-metadata -o <same dir> で記録済み warning を
+    silent に上書きしないこと (brightness_samples #644 / timing #586 同パターン)。
+    """
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    original_warning = {
+        "code": "post_match_trailing_dropped",
+        "message_en": "A trailing post-match segment was dropped.",
+        "severity": "warn",
+        "context": {"start": 1000.0, "end": 1800.0},
+    }
+    payload = {
+        **_sample_metadata(str(source)),
+        "warnings": [original_warning],
+    }
+    meta_path = _write_metadata(tmp_path, payload)
+    config = SplitConfig(output_dir=tmp_path / "out", min_match_duration=60.0)
+
+    with (
+        patch(f"{MODULE}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE}.split_video",
+            return_value=[
+                tmp_path / "out" / "match_001.mp4",
+                tmp_path / "out" / "match_002.mp4",
+            ],
+        ),
+    ):
+        run_split_from_metadata(meta_path, config, quiet=True)
+
+    out_meta = tmp_path / "out" / "metadata.json"
+    fresh = json.loads(out_meta.read_text("utf-8"))
+    assert fresh["warnings"] == [original_warning], (
+        "--from-metadata は元 metadata の post_match_trailing_dropped warning を "
+        "新 metadata に preserve するはず (#805 段階1)"
+    )
+
+
+def test_run_split_from_metadata_empty_warnings_when_source_lacks(tmp_path):
+    """#805 段階1 -- 元 metadata が warning を持たない (or 非 dict entry) なら
+    新 metadata の warnings は [] (preserve は code を持つ dict のみ拾う)。
+    """
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    # _sample_metadata はデフォルトで warnings を含めない (= 欠落)。
+    payload = _sample_metadata(str(source))
+    assert "warnings" not in payload
+    meta_path = _write_metadata(tmp_path, payload)
+    config = SplitConfig(output_dir=tmp_path / "out", min_match_duration=60.0)
+
+    with (
+        patch(f"{MODULE}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE}.split_video",
+            return_value=[
+                tmp_path / "out" / "match_001.mp4",
+                tmp_path / "out" / "match_002.mp4",
+            ],
+        ),
+    ):
+        run_split_from_metadata(meta_path, config, quiet=True)
+
+    out_meta = tmp_path / "out" / "metadata.json"
+    fresh = json.loads(out_meta.read_text("utf-8"))
+    assert fresh["warnings"] == []

--- a/tests/test_split_from_metadata.py
+++ b/tests/test_split_from_metadata.py
@@ -540,23 +540,39 @@ def test_run_split_from_metadata_empty_warnings_when_source_lacks(tmp_path):
 
 
 def test_run_split_from_metadata_drops_malformed_warning_entries(tmp_path):
-    """#805 段階1 -- preserve_warnings フィルタが壊れた entry を除外する。
+    """#805 段階1 -- preserve_warnings が壊れた entry / fields を sanitize する。
 
-    warnings に [42, {"no_code": True}, <valid>] を書いた source metadata を
-    --from-metadata で処理すると、malformed な 2 エントリは捨てられ valid 1 件
-    だけが新 metadata に残る。また warnings が非リスト (文字列 "oops") の場合は
-    出力 warnings が [] になる。
+    warnings に malformed entry (非 dict / code なし / 非 str code / 空 code) と
+    schema 違反 optional field (不正 severity / 非 dict context) を持つ valid
+    entry を混ぜた source metadata を --from-metadata で処理すると、malformed
+    entry は捨てられ、valid entry は schema 違反 field を strip した形で新
+    metadata に残る。また warnings が非リスト (文字列 "oops") の場合は出力
+    warnings が [] になる。sanitize_warnings の helper unit は test_warnings.py。
     """
-    # --- case A: list with mixed malformed / valid entries ---
+    # --- case A: valid post_match_trailing_dropped entry mixed with malformed ---
     source = tmp_path / "input.mp4"
     source.write_bytes(b"")
-    valid_warning = {
+    # valid entry だが optional field が schema 違反 (severity 不正 / context 非
+    # dict) -> sanitize で当該 field は strip され code (+ valid field) のみ残る。
+    valid_but_dirty_warning = {
         "code": "post_match_trailing_dropped",
-        "context": {"start": 1.0, "end": 2.0},
+        "message_en": "A trailing post-match segment was dropped.",
+        "severity": "totally-bogus",  # invalid -> stripped
+        "context": "not-a-dict",  # invalid -> stripped
+    }
+    sanitized_valid = {
+        "code": "post_match_trailing_dropped",
+        "message_en": "A trailing post-match segment was dropped.",
     }
     payload_a = {
         **_sample_metadata(str(source)),
-        "warnings": [42, {"no_code": True}, valid_warning],
+        "warnings": [
+            42,  # non-dict -> dropped
+            {"no_code": True},  # missing code -> dropped
+            {"code": 7},  # non-str code -> dropped
+            {"code": ""},  # empty code -> dropped
+            valid_but_dirty_warning,
+        ],
     }
     meta_path_a = tmp_path / "meta_a.json"
     meta_path_a.write_text(json.dumps(payload_a), encoding="utf-8")
@@ -575,8 +591,9 @@ def test_run_split_from_metadata_drops_malformed_warning_entries(tmp_path):
         run_split_from_metadata(meta_path_a, config_a, quiet=True)
 
     fresh_a = json.loads((tmp_path / "out_a" / "metadata.json").read_text("utf-8"))
-    assert fresh_a["warnings"] == [valid_warning], (
-        "42 と {'no_code': True} は code を持たないため除外され、valid entry のみ残る"
+    assert fresh_a["warnings"] == [sanitized_valid], (
+        "malformed entry は除外され、valid entry は不正な severity / context を "
+        "strip した形 (code + message_en) で残る"
     )
 
     # --- case B: warnings is a non-list scalar ---

--- a/tests/test_split_from_metadata.py
+++ b/tests/test_split_from_metadata.py
@@ -511,8 +511,8 @@ def test_run_split_from_metadata_preserves_trailing_drop_warning(tmp_path):
 
 
 def test_run_split_from_metadata_empty_warnings_when_source_lacks(tmp_path):
-    """#805 段階1 -- 元 metadata が warning を持たない (or 非 dict entry) なら
-    新 metadata の warnings は [] (preserve は code を持つ dict のみ拾う)。
+    """#805 段階1 -- 元 metadata が warnings キー自体を持たない場合、
+    新 metadata の warnings は [] になる (preserve は code を持つ dict のみ拾う)。
     """
     source = tmp_path / "input.mp4"
     source.write_bytes(b"")
@@ -537,3 +537,70 @@ def test_run_split_from_metadata_empty_warnings_when_source_lacks(tmp_path):
     out_meta = tmp_path / "out" / "metadata.json"
     fresh = json.loads(out_meta.read_text("utf-8"))
     assert fresh["warnings"] == []
+
+
+def test_run_split_from_metadata_drops_malformed_warning_entries(tmp_path):
+    """#805 段階1 -- preserve_warnings フィルタが壊れた entry を除外する。
+
+    warnings に [42, {"no_code": True}, <valid>] を書いた source metadata を
+    --from-metadata で処理すると、malformed な 2 エントリは捨てられ valid 1 件
+    だけが新 metadata に残る。また warnings が非リスト (文字列 "oops") の場合は
+    出力 warnings が [] になる。
+    """
+    # --- case A: list with mixed malformed / valid entries ---
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"")
+    valid_warning = {
+        "code": "post_match_trailing_dropped",
+        "context": {"start": 1.0, "end": 2.0},
+    }
+    payload_a = {
+        **_sample_metadata(str(source)),
+        "warnings": [42, {"no_code": True}, valid_warning],
+    }
+    meta_path_a = tmp_path / "meta_a.json"
+    meta_path_a.write_text(json.dumps(payload_a), encoding="utf-8")
+    config_a = SplitConfig(output_dir=tmp_path / "out_a", min_match_duration=60.0)
+
+    with (
+        patch(f"{MODULE}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE}.split_video",
+            return_value=[
+                tmp_path / "out_a" / "match_001.mp4",
+                tmp_path / "out_a" / "match_002.mp4",
+            ],
+        ),
+    ):
+        run_split_from_metadata(meta_path_a, config_a, quiet=True)
+
+    fresh_a = json.loads((tmp_path / "out_a" / "metadata.json").read_text("utf-8"))
+    assert fresh_a["warnings"] == [valid_warning], (
+        "42 と {'no_code': True} は code を持たないため除外され、valid entry のみ残る"
+    )
+
+    # --- case B: warnings is a non-list scalar ---
+    payload_b = {
+        **_sample_metadata(str(source)),
+        "warnings": "oops",
+    }
+    meta_path_b = tmp_path / "meta_b.json"
+    meta_path_b.write_text(json.dumps(payload_b), encoding="utf-8")
+    config_b = SplitConfig(output_dir=tmp_path / "out_b", min_match_duration=60.0)
+
+    with (
+        patch(f"{MODULE}.probe_video", return_value=PROBE_RESULT),
+        patch(
+            f"{MODULE}.split_video",
+            return_value=[
+                tmp_path / "out_b" / "match_001.mp4",
+                tmp_path / "out_b" / "match_002.mp4",
+            ],
+        ),
+    ):
+        run_split_from_metadata(meta_path_b, config_b, quiet=True)
+
+    fresh_b = json.loads((tmp_path / "out_b" / "metadata.json").read_text("utf-8"))
+    assert fresh_b["warnings"] == [], (
+        "warnings が非リスト ('oops') なら出力 warnings は [] になる"
+    )

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1036,6 +1036,7 @@ def test_pipeline_config_params_forwarded(
         sample_interval=2.0,
         blackout_threshold=20.0,
         min_match_duration=120.0,
+        keep_trailing=True,
     )
 
     run_split(Path("input.mp4"), config)
@@ -1046,6 +1047,10 @@ def test_pipeline_config_params_forwarded(
     assert detect_kwargs["blackout_threshold"] == 20.0
     assert detect_kwargs["min_match_duration"] == 120.0
     assert detect_kwargs["min_blackout_duration"] == 3.0
+    # #805 段階1: keep_trailing flag + trailing_drop_callback seam reach the
+    # detector through _run_detection's detect_kwargs assembly.
+    assert detect_kwargs["keep_trailing"] is True
+    assert callable(detect_kwargs["trailing_drop_callback"])
 
 
 # ============================================================
@@ -4561,3 +4566,135 @@ def test_run_split_cache_hit_omits_brightness_samples(
         "cache hit 経路では Pass 1 を skip するため brightness_samples キー"
         "は欠落するはず (#644、metadata-spec.md 書き込みパス表と整合)"
     )
+
+
+# -- #805 段階1: post_match_trailing_dropped warning wiring through run_split --
+
+# trailing_drop_callback の wiring を assert したいので mock_pipeline ではなく
+# `_run_detection` を直接 patch する (brightness_samples #644 と同型)。
+
+
+@patch(f"{MODULE}._run_detection")
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_run_split_records_trailing_drop_warning(
+    mock_probe, mock_split, mock_run_detection, tmp_path
+):
+    """#805 段階1 -- run_split (一気通貫) で trailing drop が起きたら
+    metadata.json の warnings に post_match_trailing_dropped が記録される。
+
+    `_run_detection` に渡される `trailing_drop_callback` を
+    fake_run_detection から (1000.0, 1800.0) で呼び、最終 metadata.json
+    の warnings に 1 件現れることを assert する (brightness #644 同型)。
+    """
+    mock_probe.return_value = PROBE_RESULT
+
+    def fake_run_detection(*args, **kwargs):
+        cb = kwargs.get("trailing_drop_callback")
+        assert cb is not None, (
+            "run_split must pass trailing_drop_callback to _run_detection (#805)"
+        )
+        cb(1000.0, 1800.0)
+        return BOUNDARIES
+
+    mock_run_detection.side_effect = fake_run_detection
+
+    output_dir = tmp_path / "out_drop"
+    mock_split.return_value = [
+        output_dir / "match_001.mp4",
+        output_dir / "match_002.mp4",
+    ]
+
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"")
+    config = SplitConfig(output_dir=output_dir, min_match_duration=60.0, no_cache=True)
+
+    run_split(video, config, verbose=False, quiet=True)
+
+    payload = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert payload["warnings"] == [
+        {
+            "code": "post_match_trailing_dropped",
+            "message_en": payload["warnings"][0]["message_en"],
+            "severity": "warn",
+            "context": {"start": 1000.0, "end": 1800.0},
+        }
+    ]
+
+
+@patch(f"{MODULE}._run_detection")
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_run_split_no_trailing_drop_writes_empty_warnings(
+    mock_probe, mock_split, mock_run_detection, tmp_path
+):
+    """#805 段階1 -- 何も drop されない (callback 不発) なら warnings は []。"""
+    mock_probe.return_value = PROBE_RESULT
+
+    def fake_run_detection(*args, **kwargs):
+        # callback を呼ばない (trailing drop なし)
+        return BOUNDARIES
+
+    mock_run_detection.side_effect = fake_run_detection
+
+    output_dir = tmp_path / "out_nodrop"
+    mock_split.return_value = [
+        output_dir / "match_001.mp4",
+        output_dir / "match_002.mp4",
+    ]
+
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"")
+    config = SplitConfig(output_dir=output_dir, min_match_duration=60.0, no_cache=True)
+
+    run_split(video, config, verbose=False, quiet=True)
+
+    payload = json.loads((output_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert payload["warnings"] == []
+
+
+def test_build_metadata_payload_round_trips_warnings(tmp_path):
+    """#805 段階1 -- `_build_metadata_payload(warnings=[...])` emits the list
+    verbatim; default (no arg) keeps the historical `[]` for existing callers.
+    """
+    from allaganeye.commands.split_matches import _build_metadata_payload
+    from allaganeye.detection.warnings import WARNING_CODES, build_warnings
+
+    system_info = {
+        "gpu_vendors_available": [],
+        "gpu_vendor_used": None,
+        "vendor_preference": ["nvidia", "amd", "intel"],
+    }
+    common = dict(
+        video_path=tmp_path / "input.mp4",
+        source_duration=1800.0,
+        source_fps=30.0,
+        detected_at="2026-06-16T00:00:00Z",
+        detection_started_at="2026-06-16T00:00:00Z",
+        detection_completed_at="2026-06-16T00:01:00Z",
+        effective_interval=1.0,
+        config=SplitConfig(output_dir=tmp_path / "out", min_match_duration=60.0),
+        boundaries=BOUNDARIES,
+        output_files=_output_files(tmp_path / "out"),
+        gaps=[],
+        system_info=system_info,
+    )
+
+    # Default: no warnings arg -> [] (existing callers/tests stay green).
+    default_payload = _build_metadata_payload(**common)  # type: ignore[arg-type]
+    assert default_payload.get("warnings") == []
+
+    warned = build_warnings(trailing_drops=[(1000.0, 1800.0)])
+    # The producer emits exactly this shape; pin it explicitly so the round
+    # trip below also documents the wire contract.
+    assert warned == [
+        {
+            "code": "post_match_trailing_dropped",
+            "message_en": WARNING_CODES["post_match_trailing_dropped"],
+            "severity": "warn",
+            "context": {"start": 1000.0, "end": 1800.0},
+        }
+    ]
+    payload = _build_metadata_payload(**common, warnings=warned)  # type: ignore[arg-type]
+    # _build_metadata_payload forwards the list verbatim (not rebuilt).
+    assert payload.get("warnings") == warned

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -1218,6 +1218,70 @@ class TestCacheRoundTrip:
         masked_config = SplitConfig(output_dir=tmp_path / "output", masked=True)
         assert _load_cache(cache_path, cache_video, 1.0, masked_config) is None
 
+    def test_param_mismatch_keep_trailing(self, cache_video, cache_config, tmp_path):
+        """default run の cache を --keep-trailing run が再利用しない -> None。
+
+        keep_trailing は detect_match_boundaries の trailing-drop を skip して
+        検出境界を変える (#805 段階1) ので、cache 済み境界 (drop 済み) を
+        --keep-trailing run が再利用すると opt-out が silent に効かなくなる。
+        vtuber / masked key と同型に cache key へ含める。
+        """
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        keep_config = SplitConfig(output_dir=tmp_path / "output", keep_trailing=True)
+        assert _load_cache(cache_path, cache_video, 1.0, keep_config) is None
+
+    def test_param_mismatch_keep_trailing_reverse(
+        self, cache_video, cache_config, tmp_path
+    ):
+        """--keep-trailing run の cache を default run が再利用しない -> None。
+
+        --keep-trailing cache (drop なし境界) を default path が再利用すると
+        #797 の trailing drop が抑止され released-default が regress するため、
+        reverse 方向も miss させる (vtuber/masked reverse と同型)。
+        """
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        keep_config = SplitConfig(output_dir=tmp_path / "output", keep_trailing=True)
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, keep_config, CACHE_BOUNDARIES
+        )
+        assert _load_cache(cache_path, cache_video, 1.0, cache_config) is None
+
+    def test_keep_trailing_cache_hit(self, cache_video, tmp_path):
+        """--keep-trailing 同士は hit する (round-trip)。"""
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        keep_config = SplitConfig(output_dir=tmp_path / "output", keep_trailing=True)
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, keep_config, CACHE_BOUNDARIES
+        )
+        assert (
+            _load_cache(cache_path, cache_video, 1.0, keep_config) == CACHE_BOUNDARIES
+        )
+
+    def test_legacy_cache_without_keep_trailing_key(
+        self, cache_video, cache_config, tmp_path
+    ):
+        """keep_trailing key なし legacy cache: default run は有効、keep run は無効。
+
+        --keep-trailing 導入前の cache はすべて drop ON (= keep_trailing=False) の
+        結果なので missing = False と同値に扱う (vtuber/masked key と同じ後方互換
+        規約)。version bump 不要の根拠でもある。
+        """
+        cache_path = tmp_path / "output" / ".detection_cache.json"
+        _save_cache(
+            cache_path, cache_video, PROBE_RESULT, 1.0, cache_config, CACHE_BOUNDARIES
+        )
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        data["params"].pop("keep_trailing", None)
+        cache_path.write_text(json.dumps(data), encoding="utf-8")
+        assert (
+            _load_cache(cache_path, cache_video, 1.0, cache_config) == CACHE_BOUNDARIES
+        )
+        keep_config = SplitConfig(output_dir=tmp_path / "output", keep_trailing=True)
+        assert _load_cache(cache_path, cache_video, 1.0, keep_config) is None
+
     def test_legacy_v2_cache_rejected(self, cache_video, cache_config, tmp_path):
         """pre-#821 (v2) cache は version bump で全面 invalidate (Codex high finding).
 
@@ -3758,6 +3822,34 @@ def test_verbose_cache_hit_prints_masked_on_token(
     header_idx = out.find("Cache hit:")
     assert header_idx >= 0
     assert "masked=on" in out[header_idx:]
+
+
+@patch(f"{MODULE}.split_video")
+@patch(f"{MODULE}.probe_video")
+def test_verbose_cache_hit_prints_keep_trailing_on_token(
+    mock_probe, mock_split, tmp_path, capsys
+):
+    """keep_trailing=True で生成した cache の hit 表示は keep_trailing=on。
+
+    cache key fix (#805 段階1) で mode 混在 hit は不可能になったが、表示にも
+    provenance を出して troubleshoot 報告から keep_trailing を判別可能にする
+    (vtuber/masked token と同型)。
+    """
+    source = tmp_path / "input.mp4"
+    config = SplitConfig(
+        output_dir=tmp_path, min_match_duration=60.0, keep_trailing=True
+    )
+    _seed_cache(source, tmp_path, config)
+
+    mock_probe.return_value = PROBE_RESULT
+    mock_split.return_value = _output_files(tmp_path)
+
+    run_split(source, config, verbose=True)
+    out = capsys.readouterr().out
+
+    header_idx = out.find("Cache hit:")
+    assert header_idx >= 0
+    assert "keep_trailing=on" in out[header_idx:]
 
 
 @patch(f"{MODULE}._run_detection")

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -18,6 +18,7 @@ from allaganeye.commands.split_matches import (
     run_split,
 )
 from allaganeye.config import SplitConfig
+from allaganeye.detection.warnings import WARNING_CODES
 from allaganeye.exceptions import AllaganEyeError, DetectionError, VideoProcessingError
 from allaganeye.video.detector import MatchBoundary
 from allaganeye.video.probe import ProbeResult
@@ -4615,7 +4616,7 @@ def test_run_split_records_trailing_drop_warning(
     assert payload["warnings"] == [
         {
             "code": "post_match_trailing_dropped",
-            "message_en": payload["warnings"][0]["message_en"],
+            "message_en": WARNING_CODES["post_match_trailing_dropped"],
             "severity": "warn",
             "context": {"start": 1000.0, "end": 1800.0},
         }

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -24,3 +24,30 @@ def test_build_warnings_returns_new_list_each_call():
     a.append({"code": "x"})  # type: ignore[arg-type]
     b = build_warnings()
     assert b == []
+
+
+def test_post_match_trailing_dropped_code_registered():
+    # #805 段階1: the trailing-drop warning code carries a human-readable
+    # default message so readers can surface it from the code alone.
+    assert "post_match_trailing_dropped" in WARNING_CODES
+    assert "--keep-trailing" in WARNING_CODES["post_match_trailing_dropped"]
+
+
+def test_build_warnings_emits_post_match_trailing_dropped():
+    # One (start, end) drop -> exactly one structured warn entry recording
+    # the lost segment span, so manual recovery is possible (#805 P1-4).
+    result = build_warnings(trailing_drops=[(1000.0, 1800.0)])
+    assert result == [
+        {
+            "code": "post_match_trailing_dropped",
+            "message_en": WARNING_CODES["post_match_trailing_dropped"],
+            "severity": "warn",
+            "context": {"start": 1000.0, "end": 1800.0},
+        }
+    ]
+
+
+def test_build_warnings_empty_trailing_drops_is_empty():
+    # Explicit empty input keeps the backward-compatible empty result.
+    assert build_warnings(trailing_drops=[]) == []
+    assert build_warnings(trailing_drops=()) == []

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from allaganeye.detection.warnings import (
     WARNING_CODES,
     build_warnings,
+    sanitize_warnings,
 )
 
 
@@ -51,3 +52,50 @@ def test_build_warnings_empty_trailing_drops_is_empty():
     # Explicit empty input keeps the backward-compatible empty result.
     assert build_warnings(trailing_drops=[]) == []
     assert build_warnings(trailing_drops=()) == []
+
+
+# -- #805 段階1: sanitize_warnings (preserve hazard guard) --
+
+
+def test_sanitize_warnings_strips_invalid_and_drops_codeless():
+    # #805 段階1: warnings read from an existing metadata.json may carry
+    # schema-violating entries (the writer doesn't validate). sanitize_warnings
+    # drops non-dict / codeless / non-string-code entries and strips any optional
+    # field whose value violates the schema, so only schema-valid entries survive
+    # into a freshly written metadata.json.
+    raw = [
+        {"code": 123},  # non-str code -> dropped
+        {"code": ""},  # empty code -> dropped
+        {"code": "x", "severity": "bad"},  # invalid severity stripped
+        {"code": "y", "context": "oops"},  # non-dict context stripped
+        {"code": "z", "message_en": 5},  # non-str message_en stripped
+        {
+            "code": "ok",
+            "severity": "warn",
+            "context": {"start": 1.0},
+            "message_en": "m",
+        },  # fully valid -> preserved as-is
+        42,  # non-dict -> dropped
+        "s",  # non-dict -> dropped
+        {"no_code": True},  # missing code -> dropped
+    ]
+    assert sanitize_warnings(raw) == [
+        {"code": "x"},
+        {"code": "y"},
+        {"code": "z"},
+        {
+            "code": "ok",
+            "severity": "warn",
+            "context": {"start": 1.0},
+            "message_en": "m",
+        },
+    ]
+
+
+def test_sanitize_warnings_non_list_returns_empty():
+    # A non-list value (scalar / dict / None) yields an empty list, matching
+    # the pre-#805 "rebuild as []" behaviour for malformed sources.
+    assert sanitize_warnings("oops") == []
+    assert sanitize_warnings(None) == []
+    assert sanitize_warnings({"code": "x"}) == []
+    assert sanitize_warnings(42) == []


### PR DESCRIPTION
## 概要

[#805](https://github.com/Idios/kobutachan-allaganeye/issues/805) 段階1。`_drop_post_match_trailing` (#797) が試合後 trailing を不可逆削除しても metadata.json に痕跡が残らない (audit P1-4) / opt-out gate が無い (P2-2) 問題を「痕跡記録 + escape hatch」で解消する。**default 挙動 (drop ON) は不変** = v0.3.0 baseline は bit-exact 維持。非破壊化 (drop → フラグ方式) は段階2 として #805 に継続。

- 実装 plan: `docs/superpowers/plans/2026-06-16-audit-w1-g4.md` (先頭 commit に同梱)
- 設計 spec: `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` §G4

## 設計

- **痕跡記録**: drop 時に `warnings[]` へ `post_match_trailing_dropped` (`context:{start,end}`) を記録。`stats` は verbose 時のみ生成されるため、verbose 非依存の callback seam (`trailing_drop_callback`、既存 `masked_fallback_callback` と同型) で痕跡を表に出す
- **escape hatch**: `--keep-trailing` (split/detect 共通、`SplitConfig.keep_trailing`)。True で drop gate (`and not keep_trailing`) を skip
- **cache key**: `keep_trailing` を検出キャッシュ params に追加 (detection 出力を変えるため。vtuber/masked と同型、`_CACHE_VERSION` bump 不要 = legacy cache は False 扱い)
- **from-metadata preserve**: `split --from-metadata` は元 metadata の warnings を `sanitize_warnings` で schema 検証して preserve (#586/#644 と同型、再 split での痕跡消失を防止)

## 受け入れ条件 (spec §G4 逐条)

- [x] **AC1** drop 発生時に `warnings[]` へ記録される — `_drop_post_match_trailing` callback → `build_warnings` → payload。test: `test_detect_records_trailing_drop_warning` / `test_run_split_records_trailing_drop_warning` (書き込まれた metadata.json で `context` 検証)
- [x] **AC2** `--keep-trailing` で drop 無効化 — gate `and not keep_trailing` (detector.py)。test: `test_keep_trailing_gates_trailing_drop` (両方向) + 既存 `test_obs_runs_trailing_drop_and_filter_sees_vtuber_false`
- **AC3** v0.3.0 baseline 5 本 bit-exact — **要 Idios 実機 `pytest -m slow_detect`** (下記)。構造的保証: drop 決定ロジック byte 不変 / 新 param default OFF / callback は drop 発生時のみ・`segments` 非改変
- [x] **AC4** warnings field が `compare-baseline.py` projection に非影響 — `normalize_metadata` は `{matches,gaps}` のみへ projection (warnings 除外)
- [x] **AC5** `MetadataWarning` forward-compat pin — `test_post_match_trailing_dropped_warning_validates` (schema `code` は free string、unknown code 受容)

## Self-Test Report

machine-verified:

- [x] `python -m ruff check allaganeye tests scripts` — All checks passed
- [x] `python -m ruff format --check allaganeye tests scripts` — 130 files already formatted
- [x] `python -m pyright allaganeye tests scripts` — 0 errors, 0 warnings
- [x] `python -m pytest` (slow 除外) — 1459 passed, 1 skipped, 60 deselected
- [x] `bash scripts/check-markdownlint.sh` — 変更 docs clean

要 Idios 実機検証 (detector.py 変更 = Iron Law 6 trigger、mock 不可):

- `pytest -m slow_detect` — v0.3.0 baseline 5 本 (1080p OBS) の detect projection (matches+gaps) が bit-exact (AC3)

GUI path: 非該当 (Python + docs のみ。`gui/` 未変更 → npm/cargo job 不要)

## Pre-flight

- Step 0/4: #805 紐づけ open PR なし (#806 は既 merged)
- Step 1-3: base `origin/develop-0.3.0` と同期済 (`HEAD..origin` 空)
- Step 5: codex `adversarial-review` 2 pass 実施。**[high]** cache が `keep_trailing` を key に含めず双方向で誤 cache 再利用 (opt-out 無効化 / default 挙動 regression) → 修正 (`90c2bf4`)。**[medium]** from-metadata が malformed warning を無検証 passthrough → `sanitize_warnings` で修正 (`90c2bf4`)。**[medium]** cache-hit 再 split が既存 warning を `[]` 上書き → Idios 判断で段階1 既知制限として明文化 (`25b61af`、durable 化は段階2)

## スコープ

- **IN**: fresh 検出での痕跡 emit / `--keep-trailing` / cache key / from-metadata preserve / docs / forward-compat pin
- **OUT (段階1 既知制限、#805 段階2 で解消)**: cache-hit 再 split での warning 再構成 (検出キャッシュが dropped span を保持しないため `[]`。Idios 判断 = 現状維持 + 明示文書化、`docs/metadata-spec.md` §warnings に記載)

## 注意

- **#805 は close しない** (段階2 = trailing drop 非破壊化が継続)。本 PR は `Refs` のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session-id: audit-w1-g4-20260616
