### PR TITLE
fix(gui): W3 GUI metadata/polish (P2-18/19/21 + 低リスク P3) (Refs #834)

### DIFF
--- a/docs/superpowers/plans/2026-06-18-audit-w2-w3.md
+++ b/docs/superpowers/plans/2026-06-18-audit-w2-w3.md
@@ -616,7 +616,7 @@ cd gui/src-tauri && cargo test 2>&1 | tail -15
 cd gui/src-tauri && cargo build 2>&1 | tail -15
 ```
 
-Expected: 全 0 error。**いずれかが fail したら、その crate は直接/feature 依存があるため Cargo.toml に戻し**、PR 本文に「除去不可: <crate> (<理由>)」を記録。
+Expected: 全 0 error。**いずれかが fail したら、その crate は直接/feature 依存があるため Cargo.toml に戻し**、PR 本文に「除去不可: `<crate>` (`<理由>`)」を記録。
 
 - [ ] **Step 3 (lock sanity):** `git diff gui/src-tauri/Cargo.lock` を確認。除去 crate が lockfile から消える / transitive で同一 version 維持なら OK。予期せぬ major version 変化があれば該当 crate を戻す。
 

--- a/docs/superpowers/plans/2026-06-18-audit-w2-w3.md
+++ b/docs/superpowers/plans/2026-06-18-audit-w2-w3.md
@@ -1,0 +1,718 @@
+# Audit Remediation Wave 2 — W3 (#834 GUI metadata/polish) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` (fresh subagent per task + spec/quality 2-stage review). TDD HARD-GATE (`superpowers:test-driven-development`): NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST. Steps use checkbox (`- [ ]`).
+
+**Goal:** GUI metadata 編集の name/type_override が apply 後も in-memory に残り (P2-18)、UTF-8 BOM 付き metadata.json が読め (P2-19)、thumbnail ffmpeg 並列が画面全体で 1 つの Semaphore に従い (P2-21)、加えて低リスク GUI P3 (mtime を read 前取得 / sample mode keyboard nudge 抑止 / 受理拡張子 hint を SSoT 整合 / 未使用依存・dead code 整理) を消化する。
+
+**Architecture:**
+
+- **P2-18 (name 保持)**: metadata.json への書き戻しは契約上 strip 維持 ([metadata-spec.md](../../metadata-spec.md) §GUI 編集契約 / schema `additionalProperties:false`)。`runApply` の apply 成功後に **disk へ渡す `normalized` (strip 済) と in-memory へ set する metadata を分離**し、in-memory 側のみ `name`/`type_override` を index 突合で復元する。`apply_changes` payload は従来どおり `normalized`。
+- **P2-19 (BOM)**: lib.rs に `strip_bom(&str) -> &str` 純関数を 1 つ追加し、ディスク読込 4 関数 (`load_metadata_sync` / `load_draft_sync` / `restore_from_original_sync` / `read_recent_sync`) の `serde_json::from_str` 引数を `strip_bom(&content)` に統一 (CLAUDE.md encoding boundary audit checklist の「全層」を Rust 層内で網羅)。
+- **P2-21 (Semaphore)**: `static THUMBNAIL_SEMAPHORE: OnceLock<Semaphore>` + getter `thumbnail_semaphore()` を既存 `VIDEO_SERVER` / `PROCESS_TRACKER` の OnceLock パターンで追加し、`generate_match_thumbnails` の per-invoke `Semaphore::new(4)` を static 参照へ置換。並列上限 4 が画面全体で共有される。
+- **mtime 順序**: `metadataStore.load()` で `get_metadata_mtime` を `load_metadata` の**前**に invoke。記録 mtime が読んだ内容より新しくならず、競合は silent overwrite ではなく conflict 検出側に倒れる。
+- **sample nudge**: `PreviewScreen` の keyboard handler の arrow-nudge 分岐に `if (isSample) return;` を追加 (ボタンは既に disabled、keyboard だけ貫通していた)。playback (space) は read-only に反しないため維持。
+- **拡張子 hint**: error.rs `validation.path_invalid` hint の拡張子列を SSoT (`config.py SUPPORTED_EXTENSIONS = mp4/mkv/avi/mov`) に合わせ、`docs/tauri-commands.md` の hint mapping table を同期 (drift CI)。
+- **cleanup**: Cargo.toml 未使用 5 件除去 (build/lock 検証付き) / `@tauri-apps/api` を devDependencies → dependencies / `cancelRequestedRef` (write-only) 除去。
+
+**Tech Stack:** React 19 + TS (Vitest/jsdom) / Zustand / Rust (Tauri 2, serde_json, tokio::sync::Semaphore) / cargo test。
+
+**元 issue:** [#834](https://github.com/Idios/kobutachan-allaganeye/issues/834) (bug, P2-medium, l2a-gui)。受け入れ条件 (issue 本文の正式 AC、逐条検証する):
+
+1. **P2-18**: name/type_override 編集 → [適用] 後も in-memory に保持され UI 表示が残る (修正前 strip 消失 → 修正後 保持)。metadata.json への書き戻しは strip 維持
+2. **P2-19**: BOM 付き metadata.json が load_metadata で読める。load_draft / restore_from_original / read_recent も BOM 耐性
+3. **P2-21**: thumbnail 並列上限が画面全体で 1 つの Semaphore に従う (cargo test で singleton + cap 発火を実証)
+4. **mtime 順序**: load() で get_metadata_mtime が load_metadata より前に取得される
+5. **sample nudge**: sample mode で arrow key nudge が境界を変えない
+6. **拡張子 hint**: error.rs hint が config.py SUPPORTED_EXTENSIONS と一致し doc/tauri-commands.md + drift check pass
+7. **dead code/依存**: 不要 Cargo 依存除去後 cargo check/test/build green / @tauri-apps/api が dependencies / cancelRequestedRef 除去後 lint+typecheck green
+
+---
+
+## 前提条件 / 事実 (2026-06-18 実測、#833 merge 後 = develop-0.3.0 @ b48f424)
+
+- main worktree、branch `claude/audit-w2-w3` (origin/develop-0.3.0 起点)。session-id: `audit-w2-w3-20260618`
+- **metadataStore.ts** ([metadataStore.ts](../../../gui/src/state/metadataStore.ts)):
+  - `normalizeForPersistence` (L154-178): return object が `name`/`type_override` を**含まない** (`type_override` は `nextType` 経由で `type` に畳まれるが field 自体は残さない、`name` は完全 drop) = **disk strip = 契約どおり維持する**
+  - `runApply` (L186-246): apply 成功時 `set({ metadata: normalized, ... })` (L222-229) で in-memory を strip 済 `normalized` に置換 ← **P2-18 の原因** ← in-memory のみ name/type_override 復元
+  - `load` (L267-310): `invoke('load_metadata')` (L269) → `MetadataSchema.parse` (L270) → `invoke('get_metadata_mtime')` (L274) の順 ← **mtime 順序の原因** ← mtime を先に
+  - `updateMatch` (L312-329): `{ ...m, ...patch }` で name/type_override を in-memory に格納済 (編集経路は機能している)
+  - test 既存 helper: `validMetadata()` / `configureInvoke({...})` / `invokeMock` ([metadataStore.test.ts](../../../gui/src/state/metadataStore.test.ts)、G3 で AC test 追加済)
+- **types/metadata.ts** ([metadata.ts](../../../gui/src/types/metadata.ts)): `Match.name?: string` / `Match.type_override?: TypeOverride` / `Match.edited?` は optional。`TypeOverride = 'fl_match' | 'unknown' | 'skip'`
+- **lib.rs** ([lib.rs](../../../gui/src-tauri/src/lib.rs)) — JSON ディスク読込 4 関数 (いずれも `fs::read_to_string` → `serde_json::from_str(&content)`):
+  - `load_metadata_sync` (L79-112、from_str at L94)
+  - `load_draft_sync` (L187-207、from_str at L199)
+  - `restore_from_original_sync` (L231-262、from_str at L254)
+  - `read_recent_sync` (L360-368、from_str at L367、失敗は `unwrap_or_default`)
+  - thumbnail: `generate_match_thumbnails` (#[tauri::command] L1225-、`let semaphore = Arc::new(Semaphore::new(4));` at L1285、per-task `sem.acquire_owned().await` at L1294)
+  - 既存 OnceLock パターン: `static VIDEO_SERVER: OnceLock<Mutex<VideoServer>>` (L58) / `static PROCESS_TRACKER: OnceLock<ProcessMap>` (L1554)。import に `OnceLock` (L5) / `Semaphore` (L20 `tokio::sync::{Mutex, Semaphore}`) 済
+  - cargo test の先例: `TempDir::new()` + `serde_json::json!` (`#[cfg(test)] mod tests`)
+- **error.rs** ([error.rs](../../../gui/src-tauri/src/error.rs)): `validation.path_invalid` hint (L182-184) = `"入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v)"` ← **拡張子列が誤り** (真の SSoT `config.py SUPPORTED_EXTENSIONS = {mp4, mkv, avi, mov}` = DropScreen `ACCEPTED_EXTENSIONS` と一致、error.rs だけ avi 欠落 + m4v 誤記)。code 追加ではなく**既存 hint の text 修正のみ**なので comment count (L116 "25 codes") と `default_hint_covers_all_known_codes` test は不変。`default_hint_for_code` が SSoT、`docs/tauri-commands.md` は mirror、`.github/scripts/check-error-hint-drift.sh` が drift gate
+- **PreviewScreen.tsx** ([PreviewScreen.tsx](../../../gui/src/screens/PreviewScreen.tsx)): `isSample` (L114 = `filePath === null && metadata !== null`)。keyboard handler (`useEffect` + `window.addEventListener('keydown', handleKey)`、L526-555) の arrow-nudge 分岐が `isSample` 未チェック (nudge ボタンは L743-798 で `disabled={isSample}` 済)。`nudge`/`nudgeFrame`/`commitStart`/`commitEnd` は G3 で clamp 化済
+- **ExportScreen.tsx** ([ExportScreen.tsx](../../../gui/src/screens/ExportScreen.tsx)): `cancelRequestedRef` = write-only (decl L161 / reset L344 / set L394、read ゼロ)
+- **Cargo.toml** ([Cargo.toml](../../../gui/src-tauri/Cargo.toml)): 未使用 5 件 = `tokio-util` (L28) / `hyper` (L31) / `urlencoding` (L33) / `percent-encoding` (L34) / `dirs` (L37)。いずれも `gui/src-tauri/src` に直接 use なし (`hyper`/`tokio-util` は axum/tower-http の transitive、直接宣言は redundant)
+- **package.json** ([package.json](../../../gui/package.json)): `@tauri-apps/api` (L26) が **devDependencies** にある (runtime import `@tauri-apps/api/core` 使用)。`@tauri-apps/plugin-dialog` は dependencies (L18、正)
+- 検証: GUI path 全チェック (`cd gui && npm run lint|typecheck|test|build` + `cd gui/src-tauri && cargo check|test`) + **Tauri 実機検証を AskUserQuestion で Idios に依頼** (Iron Law 6、GUI/Rust ロジック変更 = mock 不可)
+
+### スコープ判断 (Iron Law 3 整合)
+
+- **IN**: P2-18/19/21 + 採用済み低リスク P3 (mtime 順序 / sample nudge / 拡張子 hint / 未使用依存 5 件 / @tauri-apps/api 配置 / cancelRequestedRef)。各 unit test。拡張子 hint に伴う tauri-commands.md 同期 (drift CI 整合、correctness requirement)
+- **OUT (本 PR では触らない、Idios 2026-06-18 scope 確認済)**: register_video token 累積 / capabilities 過剰権限 (shell:allow-execute/spawn) / clear_recent UI 不在 → **Wave 3 P3 batch (別 issue)**。detect-progress 間引き等の responsiveness → #670。metadata.json への name persist (契約変更 = 別レイヤー)
+
+---
+
+## File Structure
+
+| 区分 | path | 責務 |
+| --- | --- | --- |
+| Create | `docs/superpowers/plans/2026-06-18-audit-w2-w3.md` | 本 plan |
+| Modify | `gui/src-tauri/src/lib.rs` | `strip_bom` + 4 read fn 経由化 (P2-19) / `THUMBNAIL_SEMAPHORE` static + getter + generate_match_thumbnails 置換 (P2-21) / 各 cargo test |
+| Modify | `gui/src-tauri/src/error.rs` | `validation.path_invalid` hint 拡張子列修正 + RED test (拡張子 hint) |
+| Modify | `docs/tauri-commands.md` | hint mapping table の `validation.path_invalid` 行同期 |
+| Modify | `gui/src/state/metadataStore.ts` | `runApply` apply 後 in-memory name/type_override 復元 (P2-18) / `load` mtime 先取得 (mtime 順序) |
+| Modify | `gui/src/state/metadataStore.test.ts` | P2-18 retention + mtime 順序 unit |
+| Modify | `gui/src/screens/PreviewScreen.tsx` | keyboard nudge を isSample でガード (sample nudge) |
+| Modify | `gui/src/screens/PreviewScreen.test.tsx` | sample nudge unit |
+| Modify | `gui/src-tauri/Cargo.toml` | 未使用 5 件除去 (cleanup) |
+| Modify | `gui/src-tauri/Cargo.lock` | dep 除去に伴う lock 再生成 |
+| Modify | `gui/package.json` | `@tauri-apps/api` を dependencies へ (cleanup) |
+| Modify | `gui/package-lock.json` | 配置変更に伴う lock 同期 |
+| Modify | `gui/src/screens/ExportScreen.tsx` | `cancelRequestedRef` 除去 (cleanup) |
+
+---
+
+## Task A: plan commit (controller)
+
+- [ ] **Step 1:** branch = `claude/audit-w2-w3` (作成済、origin/develop-0.3.0 起点)。本 plan のみ untracked を確認:
+
+```bash
+git branch --show-current          # claude/audit-w2-w3
+git status --short                 # docs/superpowers/plans/2026-06-18-audit-w2-w3.md のみ
+git add docs/superpowers/plans/2026-06-18-audit-w2-w3.md
+git commit -F - <<'EOF'
+doc: W3 (#834 GUI metadata/polish) の実装 plan を追加 (Refs #834)
+
+audit remediation Wave 2 W3。spec §W3 の just-in-time plan。#833 後の
+metadataStore.ts / lib.rs / error.rs / PreviewScreen.tsx / Cargo.toml /
+package.json 実測 + P2-18 in-memory 保持 (disk strip 維持) / P2-19 BOM strip
+共有ヘルパ 4 fn 経由 / P2-21 thumbnail Semaphore static 化 / mtime 先取得 /
+sample nudge ガード / 拡張子 hint SSoT 整合 / 未使用依存・dead code 整理 の確定。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task B: lib.rs — P2-19 BOM strip + P2-21 thumbnail Semaphore static (TDD, Rust)
+
+**Files:**
+
+- Modify: `gui/src-tauri/src/lib.rs`
+
+> 実装前に該当関数を Read して現在行を確認してから surgical edit する (commit 進行で行がずれるため)。
+
+### B-1: P2-19 BOM strip
+
+- [ ] **Step 1 (RED):** `lib.rs` の `#[cfg(test)] mod tests` 内に 2 test を追加 (既存 `load_metadata` 系 test 近傍。`load_metadata_sync` が要求する最小 valid JSON は実装を Read して合わせる — 下記 fixture は `source` + 空 `matches` を含む):
+
+```rust
+    // #834 (P2-19) -- strip_bom 純関数の単体。先頭 BOM のみ除去、それ以外は素通し。
+    #[test]
+    fn strip_bom_removes_leading_bom_only() {
+        assert_eq!(strip_bom("\u{FEFF}{}"), "{}");
+        assert_eq!(strip_bom("{}"), "{}");
+        // 先頭以外の U+FEFF は保持
+        assert_eq!(strip_bom("a\u{FEFF}b"), "a\u{FEFF}b");
+    }
+
+    // #834 (P2-19) -- UTF-8 BOM 付き metadata.json が load できる (audit P2-19)。
+    #[test]
+    fn load_metadata_accepts_utf8_bom() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        // EF BB BF (U+FEFF) + 最小 valid metadata。load_metadata_sync が追加検証を
+        // 課す場合は実装に合わせて body を補う。
+        let body = "\u{FEFF}{\"source\":\"a.mkv\",\"matches\":[]}";
+        std::fs::write(&meta, body.as_bytes()).unwrap();
+        let value = load_metadata_sync(&meta)
+            .expect("BOM-prefixed metadata.json should load");
+        assert_eq!(value.get("source").and_then(|v| v.as_str()), Some("a.mkv"));
+    }
+```
+
+- [ ] **Step 2 (RED 確認):**
+
+Run: `cd gui/src-tauri && cargo test strip_bom load_metadata_accepts_utf8_bom 2>&1 | tail -30`
+Expected: FAIL — `strip_bom` 未定義でコンパイルエラー (test が compile しない = RED)
+
+- [ ] **Step 3 (GREEN):** `lib.rs` に `strip_bom` 純関数を追加 (module top-level、他のヘルパ近傍):
+
+```rust
+/// Strip a leading UTF-8 BOM (U+FEFF / bytes EF BB BF) so serde_json::from_str
+/// accepts files an editor saved with one. serde_json rejects a BOM with
+/// "expected value" (audit P2-19); metadata.json hand-edited on Windows
+/// commonly carries one. Returns the input unchanged when no BOM is present.
+fn strip_bom(s: &str) -> &str {
+    s.strip_prefix('\u{FEFF}').unwrap_or(s)
+}
+```
+
+- [ ] **Step 4 (GREEN):** 4 read fn の `serde_json::from_str(&content)` を `serde_json::from_str(strip_bom(&content))` に置換 (引数のみ変更、error code / message はそのまま):
+  - `load_metadata_sync` (L94 付近)
+  - `load_draft_sync` (L199 付近)
+  - `restore_from_original_sync` (L254 付近)
+  - `read_recent_sync` (L367 付近、`serde_json::from_str::<Vec<RecentEntry>>(strip_bom(&content))`)
+
+- [ ] **Step 5 (GREEN 確認):**
+
+Run: `cd gui/src-tauri && cargo test strip_bom load_metadata_accepts_utf8_bom 2>&1 | tail -20`
+Expected: PASS (新 2 test green)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/src-tauri/src/lib.rs
+git commit -F - <<'EOF'
+fix(gui): JSON ディスク読込に BOM strip を統一 (Refs #834)
+
+strip_bom(&str) 純関数を追加し、ディスク読込 4 関数 (load_metadata /
+load_draft / restore_from_original / read_recent) の serde_json::from_str を
+strip_bom 経由に統一。UTF-8 BOM 付き metadata.json が "invalid JSON" で拒否
+される問題 (audit P2-19、CLAUDE.md encoding checklist の既知クラス) を Rust 層
+全体で解消。strip_bom 単体 + load_metadata BOM fixture で RED→GREEN。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+### B-2: P2-21 thumbnail Semaphore static
+
+- [ ] **Step 1 (RED):** `lib.rs` の `#[cfg(test)] mod tests` 内に 1 test を追加 (この test が test suite 内で唯一 thumbnail semaphore の permit を触る = 並列実行でも race しない):
+
+```rust
+    // #834 (P2-21) -- thumbnail semaphore は process-global な 1 インスタンスで、
+    // 並列上限 4 が画面全体に効く (修正前は invoke ごとに別 Semaphore::new(4) で
+    // 4N 並列。audit P2-21)。本 test が suite 内で唯一 permit を取得する。
+    #[tokio::test]
+    async fn thumbnail_semaphore_caps_concurrency_at_4_globally() {
+        let a = thumbnail_semaphore() as *const Semaphore;
+        let b = thumbnail_semaphore() as *const Semaphore;
+        assert_eq!(a, b, "one process-global semaphore, not per-invoke");
+        let s = thumbnail_semaphore();
+        assert_eq!(s.available_permits(), 4);
+        let permits: Vec<_> = (0..4).map(|_| s.try_acquire().unwrap()).collect();
+        // cap 発火: 5 本目の同時 job は拒否される
+        assert!(s.try_acquire().is_err(), "5th concurrent thumbnail must be capped");
+        drop(permits);
+        assert_eq!(s.available_permits(), 4);
+    }
+```
+
+- [ ] **Step 2 (RED 確認):**
+
+Run: `cd gui/src-tauri && cargo test thumbnail_semaphore_caps 2>&1 | tail -30`
+Expected: FAIL — `thumbnail_semaphore` 未定義でコンパイルエラー (RED)
+
+- [ ] **Step 3 (GREEN):** `lib.rs` に static + getter を追加 (既存 `static VIDEO_SERVER` / `static PROCESS_TRACKER` 近傍):
+
+```rust
+/// Process-global cap on concurrent thumbnail ffmpeg jobs. Previously a fresh
+/// Semaphore::new(4) was created inside generate_match_thumbnails on each invoke,
+/// so N matches each spawned up to 4 ffmpeg => up to 4N concurrent (audit P2-21).
+/// A single static semaphore bounds the whole screen to 4 at a time.
+static THUMBNAIL_SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
+
+fn thumbnail_semaphore() -> &'static Semaphore {
+    THUMBNAIL_SEMAPHORE.get_or_init(|| Semaphore::new(4))
+}
+```
+
+- [ ] **Step 4 (GREEN):** `generate_match_thumbnails` (L1285 付近) の `let semaphore = Arc::new(Semaphore::new(4));` を削除。per-task の `let sem = Arc::clone(&semaphore);` を削除し、task 内の permit 取得を static 参照経由へ:
+
+```rust
+        // (旧: let sem = Arc::clone(&semaphore);  を削除)
+        tasks.push(async move {
+            // #834 -- acquire from the process-global semaphore so concurrency is
+            // bounded across the whole screen, not per-invoke.
+            let _permit = thumbnail_semaphore().acquire().await.map_err(|e| {
+                AppError::new("internal.error", format!("semaphore closed: {}", e))
+            })?;
+            ensure_thumbnail_exists(&video_for_task, t, &out_path).await?;
+            Ok::<ThumbnailEntry, AppError>(ThumbnailEntry { /* 既存のまま */ })
+        });
+```
+
+> `acquire().await` は `&'static Semaphore` から `SemaphorePermit<'static>` を返すため `async move` 内で保持・await 跨ぎ可。`Arc`/`acquire_owned` は不要。`ThumbnailEntry { ... }` の中身は既存コードを保持。
+
+- [ ] **Step 5 (GREEN 確認):**
+
+Run: `cd gui/src-tauri && cargo test thumbnail_semaphore_caps 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 6:** `cd gui/src-tauri && cargo check 2>&1 | tail -15` → 0 error (未使用 `Arc` import 等の warning が出たら該当 import の要否を確認。`Arc` は他で使用中のため残す)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/src-tauri/src/lib.rs
+git commit -F - <<'EOF'
+fix(gui): thumbnail Semaphore を画面全体 static 化 (Refs #834)
+
+generate_match_thumbnails が invoke ごとに Semaphore::new(4) を新規生成し、試合
+N 件で最大 4N 本の ffmpeg が同時 spawn されうる問題 (audit P2-21) を解消。
+OnceLock<Semaphore> の process-global static (既存 VIDEO_SERVER / PROCESS_TRACKER
+パターン) + getter thumbnail_semaphore() を追加し、並列上限 4 を画面全体で共有。
+singleton + cap 発火 (5 本目拒否) を cargo test で RED→GREEN 実証。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task C: error.rs 受理拡張子 hint 修正 + tauri-commands.md 同期 (TDD, Rust + doc)
+
+**Files:**
+
+- Modify: `gui/src-tauri/src/error.rs`
+- Modify: `docs/tauri-commands.md`
+
+- [ ] **Step 1 (RED):** `error.rs` の `#[cfg(test)] mod tests` 内に 1 test を追加:
+
+```rust
+    // #834 -- path_invalid hint は config.py SUPPORTED_EXTENSIONS (mp4/mkv/avi/mov)
+    // と一致させる。旧 hint は avi 欠落 + m4v 誤記 (DropScreen / config.py と不整合)。
+    #[test]
+    fn path_invalid_hint_lists_supported_extensions() {
+        let hint = default_hint_for_code("validation.path_invalid").unwrap();
+        assert!(hint.contains("avi"), "hint should list avi (config.py accepts it)");
+        assert!(!hint.contains("m4v"), "hint should not list m4v (not accepted)");
+    }
+```
+
+- [ ] **Step 2 (RED 確認):**
+
+Run: `cd gui/src-tauri && cargo test path_invalid_hint_lists 2>&1 | tail -15`
+Expected: FAIL — 現 hint は `mov / m4v` (avi 無し / m4v 有り) で両 assert が落ちる
+
+- [ ] **Step 3 (GREEN):** `error.rs` の `validation.path_invalid` hint (L182-184) の拡張子列を修正:
+
+```rust
+        "validation.path_invalid" => Some(
+            "入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / avi / mov)"
+        ),
+```
+
+- [ ] **Step 4 (GREEN 確認):**
+
+Run: `cd gui/src-tauri && cargo test path_invalid_hint_lists 2>&1 | tail -15`
+Expected: PASS
+
+- [ ] **Step 5:** `docs/tauri-commands.md` の AppError default hint mapping table で `validation.path_invalid` 行を Read し、hint 文言を error.rs と**完全一致**に更新 (`mov / m4v` → `avi / mov`)。
+
+- [ ] **Step 6 (確認):**
+
+```bash
+bash .github/scripts/check-error-hint-drift.sh 2>&1 | tail -5
+```
+
+Expected: `OK: ... in sync (25 entries)` (error.rs ↔ tauri-commands.md 一致)
+
+Run: `bash scripts/check-markdownlint.sh 2>&1 | grep -E "tauri-commands"` → 0 件
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/src-tauri/src/error.rs docs/tauri-commands.md
+git commit -F - <<'EOF'
+fix(gui): 受理拡張子 hint を SSoT (config.py) に整合 (Refs #834)
+
+validation.path_invalid hint の拡張子列が config.py SUPPORTED_EXTENSIONS
+(mp4/mkv/avi/mov、DropScreen ACCEPTED_EXTENSIONS と一致) に対し avi 欠落 +
+m4v 誤記だった (audit GUI P3) のを修正。docs/tauri-commands.md の hint mapping
+table を同期し doc-error-hint-drift CI と整合。hint 文字列 RED→GREEN で実証。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task D: metadataStore.ts — P2-18 retention + mtime 順序 (TDD, frontend)
+
+**Files:**
+
+- Modify: `gui/src/state/metadataStore.ts`
+- Test: `gui/src/state/metadataStore.test.ts`
+
+### D-1: P2-18 name/type_override in-memory 保持
+
+- [ ] **Step 1 (RED):** `metadataStore.test.ts` の `describe('useMetadataStore.apply', ...)` 内に追加:
+
+```ts
+  // #834 (P2-18) -- name/type_override は apply 後も in-memory に残る (UI 表示維持)。
+  // 一方 metadata.json (apply_changes payload) には書き戻さない (契約維持)。
+  it('retains name and type_override in-memory after apply but strips them from disk (#834)', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      apply_changes: 2000,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, {
+      name: 'highlight reel',
+      type_override: 'skip',
+    });
+    await useMetadataStore.getState().apply();
+
+    // in-memory: 保持
+    const m = useMetadataStore
+      .getState()
+      .metadata!.matches.find((x) => x.index === 1)!;
+    expect(m.name).toBe('highlight reel');
+    expect(m.type_override).toBe('skip');
+
+    // disk (apply_changes payload): strip 維持 (契約)
+    const applyCall = invokeMock.mock.calls.find((c) => c[0] === 'apply_changes');
+    const persisted = (applyCall![1] as { metadata: Metadata }).metadata
+      .matches[0] as Record<string, unknown>;
+    expect(persisted.name).toBeUndefined();
+    expect(persisted.type_override).toBeUndefined();
+  });
+```
+
+- [ ] **Step 2 (RED 確認):**
+
+Run: `cd gui && npx vitest run src/state/metadataStore.test.ts -t "retains name and type_override" 2>&1 | tail -20`
+Expected: FAIL — `m.name` が undefined (現 `set({ metadata: normalized })` が strip 済を in-memory にも置く)
+
+- [ ] **Step 3 (GREEN):** `runApply` の apply 成功ブロック (L222-229 の `set({ metadata: normalized, ... })`) を、in-memory 用に name/type_override を index 突合で復元した metadata へ置換。`const newMtime = await invoke...` の直後を以下に:
+
+```ts
+      // #834 (P2-18) -- disk へ書く normalized は GUI-local field を strip 済
+      // (metadata-spec §GUI 編集契約)。in-memory には name/type_override を復元し
+      // apply 後も UI 表示が消えないようにする (disk と in-memory を分離)。
+      const editedById = new Map(metadata.matches.map((m) => [m.index, m]));
+      const retained: Metadata = {
+        ...normalized,
+        matches: normalized.matches.map((m) => {
+          const orig = editedById.get(m.index);
+          return {
+            ...m,
+            ...(orig?.name !== undefined ? { name: orig.name } : {}),
+            ...(orig?.type_override !== undefined
+              ? { type_override: orig.type_override }
+              : {}),
+          };
+        }),
+      };
+      set({
+        metadata: retained,
+        dirty: false,
+        applying: false,
+        applyErrorState: null,
+        loadedMtimeMs: newMtime,
+        conflictErrorState: null,
+      });
+```
+
+> `normalized` (disk payload) は変更しない。`apply_changes` invoke の引数も `normalized` のまま。`retained` は in-memory set 専用。
+
+- [ ] **Step 4 (GREEN 確認):**
+
+Run: `cd gui && npx vitest run src/state/metadataStore.test.ts -t "retains name and type_override" 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/src/state/metadataStore.ts gui/src/state/metadataStore.test.ts
+git commit -F - <<'EOF'
+fix(gui): name/type_override を apply 後も in-memory 保持 (Refs #834)
+
+runApply の apply 成功時に disk へ渡す normalized (GUI-local field strip 済、
+契約維持) と in-memory へ set する metadata を分離し、in-memory 側のみ
+name/type_override を index 突合で復元。試合名編集 → [適用] で name が UI から
+黙って消える問題 (audit P2-18) を解消。metadata.json への書き戻しは従来どおり
+strip (metadata-spec §GUI 編集契約)。in-memory 保持 + disk strip を unit で実証。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+### D-2: mtime を read 前に取得
+
+- [ ] **Step 1 (RED):** `metadataStore.test.ts` の `describe('useMetadataStore.load', ...)` (無ければ load 系 test 近傍) に追加:
+
+```ts
+  // #834 -- mtime は内容 read より前に取得する (TOCTOU を silent overwrite では
+  // なく conflict 検出側に倒す)。
+  it('captures mtime before reading metadata content (#834)', async () => {
+    const order: string[] = [];
+    invokeMock.mockImplementation((cmd: string) => {
+      order.push(cmd);
+      if (cmd === 'get_metadata_mtime') return Promise.resolve(1700);
+      if (cmd === 'load_metadata') return Promise.resolve(validMetadata());
+      if (cmd === 'check_backup_exists') return Promise.resolve(false);
+      if (cmd === 'load_draft') return Promise.resolve(null);
+      return Promise.resolve(null);
+    });
+    await useMetadataStore.getState().load('p');
+    const mIdx = order.indexOf('get_metadata_mtime');
+    const lIdx = order.indexOf('load_metadata');
+    expect(mIdx).toBeGreaterThanOrEqual(0);
+    expect(lIdx).toBeGreaterThanOrEqual(0);
+    expect(mIdx).toBeLessThan(lIdx);
+  });
+```
+
+- [ ] **Step 2 (RED 確認):**
+
+Run: `cd gui && npx vitest run src/state/metadataStore.test.ts -t "captures mtime before reading" 2>&1 | tail -20`
+Expected: FAIL — 現 `load` は load_metadata を先に呼ぶため `mIdx > lIdx`
+
+- [ ] **Step 3 (GREEN):** `load` (L267-) の冒頭を、mtime 先取得へ:
+
+```ts
+  load: async (path) => {
+    try {
+      // #834 -- capture mtime BEFORE reading contents so the recorded mtime is
+      // never newer than the parsed bytes. If the file is modified between the
+      // two calls, the stored mtime stays <= the content's, so a later apply
+      // detects the conflict (conservative) instead of silently overwriting.
+      const mtime = await invoke<number | null>('get_metadata_mtime', { path });
+      const raw = await invoke<unknown>('load_metadata', { path });
+      const parsed = MetadataSchema.parse(raw);
+      set({
+        metadata: parsed as unknown as Metadata,
+        filePath: path,
+        dirty: false,
+        loadErrorState: null,
+        applyErrorState: null,
+        restoreErrorState: null,
+        loadedMtimeMs: mtime ?? null,
+        conflictErrorState: null,
+        pendingDraft: null,
+        draftLoadErrorState: null,
+        draftSaveErrorState: null,
+      });
+      await get().refreshBackupStatus();
+      await get().loadDraft();
+    } catch (e) {
+      // (catch ブロックは変更なし)
+```
+
+> 旧 `const mtime = await invoke...('get_metadata_mtime')` 行 (L274 付近、parse の後) は削除。L271-273 の旧コメントは新コメントへ統合。catch 以降は不変。
+
+- [ ] **Step 4 (GREEN 確認):**
+
+Run: `cd gui && npx vitest run src/state/metadataStore.test.ts 2>&1 | tail -20`
+Expected: 全 PASS (新 mtime test + 既存 load/apply/restore 群 green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gui/src/state/metadataStore.ts gui/src/state/metadataStore.test.ts
+git commit -F - <<'EOF'
+fix(gui): load 時 mtime を内容 read より前に取得 (Refs #834)
+
+load() が get_metadata_mtime を load_metadata の後に呼んでいたため、read と
+mtime 取得の間に外部書き換えが起きると記録 mtime が新しい方に倒れ、後続 apply
+の競合検出をすり抜けて silent overwrite していた (audit GUI P3 TOCTOU)。mtime を
+先取得し、競合を保守的に conflict 検出側へ倒す。invoke 呼び出し順を unit で実証。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task E: PreviewScreen.tsx — sample mode keyboard nudge ガード (TDD, frontend)
+
+**Files:**
+
+- Modify: `gui/src/screens/PreviewScreen.tsx`
+- Test: `gui/src/screens/PreviewScreen.test.tsx`
+
+> sample mode の有効な match index / 既存 keyboard test の pattern は `PreviewScreen.test.tsx` と `data/sampleMetadata` を Read して合わせる。
+
+- [ ] **Step 1 (RED):** `PreviewScreen.test.tsx` の `describe('PreviewScreen', ...)` 内に追加 (sample mode = `loadSample()`):
+
+```ts
+  // #834 -- sample mode は read-only。nudge ボタンは disabled 済だが keyboard が
+  // 貫通して境界を編集できていた。arrow nudge を sample mode で無効化する。
+  it('does not nudge boundaries via keyboard in sample mode (#834)', () => {
+    useMetadataStore.getState().loadSample();
+    const sampleIdx = useMetadataStore.getState().metadata!.matches[0].index;
+    useAppStateStore.getState().selectMatch(sampleIdx);
+    render(<PreviewScreen />);
+    const inTc = screen.getByLabelText('IN (start) timecode') as HTMLInputElement;
+    const before = inTc.value;
+    fireEvent.keyDown(window, { key: 'ArrowRight', shiftKey: true }); // +10s
+    expect(
+      (screen.getByLabelText('IN (start) timecode') as HTMLInputElement).value,
+    ).toBe(before);
+  });
+```
+
+> `fireEvent` を import に追加 (G3 で追加済の可能性あり、無ければ `import { fireEvent, render, screen, ... } from '@testing-library/react';`)。`useAppStateStore` も import 済を確認。
+
+- [ ] **Step 2 (RED 確認):**
+
+Run: `cd gui && npx vitest run src/screens/PreviewScreen.test.tsx -t "does not nudge boundaries via keyboard in sample" 2>&1 | tail -25`
+Expected: FAIL — sample mode で ArrowRight が start を動かし IN timecode が変わる
+
+- [ ] **Step 3 (GREEN):** `PreviewScreen.tsx` の keyboard handler (`handleKey`、L526-555) の arrow 分岐先頭に isSample ガードを追加:
+
+```ts
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      // #834 -- sample mode は read-only。nudge ボタンと挙動を揃え、keyboard
+      // からの境界編集を抑止する (playback (space) は read-only に反しないため許可)。
+      if (isSample) return;
+      const sign = e.key === 'ArrowLeft' ? -1 : 1;
+      if (e.altKey) {
+        nudgeFrame(sign);
+      } else {
+        const magnitude = e.shiftKey ? 10 : 1;
+        nudge(sign * magnitude);
+      }
+      e.preventDefault();
+      return;
+    }
+```
+
+- [ ] **Step 4 (GREEN):** `useEffect` の dependency 配列に `isSample` を追加 (`}, [nudge, nudgeFrame, activeVideoRef]);` → `}, [nudge, nudgeFrame, activeVideoRef, isSample]);`)。
+
+- [ ] **Step 5 (GREEN 確認):**
+
+Run: `cd gui && npx vitest run src/screens/PreviewScreen.test.tsx 2>&1 | tail -25`
+Expected: 全 PASS (新 sample nudge + 既存 PreviewScreen 群 green)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gui/src/screens/PreviewScreen.tsx gui/src/screens/PreviewScreen.test.tsx
+git commit -F - <<'EOF'
+fix(gui): sample mode で keyboard nudge を抑止 (Refs #834)
+
+PreviewScreen の keyboard handler の arrow nudge 分岐が isSample 未チェックで、
+nudge ボタンが disabled の sample mode でも矢印キーで境界を編集できていた
+(audit GUI P3)。arrow 分岐に isSample ガードを追加しボタンと挙動を揃える
+(playback は維持)。sample mode で ArrowRight が境界を変えないことを unit で実証。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task F: cleanup — 未使用依存 + dead code (verify-driven)
+
+**Files:**
+
+- Modify: `gui/src-tauri/Cargo.toml` + `gui/src-tauri/Cargo.lock`
+- Modify: `gui/package.json` + `gui/package-lock.json`
+- Modify: `gui/src/screens/ExportScreen.tsx`
+
+> dead code 除去 / dep hygiene のため新規 behavior なし = 新規 test なし。**検証は build/lint/test green + grep による除去確認**。TDD gate は production logic 追加に適用されるもので、本 task は対象外。
+
+- [ ] **Step 1:** `Cargo.toml` から未使用 5 件を削除: `tokio-util` (L28) / `hyper` (L31) / `urlencoding` (L33) / `percent-encoding` (L34) / `dirs` (L37)。
+
+- [ ] **Step 2 (検証):**
+
+```bash
+cd gui/src-tauri && cargo check 2>&1 | tail -15
+cd gui/src-tauri && cargo test 2>&1 | tail -15
+cd gui/src-tauri && cargo build 2>&1 | tail -15
+```
+
+Expected: 全 0 error。**いずれかが fail したら、その crate は直接/feature 依存があるため Cargo.toml に戻し**、PR 本文に「除去不可: <crate> (<理由>)」を記録。
+
+- [ ] **Step 3 (lock sanity):** `git diff gui/src-tauri/Cargo.lock` を確認。除去 crate が lockfile から消える / transitive で同一 version 維持なら OK。予期せぬ major version 変化があれば該当 crate を戻す。
+
+- [ ] **Step 4:** `gui/package.json` の `@tauri-apps/api` (devDependencies L26) を `dependencies` セクションへ移動 (alphabetical 順に挿入、`@tauri-apps/plugin-dialog` の前)。devDependencies からは削除。
+
+- [ ] **Step 5 (検証):**
+
+```bash
+cd gui && npm install 2>&1 | tail -10
+cd gui && npm run typecheck 2>&1 | tail -10
+```
+
+Expected: package-lock.json が更新され typecheck 0 error。
+
+- [ ] **Step 6:** `ExportScreen.tsx` から `cancelRequestedRef` を除去 (decl L161 / reset L344 / set L394 の 3 箇所)。除去後に残参照が無いことを確認:
+
+```bash
+cd gui && grep -rn "cancelRequestedRef" src/ ; echo "exit: $?"
+```
+
+Expected: 0 hit (grep exit 1)。
+
+- [ ] **Step 7 (検証):**
+
+```bash
+cd gui && npm run lint 2>&1 | tail -10
+cd gui && npm run typecheck 2>&1 | tail -10
+cd gui && npm test 2>&1 | tail -15
+```
+
+Expected: 全 pass。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add gui/src-tauri/Cargo.toml gui/src-tauri/Cargo.lock gui/package.json gui/package-lock.json gui/src/screens/ExportScreen.tsx
+git commit -F - <<'EOF'
+chore(gui): 未使用依存 / dead code 整理 (Refs #834)
+
+Cargo.toml の直接未使用 5 件 (tokio-util / hyper / urlencoding /
+percent-encoding / dirs、hyper/tokio-util は axum/tower-http の transitive で
+直接宣言が redundant) を除去 (cargo check/test/build + lock sanity で検証)。
+runtime import される @tauri-apps/api を devDependencies → dependencies へ移動。
+write-only な cancelRequestedRef (ExportScreen) を除去。audit GUI P3 整理。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task G: Pre-flight + PR (controller)
+
+- [ ] **Step 0 (hard-gate):** `gh pr list --search "834" --state open` → W3 PR 0 件
+- [ ] **Step 1-3:** `git fetch origin develop-0.3.0` → `git log HEAD..origin/develop-0.3.0 --oneline` (取り込み未済確認) → touched files 交差判定 (lib.rs / error.rs / metadataStore.ts / PreviewScreen.tsx / ExportScreen.tsx / Cargo.toml / package.json / tauri-commands.md が develop-0.3.0 の新規 commit と交差しないか)
+- [ ] **Step 4:** `gh pr list --search "834" --state all` → 重複なし
+- [ ] **Step 5:** codex `adversarial-review` (memory `project_codex_adversarial_review_direct_invocation`: companion script `C:/Users/idios/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs` の `adversarial-review` subcommand を `--wait --base origin/develop-0.3.0 --scope branch "<focus ASCII>"` で Bash run_in_background 直接呼出、final block marker `# Codex Adversarial Review` を待つ)。focus ASCII 候補: `P2-18 in-memory retain merges name/type_override by index but normalized vs original match count or index mismatch drops or mis-maps a field / retained type_override skip later re-applied changes persisted type unexpectedly / strip_bom only strips leading BOM but a mid-content or double BOM still breaks parse / strip_bom applied to read_recent unwrap_or_default masks real corruption / thumbnail_semaphore static cap 4 but acquire().await on static held across spawn leaks permit on task drop or error path / mtime captured before read widens a benign race into spurious conflicts on every load / sample isSample guard added to arrow branch but frame-step alt path or other key still mutates in sample / removing Cargo deps floats a transitive pinned version or breaks build feature / @tauri-apps/api move changes bundle`。不可なら CLAUDE.md §C6 fallback (`superpowers:requesting-code-review` subagent) + PR 本文に **Codex fallback notice 必須**
+- [ ] **Step 6 (machine verify、全 pass、各コマンドを個別行で):**
+
+```bash
+cd gui && npm run lint
+cd gui && npm run typecheck
+cd gui && npm test
+cd gui && npm run build
+cd gui/src-tauri && cargo check
+cd gui/src-tauri && cargo test
+bash .github/scripts/check-error-hint-drift.sh
+bash scripts/check-markdownlint.sh
+```
+
+(lint と他コマンドを `&&` で同一行連結しない)
+
+- [ ] **Step 7 (実機 trigger):** GUI/Rust ロジック変更のため **`AskUserQuestion` で Idios に実機検証を依頼**:
+  - (a) **P2-18**: Tauri 起動 → 実動画 detect → preview で試合名を編集 + type を skip に → [適用] → **name / skip が画面に残る** こと + 出力 metadata.json には name/type_override が**書かれない**こと
+  - (b) **P2-19**: metadata.json を BOM 付き (UTF-8 with BOM) で保存 → GUI で再 load → **読める** こと
+  - (c) **P2-21**: 多数試合 (N≥8) の complete 画面で thumbnail 生成中の ffmpeg 同時数が ~4 で頭打ちになる (タスクマネージャ) / UI が固まりにくい こと
+  - (d) **sample nudge**: sample mode の preview で矢印キーが境界を動かさない こと
+  - 回答まで PR を merge 可能と扱わない
+- [ ] **Step 8:** push + PR (base `develop-0.3.0`, **Refs #834 / Closes 禁止**)。session-id `audit-w2-w3-20260618`。Self-Test Report: machine-verified (lint/typecheck/test/build/cargo check/cargo test/drift/markdownlint) は `[x]`、実機 (a)(b)(c)(d) は plain bullet `-` (Idios 依頼中)。AC 7 項目を逐条 + diff/test 引用。Cargo dep 除去で「除去不可」が出た場合は本文に記録
+
+## Task H: /iterate-review (controller)
+
+- [ ] **Step 1:** `/iterate-review <PR#>` 自走 (1 round = 1 commit `fix(round-N): ... (Refs #834)`、divergence cap Round 5、AskUserQuestion で controller から scope 拡大選択肢を足さない — subagent recommendation 第一)
+- [ ] **Step 2:** Step 5b 表が全ゼロ or Round 5 / 発散検知で収束 → summary コメント 1 個
+
+## マージ後 (Idios merge 後、controller)
+
+- `/close-issue 834` を呼び、AC 7 項目を merge 後 base ブランチで実測再検証 (実機分は Idios 検証結果を引用)。未消化チェックボックスや残タスクを (B)/(C) トリアージしてからユーザー承認で `gh issue close 834`
+- 次サイクル候補 = W2 (#? GUI export/cancel) / W4 (#? core 堅牢化)。W3/W2/W4 は並列着手可
+
+---
+
+## Self-Review (writing-plans 自己点検)
+
+- **Spec coverage**: issue #834 AC 7 項目 → AC1 (P2-18)=Task D-1 / AC2 (P2-19)=Task B-1 / AC3 (P2-21)=Task B-2 / AC4 (mtime)=Task D-2 / AC5 (sample nudge)=Task E / AC6 (拡張子 hint)=Task C / AC7 (cleanup)=Task F。spec §W3 骨子 4 点 (name 保持 / BOM / Semaphore static / mtime) = D-1 / B-1 / B-2 / D-2。✓
+- **Placeholder scan**: 全 step に実コード / 実コマンド / 期待出力あり。fixture の最小 valid JSON と sample match index は「実装を Read して合わせる」と明記 (実装依存の正確値は subagent が確定)。TBD・「適切に」等なし。✓
+- **Type consistency**: `strip_bom(&str) -> &str` (B-1 定義) を 4 read fn (B-1) で使用。`thumbnail_semaphore() -> &'static Semaphore` (B-2 定義) を generate_match_thumbnails (B-2) で使用。`retained: Metadata` の matches は `normalized.matches` を base に `name`/`type_override` (types/metadata.ts の optional field) を merge。`editedById: Map<number, Match>`。test helper `validMetadata()` / `configureInvoke` / `invokeMock` は既存。✓
+- **TDD gate**: Task B-1 (cargo RED→GREEN) / B-2 (cargo RED→GREEN) / C (cargo RED→GREEN) / D-1 (vitest RED→GREEN) / D-2 (vitest RED→GREEN) / E (vitest RED→GREEN)。Task F は dead code/dep hygiene で新規 behavior なし = build/lint/test green + grep 除去確認で検証 (TDD gate 非対象、理由明記)。✓
+- **保護機構の発火側 red 実証** (memory `feedback_protective_mechanism_red_verification`): P2-21 cap は `thumbnail_semaphore_caps_concurrency_at_4_globally` が 5 本目 `try_acquire().is_err()` で cap 発火を観測 (suite 内唯一の permit 取得者で race なし)。P2-19 は BOM fixture で実 fail→pass。✓
+- **契約非破壊** (memory `feedback_position_independent_detector_not_a_discriminator` / metadata-spec): P2-18 で `normalized` (disk payload) は不変、in-memory `retained` のみ name/type_override 復元。disk strip 契約 (metadata-spec §GUI 編集契約 / schema additionalProperties:false) を test (`persisted.name` undefined) で pin。✓
+- **error.rs drift** (dispatch 規約): Task C は新 code 追加でなく既存 hint text 修正 = comment count / covers test 不変。error.rs + tauri-commands.md + drift check を同 PR で同期。✓

--- a/docs/tauri-commands.md
+++ b/docs/tauri-commands.md
@@ -151,7 +151,7 @@ PR #669 で追加した 2 command (`read_error_log_tail` / `probe_environment_in
 | `subprocess.spawn_failed` | 外部プロセスの起動に失敗しました。ffmpeg / Python / 同梱 runtime が壊れていないか確認してください |
 | `subprocess.exit_failed` | 外部プロセスが異常終了しました。logs フォルダの最新ログから詳細を確認してください |
 | `subprocess.cancelled` | (hint なし: ユーザー操作によるキャンセルは UI 側で十分な情報を出す) |
-| `validation.path_invalid` | 入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v) |
+| `validation.path_invalid` | 入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / avi / mov) |
 | `validation.not_a_file` | 指定されたパスはファイルではありません (フォルダや symlink ではなく動画ファイルを選択してください) |
 | `validation.range_invalid` | 入力された数値が許容範囲外です。フォーム下のヒント表示を確認してください |
 | `validation.boundary_invalid` | 試合の終了 (OUT) が開始 (IN) 以前になっています。終了が開始より後になるよう境界を調整してください |

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "allaganeye-gui",
       "version": "0.3.0",
       "dependencies": {
+        "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -16,7 +17,6 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/cli": "^2.11.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",

--- a/gui/package.json
+++ b/gui/package.json
@@ -15,6 +15,7 @@
     "generate-types": "node scripts/generate-ts.mjs"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "react": "19.2.5",
     "react-dom": "19.2.5",
@@ -23,7 +24,6 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/cli": "^2.11.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -22,10 +22,7 @@ name = "allaganeye-gui"
 version = "0.3.0"
 dependencies = [
  "axum",
- "dirs",
  "futures",
- "hyper",
- "percent-encoding",
  "serde",
  "serde_json",
  "sha2",
@@ -37,9 +34,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tempfile",
  "tokio",
- "tokio-util",
  "tower-http",
- "urlencoding",
  "uuid",
  "windows 0.61.3",
 ]
@@ -4510,12 +4505,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -25,16 +25,11 @@ serde_json = "=1.0.149"
 #   - time: tokio::time::{sleep, timeout}
 # bytes / fs / io-std / mio / parking_lot / signal / socket2 / tracing は未使用。
 tokio = { version = "=1.52.1", features = ["rt-multi-thread", "macros", "process", "sync", "io-util", "net", "time"] }
-tokio-util = { version = "=0.7.18", features = ["io"] }
 axum = { version = "=0.8.9", features = ["macros"] }
 tower-http = { version = "=0.6.8", features = ["fs"] }
-hyper = "=1.9.0"
 futures = "=0.3.32"
-urlencoding = "=2.1.3"
-percent-encoding = "=2.3.2"
 uuid = { version = "=1.23.1", features = ["v4"] }
 sha2 = "=0.10.9"
-dirs = "=6.0.0"
 # #669 -- ErrorModal `[Issue 本文をコピー]` button が clipboard に書き込む Markdown
 # 本文の `## 環境情報` section を組み立てるために OS / CPU / Memory / Disk 情報を
 # probe する。Tauri command `probe_environment_info` から使用。`metadata.system_info`

--- a/gui/src-tauri/src/error.rs
+++ b/gui/src-tauri/src/error.rs
@@ -180,7 +180,7 @@ fn default_hint_for_code(code: &str) -> Option<&'static str> {
             "試合の終了 (OUT) が開始 (IN) 以前になっています。終了が開始より後になるよう境界を調整してください"
         ),
         "validation.path_invalid" => Some(
-            "入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / mov / m4v)"
+            "入力されたパスが不正です。ファイル名と拡張子を確認してください (対応: mp4 / mkv / avi / mov)"
         ),
         "validation.not_a_file" => Some(
             "指定されたパスはファイルではありません (フォルダや symlink ではなく動画ファイルを選択してください)"
@@ -353,5 +353,14 @@ mod tests {
         let e: AppError = json_err.into();
         assert_eq!(e.code, "parse.json_invalid");
         assert!(e.hint.is_some());
+    }
+
+    // #834 -- path_invalid hint は config.py SUPPORTED_EXTENSIONS (mp4/mkv/avi/mov)
+    // と一致させる。旧 hint は avi 欠落 + m4v 誤記 (DropScreen / config.py と不整合)。
+    #[test]
+    fn path_invalid_hint_lists_supported_extensions() {
+        let hint = default_hint_for_code("validation.path_invalid").unwrap();
+        assert!(hint.contains("avi"), "hint should list avi (config.py accepts it)");
+        assert!(!hint.contains("m4v"), "hint should not list m4v (not accepted)");
     }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1290,16 +1290,16 @@ async fn generate_match_thumbnails(
     })?;
 
     let timestamps = compute_candidate_timestamps(boundary_t_seconds, window_seconds, count);
-    let semaphore = Arc::new(Semaphore::new(4));
 
     let mut tasks = Vec::with_capacity(timestamps.len());
     for t in timestamps.iter().copied() {
         let token = thumb_token(match_index, t);
         let out_path = cache_dir.join(format!("{}.webp", token));
         let video_for_task = canonical.clone();
-        let sem = Arc::clone(&semaphore);
         tasks.push(async move {
-            let _permit = sem.acquire_owned().await.map_err(|e| {
+            // #834 -- acquire from the process-global semaphore so concurrency is
+            // bounded across the whole screen, not per-invoke.
+            let _permit = thumbnail_semaphore().acquire().await.map_err(|e| {
                 AppError::new(
                     "internal.error",
                     format!("semaphore closed: {}", e),
@@ -1563,6 +1563,16 @@ static PROCESS_TRACKER: OnceLock<ProcessMap> = OnceLock::new();
 
 fn process_tracker() -> &'static ProcessMap {
     PROCESS_TRACKER.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+}
+
+/// Process-global cap on concurrent thumbnail ffmpeg jobs. Previously a fresh
+/// Semaphore::new(4) was created inside generate_match_thumbnails on each invoke,
+/// so N matches each spawned up to 4 ffmpeg => up to 4N concurrent (audit P2-21).
+/// A single static semaphore bounds the whole screen to 4 at a time.
+static THUMBNAIL_SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
+
+fn thumbnail_semaphore() -> &'static Semaphore {
+    THUMBNAIL_SEMAPHORE.get_or_init(|| Semaphore::new(4))
 }
 
 /// #523 -- report whether any child process is currently being tracked.
@@ -3956,6 +3966,22 @@ mod tests {
         let value = load_metadata_sync(&meta)
             .expect("BOM-prefixed metadata.json should load");
         assert_eq!(value.get("source").and_then(|v| v.as_str()), Some("a.mkv"));
+    }
+
+    // #834 (P2-21) -- thumbnail semaphore は process-global な 1 インスタンスで、
+    // 並列上限 4 が画面全体に効く (修正前は invoke ごとに別 Semaphore::new(4) で
+    // 4N 並列。audit P2-21)。本 test が suite 内で唯一 permit を取得する。
+    #[tokio::test]
+    async fn thumbnail_semaphore_caps_concurrency_at_4_globally() {
+        let a = thumbnail_semaphore() as *const Semaphore;
+        let b = thumbnail_semaphore() as *const Semaphore;
+        assert_eq!(a, b, "one process-global semaphore, not per-invoke");
+        let s = thumbnail_semaphore();
+        assert_eq!(s.available_permits(), 4);
+        let permits: Vec<_> = (0..4).map(|_| s.try_acquire().unwrap()).collect();
+        assert!(s.try_acquire().is_err(), "5th concurrent thumbnail must be capped");
+        drop(permits);
+        assert_eq!(s.available_permits(), 4);
     }
 
     // #514 — mtime-based exclusive control for apply_changes.

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -61,6 +61,14 @@ fn video_server() -> &'static Mutex<VideoServer> {
     VIDEO_SERVER.get_or_init(|| Mutex::new(VideoServer::new()))
 }
 
+/// Strip a leading UTF-8 BOM (U+FEFF / bytes EF BB BF) so serde_json::from_str
+/// accepts files an editor saved with one. serde_json rejects a BOM with
+/// "expected value" (audit P2-19); metadata.json hand-edited on Windows
+/// commonly carries one. Returns the input unchanged when no BOM is present.
+fn strip_bom(s: &str) -> &str {
+    s.strip_prefix('\u{FEFF}').unwrap_or(s)
+}
+
 /// #465 -- payload returned to the GUI from `register_video`.
 ///
 /// The frontend sets `url` as the `<video>` element's `src` and keeps `token`
@@ -91,7 +99,7 @@ fn load_metadata_sync(meta_path: &Path) -> Result<Value, AppError> {
         )
         .with_default_hint()
     })?;
-    let value: Value = serde_json::from_str(&content).map_err(|e| {
+    let value: Value = serde_json::from_str(strip_bom(&content)).map_err(|e| {
         AppError::new(
             "parse.json_invalid",
             format!("invalid JSON in {}: {}", meta_path.display(), e),
@@ -196,7 +204,7 @@ fn load_draft_sync(meta_path: &Path) -> Result<Option<Value>, AppError> {
         )
         .with_default_hint()
     })?;
-    let value: Value = serde_json::from_str(&content).map_err(|e| {
+    let value: Value = serde_json::from_str(strip_bom(&content)).map_err(|e| {
         AppError::new(
             "parse.json_invalid",
             format!("invalid JSON in draft {}: {}", draft_path.display(), e),
@@ -251,7 +259,7 @@ fn restore_from_original_sync(meta_path: &Path) -> Result<(), AppError> {
         )
         .with_default_hint()
     })?;
-    let value: Value = serde_json::from_str(&content).map_err(|e| {
+    let value: Value = serde_json::from_str(strip_bom(&content)).map_err(|e| {
         AppError::new(
             "parse.json_invalid",
             format!("parse backup failed ({}): {}", original_path.display(), e),
@@ -364,7 +372,7 @@ fn read_recent_sync(path: &Path) -> Vec<RecentEntry> {
     let Ok(content) = fs::read_to_string(path) else {
         return Vec::new();
     };
-    serde_json::from_str::<Vec<RecentEntry>>(&content).unwrap_or_default()
+    serde_json::from_str::<Vec<RecentEntry>>(strip_bom(&content)).unwrap_or_default()
 }
 
 /// #571 — normalize a path string for the recent-list dedup key.
@@ -3928,6 +3936,26 @@ mod tests {
         fs::write(&meta, r#"["not", "an", "object"]"#).unwrap();
         let err = load_metadata_sync(&meta).unwrap_err();
         assert!(err.message.contains("must be a JSON object"));
+    }
+
+    // #834 (P2-19) -- strip_bom 純関数の単体。先頭 BOM のみ除去、それ以外は素通し。
+    #[test]
+    fn strip_bom_removes_leading_bom_only() {
+        assert_eq!(strip_bom("\u{FEFF}{}"), "{}");
+        assert_eq!(strip_bom("{}"), "{}");
+        assert_eq!(strip_bom("a\u{FEFF}b"), "a\u{FEFF}b");
+    }
+
+    // #834 (P2-19) -- UTF-8 BOM 付き metadata.json が load できる (audit P2-19)。
+    #[test]
+    fn load_metadata_accepts_utf8_bom() {
+        let tmp = TempDir::new().unwrap();
+        let meta = tmp.path().join("metadata.json");
+        let body = "\u{FEFF}{\"source\":\"a.mkv\",\"matches\":[]}";
+        std::fs::write(&meta, body.as_bytes()).unwrap();
+        let value = load_metadata_sync(&meta)
+            .expect("BOM-prefixed metadata.json should load");
+        assert_eq!(value.get("source").and_then(|v| v.as_str()), Some("a.mkv"));
     }
 
     // #514 — mtime-based exclusive control for apply_changes.

--- a/gui/src/screens/ExportScreen.tsx
+++ b/gui/src/screens/ExportScreen.tsx
@@ -1,7 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
-import { useEffect, useReducer, useRef, useState } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 
 import { DisabledTooltip } from '../components/DisabledTooltip';
 import { InlineErrorHint } from '../components/InlineErrorHint';
@@ -158,7 +158,6 @@ export function ExportScreen() {
   const [excludedIndexes, setExcludedIndexes] = useState<ReadonlySet<number>>(
     () => new Set(),
   );
-  const cancelRequestedRef = useRef(false);
   // #545 review #7 (2026-04-25): progress bar 下の「経過 / 残り」時間表示用。
   // START_CLICKED 時の wall-clock を記録し、`elapsedSec` / `remainingSec` を
   // 描画ループで更新する。残り時間は `(elapsed / done) * remaining` の線形
@@ -341,7 +340,6 @@ export function ExportScreen() {
     // 旧 `!filePath` early return + button disabled 条件は誤検知になる。
     if (!metadata) return;
     if (!videoSource) return;
-    cancelRequestedRef.current = false;
 
     // Initialize per-match state. Skip = `type_override === 'skip'` (永続)
     // または excludedIndexes に含まれる (ad-hoc UI 選択、#466 review #1)。
@@ -391,7 +389,6 @@ export function ExportScreen() {
   }
 
   function handleCancelClicked() {
-    cancelRequestedRef.current = true;
     dispatch({ type: 'CANCEL_CLICKED' });
     // #523: kill any tracked ffmpeg child so the current export can't run
     // to completion after the user asked to stop.

--- a/gui/src/screens/PreviewScreen.test.tsx
+++ b/gui/src/screens/PreviewScreen.test.tsx
@@ -66,6 +66,36 @@ describe('PreviewScreen', () => {
     ).toBe(before);
   });
 
+  // #834 (codex) -- sample mode must be read-only through the PLAYBACK path too,
+  // not just keyboard. Playing the pane video fires onTimeUpdate -> onTChange ->
+  // commitStart/commitEnd; in sample mode that must NOT move the boundary.
+  it('does not mutate boundaries via playback timeupdate in sample mode (#834)', async () => {
+    useMetadataStore.getState().loadSample();
+    const sampleIdx = useMetadataStore.getState().metadata!.matches[0].index;
+    useAppStateStore.getState().selectMatch(sampleIdx);
+    render(<PreviewScreen />);
+    const inTc = screen.getByLabelText('IN (start) timecode') as HTMLInputElement;
+    const before = inTc.value;
+    const video = (await screen.findByLabelText(
+      'IN (start) video',
+    )) as HTMLVideoElement;
+    // simulate playback: paused=false + advanced currentTime, then timeupdate.
+    // match[0] starts at 0.0 (IN = 0:00:00.00), so 12.5 is genuinely different.
+    Object.defineProperty(video, 'paused', { value: false, configurable: true });
+    Object.defineProperty(video, 'currentTime', {
+      value: 12.5,
+      configurable: true,
+    });
+    video.dispatchEvent(new Event('timeupdate'));
+    await new Promise((r) => setTimeout(r, 20));
+    // (a) the IN timecode must be unchanged ...
+    expect(
+      (screen.getByLabelText('IN (start) timecode') as HTMLInputElement).value,
+    ).toBe(before);
+    // ... and (b) a read-only-mode playback must not flip the store dirty.
+    expect(useMetadataStore.getState().dirty).toBe(false);
+  });
+
   // #663 — Phase 4 / #694 — *ErrorState form: when applyErrorState is set in the
   // store, render message + companion hint as 2nd line so the user sees the
   // recommended next step. Hint stays inside the existing role="alert"
@@ -657,6 +687,10 @@ describe('PreviewScreen', () => {
   // #465 review 追加: 再生中の TC 表示は video.currentTime に追従する。
 
   it('TC display follows video.currentTime during playback (timeupdate event)', async () => {
+    // #834 (codex): TC が再生に追従するのは editable mode の挙動。commitStart/
+    // commitEnd は sample mode で no-op 化されたため、filePath を与えて編集可能
+    // mode に切り替える (sample mode の read-only 化は別 test で検証)。
+    useMetadataStore.setState({ filePath: '/x' });
     render(<PreviewScreen />);
     const video = (await screen.findByLabelText(
       'IN (start) video',

--- a/gui/src/screens/PreviewScreen.test.tsx
+++ b/gui/src/screens/PreviewScreen.test.tsx
@@ -51,6 +51,21 @@ describe('PreviewScreen', () => {
     expect(screen.getByText(/#004 · of 9/)).toBeInTheDocument();
   });
 
+  // #834 -- sample mode は read-only。nudge ボタンは disabled 済だが keyboard が
+  // 貫通して境界を編集できていた。arrow nudge を sample mode で無効化する。
+  it('does not nudge boundaries via keyboard in sample mode (#834)', () => {
+    useMetadataStore.getState().loadSample();
+    const sampleIdx = useMetadataStore.getState().metadata!.matches[0].index;
+    useAppStateStore.getState().selectMatch(sampleIdx);
+    render(<PreviewScreen />);
+    const inTc = screen.getByLabelText('IN (start) timecode') as HTMLInputElement;
+    const before = inTc.value;
+    fireEvent.keyDown(window, { key: 'ArrowRight', shiftKey: true }); // +10s
+    expect(
+      (screen.getByLabelText('IN (start) timecode') as HTMLInputElement).value,
+    ).toBe(before);
+  });
+
   // #663 — Phase 4 / #694 — *ErrorState form: when applyErrorState is set in the
   // store, render message + companion hint as 2nd line so the user sees the
   // recommended next step. Hint stays inside the existing role="alert"
@@ -516,6 +531,9 @@ describe('PreviewScreen', () => {
   });
 
   it('ArrowRight key nudges the active timestamp forward by 1s', async () => {
+    // #834: keyboard nudge is now blocked in sample mode (read-only). Exit
+    // sample mode so the nudge mechanics under test stay exercisable.
+    useMetadataStore.setState({ filePath: '/x' });
     render(<PreviewScreen />);
     const before = (
       screen.getByLabelText('IN (start) timecode') as HTMLInputElement
@@ -528,6 +546,9 @@ describe('PreviewScreen', () => {
   });
 
   it('Shift+ArrowLeft nudges the active timestamp (10s step) — different value from plain ArrowLeft', async () => {
+    // #834: keyboard nudge is now blocked in sample mode (read-only). Exit
+    // sample mode so the nudge mechanics under test stay exercisable.
+    useMetadataStore.setState({ filePath: '/x' });
     render(<PreviewScreen />);
     const before = (
       screen.getByLabelText('IN (start) timecode') as HTMLInputElement
@@ -684,9 +705,12 @@ describe('PreviewScreen', () => {
   // なることを確認する。
 
   it('Alt+ArrowRight steps 1/120 sec when source_fps is 120', async () => {
-    // metadata.source_fps を 120 に上書き (state を直接書き換え)
+    // metadata.source_fps を 120 に上書き (state を直接書き換え)。
+    // #834: keyboard nudge は sample mode で無効化されたため filePath を与えて
+    // 編集可能 mode に切り替え、frame-step の挙動を検証可能にする。
     const sample = useMetadataStore.getState().metadata!;
     useMetadataStore.setState({
+      filePath: '/x',
       metadata: { ...sample, source_fps: 120 },
     });
     render(<PreviewScreen />);
@@ -704,8 +728,11 @@ describe('PreviewScreen', () => {
   });
 
   it('Alt+ArrowRight steps 1/240 sec when source_fps is 240', async () => {
+    // #834: keyboard nudge は sample mode で無効化されたため filePath を与えて
+    // 編集可能 mode に切り替える (上の 120fps test と同じ理由)。
     const sample = useMetadataStore.getState().metadata!;
     useMetadataStore.setState({
+      filePath: '/x',
       metadata: { ...sample, source_fps: 240 },
     });
     render(<PreviewScreen />);

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -492,12 +492,21 @@ export function PreviewScreen() {
   // produce a zero-length clip and disable [適用]; iterate-review Round 1 F3).
   // The strict end > start guard at apply time (store + Rust) is the backstop.
   const commitStart = useCallback(
-    (next: number) => setStartT(Math.max(0, Math.min(next, endT - 1 / fps))),
-    [endT, fps],
+    (next: number) => {
+      // #834 (codex) -- sample mode is read-only. Gate the single boundary-
+      // mutation choke point so every path (keyboard nudge / frame step /
+      // FrameStrip / TC input / playback timeupdate) is read-only at once.
+      if (isSample) return;
+      setStartT(Math.max(0, Math.min(next, endT - 1 / fps)));
+    },
+    [endT, fps, isSample],
   );
   const commitEnd = useCallback(
-    (next: number) => setEndT(Math.max(next, startT + 1 / fps)),
-    [startT, fps],
+    (next: number) => {
+      if (isSample) return;
+      setEndT(Math.max(next, startT + 1 / fps));
+    },
+    [startT, fps, isSample],
   );
   const commitCurrentT = useCallback(
     (next: number) => (editing === 'start' ? commitStart(next) : commitEnd(next)),

--- a/gui/src/screens/PreviewScreen.tsx
+++ b/gui/src/screens/PreviewScreen.tsx
@@ -531,6 +531,9 @@ export function PreviewScreen() {
       if (target && interactiveTags.has(target.tagName)) return;
 
       if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        // #834 -- sample mode は read-only。nudge ボタンと挙動を揃え、keyboard
+        // からの境界編集を抑止する (playback (space) は read-only に反しないため許可)。
+        if (isSample) return;
         const sign = e.key === 'ArrowLeft' ? -1 : 1;
         if (e.altKey) {
           nudgeFrame(sign);
@@ -552,7 +555,7 @@ export function PreviewScreen() {
     }
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [nudge, nudgeFrame, activeVideoRef]);
+  }, [nudge, nudgeFrame, activeVideoRef, isSample]);
 
   const matchLabel = useMemo(
     () => (match ? `match_${String(match.index).padStart(3, '0')}` : ''),

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -179,6 +179,26 @@ describe('useMetadataStore.load', () => {
     expect(useMetadataStore.getState().metadata).toBeNull();
     expect(useMetadataStore.getState().loadErrorState).toBeTruthy();
   });
+
+  // #834 -- mtime は内容 read より前に取得する (TOCTOU を silent overwrite では
+  // なく conflict 検出側に倒す)。
+  it('captures mtime before reading metadata content (#834)', async () => {
+    const order: string[] = [];
+    invokeMock.mockImplementation((cmd: string) => {
+      order.push(cmd);
+      if (cmd === 'get_metadata_mtime') return Promise.resolve(1700);
+      if (cmd === 'load_metadata') return Promise.resolve(validMetadata());
+      if (cmd === 'check_backup_exists') return Promise.resolve(false);
+      if (cmd === 'load_draft') return Promise.resolve(null);
+      return Promise.resolve(null);
+    });
+    await useMetadataStore.getState().load('p');
+    const mIdx = order.indexOf('get_metadata_mtime');
+    const lIdx = order.indexOf('load_metadata');
+    expect(mIdx).toBeGreaterThanOrEqual(0);
+    expect(lIdx).toBeGreaterThanOrEqual(0);
+    expect(mIdx).toBeLessThan(lIdx);
+  });
 });
 
 describe('useMetadataStore.updateMatch', () => {

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -382,7 +382,7 @@ describe('useMetadataStore.apply', () => {
 
     const applyCall = invokeMock.mock.calls.find((c) => c[0] === 'apply_changes');
     const persisted = (applyCall![1] as { metadata: Metadata }).metadata
-      .matches[0] as Record<string, unknown>;
+      .matches[0];
     expect(persisted.name).toBeUndefined();
     expect(persisted.type_override).toBeUndefined();
   });

--- a/gui/src/state/metadataStore.test.ts
+++ b/gui/src/state/metadataStore.test.ts
@@ -338,6 +338,34 @@ describe('useMetadataStore.apply', () => {
       '01:05',
     );
   });
+
+  // #834 (P2-18) -- name/type_override は apply 後も in-memory に残る (UI 表示維持)。
+  // 一方 metadata.json (apply_changes payload) には書き戻さない (契約維持)。
+  it('retains name and type_override in-memory after apply but strips them from disk (#834)', async () => {
+    configureInvoke({
+      load_metadata: validMetadata(),
+      apply_changes: 2000,
+      check_backup_exists: false,
+    });
+    await useMetadataStore.getState().load('p');
+    useMetadataStore.getState().updateMatch(1, {
+      name: 'highlight reel',
+      type_override: 'skip',
+    });
+    await useMetadataStore.getState().apply();
+
+    const m = useMetadataStore
+      .getState()
+      .metadata!.matches.find((x) => x.index === 1)!;
+    expect(m.name).toBe('highlight reel');
+    expect(m.type_override).toBe('skip');
+
+    const applyCall = invokeMock.mock.calls.find((c) => c[0] === 'apply_changes');
+    const persisted = (applyCall![1] as { metadata: Metadata }).metadata
+      .matches[0] as Record<string, unknown>;
+    expect(persisted.name).toBeUndefined();
+    expect(persisted.type_override).toBeUndefined();
+  });
 });
 
 describe('useMetadataStore.clear', () => {

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -219,8 +219,25 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
         metadata: normalized,
         expectedMtimeMs: overwrite ? null : loadedMtimeMs,
       });
+      // #834 (P2-18) -- disk へ書く normalized は GUI-local field を strip 済
+      // (metadata-spec §GUI 編集契約)。in-memory には name/type_override を復元し
+      // apply 後も UI 表示が消えないようにする (disk と in-memory を分離)。
+      const editedById = new Map(metadata.matches.map((m) => [m.index, m]));
+      const retained: Metadata = {
+        ...normalized,
+        matches: normalized.matches.map((m) => {
+          const orig = editedById.get(m.index);
+          return {
+            ...m,
+            ...(orig?.name !== undefined ? { name: orig.name } : {}),
+            ...(orig?.type_override !== undefined
+              ? { type_override: orig.type_override }
+              : {}),
+          };
+        }),
+      };
       set({
-        metadata: normalized,
+        metadata: retained,
         dirty: false,
         applying: false,
         applyErrorState: null,

--- a/gui/src/state/metadataStore.ts
+++ b/gui/src/state/metadataStore.ts
@@ -283,12 +283,15 @@ export const useMetadataStore = create<MetadataState>((set, get) => {
 
   load: async (path) => {
     try {
+      // #834 -- capture mtime BEFORE reading contents so the recorded mtime is
+      // never newer than the parsed bytes. If the file is modified between the
+      // two calls, the stored mtime stays <= the content's, so a later apply
+      // detects the conflict (conservative) instead of silently overwriting.
+      // A missing mtime (file vanished between the two calls) is recorded as
+      // null; apply will then skip the check (#514).
+      const mtime = await invoke<number | null>('get_metadata_mtime', { path });
       const raw = await invoke<unknown>('load_metadata', { path });
       const parsed = MetadataSchema.parse(raw);
-      // #514: record mtime alongside contents so subsequent apply can detect
-      // external modifications. A missing mtime (file vanished between the
-      // two calls) is recorded as null; apply will then skip the check.
-      const mtime = await invoke<number | null>('get_metadata_mtime', { path });
       set({
         metadata: parsed as unknown as Metadata,
         filePath: path,


### PR DESCRIPTION
## 概要

audit remediation Wave 2 W3 ([#834](https://github.com/Idios/kobutachan-allaganeye/issues/834))。GUI metadata 編集・load・thumbnail 周りの確実 bug 3 件 (P2-18/19/21) + 低リスク GUI P3 (mtime 順序 / sample mode read-only / 拡張子 hint / 未使用依存・dead code 整理) を消化。

- spec: [docs/superpowers/specs/2026-06-10-audit-remediation-design.md](docs/superpowers/specs/2026-06-10-audit-remediation-design.md) §W3
- plan: [docs/superpowers/plans/2026-06-18-audit-w2-w3.md](docs/superpowers/plans/2026-06-18-audit-w2-w3.md)
- スコープ外 (Idios 2026-06-18 確認、Wave 3 P3 batch / 別 issue): register_video 累積 / capabilities 過剰権限 / clear_recent UI

## 受け入れ条件 (issue #834) 逐条

各 AC を「修正前 red / 修正後 green」を unit で実証。

- [x] **P2-18 name/type_override の apply 後 in-memory 保持 (disk strip 維持)** — runApply で disk payload (`normalized`, strip 済 = 契約) と in-memory (`retained`, index 突合で name/type_override 復元) を分離 ([metadataStore.ts](gui/src/state/metadataStore.ts), b400881)。test `retains name and type_override in-memory after apply but strips them from disk`: in-memory `m.name`/`type_override` 保持 + apply_changes payload の `persisted.name`/`type_override` undefined。metadata.json への書き戻しは [metadata-spec.md](docs/metadata-spec.md) §GUI 編集契約 / schema `additionalProperties:false` どおり strip 維持
- [x] **P2-19 BOM 付き metadata.json が load 可 (draft/restore/recent も)** — `strip_bom(&str)` 共有ヘルパ + ディスク読込 4 fn (load_metadata / load_draft / restore_from_original / read_recent) 経由化 ([lib.rs](gui/src-tauri/src/lib.rs), 6a2f8b0)。test `strip_bom_removes_leading_bom_only` + `load_metadata_accepts_utf8_bom`
- [x] **P2-21 thumbnail 並列上限が画面全体で 1 Semaphore** — `THUMBNAIL_SEMAPHORE: OnceLock<Semaphore>` static + getter、generate_match_thumbnails を static 経由に ([lib.rs](gui/src-tauri/src/lib.rs), 3c676fb)。test `thumbnail_semaphore_caps_concurrency_at_4_globally` (singleton + 5 本目 `try_acquire().is_err()` = cap 発火)
- [x] **mtime 順序 (read 前取得)** — load() で `get_metadata_mtime` を `load_metadata` より前に ([metadataStore.ts](gui/src/state/metadataStore.ts), 578c1fd)。test `captures mtime before reading metadata content` (invoke 呼び出し順)。TOCTOU を silent overwrite ではなく conflict 検出側へ
- [x] **sample mode read-only (keyboard + playback)** — keyboard arrow guard (e4b4466) に加え、codex 指摘で判明した playback timeupdate 経路も含め、全境界変更が通る単一 choke point の `commitStart`/`commitEnd` を `isSample` で no-op 化 ([PreviewScreen.tsx](gui/src/screens/PreviewScreen.tsx), 9339f63)。test `does not nudge boundaries via keyboard in sample mode` + `does not mutate boundaries via playback timeupdate in sample mode` (境界不変 + store dirty false)
- [x] **拡張子 hint を SSoT (config.py) に整合** — error.rs `validation.path_invalid` hint を mp4/mkv/avi/mov に修正 + [docs/tauri-commands.md](docs/tauri-commands.md) 同期 ([error.rs](gui/src-tauri/src/error.rs), e290e1d)。test `path_invalid_hint_lists_supported_extensions`。drift check 25 in sync
- [x] **dead code / 不要依存整理** — Cargo 未使用 5 件 (tokio-util / hyper / urlencoding / percent-encoding / dirs) 除去 (cargo check/test/build green、Cargo.lock pure subtraction、除去不可なし) / `@tauri-apps/api` を dependencies へ / `cancelRequestedRef` + orphan `useRef` import 除去 ([Cargo.toml](gui/src-tauri/Cargo.toml) / [package.json](gui/package.json) / [ExportScreen.tsx](gui/src/screens/ExportScreen.tsx), 79fda46)

## Self-Test Report

machine-verified:

- [x] `cd gui && npm run lint` — clean
- [x] `cd gui && npm run typecheck` — clean
- [x] `cd gui && npm test` — 749 passed
- [x] `cd gui && npm run build` — built OK
- [x] `cd gui/src-tauri && cargo check` — 0 error
- [x] `cd gui/src-tauri && cargo test` — 193 passed (lib) + 2 (integration, 1 video-gated ignored)
- [x] `bash .github/scripts/check-error-hint-drift.sh` — 25 entries in sync
- [x] `bash scripts/check-markdownlint.sh` — 変更 md (tauri-commands / plan) 0 違反

machine-unverifiable (Idios 実機検証 依頼、回答まで merge 不可):

- (a) P2-18: 実動画 detect → preview で試合名編集 + type=skip → [適用] → name/skip が画面に残る + 出力 metadata.json には書かれない
- (b) P2-19: BOM 付き (UTF-8 with BOM) metadata.json を GUI で再 load → 読める
- (c) P2-21: 多数試合 (N≥8) complete でサムネ生成中の ffmpeg 同時数が ~4 で頭打ち / UI が固まりにくい
- (d) sample mode read-only: sample preview で矢印キー / 再生 (Space) が境界を動かさない

## Codex adversarial-review (Iron Law 6 Step 5)

- Round 1: `needs-attention / No-ship` — [medium] sample mode の read-only が playback `onTimeUpdate` 経路で貫通 (keyboard だけ guard していた)。
- 対応: input path ごとの guard ではなく、全境界変更が通る単一 choke point (`commitStart`/`commitEnd`) を `isSample` で gate する architectural fix (9339f63) + playback timeupdate の regression test。
- Round 2 (再 review): `approve` — "The sample-mode bypass is closed at the shared boundary mutation choke point ... No material findings."

## レビュー / TDD

全 task fresh subagent 実装 + spec/quality 2 段独立レビュー (`superpowers:subagent-driven-development`)。各 protective mechanism (Semaphore cap / BOM / sample read-only) は「発火する側」を red 実証 (memory `feedback_protective_mechanism_red_verification`)。codex 指摘は whack-a-mole を避け choke point で根治 (memory `feedback_adversarial_review_whackamole`)。

作成: audit-w2-w3-20260618


<!-- iterate-review:deferred:start -->
## Deferred Findings (managed by /iterate-review)

- [B] Round 1: gui npm 依存の既知脆弱性 (vite HIGH 他、dev/build tooling、pre-existing・非必須 check) → deferred-to: #836 (新規)

<!-- iterate-review:deferred:end -->
