### PR TITLE
fix(cli): W1 export/CLI 整合 (P2-7/8/9/10/11/20/40 + P3) (Refs #840)

### DIFF
--- a/allaganeye/commands/debug_brightness.py
+++ b/allaganeye/commands/debug_brightness.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import typer
 
-from allaganeye.exceptions import VideoProcessingError
+from allaganeye.exceptions import ConfigValidationError, VideoProcessingError
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
     _SCOREBAR_ROI_X_END,
@@ -33,6 +33,8 @@ def run_debug_brightness(
     roi_mode: str | None = None,
 ) -> None:
     """Probe brightness at regular intervals and print CSV to stdout."""
+    if interval <= 0:
+        raise ConfigValidationError(f"--interval must be positive, got {interval}")
     metadata = probe_video(video_path)
     duration: float = metadata["duration"]
 

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -125,6 +125,10 @@ def register(app: typer.Typer) -> None:
             raise typer.BadParameter(f"--codec must be 'copy' or 'h264', got {codec!r}")
         if json_mode and quiet:
             raise typer.BadParameter("--json and --quiet are mutually exclusive")
+        if concurrency is not None and concurrency <= 0:
+            raise typer.BadParameter(
+                f"--concurrency must be >= 1, got {concurrency}"
+            )
 
         try:
             metadata = _load_metadata(metadata_path, stdin)
@@ -185,7 +189,7 @@ def register(app: typer.Typer) -> None:
             # parallel ffmpeg -c copy of the same source would just thrash
             # disk I/O without throughput gain. Truncate to 1 slot.
             slots = slots[:1]
-        elif concurrency is not None and concurrency > 0:
+        elif concurrency is not None:
             slots = slots[:concurrency]
 
         # Cancel: SIGINT (Ctrl+C) -> cancel_event set -> workers stop

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -145,13 +145,17 @@ def register(app: typer.Typer) -> None:
         exclude_set = _parse_indexes_csv(exclude) or set()
         all_matches = metadata.get("matches") or []
         filtered: list[ExportMatch] = []
+        skipped_count = 0  # P2-9: count filtered-out matches for the summary
         for raw in all_matches:
             idx = int(raw["index"])
             if include_set is not None and idx not in include_set:
+                skipped_count += 1
                 continue
             if idx in exclude_set:
+                skipped_count += 1
                 continue
             if raw.get("type_override") == "skip":
+                skipped_count += 1
                 continue
             edited = raw.get("edited") or {}
             edited_start = edited.get("start_time")
@@ -240,6 +244,8 @@ def register(app: typer.Typer) -> None:
                 progress_cb=progress_cb,
                 cancel_event=cancel_event,
             )
+            # P2-9: reflect filtered-out matches in the summary (was always 0).
+            summary.skipped = skipped_count
         finally:
             signal.signal(signal.SIGINT, original_handler)
 

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -22,7 +22,7 @@ import typer
 
 from allaganeye.exceptions import AllaganEyeError
 from allaganeye.export.encoder import enumerate_h264_encoders
-from allaganeye.export.pool import ExportMatch, export_matches
+from allaganeye.export.pool import ExportMatch, _format_filename, export_matches
 from allaganeye.export.schema import ExportSummary, ProgressEvent
 from allaganeye.export.wire import WireWriter
 
@@ -179,6 +179,21 @@ def register(app: typer.Typer) -> None:
                     ),
                     type_label=str(raw.get("type", "match")),
                 )
+            )
+
+        # P3 I-3: detect output-name collisions (e.g. a pattern without {idx} maps
+        # every match to the same file, silently overwriting). Warn, don't fail.
+        seen_names: dict[str, int] = {}
+        for m in filtered:
+            name = _format_filename(m, name_pattern)
+            seen_names[name] = seen_names.get(name, 0) + 1
+        collisions = [n for n, c in seen_names.items() if c > 1]
+        if collisions:
+            typer.echo(
+                f"warning: name pattern produces {len(collisions)} duplicate "
+                f"filename(s) (e.g. {collisions[0]!r}); add {{idx}} or {{idx:03}} "
+                f"to avoid overwriting",
+                err=True,
             )
 
         slots = enumerate_h264_encoders(

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -20,9 +20,10 @@ from typing import Annotated
 
 import typer
 
+from allaganeye.exceptions import AllaganEyeError
 from allaganeye.export.encoder import enumerate_h264_encoders
 from allaganeye.export.pool import ExportMatch, export_matches
-from allaganeye.export.schema import ProgressEvent
+from allaganeye.export.schema import ExportSummary, ProgressEvent
 from allaganeye.export.wire import WireWriter
 
 
@@ -193,6 +194,13 @@ def register(app: typer.Typer) -> None:
         def _sigint_handler(signum: int, frame: object) -> None:
             cancel_event.set()
 
+        # P2-7: import the shared error reporters lazily. cli.py registers this
+        # command from its module bottom (`_export_cmd.register(app)`), so a
+        # top-level `from allaganeye.cli import ...` would be circular; a local
+        # import matches how split/detect pull in their command impls.
+        from allaganeye.cli import _report_app_error, _report_unexpected_error
+
+        summary: ExportSummary
         original_handler = signal.getsignal(signal.SIGINT)
         signal.signal(signal.SIGINT, _sigint_handler)
         try:
@@ -254,6 +262,16 @@ def register(app: typer.Typer) -> None:
             )
             # P2-9: reflect filtered-out matches in the summary (was always 0).
             summary.skipped = skipped_count
+        except AllaganEyeError as e:
+            # P2-7: do NOT emit a summary here -- start_export treats any summary
+            # line as success (lib.rs) and would mask the error in the GUI. A
+            # clean stderr + mapped non-zero exit is the correct wire signal for
+            # a hard error.
+            _report_app_error(e, verbose=False, quiet=quiet, show_hint=False)
+            raise typer.Exit(code=e.exit_code) from None
+        except Exception:
+            _report_unexpected_error(verbose=False, quiet=quiet, show_hint=False)
+            raise typer.Exit(code=1) from None
         finally:
             signal.signal(signal.SIGINT, original_handler)
 

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -226,6 +226,10 @@ def register(app: typer.Typer) -> None:
                             err=True,
                         )
 
+            # P2-10: create the output dir up front (mirrors split/detect).
+            # Without this every match's ffmpeg fails to write and the run
+            # exits 1. The mkdir OSError rides the P2-7 error frame below.
+            output_dir.mkdir(parents=True, exist_ok=True)
             summary = export_matches(
                 matches=filtered,
                 slots=slots,

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -20,7 +20,7 @@ from typing import Annotated
 
 import typer
 
-from allaganeye.exceptions import AllaganEyeError
+from allaganeye.exceptions import AllaganEyeError, ConfigValidationError
 from allaganeye.export.encoder import enumerate_h264_encoders
 from allaganeye.export.pool import ExportMatch, _format_filename, export_matches
 from allaganeye.export.schema import ExportSummary, ProgressEvent
@@ -198,21 +198,6 @@ def register(app: typer.Typer) -> None:
                         err=True,
                     )
 
-        # P3 I-3: detect output-name collisions (e.g. a pattern without {idx} maps
-        # every match to the same file, silently overwriting). Warn, don't fail.
-        seen_names: dict[str, int] = {}
-        for m in filtered:
-            name = _format_filename(m, name_pattern)
-            seen_names[name] = seen_names.get(name, 0) + 1
-        collisions = [n for n, c in seen_names.items() if c > 1]
-        if collisions:
-            typer.echo(
-                f"warning: name pattern produces {len(collisions)} duplicate "
-                f"filename(s) (e.g. {collisions[0]!r}); add {{idx}} or {{idx:03}} "
-                f"to avoid overwriting",
-                err=True,
-            )
-
         slots = enumerate_h264_encoders(
             vendors=vendors, preference=preference, gpu_models=gpu_models
         )
@@ -281,6 +266,22 @@ def register(app: typer.Typer) -> None:
                             f"{ev.payload['fallback_from']} -> {ev.payload['fallback_to']}",
                             err=True,
                         )
+
+            # Finding 3 (was P3 I-3 warning): a name pattern without {idx}/{idx:03}
+            # maps every match to the same output file -- overwrite, parallel-write
+            # race, and a misleading "success" summary. Fail hard BEFORE any ffmpeg
+            # work (inside the P2-7 frame -> exit 5, clean stderr, no summary line).
+            seen_names: dict[str, int] = {}
+            for m in filtered:
+                name = _format_filename(m, name_pattern)
+                seen_names[name] = seen_names.get(name, 0) + 1
+            collisions = [n for n, c in seen_names.items() if c > 1]
+            if collisions:
+                raise ConfigValidationError(
+                    "name pattern produces duplicate output filenames "
+                    f"(e.g. {collisions[0]!r}); add {{idx}} or {{idx:03}} to the "
+                    "--name-pattern"
+                )
 
             # P2-10: create the output dir up front (mirrors split/detect).
             # Without this every match's ffmpeg fails to write and the run

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -132,9 +132,7 @@ def register(app: typer.Typer) -> None:
         if json_mode and quiet:
             raise typer.BadParameter("--json and --quiet are mutually exclusive")
         if concurrency is not None and concurrency <= 0:
-            raise typer.BadParameter(
-                f"--concurrency must be >= 1, got {concurrency}"
-            )
+            raise typer.BadParameter(f"--concurrency must be >= 1, got {concurrency}")
 
         try:
             metadata = _load_metadata(metadata_path, stdin)

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -136,67 +136,92 @@ def register(app: typer.Typer) -> None:
 
         try:
             metadata = _load_metadata(metadata_path, stdin)
-        except (OSError, json.JSONDecodeError) as e:
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+            # Round 1 FIX 1 (a): a --stdin payload of invalid bytes makes
+            # sys.stdin.buffer.read().decode("utf-8") raise UnicodeDecodeError
+            # (a ValueError subclass, NOT OSError/JSONDecodeError). Map it here
+            # so the GUI --json --stdin path gets exit 2 + clean stderr instead
+            # of a raw traceback / exit 1.
             typer.echo(f"error: cannot read metadata: {e}", err=True)
             raise typer.Exit(code=2) from e
 
-        source_value = metadata.get("source")
-        if not source_value:
-            typer.echo("error: metadata.json missing required 'source' field", err=True)
-            raise typer.Exit(code=2)
-        source_video = Path(source_value)
-        sys_info = metadata.get("system_info") or {}
-        vendors = list(sys_info.get("gpu_vendors_available") or [])
-        preference = list(
-            sys_info.get("vendor_preference") or ["nvidia", "amd", "intel"]
-        )
-        gpu_models = list(sys_info.get("gpu") or [])
-
-        # Filter matches per include/exclude
-        include_set = _parse_indexes_csv(include)
-        exclude_set = _parse_indexes_csv(exclude) or set()
-        all_matches = metadata.get("matches") or []
-        filtered: list[ExportMatch] = []
-        skipped_count = 0  # P2-9: count filtered-out matches for the summary
-        for raw in all_matches:
-            idx = int(raw["index"])
-            if include_set is not None and idx not in include_set:
-                skipped_count += 1
-                continue
-            if idx in exclude_set:
-                skipped_count += 1
-                continue
-            if raw.get("type_override") == "skip":
-                skipped_count += 1
-                continue
-            edited = raw.get("edited") or {}
-            edited_start = edited.get("start_time")
-            edited_end = edited.get("end_time")
-            filtered.append(
-                ExportMatch(
-                    index=idx,
-                    start=float(
-                        edited_start if edited_start is not None else raw["start_time"]
-                    ),
-                    end=float(
-                        edited_end if edited_end is not None else raw["end_time"]
-                    ),
-                    type_label=str(raw.get("type", "match")),
+        # Round 1 FIX 1 (b): the metadata-content parsing below (source field,
+        # the include/exclude filter loop's int(raw["index"]) / float(...), and
+        # the I-4 valid_indexes set comprehension) runs BEFORE the P2-7 frame and
+        # can raise KeyError/ValueError/TypeError on malformed metadata. Wrap it
+        # so a bad payload on the GUI --json --stdin path maps to exit 2 + clean
+        # stderr instead of a raw traceback / exit 1. The existing
+        # typer.Exit(code=2) (missing-source) and _parse_indexes_csv's
+        # typer.BadParameter are NOT KeyError/ValueError/TypeError, so they keep
+        # propagating with their own exit codes (2 / click usage).
+        try:
+            source_value = metadata.get("source")
+            if not source_value:
+                typer.echo(
+                    "error: metadata.json missing required 'source' field", err=True
                 )
+                raise typer.Exit(code=2)
+            source_video = Path(source_value)
+            sys_info = metadata.get("system_info") or {}
+            vendors = list(sys_info.get("gpu_vendors_available") or [])
+            preference = list(
+                sys_info.get("vendor_preference") or ["nvidia", "amd", "intel"]
             )
+            gpu_models = list(sys_info.get("gpu") or [])
 
-        # P3 I-4: warn for include/exclude indexes that match no actual match
-        # (1-based). Helps catch off-by-one mistakes early.
-        valid_indexes = {int(r["index"]) for r in all_matches}
-        for label, given in (("--include", include_set), ("--exclude", exclude_set)):
-            if given:
-                missing = sorted(given - valid_indexes)
-                if missing:
-                    typer.echo(
-                        f"warning: {label} index(es) not found in matches: "
-                        f"{', '.join(map(str, missing))}",
-                        err=True,
+            # Filter matches per include/exclude
+            include_set = _parse_indexes_csv(include)
+            exclude_set = _parse_indexes_csv(exclude) or set()
+            all_matches = metadata.get("matches") or []
+            filtered: list[ExportMatch] = []
+            skipped_count = 0  # P2-9: count filtered-out matches for the summary
+            for raw in all_matches:
+                idx = int(raw["index"])
+                if include_set is not None and idx not in include_set:
+                    skipped_count += 1
+                    continue
+                if idx in exclude_set:
+                    skipped_count += 1
+                    continue
+                if raw.get("type_override") == "skip":
+                    skipped_count += 1
+                    continue
+                edited = raw.get("edited") or {}
+                edited_start = edited.get("start_time")
+                edited_end = edited.get("end_time")
+                filtered.append(
+                    ExportMatch(
+                        index=idx,
+                        start=float(
+                            edited_start
+                            if edited_start is not None
+                            else raw["start_time"]
+                        ),
+                        end=float(
+                            edited_end if edited_end is not None else raw["end_time"]
+                        ),
+                        type_label=str(raw.get("type", "match")),
                     )
+                )
+
+            # P3 I-4: warn for include/exclude indexes that match no actual match
+            # (1-based). Helps catch off-by-one mistakes early.
+            valid_indexes = {int(r["index"]) for r in all_matches}
+            for label, given in (
+                ("--include", include_set),
+                ("--exclude", exclude_set),
+            ):
+                if given:
+                    missing = sorted(given - valid_indexes)
+                    if missing:
+                        typer.echo(
+                            f"warning: {label} index(es) not found in matches: "
+                            f"{', '.join(map(str, missing))}",
+                            err=True,
+                        )
+        except (KeyError, ValueError, TypeError) as e:
+            typer.echo(f"error: invalid metadata content: {e}", err=True)
+            raise typer.Exit(code=2) from e
 
         slots = enumerate_h264_encoders(
             vendors=vendors, preference=preference, gpu_models=gpu_models
@@ -224,6 +249,13 @@ def register(app: typer.Typer) -> None:
         summary: ExportSummary
         original_handler = signal.getsignal(signal.SIGINT)
         signal.signal(signal.SIGINT, _sigint_handler)
+        # Round 1 FIX 4 (regression guard): the `except Exception` below catches
+        # ANY Exception subclass -- which includes typer.Exit (RuntimeError) and
+        # typer.BadParameter (ClickException). NEVER raise either inside this
+        # try: `except Exception` would swallow it and downgrade the intended
+        # exit code to 1. That is why the cancelled (130) and failure (1)
+        # typer.Exit raises, plus all preflight typer.Exit/typer.BadParameter,
+        # live OUTSIDE (before/after) this frame -- keep them there.
         try:
             # Progress callback wiring -- construct WireWriter once for json_mode.
             # writer is always assigned when json_mode=True (initialized to None otherwise
@@ -316,6 +348,9 @@ def register(app: typer.Typer) -> None:
         if json_mode and writer is not None:
             writer.emit(ProgressEvent.summary(summary))
 
+        # Round 1 FIX 4: these typer.Exit raises are intentionally OUTSIDE the
+        # P2-7 try -- raising them inside would be swallowed by `except Exception`
+        # and downgraded to exit 1 (130/1 would be lost).
         if summary.cancelled:
             raise typer.Exit(code=130)
         if summary.failure > 0:

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -45,7 +45,10 @@ def _load_metadata(metadata_path: Path | None, use_stdin: bool) -> dict:
     if use_stdin:
         if metadata_path is not None:
             raise typer.BadParameter("--stdin is mutually exclusive with metadata_path")
-        return json.load(sys.stdin)
+        # P2-8: read stdin as bytes and decode UTF-8 explicitly so a cp932
+        # default stdin encoding (Windows) can't corrupt non-ASCII paths.
+        raw = sys.stdin.buffer.read()
+        return json.loads(raw.decode("utf-8"))
     if metadata_path is None:
         raise typer.BadParameter("metadata_path is required unless --stdin is set")
     return json.loads(metadata_path.read_text(encoding="utf-8"))
@@ -198,6 +201,11 @@ def register(app: typer.Typer) -> None:
             # to satisfy the type checker; the second use is guarded by the same condition).
             writer: WireWriter | None = None
             if json_mode:
+                # P2-8: harden the wire's stdout encoding so non-ASCII output_path
+                # / error_message survive a cp932 console without relying on the
+                # Rust caller's PYTHONIOENCODING injection.
+                if hasattr(sys.stdout, "reconfigure"):
+                    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
                 writer = WireWriter(stream=sys.stdout)
 
                 def progress_cb(ev: ProgressEvent) -> None:

--- a/allaganeye/commands/export.py
+++ b/allaganeye/commands/export.py
@@ -112,12 +112,18 @@ def register(app: typer.Typer) -> None:
             str | None,
             typer.Option(
                 "--include",
-                help="Comma-separated match indexes to include (others skipped).",
+                help=(
+                    "Comma-separated 1-based match indexes to include"
+                    " (matches metadata 'index'; others skipped)."
+                ),
             ),
         ] = None,
         exclude: Annotated[
             str | None,
-            typer.Option("--exclude", help="Comma-separated match indexes to skip."),
+            typer.Option(
+                "--exclude",
+                help="Comma-separated 1-based match indexes to skip.",
+            ),
         ] = None,
     ) -> None:
         """Parallel H.264 / copy export from metadata.json."""
@@ -180,6 +186,19 @@ def register(app: typer.Typer) -> None:
                     type_label=str(raw.get("type", "match")),
                 )
             )
+
+        # P3 I-4: warn for include/exclude indexes that match no actual match
+        # (1-based). Helps catch off-by-one mistakes early.
+        valid_indexes = {int(r["index"]) for r in all_matches}
+        for label, given in (("--include", include_set), ("--exclude", exclude_set)):
+            if given:
+                missing = sorted(given - valid_indexes)
+                if missing:
+                    typer.echo(
+                        f"warning: {label} index(es) not found in matches: "
+                        f"{', '.join(map(str, missing))}",
+                        err=True,
+                    )
 
         # P3 I-3: detect output-name collisions (e.g. a pattern without {idx} maps
         # every match to the same file, silently overwriting). Warn, don't fail.

--- a/allaganeye/export/ffmpeg_runner.py
+++ b/allaganeye/export/ffmpeg_runner.py
@@ -119,10 +119,20 @@ def _run_single_attempt(
     assert proc.stderr is not None
     stderr = proc.stderr  # bind narrowed (non-None) handle for the reader closure
     line_q: _queue.Queue[bytes | None] = _queue.Queue()
+    # P2-40 follow-up (OOM fix): bound the reader thread to this attempt. Without
+    # a stop signal, a child whose stderr never reaches EOF -- a stalled producer,
+    # or a test double whose readline never returns b"" -- would make the daemon
+    # pump spin forever filling the unbounded queue and exhaust memory (the same
+    # bounded-drain concern as start_detect / #838). The flag is set in the
+    # ``finally`` below so the pump exits once the attempt is over.
+    stop_reading = threading.Event()
 
     def _pump() -> None:
         try:
-            for line in iter(stderr.readline, b""):
+            while not stop_reading.is_set():
+                line = stderr.readline()
+                if not line:  # EOF
+                    break
                 line_q.put(line)
         finally:
             line_q.put(None)  # EOF sentinel
@@ -132,35 +142,40 @@ def _run_single_attempt(
 
     stderr_tail_bytes: list[bytes] = []
     max_tail = 2048
-    while True:
-        if cancel_event.is_set():
-            proc.kill()
-            break
-        try:
-            line = line_q.get(timeout=0.1)  # bounded: re-check cancel every 100ms
-        except _queue.Empty:
-            continue
-        if line is None:  # EOF
-            break
-        line_str = line.decode("utf-8", errors="replace").rstrip("\n")
-        # Parse progress (ffmpeg -progress pipe:2 format)
-        if line_str.startswith("out_time_ms="):
-            raw = line_str.split("=", 1)[1]
-            us = int(raw) if raw.strip().lstrip("-").isdigit() else 0
-            seconds = us / 1_000_000.0
-            percent = (seconds / duration_s * 100.0) if duration_s > 0 else 0.0
-            percent = max(0.0, min(100.0, percent))
-            progress_cb(percent, "encoding")
-            continue
-        if line_str.strip() == "progress=end":
-            progress_cb(100.0, "done")
-            continue
-        # Accumulate remaining lines in stderr_tail buffer
-        stderr_tail_bytes.append(line)
-        if sum(len(b) for b in stderr_tail_bytes) > max_tail * 2:
-            # Keep only the tail
-            while sum(len(b) for b in stderr_tail_bytes) > max_tail:
-                stderr_tail_bytes.pop(0)
+    try:
+        while True:
+            if cancel_event.is_set():
+                proc.kill()
+                break
+            try:
+                line = line_q.get(timeout=0.1)  # bounded: re-check cancel every 100ms
+            except _queue.Empty:
+                continue
+            if line is None:  # EOF
+                break
+            line_str = line.decode("utf-8", errors="replace").rstrip("\n")
+            # Parse progress (ffmpeg -progress pipe:2 format)
+            if line_str.startswith("out_time_ms="):
+                raw = line_str.split("=", 1)[1]
+                us = int(raw) if raw.strip().lstrip("-").isdigit() else 0
+                seconds = us / 1_000_000.0
+                percent = (seconds / duration_s * 100.0) if duration_s > 0 else 0.0
+                percent = max(0.0, min(100.0, percent))
+                progress_cb(percent, "encoding")
+                continue
+            if line_str.strip() == "progress=end":
+                progress_cb(100.0, "done")
+                continue
+            # Accumulate remaining lines in stderr_tail buffer
+            stderr_tail_bytes.append(line)
+            if sum(len(b) for b in stderr_tail_bytes) > max_tail * 2:
+                # Keep only the tail
+                while sum(len(b) for b in stderr_tail_bytes) > max_tail:
+                    stderr_tail_bytes.pop(0)
+    finally:
+        # Stop the reader so it cannot outlive the attempt (bounds memory and
+        # threads even when the child's stderr never reaches EOF).
+        stop_reading.set()
 
     # Bounded wait: kill if the process doesn't exit promptly (cancel already
     # killed above; this guards a stalled-but-EOF process).

--- a/allaganeye/export/ffmpeg_runner.py
+++ b/allaganeye/export/ffmpeg_runner.py
@@ -19,6 +19,12 @@ from allaganeye.export.schema import ExportError, ExportResult
 from allaganeye.ffmpeg_path import find_ffmpeg
 
 
+# P2-40: cap the stderr reader queue so a noisy/runaway ffmpeg can't grow it
+# without bound (memory). Excess lines under a flood are dropped; the consumer
+# keeps the recent tail, which is what matters for the error message.
+_STDERR_QUEUE_MAX = 4096
+
+
 _DECODE_HWACCEL_ARGS: dict[H264Encoder, tuple[str, ...]] = {
     # #791: encoder->decode hwaccel mapping.
     # NVENC: NVDEC -> NVENC zero-copy (CUDA memory) on RTX 5090 / driver
@@ -118,24 +124,25 @@ def _run_single_attempt(
     )
     assert proc.stderr is not None
     stderr = proc.stderr  # bind narrowed (non-None) handle for the reader closure
-    line_q: _queue.Queue[bytes | None] = _queue.Queue()
-    # P2-40 follow-up (OOM fix): bound the reader thread to this attempt. Without
-    # a stop signal, a child whose stderr never reaches EOF -- a stalled producer,
-    # or a test double whose readline never returns b"" -- would make the daemon
-    # pump spin forever filling the unbounded queue and exhaust memory (the same
-    # bounded-drain concern as start_detect / #838). The flag is set in the
-    # ``finally`` below so the pump exits once the attempt is over.
+    # P2-40: a bounded queue + stop flag keep the stderr reader thread from
+    # outliving the attempt or growing memory without bound. The pump exits on
+    # stderr EOF or when stop_reading is set (finally below); the main loop
+    # detects completion via reader.is_alive() + a drained queue, so a missing
+    # sentinel can't hang it and excess lines under a flood are dropped (the
+    # recent tail is what matters for the error message). Same bounded-drain
+    # concern as start_detect / #838.
+    line_q: _queue.Queue[bytes] = _queue.Queue(maxsize=_STDERR_QUEUE_MAX)
     stop_reading = threading.Event()
 
     def _pump() -> None:
-        try:
-            while not stop_reading.is_set():
-                line = stderr.readline()
-                if not line:  # EOF
-                    break
-                line_q.put(line)
-        finally:
-            line_q.put(None)  # EOF sentinel
+        while not stop_reading.is_set():
+            line = stderr.readline()
+            if not line:  # EOF
+                break
+            try:
+                line_q.put_nowait(line)
+            except _queue.Full:
+                pass  # drop under flood; the consumer keeps the recent tail
 
     reader = threading.Thread(target=_pump, name="ffmpeg-stderr", daemon=True)
     reader.start()
@@ -150,9 +157,10 @@ def _run_single_attempt(
             try:
                 line = line_q.get(timeout=0.1)  # bounded: re-check cancel every 100ms
             except _queue.Empty:
+                # Reader finished (EOF or stopped) and the queue is drained.
+                if not reader.is_alive() and line_q.empty():
+                    break
                 continue
-            if line is None:  # EOF
-                break
             line_str = line.decode("utf-8", errors="replace").rstrip("\n")
             # Parse progress (ffmpeg -progress pipe:2 format)
             if line_str.startswith("out_time_ms="):
@@ -169,12 +177,9 @@ def _run_single_attempt(
             # Accumulate remaining lines in stderr_tail buffer
             stderr_tail_bytes.append(line)
             if sum(len(b) for b in stderr_tail_bytes) > max_tail * 2:
-                # Keep only the tail
                 while sum(len(b) for b in stderr_tail_bytes) > max_tail:
                     stderr_tail_bytes.pop(0)
     finally:
-        # Stop the reader so it cannot outlive the attempt (bounds memory and
-        # threads even when the child's stderr never reaches EOF).
         stop_reading.set()
 
     # Bounded wait: kill if the process doesn't exit promptly (cancel already

--- a/allaganeye/export/ffmpeg_runner.py
+++ b/allaganeye/export/ffmpeg_runner.py
@@ -244,6 +244,9 @@ def run_export_attempt(
     outcome = _run_single_attempt(args, duration, progress_cb, cancel_event)
 
     if cancel_event.is_set():
+        # P3 I-5: clean up the partial output on cancel so a half-written .mp4
+        # is not left behind. NEVER unlink on success returns.
+        output.unlink(missing_ok=True)
         raise ExportError(kind="cancelled", message="export cancelled by user")
 
     if outcome.returncode == 0:
@@ -267,6 +270,7 @@ def run_export_attempt(
                 H264Encoder.LIBX264,
                 f"{encoder.display_label} init failed; retrying with libx264",
             )
+        # NOTE: do NOT unlink here -- the retry uses -y to overwrite in place.
         retry_args = _build_ffmpeg_args(
             ffmpeg, video, start, end, output, codec, H264Encoder.LIBX264
         )
@@ -275,6 +279,8 @@ def run_export_attempt(
         )
 
         if cancel_event.is_set():
+            # P3 I-5: clean up partial from the retry attempt on cancel.
+            output.unlink(missing_ok=True)
             raise ExportError(kind="cancelled", message="export cancelled by user")
 
         if retry_outcome.returncode == 0:
@@ -285,6 +291,8 @@ def run_export_attempt(
                 encoder_used=H264Encoder.LIBX264.value,
                 fallback_from=encoder.value,
             )
+        # P3 I-5: final failure (libx264 retry also failed) -> remove partial.
+        output.unlink(missing_ok=True)
         raise ExportError(
             kind="ffmpeg.exit_failed",
             message=f"libx264 retry exited with {retry_outcome.returncode}: "
@@ -293,6 +301,8 @@ def run_export_attempt(
         )
 
     # Other failures (libx264 1st attempt fail, codec=copy fail, etc.)
+    # P3 I-5: remove the partial output left by a failed encode.
+    output.unlink(missing_ok=True)
     raise ExportError(
         kind="ffmpeg.exit_failed",
         message=f"ffmpeg ({encoder.value}) exited with {outcome.returncode}: "

--- a/allaganeye/export/ffmpeg_runner.py
+++ b/allaganeye/export/ffmpeg_runner.py
@@ -6,6 +6,7 @@ Ported from gui/src-tauri/src/lib.rs (pre-#761 run_ffmpeg_export_attempt
 
 from __future__ import annotations
 
+import queue as _queue
 import subprocess
 import threading
 import time
@@ -101,9 +102,12 @@ def _run_single_attempt(
 ) -> _AttemptOutcome:
     """Launch one ffmpeg process and wait for completion.
 
-    Reads stderr line by line, converts ``out_time_ms`` to a percent and
-    passes it to progress_cb. Checks ``cancel_event.is_set()`` on each read;
-    calls ``proc.kill()`` if set.
+    stderr is pumped by a daemon reader thread into a queue so the main loop
+    can poll ``cancel_event`` on a bounded cadence even when ffmpeg produces no
+    output (audit P2-40 -- the old direct ``readline()`` blocked indefinitely
+    and ignored cancel until the next line arrived). ``out_time_ms`` lines are
+    converted to a percent and passed to ``progress_cb``; the rest accumulate in
+    a bounded stderr tail buffer.
     """
     proc = subprocess.Popen(
         args,
@@ -112,16 +116,31 @@ def _run_single_attempt(
         stderr=subprocess.PIPE,
         bufsize=0,
     )
+    assert proc.stderr is not None
+    stderr = proc.stderr  # bind narrowed (non-None) handle for the reader closure
+    line_q: _queue.Queue[bytes | None] = _queue.Queue()
+
+    def _pump() -> None:
+        try:
+            for line in iter(stderr.readline, b""):
+                line_q.put(line)
+        finally:
+            line_q.put(None)  # EOF sentinel
+
+    reader = threading.Thread(target=_pump, name="ffmpeg-stderr", daemon=True)
+    reader.start()
+
     stderr_tail_bytes: list[bytes] = []
     max_tail = 2048
-
-    assert proc.stderr is not None
     while True:
         if cancel_event.is_set():
             proc.kill()
             break
-        line = proc.stderr.readline()
-        if not line:
+        try:
+            line = line_q.get(timeout=0.1)  # bounded: re-check cancel every 100ms
+        except _queue.Empty:
+            continue
+        if line is None:  # EOF
             break
         line_str = line.decode("utf-8", errors="replace").rstrip("\n")
         # Parse progress (ffmpeg -progress pipe:2 format)
@@ -143,7 +162,13 @@ def _run_single_attempt(
             while sum(len(b) for b in stderr_tail_bytes) > max_tail:
                 stderr_tail_bytes.pop(0)
 
-    returncode = proc.wait()
+    # Bounded wait: kill if the process doesn't exit promptly (cancel already
+    # killed above; this guards a stalled-but-EOF process).
+    try:
+        returncode = proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        returncode = proc.wait()
     tail = b"".join(stderr_tail_bytes).decode("utf-8", errors="replace")
     return _AttemptOutcome(returncode=returncode, stderr_tail=tail[-max_tail:])
 

--- a/allaganeye/export/ffmpeg_runner.py
+++ b/allaganeye/export/ffmpeg_runner.py
@@ -253,6 +253,11 @@ def run_export_attempt(
     ffmpeg = find_ffmpeg()
     duration = end - start
     started = time.monotonic()
+    # Finding 1: record whether the output already existed BEFORE this attempt.
+    # The I-5 cleanup below must only remove a partial THIS attempt created --
+    # never a pre-existing valid file (left by a prior run, or a path that
+    # already held content) that ffmpeg failed before rewriting/truncating.
+    output_pre_existed = output.exists()
 
     # 1st attempt
     args = _build_ffmpeg_args(ffmpeg, video, start, end, output, codec, encoder)
@@ -260,8 +265,10 @@ def run_export_attempt(
 
     if cancel_event.is_set():
         # P3 I-5: clean up the partial output on cancel so a half-written .mp4
-        # is not left behind. NEVER unlink on success returns.
-        output.unlink(missing_ok=True)
+        # is not left behind. NEVER unlink on success returns. Finding 1: only
+        # remove a file THIS attempt created (a pre-existing one is preserved).
+        if not output_pre_existed:
+            output.unlink(missing_ok=True)
         raise ExportError(kind="cancelled", message="export cancelled by user")
 
     if outcome.returncode == 0:
@@ -295,7 +302,9 @@ def run_export_attempt(
 
         if cancel_event.is_set():
             # P3 I-5: clean up partial from the retry attempt on cancel.
-            output.unlink(missing_ok=True)
+            # Finding 1: only if this attempt created it (skip pre-existing).
+            if not output_pre_existed:
+                output.unlink(missing_ok=True)
             raise ExportError(kind="cancelled", message="export cancelled by user")
 
         if retry_outcome.returncode == 0:
@@ -307,7 +316,9 @@ def run_export_attempt(
                 fallback_from=encoder.value,
             )
         # P3 I-5: final failure (libx264 retry also failed) -> remove partial.
-        output.unlink(missing_ok=True)
+        # Finding 1: only if this attempt created it (skip pre-existing).
+        if not output_pre_existed:
+            output.unlink(missing_ok=True)
         raise ExportError(
             kind="ffmpeg.exit_failed",
             message=f"libx264 retry exited with {retry_outcome.returncode}: "
@@ -317,7 +328,9 @@ def run_export_attempt(
 
     # Other failures (libx264 1st attempt fail, codec=copy fail, etc.)
     # P3 I-5: remove the partial output left by a failed encode.
-    output.unlink(missing_ok=True)
+    # Finding 1: only if this attempt created it (skip pre-existing).
+    if not output_pre_existed:
+        output.unlink(missing_ok=True)
     raise ExportError(
         kind="ffmpeg.exit_failed",
         message=f"ffmpeg ({encoder.value}) exited with {outcome.returncode}: "

--- a/allaganeye/export/ffmpeg_runner.py
+++ b/allaganeye/export/ffmpeg_runner.py
@@ -20,8 +20,9 @@ from allaganeye.ffmpeg_path import find_ffmpeg
 
 
 # P2-40: cap the stderr reader queue so a noisy/runaway ffmpeg can't grow it
-# without bound (memory). Excess lines under a flood are dropped; the consumer
-# keeps the recent tail, which is what matters for the error message.
+# without bound (memory). Round 1 FIX 2: under a flood the queue evicts the
+# OLDEST line (ring), so the recent tail -- where a fatal ffmpeg error appears --
+# survives, which is what matters for the error message.
 _STDERR_QUEUE_MAX = 4096
 
 
@@ -128,9 +129,10 @@ def _run_single_attempt(
     # outliving the attempt or growing memory without bound. The pump exits on
     # stderr EOF or when stop_reading is set (finally below); the main loop
     # detects completion via reader.is_alive() + a drained queue, so a missing
-    # sentinel can't hang it and excess lines under a flood are dropped (the
-    # recent tail is what matters for the error message). Same bounded-drain
-    # concern as start_detect / #838.
+    # sentinel can't hang it. Round 1 FIX 2: under a flood the queue drops the
+    # OLDEST line (ring), so the recent tail -- where a fatal ffmpeg error
+    # appears -- is retained for the error message. Same bounded-drain concern
+    # as start_detect / #838.
     line_q: _queue.Queue[bytes] = _queue.Queue(maxsize=_STDERR_QUEUE_MAX)
     stop_reading = threading.Event()
 
@@ -142,12 +144,26 @@ def _run_single_attempt(
             try:
                 line_q.put_nowait(line)
             except _queue.Full:
-                pass  # drop under flood; the consumer keeps the recent tail
+                # Round 1 FIX 2: ring under flood -- drop the OLDEST queued line
+                # so the most recent output (where a fatal ffmpeg error appears)
+                # is retained. Dropping the NEW line instead would discard exactly
+                # the error tail we need for the failure message.
+                try:
+                    line_q.get_nowait()
+                except _queue.Empty:
+                    pass
+                try:
+                    line_q.put_nowait(line)
+                except _queue.Full:
+                    pass
 
     reader = threading.Thread(target=_pump, name="ffmpeg-stderr", daemon=True)
     reader.start()
 
     stderr_tail_bytes: list[bytes] = []
+    # Round 1 FIX 5: track the running byte total so the tail trim is O(1)
+    # amortized instead of recomputing sum(len(b) ...) on every append/pop.
+    stderr_tail_total = 0
     max_tail = 2048
     try:
         while True:
@@ -174,11 +190,14 @@ def _run_single_attempt(
             if line_str.strip() == "progress=end":
                 progress_cb(100.0, "done")
                 continue
-            # Accumulate remaining lines in stderr_tail buffer
+            # Accumulate remaining lines in stderr_tail buffer. Trim from the
+            # front once it grows past max_tail*2, keeping ~max_tail trailing
+            # bytes. The running total avoids an O(n) sum() on each iteration.
             stderr_tail_bytes.append(line)
-            if sum(len(b) for b in stderr_tail_bytes) > max_tail * 2:
-                while sum(len(b) for b in stderr_tail_bytes) > max_tail:
-                    stderr_tail_bytes.pop(0)
+            stderr_tail_total += len(line)
+            if stderr_tail_total > max_tail * 2:
+                while stderr_tail_total > max_tail:
+                    stderr_tail_total -= len(stderr_tail_bytes.pop(0))
     finally:
         stop_reading.set()
 
@@ -259,9 +278,15 @@ def run_export_attempt(
     duration = end - start
     started = time.monotonic()
     # Finding 1: record whether the output already existed BEFORE this attempt.
-    # The I-5 cleanup below must only remove a partial THIS attempt created --
-    # never a pre-existing valid file (left by a prior run, or a path that
-    # already held content) that ffmpeg failed before rewriting/truncating.
+    # The I-5 cleanup below skips any path that existed before the attempt, so
+    # we never delete a file the current attempt did not create.
+    # Round 1 FIX 3 (comment accuracy): with ffmpeg's `-y`, the output is
+    # truncated on open, so a pre-existing file that ffmpeg opened-then-failed
+    # is ALREADY destroyed (and may remain as a truncated partial) -- the gate
+    # cannot preserve its contents. The gate's real guarantee is narrower: it
+    # only protects a file ffmpeg failed to open at all. Leaving a truncated
+    # pre-existing partial in place is the accepted lesser-evil vs. unlinking a
+    # file ffmpeg never touched.
     output_pre_existed = output.exists()
 
     # 1st attempt

--- a/allaganeye/export/pool.py
+++ b/allaganeye/export/pool.py
@@ -7,6 +7,7 @@ propagates to workers and kills in-flight ffmpeg processes. See spec section 4.4
 
 from __future__ import annotations
 
+import math
 import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -53,10 +54,21 @@ def _format_filename(m: ExportMatch, pattern: str, codec: str) -> str:
 
 
 def _format_start_for_filename(seconds: float) -> str:
-    """mm-ss form (`:` is invalid in Windows filenames)."""
-    minutes = int(seconds // 60)
-    rem = int(seconds % 60)
-    return f"{minutes:02d}-{rem:02d}"
+    """H-MM-SS / MM-SS form (`:` is invalid in Windows filenames).
+
+    Mirrors gui/src/screens/ExportScreen.tsx ``formatStartForFilename`` so the
+    GUI preview and the CLI's actual output agree past the 1-hour mark
+    (audit P2-20). Non-finite / negative inputs clamp to 0.
+    """
+    if not math.isfinite(seconds) or seconds < 0:
+        seconds = 0.0
+    total = int(seconds)
+    h = total // 3600
+    m = (total % 3600) // 60
+    s = total % 60
+    if h > 0:
+        return f"{h}-{m:02d}-{s:02d}"
+    return f"{m:02d}-{s:02d}"
 
 
 def export_matches(

--- a/allaganeye/export/pool.py
+++ b/allaganeye/export/pool.py
@@ -36,7 +36,7 @@ class ExportMatch:
     type_label: str  # "match" / "non_fl" / etc. -- used by name_pattern
 
 
-def _format_filename(m: ExportMatch, pattern: str, codec: str) -> str:
+def _format_filename(m: ExportMatch, pattern: str) -> str:
     """Render the output filename per ``pattern``.
 
     Tokens: ``{idx}`` / ``{idx:03}`` / ``{type}`` / ``{start}`` / ``{date}``.
@@ -120,7 +120,7 @@ def export_matches(
             ) -> None:
                 progress_cb(ProgressEvent.fallback(_idx, src.value, dst.value, msg))
 
-            output_path = output_dir / _format_filename(m, name_pattern, codec)
+            output_path = output_dir / _format_filename(m, name_pattern)
             try:
                 result = run_export_attempt(
                     video=source_video,

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1112,6 +1112,8 @@ def _scan_cpu(
 
 def _generate_timestamps(duration: float, interval: float) -> list[float]:
     """Generate sample timestamps from 0 to duration at given interval."""
+    if interval <= 0:
+        raise ValueError(f"interval must be positive, got {interval}")
     timestamps: list[float] = []
     t = 0.0
     while t < duration:

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -351,7 +351,7 @@ echo '<metadata-json>' | allaganeye export --stdin [...]
 | `--output-dir DIR` | (必須) | 出力先ディレクトリ (省略不可) |
 | `--codec copy\|h264` | `copy` | `copy` (FFmpeg `-c copy`、無劣化分割) または `h264` (NVENC / QSV / AMF / libx264 で再エンコード) |
 | `--concurrency N` | SKU テーブル値 | 同時 export スロット数を上書き (`enumerate_h264_encoders` が返す値のデフォルト: RTX 5090 → 3、RTX 4090/4080/4070 → 2、RTX 4060 / 不明 NVIDIA → 1、QSV / AMF / libx264 → 1) |
-| `--name-pattern PATTERN` | `{idx:03}_{type}_{start}.mp4` | 出力ファイル名テンプレート。使用可能トークン: `{idx}` / `{idx:03}` / `{type}` / `{start}` / `{date}` |
+| `--name-pattern PATTERN` | `{idx:03}_{type}_{start}.mp4` | 出力ファイル名テンプレート。使用可能トークン: `{idx}` / `{idx:03}` / `{type}` / `{start}` (MM-SS 形式。1 時間以上の場合は H-MM-SS、例: `1-23-41`) / `{date}` |
 | `--include I,J,K` | (すべて対象) | metadata の `matches[].index` (**1 始まり**) と照合する match フィルタ (カンマ区切り)。`--exclude` との併用時は `include - exclude` が有効集合 |
 | `--exclude I,J,K` | (なし) | metadata の `matches[].index` (**1 始まり**) と照合する除外フィルタ (カンマ区切り)。`type_override == "skip"` の match は本フラグに関係なく常に除外 |
 | `--quiet` | `false` | 進捗出力を抑制 (success/error 行は stderr に出力される)。`--json` と排他 |
@@ -408,8 +408,10 @@ ALLAGANEYE_EXPORT_CONCURRENCY=2 allaganeye export <metadata.json> --codec h264
 | コード | 意味 |
 | --- | --- |
 | 0 | 全 match 成功 (exclude された match を除く) |
-| 1 | 1 件以上の match が失敗 (部分失敗または全失敗) |
-| 2 | 入力エラー (metadata 読み込み失敗 / JSON 不正 / 出力ディレクトリ未存在) |
+| 1 | 1 件以上の match が失敗 (部分失敗または全失敗) または予期せぬ例外 |
+| 2 | 入力エラー (metadata 読み込み失敗 / JSON 不正 / `source` フィールド欠落 / `--concurrency <= 0` 等の引数不正)。出力ディレクトリは不在でも自動作成されるため exit 2 にはならない |
+| 3 | ffmpeg / IO エラー (VideoProcessingError 等の `AllaganEyeError` を exit code にマッピング) |
+| 5 | 設定値不正 (ConfigValidationError 等の `AllaganEyeError` を exit code にマッピング) |
 | 130 | SIGINT (Ctrl+C) によるキャンセル |
 
 ### Wire protocol (`--json` モード)
@@ -473,7 +475,7 @@ timestamp,brightness
 | 2 | 入力ファイル不正 |
 | 3 | FFmpeg / ffprobe エラー |
 | 4 | 試合境界が見つからない |
-| 5 | 設定値不正（パラメータの範囲外等） |
+| 5 | 設定値不正（パラメータの範囲外等）。`--interval <= 0` は ConfigValidationError (exit 5) で即終了 |
 | 7 | 同梱物欠損 (Portable ZIP integrity-manifest.json で listed file が missing / size 不一致) #668 |
 
 ### エラー表示 (#428 / #405 matrix v2)

--- a/docs/superpowers/plans/2026-06-22-audit-w2-w1.md
+++ b/docs/superpowers/plans/2026-06-22-audit-w2-w1.md
@@ -1,0 +1,981 @@
+# Audit Remediation Wave 2 — W1 (#840 export/CLI 整合) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` (fresh subagent per task + spec/quality 2-stage review). TDD HARD-GATE (`superpowers:test-driven-development`): NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST. Steps use checkbox (`- [ ]`).
+
+**Goal:** `allaganeye export` (#761) と `debug-brightness` の CLI / wire 契約の品質を split/detect 水準に揃える — (P2-7) export を cli.py のエラー枠組みに収める、(P2-8) `--json` の Python 層 encoding 自衛、(P2-9) `ExportSummary.skipped` を実数化、(P2-10) output_dir mkdir、(P2-11) `debug-brightness --interval` 非正値 guard (exit 5)、(P2-20) `{start}` を GUI と同一の H-MM-SS に統一、(P2-40) export cancel を ffmpeg 無出力 stall でも応答化、+ export 系 P3。
+
+**Architecture:**
+
+- **P2-20 (`pool.py`)**: `_format_start_for_filename` を GUI `formatStartForFilename` (ExportScreen.tsx:1011-1023) と同一ロジック (`h=total//3600; m=(total%3600)//60; s=total%60`、h>0 → `{h}-{mm:02}-{ss:02}` else `{mm:02}-{ss:02}`、負/非有限は 0 clamp) に置換。pure function、parity fixture で TDD。
+- **P2-9 (`commands/export.py`)**: filter ループで除外 (include 外 / exclude / `type_override=="skip"`) した件数を数え、`export_matches` 戻り後に `summary.skipped` へ代入 (`ExportSummary` は非 frozen dataclass)。json summary emit は代入後。
+- **P2-10 (`commands/export.py`)**: `export_matches` 呼び出し前に `output_dir.mkdir(parents=True, exist_ok=True)` (split/detect と同型)。mkdir の OSError は P2-7 枠組みに乗る。
+- **P2-8 (`commands/export.py`)**: `--json` 突入時に `sys.stdout.reconfigure(encoding="utf-8")`、`--stdin` は `sys.stdin.buffer.read()` を UTF-8 で明示 decode して `json.loads`。Rust 注入の `PYTHONIOENCODING` に依存せず CLI 単体 + cp932 console で非 ASCII path/メッセージを保全。
+- **P2-7 (`commands/export.py` + 既存 `cli.py` helper 再利用)**: export 本体を `try/except AllaganEyeError → _report_app_error(stderr) + raise typer.Exit(e.exit_code)` / `except Exception → _report_unexpected_error(stderr) + raise typer.Exit(1)` で包む。**hard error 時に summary を emit しない** — Rust `start_export` は summary 行があると exit code を無視して `Ok(summary)` を返す (lib.rs:3149-3151) ため、error 時に summary を出すと GUI がエラーを mask する。error は「非ゼロ exit + stderr tail」(Rust:3177-3192 の error path) で伝える。`typer.Exit` (cancelled=130 / failure=1) の re-raise は try の外に出して握り潰さない。
+- **P2-11 (`commands/debug_brightness.py` + `video/detector.py`)**: debug-brightness で `interval <= 0` を `ConfigValidationError` (exit 5) で弾く (config.py の "must be positive" と同文体)。根本対策として `_generate_timestamps` 自体に非正値 `ValueError` guard を追加 (全 caller 保護、既存 caller は interval>0 で挙動不変)。
+- **P2-40 (`export/ffmpeg_runner.py`)**: `_run_single_attempt` の `proc.stderr.readline()` 直接ブロックを、reader thread が stderr を `queue.Queue` にポンプ + worker は `queue.get(timeout=...)` で cancel poll する形に再構成 (Windows 互換 = select 不可)。`proc.wait()` に timeout + kill。ffmpeg 無出力 stall でも cancel が有界 cadence で効く。#838 (start_detect drain) と同クラスの sync 版対策。
+- **export P3 (`commands/export.py` / `export/pool.py` / `export/ffmpeg_runner.py`)**: concurrency ≤0 を `typer.BadParameter` で弾く / ffmpeg 失敗・cancel 時に partial 出力を unlink / `_format_filename` の dead `codec` 引数除去 / `{idx}`/`{idx:03}` 欠落 (= 全 match 同名で上書き) を検出し警告 / `--include`/`--exclude` help に 1-based 基数を明記 + 範囲外 index を警告。
+
+**Tech Stack:** Python 3.12 (pytest, typer.testing.CliRunner, unittest.mock) / ruff / pyright。
+
+**元 issue:** [#840](https://github.com/Idios/kobutachan-allaganeye/issues/840) (bug, P2-medium, l2a-gui)。受け入れ条件 (issue 本文の正式 AC、逐条検証する):
+
+1. **P2-7**: export 本体が `AllaganEyeError`→exit code マッピング / 予期せぬ例外→exit 1 を split/detect 同型で行う。`--json` モードで top-level error 時も wire を破らない (誤った summary を出さない)。RED→GREEN test
+2. **P2-8**: `--json` で stdout が UTF-8 reconfigure され、`--stdin` が UTF-8 buffer 読み。cp932 想定下で非 ASCII path/メッセージが壊れない test
+3. **P2-9**: include/exclude/skip-override で除外した件数が `summary.skipped` に反映される (常に 0 でない)。test で実証
+4. **P2-10**: export が開始前に output_dir を mkdir する (`-o` 先不在でも失敗しない)。cli-spec/output-spec の exit code 記述を実態に訂正
+5. **P2-11**: `debug-brightness --interval 0`/負値が exit 5 (`ConfigValidationError`) で即座に弾かれる。`_generate_timestamps` の非正値 guard を RED→GREEN test
+6. **P2-20**: Python `_format_start_for_filename` が GUI `formatStartForFilename` と bit-identical。parity test
+7. **P2-40**: export cancel が ffmpeg 無出力 stall でも有界 cadence で応答。無出力 subprocess + cancel で即 kill/return する RED→GREEN test
+8. **export P3**: concurrency 検証 / partial file 掃除 / dead param 除去 / `{idx}` 衝突検査 / `--include`/`--exclude` 基数明記 + 範囲外警告 のうち PR scope に収まる分を消化
+9. Python path 全チェック green (`ruff check .` / `ruff format --check .` / `pyright` / `pytest`)
+10. 実機検証 (Idios): `allaganeye export --json` の非 ASCII path / cp932 console / cancel (Ctrl+C) 応答 / output_dir 不在時の挙動
+
+---
+
+## 前提条件 / 事実 (2026-06-22 実測、#839 W2 merge 後 = develop-0.3.0 @ b57c19b)
+
+- main worktree、branch `claude/audit-w2-w1` (origin/develop-0.3.0 起点、作成済)。session-id: `audit-w2-w1-20260622`
+- working tree に pre-existing `M gui/src-tauri/Cargo.toml` (CRLF 正規化のみ、内容 diff なし)。**W1 は Python のみ。Cargo.toml は触らず commit にも含めない**。
+- **`commands/export.py`** ([export.py](../../../allaganeye/commands/export.py)):
+  - `export` command (`register` 内、L57-249)。option: `metadata_path` / `--stdin` / `-o/--output-dir` (必須) / `--codec` (copy/h264) / `--concurrency` / `--name-pattern` (既定 `{idx:03}_{type}_{start}.mp4`) / `--quiet` / `--json` / `--include` / `--exclude`
+  - `_load_metadata` (L44-51): `--stdin` 時 `json.load(sys.stdin)`、file 時 `json.loads(path.read_text(encoding="utf-8"))` ← **P2-8 stdin は sys.stdin 既定 encoding 依存**
+  - 本体 (L120-249): codec/quiet 検証 → `_load_metadata` を try (`OSError`/`JSONDecodeError`→exit 2) → source 検証 → filter ループ (L147-170、include 外/exclude/skip を `continue`、**件数を数えない** = P2-9) → `enumerate_h264_encoders` → slots 調整 → SIGINT handler 設定 → `export_matches(...)` (L229-238) → json なら `writer.emit(ProgressEvent.summary(summary))` (L243-244) → `summary.cancelled`→exit 130 / `summary.failure>0`→exit 1。**`export_matches` 以降に `except AllaganEyeError` なし** = P2-7。`output_dir` の mkdir なし = P2-10
+  - test: [test_export_cli.py](../../../tests/test_export_cli.py) (typer.testing.CliRunner 想定、実装前に Read してヘルパ確認)
+- **`export/pool.py`** ([pool.py](../../../allaganeye/export/pool.py)):
+  - `_format_filename(m, pattern, codec)` (L38-52): `codec` 引数は本体未使用 (**dead param** = P3)。`{idx:03}`/`{idx}`/`{type}`/`{start}`/`{date}` を replace
+  - `_format_start_for_filename(seconds)` (L55-59): `minutes=int(seconds//60); rem=int(seconds%60); return f"{minutes:02d}-{rem:02d}"` ← **P2-20** (5021.5→`83-41`、GUI は `1-23-41`)
+  - `export_matches(...)` (L62-158): `ExportSummary()` を組み立て success/failure/cancelled を更新。**skipped は未更新** (= P2-9 の片側)
+  - test: [test_export_pool.py](../../../tests/test_export_pool.py) (`_slots(n)` / `_matches(n)` helper、`patch("allaganeye.export.pool.run_export_attempt")`)
+- **`export/schema.py`** ([schema.py](../../../allaganeye/export/schema.py)): `ExportSummary` は `@dataclass` (非 frozen、`success/failure/skipped/cancelled` 既定 0/0/0/False)。`ProgressEvent.to_json_line` は `json.dumps(payload, ensure_ascii=False) + "\n"`
+- **`export/wire.py`** ([wire.py](../../../allaganeye/export/wire.py)): `WireWriter.emit` は `stream.write(line); stream.flush()`。stream 既定 `sys.stdout` ← **encoding 自衛なし** = P2-8
+- **`export/ffmpeg_runner.py`** ([ffmpeg_runner.py](../../../allaganeye/export/ffmpeg_runner.py)):
+  - `_run_single_attempt(args, duration_s, progress_cb, cancel_event)` (L96-148): `subprocess.Popen(..., stderr=PIPE, bufsize=0)` → `while True: if cancel_event.is_set(): proc.kill(); break; line=proc.stderr.readline(); if not line: break; ...` ← **P2-40** (readline 無出力で無限ブロック、cancel は readline 戻り後のみ)。末尾 `proc.wait()` は timeout なし
+  - `run_export_attempt(...)` (L196-276): `find_ffmpeg()` (FFmpegNotFoundError 可) → 1st attempt → GPU init 失敗で libx264 retry → 失敗で `ExportError`。**失敗/cancel 時に partial 出力を unlink しない** = P3
+  - test: [test_export_ffmpeg_runner.py](../../../tests/test_export_ffmpeg_runner.py) (`patch`/`MagicMock` で subprocess.Popen を mock、threading)
+- **`commands/debug_brightness.py`** ([debug_brightness.py](../../../allaganeye/commands/debug_brightness.py)): `run_debug_brightness(..., interval=1.0, ...)` (L26-) → `_generate_timestamps(end-start, interval)` を直呼び (L48)。**interval guard なし** = P2-11
+- **`video/detector.py`** ([detector.py](../../../allaganeye/video/detector.py)) `_generate_timestamps(duration, interval)` (L1113-1120): `t=0.0; while t < duration: timestamps.append(t); t += interval`。interval≤0 で無限ループ。caller は detect Pass1 (L1049、`sample_interval` は `config.py:43` で `<=0` 検証済) と debug-brightness (無防備)
+- **`cli.py`** ([cli.py](../../../allaganeye/cli.py)): split (L282-287) / detect (L468-471) / debug-brightness (L524-532) は `except AllaganEyeError as e: _report_app_error(e, ...); raise typer.Exit(code=e.exit_code) from None` / `except Exception: _report_unexpected_error(...); raise typer.Exit(code=1) from None`。`_report_app_error(exc, *, verbose, quiet=False, show_hint=True)` (L535) / `_report_unexpected_error(*, verbose, quiet=False, show_hint=True)` (L580)。export は `_export_cmd.register(app)` (L649) で別 module 登録、`main()` (L653) は click 例外のみ捕捉 = export の AllaganEyeError は素通り → traceback
+- **`exceptions.py`** ([exceptions.py](../../../allaganeye/exceptions.py)): `AllaganEyeError.exit_code=1` / `InputFileError=2` / `VideoProcessingError=3` / `DetectionError=4` / `ConfigValidationError=5` / `IntegrityError=7`
+- **GUI 正 (P2-20 reference、変更しない)**: `gui/src/screens/ExportScreen.tsx:1011-1023` `formatStartForFilename(seconds)` = `if !isFinite || <0 → 0; total=floor(seconds); h=floor(total/3600); m=floor((total%3600)/60); s=total%60; h>0 ? "{h}-{mm:02}-{ss:02}" : "{mm:02}-{ss:02}"`。例: 915.5→`15-15`、5021.5→`1-23-41`、負→`00-00`
+- **Rust wire 終端ロジック (P2-7 設計裏付け、変更しない)**: `start_export` (lib.rs:3149-3192) は `if let Some(summary)=summary_capture { return Ok(summary) }` (summary あれば exit code 無視) → no summary + exit 0 → zero-work success → no summary + 非ゼロ exit → `subprocess.exit_failed` error に stderr tail 同梱。**∴ hard error 時に summary を出すと GUI がエラーを mask する → error 時は no-summary + 非ゼロ exit が正**
+- 検証: Python path 全チェック (`ruff check .` / `ruff format --check .` / `pyright` / `pytest`) + **実機検証を AskUserQuestion で Idios に依頼** (Iron Law 6、CLI ロジック / subprocess / encoding 変更 = mock 不可)
+
+### スコープ判断 (Iron Law 3 整合)
+
+- **IN**: P2-7 / P2-8 / P2-9 / P2-10 / P2-11 / P2-20 / P2-40 + export 系 P3 (concurrency 検証 / partial file 掃除 / dead param 除去 / `{idx}` 衝突検査 / `--include`/`--exclude` 基数明記 + 範囲外警告) + cli-spec/output-spec の exit code 同期 (W1 が実装を変える箇所のみ、W6 と重複箇所は W1 側で正を書く)。各 TDD。
+- **OUT (本 PR では触らない)**:
+  - **released `start_detect` の inline drain** (#838 で別 issue 追跡)。P2-40 は export 経路のみ対象。
+  - **detect の json 経路 encoding** (P2-8 は export 固有。detect json は phase/completed/total/elapsed_s の ASCII のみで非 ASCII を emit しない)。
+  - **GUI / Rust 側** (ExportScreen.tsx / lib.rs)。P2-20 は GUI を正として Python を合わせる (GUI 不変)。P2-7 は Rust 終端ロジックを正として Python を合わせる (Rust 不変)。
+  - **W6 範囲の doc 一括再同期** (cli-spec/output-spec の exit code 以外の drift は W6)。
+  - **P2-40 の rearchitecture が W1 想定規模を超えた場合**: #838 と同様 (B) handoff に切り替え (Task H Step で判断、PR 本文に明記)。
+
+---
+
+## File Structure
+
+| 区分 | path | 責務 |
+| --- | --- | --- |
+| Create | `docs/superpowers/plans/2026-06-22-audit-w2-w1.md` | 本 plan |
+| Modify | `allaganeye/export/pool.py` | `_format_start_for_filename` H-MM-SS 化 (P2-20) / `_format_filename` dead `codec` 除去 (P3) |
+| Modify | `tests/test_export_pool.py` | P2-20 parity unit / dead param 除去の非回帰 |
+| Modify | `allaganeye/video/detector.py` | `_generate_timestamps` 非正値 guard (P2-11 根本) |
+| Modify | `allaganeye/commands/debug_brightness.py` | interval≤0 guard (P2-11) |
+| Modify | `tests/test_debug_brightness.py` | P2-11 exit5 / `_generate_timestamps` ValueError unit |
+| Modify | `allaganeye/commands/export.py` | mkdir (P2-10) / skipped (P2-9) / encoding 自衛 (P2-8) / error 枠組み (P2-7) / concurrency 検証・`{idx}` 衝突・基数明記 (P3) |
+| Modify | `tests/test_export_cli.py` | P2-7/8/9/10 + P3 command-level unit |
+| Modify | `allaganeye/export/ffmpeg_runner.py` | cancel 応答化 (P2-40) / partial file 掃除 (P3) |
+| Modify | `tests/test_export_ffmpeg_runner.py` | P2-40 stall+cancel unit / partial 掃除 unit |
+| Modify | `docs/cli-spec.md`, `docs/output-spec.md` | export / debug-brightness exit code 同期 (P2-7/10/11) |
+
+> export.py は P2-10/9/8/7 + P3 で順次編集。各 task は実装前に現在の export.py を Read して surgical edit する (commit 進行で行がずれる)。
+
+---
+
+## Task A: plan commit (controller)
+
+- [ ] **Step 1:** branch = `claude/audit-w2-w1` (作成済)。本 plan のみ untracked を確認 (Cargo.toml は stage しない):
+
+```bash
+git branch --show-current          # claude/audit-w2-w1
+git status --short                 # docs/.../2026-06-22-audit-w2-w1.md (untracked) + M gui/src-tauri/Cargo.toml (触らない)
+git add docs/superpowers/plans/2026-06-22-audit-w2-w1.md
+git commit -F - <<'EOF'
+doc: W1 (#840 export/CLI 整合) の実装 plan を追加 (Refs #840)
+
+audit remediation Wave 2 W1。spec §W1 の just-in-time plan。#839 後の
+export.py / cli.py / export/{pool,wire,schema,ffmpeg_runner}.py /
+debug_brightness.py / detector._generate_timestamps 実測 +
+P2-7 error 枠組み / P2-8 encoding 自衛 / P2-9 skipped / P2-10 mkdir /
+P2-11 interval guard / P2-20 {start} H-MM-SS / P2-40 cancel 応答化 +
+export P3 の確定。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task B: pool.py — P2-20 `{start}` を GUI と同一 H-MM-SS に統一 (TDD, pure)
+
+**Files:** Modify `allaganeye/export/pool.py` / Test `tests/test_export_pool.py`
+
+- [ ] **Step 1 (RED):** `tests/test_export_pool.py` に GUI parity test を追加 (`_format_start_for_filename` を import):
+
+```python
+import pytest
+
+from allaganeye.export.pool import _format_start_for_filename
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0.0, "00-00"),
+        (5.0, "00-05"),
+        (65.0, "01-05"),
+        (915.5, "15-15"),      # 15m15s
+        (3599.0, "59-59"),
+        (3600.0, "1-00-00"),   # 1h ちょうど
+        (5021.5, "1-23-41"),   # 1h23m41s -- GUI formatStartForFilename と一致
+        (-10.0, "00-00"),      # 負値は 0 clamp (GUI と同じ)
+    ],
+)
+def test_format_start_matches_gui_h_mm_ss(seconds: float, expected: str):
+    # P2-20: GUI ExportScreen.tsx formatStartForFilename と bit-identical。
+    # 旧実装は通算分 (5021.5 -> "83-41") で 1h 以降に GUI プレビューと乖離した。
+    assert _format_start_for_filename(seconds) == expected
+```
+
+- [ ] **Step 2 (RED 確認):**
+Run: `python -m pytest tests/test_export_pool.py -k format_start -q 2>&1 | tail -20`
+Expected: FAIL — 5021.5 が `83-41` を返し `1-23-41` 期待と不一致 (3600.0 も `60-00`)
+
+- [ ] **Step 3 (GREEN):** `pool.py` の `_format_start_for_filename` (L55-59) を置換:
+
+```python
+import math
+
+
+def _format_start_for_filename(seconds: float) -> str:
+    """H-MM-SS / MM-SS form (`:` is invalid in Windows filenames).
+
+    Mirrors gui/src/screens/ExportScreen.tsx ``formatStartForFilename`` so the
+    GUI preview and the CLI's actual output agree past the 1-hour mark
+    (audit P2-20). Non-finite / negative inputs clamp to 0.
+    """
+    if not math.isfinite(seconds) or seconds < 0:
+        seconds = 0.0
+    total = int(seconds)
+    h = total // 3600
+    m = (total % 3600) // 60
+    s = total % 60
+    if h > 0:
+        return f"{h}-{m:02d}-{s:02d}"
+    return f"{m:02d}-{s:02d}"
+```
+
+> `import math` がファイル冒頭に無ければ追加 (既存 import 群を Read して配置)。
+
+- [ ] **Step 4 (GREEN 確認):**
+Run: `python -m pytest tests/test_export_pool.py -q 2>&1 | tail -20`
+Expected: 全 PASS (新 parity test + 既存 pool 群)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/export/pool.py tests/test_export_pool.py
+git commit -F - <<'EOF'
+fix(cli): export {start} 命名を GUI と同じ H-MM-SS に統一 (Refs #840)
+
+_format_start_for_filename が通算分 (5021.5s -> "83-41") を返し、GUI の
+formatStartForFilename (1h 以降は H-MM-SS、5021.5s -> "1-23-41") と食い違って
+いた (audit P2-20)。GUI と同一ロジック (h=total//3600 等、負/非有限は 0 clamp)
+に統一。GUI parity fixture で RED->GREEN。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task C: detector.py + debug_brightness.py — P2-11 interval 非正値 guard (TDD)
+
+**Files:** Modify `allaganeye/video/detector.py` / `allaganeye/commands/debug_brightness.py` / Test `tests/test_debug_brightness.py`
+
+### C-1: `_generate_timestamps` 根本 guard
+
+- [ ] **Step 1 (RED):** `tests/test_debug_brightness.py` に追加 (無限ループの発火側を有界 raise で観測):
+
+```python
+import pytest
+
+from allaganeye.video.detector import _generate_timestamps
+
+
+def test_generate_timestamps_rejects_nonpositive_interval():
+    # P2-11: interval<=0 は `while t < duration: t += interval` が無限ループ
+    # するため、関数自体で弾く (全 caller の根本 guard)。
+    with pytest.raises(ValueError):
+        _generate_timestamps(100.0, 0.0)
+    with pytest.raises(ValueError):
+        _generate_timestamps(100.0, -1.0)
+
+
+def test_generate_timestamps_positive_interval_unchanged():
+    assert _generate_timestamps(5.0, 2.0) == [0.0, 2.0, 4.0]
+```
+
+- [ ] **Step 2 (RED 確認):**
+Run: `python -m pytest tests/test_debug_brightness.py -k generate_timestamps -q 2>&1 | tail -20`
+Expected: `nonpositive` test が FAIL (現実装は raise せず無限ループ → pytest が hang する可能性。**timeout 付きで実行**: `python -m pytest tests/test_debug_brightness.py -k nonpositive --timeout=10 -q`。pytest-timeout 未導入なら Step 3 を先に入れてから RED を確認する代替: guard を一時 `if interval <= 0: raise ValueError("RED")` で挿入 → test green → guard を本実装に差し替え。`feedback_protective_mechanism_red_verification` の発火観測を満たす)
+
+- [ ] **Step 3 (GREEN):** `detector.py` の `_generate_timestamps` (L1113-1120) 冒頭に guard:
+
+```python
+def _generate_timestamps(duration: float, interval: float) -> list[float]:
+    """Generate sample timestamps from 0 to duration at given interval."""
+    if interval <= 0:
+        raise ValueError(f"interval must be positive, got {interval}")
+    timestamps: list[float] = []
+    t = 0.0
+    while t < duration:
+        timestamps.append(t)
+        t += interval
+    return timestamps
+```
+
+- [ ] **Step 4 (GREEN 確認):**
+Run: `python -m pytest tests/test_debug_brightness.py -k generate_timestamps -q 2>&1 | tail -20`
+Expected: 全 PASS
+
+### C-2: debug-brightness の exit 5 guard
+
+- [ ] **Step 5 (RED):** `tests/test_debug_brightness.py` に command-level test を追加 (既存の CLI invoke ヘルパ / sample fixture を Read して合わせる。動画 probe を避けるため `interval` 検証を probe より前に置く方針):
+
+```python
+from allaganeye.exceptions import ConfigValidationError
+
+
+def test_run_debug_brightness_rejects_nonpositive_interval(tmp_path):
+    # P2-11: debug-brightness は config 検証を通らず _generate_timestamps を
+    # 直呼びするため、interval<=0 を ConfigValidationError (exit 5) で弾く。
+    from allaganeye.commands.debug_brightness import run_debug_brightness
+
+    video = tmp_path / "dummy.mp4"
+    video.write_bytes(b"\x00")
+    with pytest.raises(ConfigValidationError):
+        run_debug_brightness(video, interval=0.0)
+    with pytest.raises(ConfigValidationError):
+        run_debug_brightness(video, interval=-2.0)
+```
+
+> 既存 test が `typer.testing.CliRunner` で `debug-brightness --interval 0` の exit_code==5 を見る形なら、そちらに合わせて CLI レベルの assert も追加してよい (run_debug_brightness の直接 raise が cli.py:524-529 で exit 5 にマップされる)。
+
+- [ ] **Step 6 (RED 確認):**
+Run: `python -m pytest tests/test_debug_brightness.py -k rejects_nonpositive -q 2>&1 | tail -20`
+Expected: FAIL — 現状は probe_video まで進むか `ValueError` (C-1 適用後) が出て `ConfigValidationError` 不一致
+
+- [ ] **Step 7 (GREEN):** `debug_brightness.py` の `run_debug_brightness` 冒頭 (probe より前、L35-36 付近) に guard:
+
+```python
+    if interval <= 0:
+        raise ConfigValidationError(
+            f"--interval must be positive, got {interval}"
+        )
+```
+
+> `from allaganeye.exceptions import ConfigValidationError` を import に追加 (既存 `VideoProcessingError` import の近傍)。
+
+- [ ] **Step 8 (GREEN 確認):**
+Run: `python -m pytest tests/test_debug_brightness.py -q 2>&1 | tail -20`
+Expected: 全 PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add allaganeye/video/detector.py allaganeye/commands/debug_brightness.py tests/test_debug_brightness.py
+git commit -F - <<'EOF'
+fix(cli): debug-brightness --interval 非正値の無限ループを防ぐ (Refs #840)
+
+_generate_timestamps が `while t < duration: t += interval` で interval<=0
+だと無限ループ (hang/OOM) し、debug-brightness は config 検証を通らず直呼び
+するため無防備だった (audit P2-11)。_generate_timestamps に非正値 ValueError
+guard (全 caller 根本対策)、debug-brightness で interval<=0 を
+ConfigValidationError (exit 5) に。RED->GREEN。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task D: export.py — P2-10 output_dir mkdir (TDD, command)
+
+**Files:** Modify `allaganeye/commands/export.py` / Test `tests/test_export_cli.py`
+
+> 実装前に `tests/test_export_cli.py` を Read し、`CliRunner` の起動形 + metadata fixture (`--stdin` JSON or 一時 file) のヘルパに合わせる。以降 D-G/I は同じ起動ヘルパを共有。
+
+- [ ] **Step 1 (RED):** export が存在しない output_dir を作ることを確認する test を追加 (`export_matches` を mock して ffmpeg を回避し、`output_dir` が存在する状態で呼ばれることを assert):
+
+```python
+from unittest.mock import patch
+
+from allaganeye.export.schema import ExportSummary
+
+
+def test_export_creates_missing_output_dir(tmp_path, _run_export):
+    # P2-10: export は output_dir を mkdir しない split/detect 非対称だった。
+    out = tmp_path / "nested" / "out"   # 存在しない
+    captured = {}
+
+    def fake_export_matches(**kwargs):
+        captured["output_dir"] = kwargs["output_dir"]
+        captured["exists"] = kwargs["output_dir"].exists()
+        return ExportSummary(success=1)
+
+    with patch("allaganeye.commands.export.export_matches", side_effect=fake_export_matches):
+        result = _run_export(output_dir=out, ...)   # ヘルパに合わせて引数指定
+    assert result.exit_code == 0
+    assert captured["exists"] is True               # 呼び出し時に既に存在 (mkdir 済)
+```
+
+> `_run_export` は test file の既存ヘルパ (無ければ CliRunner 直書き)。`...` は metadata/source の最小 fixture に置換。
+
+- [ ] **Step 2 (RED 確認):**
+Run: `python -m pytest tests/test_export_cli.py -k creates_missing_output_dir -q 2>&1 | tail -20`
+Expected: FAIL — `captured["exists"]` が False (mkdir なし)
+
+- [ ] **Step 3 (GREEN):** `export.py` の `export_matches` 呼び出し (L229) の直前に追加:
+
+```python
+        # P2-10: create the output dir up front (mirrors split/detect). Without
+        # this every match's ffmpeg fails to write and the run exits 1.
+        output_dir.mkdir(parents=True, exist_ok=True)
+```
+
+- [ ] **Step 4 (GREEN 確認):**
+Run: `python -m pytest tests/test_export_cli.py -k creates_missing_output_dir -q 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/commands/export.py tests/test_export_cli.py
+git commit -F - <<'EOF'
+fix(cli): export 開始前に output_dir を mkdir する (Refs #840)
+
+export は split/detect と異なり output_dir を検証も mkdir もせず、-o 先が
+不在だと全 match の ffmpeg が書き込み失敗して exit 1 になっていた (audit
+P2-10)。export_matches 前に mkdir(parents=True, exist_ok=True)。RED->GREEN。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task E: export.py — P2-9 `summary.skipped` を実数化 (TDD, command)
+
+**Files:** Modify `allaganeye/commands/export.py` / Test `tests/test_export_cli.py`
+
+- [ ] **Step 1 (RED):** include/exclude/skip で除外した件数が summary.skipped に出ることを確認する test (matches=3、1 件 exclude + 1 件 type_override=skip → skipped=2、export 対象 1 件):
+
+```python
+def test_export_counts_skipped(tmp_path, _run_export):
+    # P2-9: ExportSummary.skipped はどの経路でも increment されず常に 0 だった。
+    summaries = []
+
+    def fake_export_matches(**kwargs):
+        s = ExportSummary(success=len(kwargs["matches"]))
+        summaries.append(s)
+        return s
+
+    with patch("allaganeye.commands.export.export_matches", side_effect=fake_export_matches):
+        # matches: index 1 (normal), 2 (exclude), 3 (type_override=skip)
+        result = _run_export(exclude="2", matches=[
+            {"index": 1, "start_time": 0, "end_time": 10, "type": "match"},
+            {"index": 2, "start_time": 10, "end_time": 20, "type": "match"},
+            {"index": 3, "start_time": 20, "end_time": 30, "type": "match",
+             "type_override": "skip"},
+        ], ...)
+    assert result.exit_code == 0
+    # export 対象は index 1 の 1 件、skipped は 2 件
+    assert len(summaries[0].matches if hasattr(summaries[0], "matches") else [1]) == 1
+    # json summary または戻り summary の skipped を確認 (ヘルパに合わせる)
+```
+
+> 正確な assert 形 (戻り summary を直接見るか `--json` stdout の summary 行を parse するか) は test file のヘルパに合わせる。要点は **skipped==2** を観測すること。`--json` 経路なら stdout 最終行 `{"type":"summary",...,"skipped":2}` を parse して assert する方が堅い。
+
+- [ ] **Step 2 (RED 確認):**
+Run: `python -m pytest tests/test_export_cli.py -k counts_skipped -q 2>&1 | tail -20`
+Expected: FAIL — skipped==0
+
+- [ ] **Step 3 (GREEN):** `export.py` の filter ループ (L147-170) で除外件数を数え、`export_matches` 戻り後に代入:
+
+```python
+        # Filter matches per include/exclude
+        include_set = _parse_indexes_csv(include)
+        exclude_set = _parse_indexes_csv(exclude) or set()
+        all_matches = metadata.get("matches") or []
+        filtered: list[ExportMatch] = []
+        skipped_count = 0  # P2-9: count excluded matches for the summary
+        for raw in all_matches:
+            idx = int(raw["index"])
+            if include_set is not None and idx not in include_set:
+                skipped_count += 1
+                continue
+            if idx in exclude_set:
+                skipped_count += 1
+                continue
+            if raw.get("type_override") == "skip":
+                skipped_count += 1
+                continue
+            edited = raw.get("edited") or {}
+            ...  # (unchanged ExportMatch append)
+```
+
+そして `summary = export_matches(...)` (L238) の直後、json summary emit (L243) の前に:
+
+```python
+        # P2-9: reflect filtered-out matches in the summary (was always 0).
+        summary.skipped = skipped_count
+```
+
+- [ ] **Step 4 (GREEN 確認):**
+Run: `python -m pytest tests/test_export_cli.py -k counts_skipped -q 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/commands/export.py tests/test_export_cli.py
+git commit -F - <<'EOF'
+fix(cli): export summary の skipped を実数化 (Refs #840)
+
+ExportSummary.skipped が include/exclude/type_override=skip のどの除外経路でも
+increment されず常に 0 で、summary 表示が実態と乖離していた (audit P2-9)。
+filter ループで除外件数を数え export_matches 戻り後に summary.skipped へ反映。
+RED->GREEN。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task F: export.py — P2-8 `--json` encoding 自衛 (TDD, command)
+
+**Files:** Modify `allaganeye/commands/export.py` / Test `tests/test_export_cli.py`
+
+- [ ] **Step 1 (RED):** `--json` 突入時に stdout が UTF-8 へ reconfigure されることを確認 (`sys.stdout` を reconfigure 可能な fake stream に差し替え、呼び出しを観測):
+
+```python
+def test_export_json_reconfigures_stdout_utf8():
+    # P2-8: --json は ensure_ascii=False で非 ASCII を出すが stdout の encoding
+    # 自衛がなく Rust の PYTHONIOENCODING 頼みだった。CLI 単体 + cp932 で破損。
+    calls = []
+
+    class FakeStdout:
+        encoding = "cp932"
+        def reconfigure(self, **kw):
+            calls.append(kw)
+        def write(self, s): pass
+        def flush(self): pass
+
+    fake = FakeStdout()
+    with patch("allaganeye.commands.export.sys.stdout", fake), \
+         patch("allaganeye.commands.export.export_matches",
+               return_value=ExportSummary()):
+        # export を --json で起動 (ヘルパに合わせる)
+        _invoke_export_json(...)
+    assert {"encoding": "utf-8"} in calls or any(c.get("encoding") == "utf-8" for c in calls)
+```
+
+> stdin の test も追加: `--stdin` で UTF-8 の非 ASCII metadata を `sys.stdin.buffer` 経由で読めること (cp932 既定でも壊れない)。`io.BytesIO` を `sys.stdin.buffer` に差し替えて非 ASCII source path を含む JSON を渡し、`source` が正しく decode される assert。test file のヘルパに合わせる。
+
+- [ ] **Step 2 (RED 確認):**
+Run: `python -m pytest tests/test_export_cli.py -k reconfigures_stdout -q 2>&1 | tail -20`
+Expected: FAIL — reconfigure 未呼び出し (`calls` 空)
+
+- [ ] **Step 3 (GREEN):** `export.py` を 2 箇所変更。
+
+**(a)** `_load_metadata` の `--stdin` 経路を buffer 読みに:
+
+```python
+def _load_metadata(metadata_path: Path | None, use_stdin: bool) -> dict:
+    if use_stdin:
+        if metadata_path is not None:
+            raise typer.BadParameter("--stdin is mutually exclusive with metadata_path")
+        # P2-8: read stdin as bytes and decode UTF-8 explicitly so a cp932
+        # default stdin encoding (Windows) can't corrupt non-ASCII paths.
+        raw = sys.stdin.buffer.read()
+        return json.loads(raw.decode("utf-8"))
+    if metadata_path is None:
+        raise typer.BadParameter("metadata_path is required unless --stdin is set")
+    return json.loads(metadata_path.read_text(encoding="utf-8"))
+```
+
+**(b)** json_mode 突入時 (L196 の `writer = WireWriter(stream=sys.stdout)` の前) に reconfigure:
+
+```python
+            if json_mode:
+                # P2-8: harden the wire's stdout encoding so non-ASCII output_path /
+                # error_message survive a cp932 console without relying on the Rust
+                # caller's PYTHONIOENCODING injection.
+                if hasattr(sys.stdout, "reconfigure"):
+                    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+                writer = WireWriter(stream=sys.stdout)
+```
+
+- [ ] **Step 4 (GREEN 確認):**
+Run: `python -m pytest tests/test_export_cli.py -k "reconfigures_stdout or stdin_utf8" -q 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/commands/export.py tests/test_export_cli.py
+git commit -F - <<'EOF'
+fix(cli): export --json の Python 層 encoding 自衛を追加 (Refs #840)
+
+--json は ensure_ascii=False で非 ASCII (output_path / error_message) を出すが
+stdout を UTF-8 に reconfigure せず Rust の PYTHONIOENCODING 注入頼みで、CLI
+単体 + cp932 console では非 ASCII path が壊れた (audit P2-8)。--json 突入時に
+stdout を UTF-8 へ reconfigure、--stdin は sys.stdin.buffer を UTF-8 で明示
+decode。RED->GREEN。3 層 encoding audit: Python 側のみ (Rust 側 #657/#662、
+OS code page は対象外)。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task G: export.py — P2-7 cli.py エラー枠組みに収める (TDD, command)
+
+**Files:** Modify `allaganeye/commands/export.py` / Test `tests/test_export_cli.py`
+
+> 設計: hard error 時は **summary を emit しない** (Rust:3149 が summary 優先で exit code を無視するため、誤った summary は GUI でエラーを mask する)。error は clean stderr + mapped 非ゼロ exit で伝える (Rust の no-summary+非ゼロ exit error path が拾う)。`typer.Exit` (cancelled/failure) の re-raise は try の外。`cli.py` の `_report_app_error` / `_report_unexpected_error` を import 再利用。
+
+- [ ] **Step 1 (RED):** export が `AllaganEyeError` を mapped exit code + clean stderr で扱うことを確認:
+
+```python
+from allaganeye.exceptions import VideoProcessingError
+
+
+def test_export_maps_allagan_error_to_exit_code(_run_export):
+    # P2-7: export だけ AllaganEyeError 未捕捉で raw traceback + exit 1 だった。
+    with patch("allaganeye.commands.export.export_matches",
+               side_effect=VideoProcessingError("ffmpeg boom")):
+        result = _run_export(...)   # 非 json
+    assert result.exit_code == 3                      # VideoProcessingError.exit_code
+    assert "Error: ffmpeg boom" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_export_json_does_not_emit_summary_on_error(_run_export_json):
+    # P2-7: --json で hard error 時、誤った summary を出さない (Rust が summary を
+    # exit code より優先し error を mask するため)。terminal は非ゼロ exit + stderr。
+    with patch("allaganeye.commands.export.export_matches",
+               side_effect=VideoProcessingError("ffmpeg boom")):
+        result = _run_export_json(...)
+    assert result.exit_code == 3
+    # stdout に summary 行を含まない
+    assert '"type": "summary"' not in result.stdout and '"type":"summary"' not in result.stdout
+```
+
+- [ ] **Step 2 (RED 確認):**
+Run: `python -m pytest tests/test_export_cli.py -k "maps_allagan_error or does_not_emit_summary" -q 2>&1 | tail -25`
+Expected: FAIL — exit_code==1 + traceback (未捕捉)、json 経路も exit 1
+
+- [ ] **Step 3 (GREEN):** `export.py` を 2 箇所変更。
+
+**(a)** import 追加 (冒頭):
+
+```python
+from allaganeye.cli import _report_app_error, _report_unexpected_error
+from allaganeye.exceptions import AllaganEyeError
+```
+
+> 循環 import 回避: `cli.py` は `_export_cmd.register(app)` を **module 末尾** (L646-650) で遅延 import している。`export.py` が冒頭で `from allaganeye.cli import ...` すると循環するため、**`register()` 内の関数本体 (export() 内) でローカル import** する (split/detect が `run_split` 等を関数内 import しているのと同型)。Step 実装時に循環有無を `python -c "import allaganeye.commands.export"` で確認し、循環するならローカル import に切替。
+
+**(b)** 本体 (L191 の `try:` から `signal.signal(signal.SIGINT, original_handler)` まで) を error 枠組みで包む。`export_matches` 〜 `summary.skipped` 代入を try に入れ、`AllaganEyeError`/`Exception` を catch。`typer.Exit` (summary 判定の exit) は **try の外**:
+
+```python
+        from allaganeye.cli import _report_app_error, _report_unexpected_error
+
+        summary: ExportSummary
+        original_handler = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, _sigint_handler)
+        try:
+            # ... progress_cb 構築 (json/quiet/text) は既存のまま ...
+            summary = export_matches(...)
+            summary.skipped = skipped_count   # P2-9
+        except AllaganEyeError as e:
+            # P2-7: do NOT emit a summary here -- start_export treats any summary
+            # line as success (lib.rs:3149) and would mask the error. Clean stderr
+            # + mapped non-zero exit is the correct wire signal for a hard error.
+            _report_app_error(e, verbose=False, quiet=quiet, show_hint=False)
+            raise typer.Exit(code=e.exit_code) from None
+        except Exception:
+            _report_unexpected_error(verbose=False, quiet=quiet, show_hint=False)
+            raise typer.Exit(code=1) from None
+        finally:
+            signal.signal(signal.SIGINT, original_handler)
+
+        # 正常完了パス (summary が set 済) -- try の外なので typer.Exit を握り潰さない
+        if json_mode and writer is not None:
+            writer.emit(ProgressEvent.summary(summary))
+        if summary.cancelled:
+            raise typer.Exit(code=130)
+        if summary.failure > 0:
+            raise typer.Exit(code=1)
+```
+
+> 既存 L242-249 (summary emit + exit 判定) は上記の「正常完了パス」に統合。`writer` は json_mode 構築済 (Task F)。**重要**: `except Exception` が `typer.Exit` を捕捉しないよう、exit 判定を try の外に出す (上記構造)。`_load_metadata` の既存 try (OSError/JSONDecodeError→exit 2) はそのまま (option 検証段)。
+
+- [ ] **Step 4 (GREEN 確認):**
+Run: `python -m pytest tests/test_export_cli.py -q 2>&1 | tail -25`
+Expected: 全 PASS (P2-7 新 test + 既存 export cli 群 + Task D/E/F の test)
+
+- [ ] **Step 5 (循環 import 確認):**
+Run: `python -c "import allaganeye.cli; import allaganeye.commands.export; print('ok')" 2>&1 | tail -5`
+Expected: `ok` (循環なし。エラーが出たら import を関数内ローカルに)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add allaganeye/commands/export.py tests/test_export_cli.py
+git commit -F - <<'EOF'
+fix(cli): export を cli.py のエラー枠組みに収める (Refs #840)
+
+export だけ AllaganEyeError を捕捉せず raw traceback + exit 1 で終わり、
+split/detect/debug-brightness の except AllaganEyeError -> exit code マッピング
+枠外だった (audit P2-7)。export_matches 周りを try/except で包み
+_report_app_error / _report_unexpected_error で clean stderr + mapped exit に。
+--json の hard error 時は summary を emit しない (start_export が summary を
+exit code より優先し error を mask するため、非ゼロ exit + stderr が正)。
+cancelled/failure の typer.Exit は try の外で握り潰さない。RED->GREEN。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task H: ffmpeg_runner.py — P2-40 cancel 応答化 (TDD, subprocess)
+
+**Files:** Modify `allaganeye/export/ffmpeg_runner.py` / Test `tests/test_export_ffmpeg_runner.py`
+
+> **[要検証] スコープ判断**: reader-thread 再構成が下記規模 (~40 行、helper 1 個) に収まることを Step 3 で確認。大幅に膨らむ / 既存 progress parse を壊すリスクが高い場合は **(B) handoff** に切替 (別 issue 起票、PR 本文と #840 AC に明記)。判断は controller が Step 2-3 で行う。
+
+- [ ] **Step 1 (RED):** ffmpeg が stderr に何も出さず stall しても cancel が有界時間で効くことを確認 (fake proc: stderr.readline が Event 待ちでブロック、cancel_event を別 thread で set):
+
+```python
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from allaganeye.export.ffmpeg_runner import _run_single_attempt
+
+
+def test_run_single_attempt_responds_to_cancel_when_no_output():
+    # P2-40: stderr 無出力で stall するプロセスでも cancel が有界 cadence で効く。
+    # 旧実装は proc.stderr.readline() で無限ブロックし cancel を見なかった。
+    release = threading.Event()  # 永久に set されない -> readline は EOF を返さない
+
+    class BlockingStderr:
+        def readline(self):
+            release.wait()        # ブロック (ffmpeg 無出力 stall を模倣)
+            return b""
+
+    proc = MagicMock()
+    proc.stderr = BlockingStderr()
+    proc.kill = MagicMock()
+    proc.wait = MagicMock(return_value=-9)
+
+    cancel_event = threading.Event()
+    timer = threading.Timer(0.3, cancel_event.set)  # 0.3s 後に cancel
+    timer.start()
+
+    start = time.monotonic()
+    with patch("allaganeye.export.ffmpeg_runner.subprocess.Popen", return_value=proc):
+        outcome = _run_single_attempt(
+            ["ffmpeg"], duration_s=100.0,
+            progress_cb=lambda *a: None, cancel_event=cancel_event,
+        )
+    elapsed = time.monotonic() - start
+    timer.cancel()
+    release.set()  # cleanup: reader thread を解放
+    assert elapsed < 2.0, f"cancel should be bounded, took {elapsed:.1f}s"
+    proc.kill.assert_called()       # stall プロセスを kill した
+```
+
+- [ ] **Step 2 (RED 確認):**
+Run: `python -m pytest tests/test_export_ffmpeg_runner.py -k responds_to_cancel --timeout=10 -q 2>&1 | tail -20`
+Expected: FAIL/HANG — 旧実装は `release` 待ちの readline で無限ブロック (timeout で kill される。pytest-timeout 未導入なら `BlockingStderr.readline` が 5s で b"" を返す版に変えて「kill されず EOF まで待つ」ことを RED として観測)
+
+- [ ] **Step 3 (GREEN):** `ffmpeg_runner.py` の `_run_single_attempt` (L96-148) を reader-thread + queue に再構成:
+
+```python
+import queue as _queue
+
+
+def _run_single_attempt(
+    args: list[str],
+    duration_s: float,
+    progress_cb: Callable[[float, str], None],
+    cancel_event: threading.Event,
+) -> _AttemptOutcome:
+    """Launch one ffmpeg process and wait for completion.
+
+    stderr is pumped by a daemon reader thread into a queue so the main loop
+    can poll ``cancel_event`` on a bounded cadence even when ffmpeg produces no
+    output (audit P2-40 -- the old direct ``readline()`` blocked indefinitely
+    and ignored cancel until the next line arrived).
+    """
+    proc = subprocess.Popen(
+        args,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    assert proc.stderr is not None
+    line_q: _queue.Queue[bytes | None] = _queue.Queue()
+
+    def _pump() -> None:
+        try:
+            for line in iter(proc.stderr.readline, b""):
+                line_q.put(line)
+        finally:
+            line_q.put(None)  # EOF sentinel
+
+    reader = threading.Thread(target=_pump, name="ffmpeg-stderr", daemon=True)
+    reader.start()
+
+    stderr_tail_bytes: list[bytes] = []
+    max_tail = 2048
+    cancelled = False
+    while True:
+        if cancel_event.is_set():
+            proc.kill()
+            cancelled = True
+            break
+        try:
+            line = line_q.get(timeout=0.1)  # bounded: re-check cancel every 100ms
+        except _queue.Empty:
+            continue
+        if line is None:  # EOF
+            break
+        line_str = line.decode("utf-8", errors="replace").rstrip("\n")
+        if line_str.startswith("out_time_ms="):
+            raw = line_str.split("=", 1)[1]
+            us = int(raw) if raw.strip().lstrip("-").isdigit() else 0
+            seconds = us / 1_000_000.0
+            percent = (seconds / duration_s * 100.0) if duration_s > 0 else 0.0
+            percent = max(0.0, min(100.0, percent))
+            progress_cb(percent, "encoding")
+            continue
+        if line_str.strip() == "progress=end":
+            progress_cb(100.0, "done")
+            continue
+        stderr_tail_bytes.append(line)
+        if sum(len(b) for b in stderr_tail_bytes) > max_tail * 2:
+            while sum(len(b) for b in stderr_tail_bytes) > max_tail:
+                stderr_tail_bytes.pop(0)
+
+    # bounded wait: kill if the process doesn't exit promptly (cancel already killed)
+    try:
+        returncode = proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        returncode = proc.wait()
+    tail = b"".join(stderr_tail_bytes).decode("utf-8", errors="replace")
+    return _AttemptOutcome(returncode=returncode, stderr_tail=tail[-max_tail:])
+```
+
+> 既存 progress parse (`out_time_ms` / `progress=end`) と tail buffer ロジックは保持。変更は (1) reader thread + queue、(2) `get(timeout=0.1)` で cancel poll、(3) `proc.wait(timeout=10)` + kill。`run_export_attempt` 側の cancel 後 `raise ExportError(kind="cancelled")` (L221-222) はそのまま機能。
+
+- [ ] **Step 4 (GREEN 確認):**
+Run: `python -m pytest tests/test_export_ffmpeg_runner.py --timeout=30 -q 2>&1 | tail -25`
+Expected: 全 PASS (新 cancel test + 既存 is_gpu_encoder_failure / run_export_attempt 群が非回帰)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add allaganeye/export/ffmpeg_runner.py tests/test_export_ffmpeg_runner.py
+git commit -F - <<'EOF'
+fix(cli): export cancel を ffmpeg 無出力 stall でも応答化 (Refs #840)
+
+_run_single_attempt が proc.stderr.readline() を直接ブロックし、cancel_event
+チェックは readline 戻り後のみだったため、ffmpeg が stderr 無出力で stall すると
+無限ブロックして cancel が効かず worker が永久待ちになった (audit P2-40、#838 と
+同クラスの sync 版)。stderr を daemon reader thread が queue にポンプし、worker は
+get(timeout=0.1) で cancel を有界 cadence でポーリング、proc.wait に timeout+kill。
+無出力 subprocess + cancel で即 kill/return する RED->GREEN。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+## Task I: export P3 batch (TDD where applicable)
+
+**Files:** Modify `allaganeye/commands/export.py` / `allaganeye/export/pool.py` / `allaganeye/export/ffmpeg_runner.py` / Test `tests/test_export_cli.py` / `tests/test_export_pool.py` / `tests/test_export_ffmpeg_runner.py`
+
+> 各 P3 を個別 commit。PR scope に収まる分のみ。膨らむものは (B) handoff (PR 本文明記)。
+
+### I-1: dead param 除去 (`_format_filename` の `codec`)
+
+- [ ] **Step 1:** `pool.py` の `_format_filename(m, pattern, codec)` から `codec` を除去 → `_format_filename(m, pattern)`。call site (L111 `_format_filename(m, name_pattern, codec)`) を `_format_filename(m, name_pattern)` に。既存 test が `codec` 引数で呼んでいれば更新。
+- [ ] **Step 2:** Run `python -m pytest tests/test_export_pool.py -q` → PASS。Commit (`refactor(cli): _format_filename の未使用 codec 引数を除去 (Refs #840)`)。
+
+### I-2: concurrency ≤0 検証
+
+- [ ] **Step 1 (RED):** `--concurrency 0` / 負値が `typer.BadParameter` (exit 2、`--codec` 検証と同型) で弾かれる test。
+- [ ] **Step 2 (GREEN):** `export.py` の codec 検証 (L120-123) 付近に追加:
+
+```python
+        if concurrency is not None and concurrency <= 0:
+            raise typer.BadParameter(
+                f"--concurrency must be >= 1, got {concurrency}"
+            )
+```
+
+そして slots 調整 (L180-181) の `and concurrency > 0` は冗長になるので `elif concurrency is not None:` に簡素化 (検証済のため)。
+
+- [ ] **Step 3:** PASS 確認 + Commit。
+
+### I-3: `{idx}` 衝突検査
+
+- [ ] **Step 1 (RED):** name_pattern に `{idx}`/`{idx:03}` が無く matches 複数のとき警告 (stderr) が出る test (`--name-pattern "{type}.mp4"` + matches 2 件 → 全 match 同名で上書き)。json mode では警告も stderr へ。
+- [ ] **Step 2 (GREEN):** filter 後・export_matches 前に、出力ファイル名の重複を検出して警告:
+
+```python
+        # P3: detect output-name collisions (e.g. a pattern without {idx} maps
+        # every match to the same file, silently overwriting). Warn, don't fail.
+        seen_names: dict[str, int] = {}
+        for m in filtered:
+            name = _format_filename(m, name_pattern)
+            seen_names[name] = seen_names.get(name, 0) + 1
+        collisions = [n for n, c in seen_names.items() if c > 1]
+        if collisions:
+            typer.echo(
+                f"warning: name pattern produces {len(collisions)} duplicate "
+                f"filename(s) (e.g. {collisions[0]!r}); add {{idx}} or {{idx:03}} "
+                f"to avoid overwriting",
+                err=True,
+            )
+```
+
+> `_format_filename` を export.py から import (pool.py の private)。または pool に collision 検査ヘルパを足して呼ぶ。実装時に import 整合を確認。
+
+- [ ] **Step 3:** PASS + Commit。
+
+### I-4: `--include`/`--exclude` 基数明記 + 範囲外警告
+
+- [ ] **Step 1 (RED):** (a) help 文字列に "1-based" 相当が含まれる / (b) `--include 99` (該当 match なし) で範囲外警告が stderr に出る test。
+- [ ] **Step 2 (GREEN):**
+  - help 文言更新 (L107-117): `--include` = `"Comma-separated 1-based match indexes to include (matches metadata 'index'; others skipped)."` / `--exclude` = `"Comma-separated 1-based match indexes to skip."`
+  - filter 後に、include_set / exclude_set のうち実在 index に無いものを警告:
+
+```python
+        # P3: warn for include/exclude indexes that match no actual match (1-based).
+        valid_indexes = {int(r["index"]) for r in all_matches}
+        for label, given in (("--include", include_set), ("--exclude", exclude_set)):
+            if given:
+                missing = sorted(given - valid_indexes)
+                if missing:
+                    typer.echo(
+                        f"warning: {label} index(es) not found in matches: "
+                        f"{', '.join(map(str, missing))}",
+                        err=True,
+                    )
+```
+
+> `exclude_set` は `_parse_indexes_csv(exclude) or set()`、`include_set` は None 可なので guard。`all_matches` を参照 (filter 前の全件)。
+
+- [ ] **Step 3:** PASS + Commit。
+
+### I-5: partial file 掃除
+
+- [ ] **Step 1 (RED):** `run_export_attempt` が (a) ffmpeg 失敗時 / (b) cancel 時に partial 出力 (`output`) を unlink する test (fake proc が returncode!=0 を返し output を touch 済 → 呼び出し後に output が消えている)。
+- [ ] **Step 2 (GREEN):** `ffmpeg_runner.py` の `run_export_attempt` で、cancel raise / 最終 ExportError raise の直前に partial を unlink:
+
+```python
+    # P3: clean up the partial output on cancel / failure so a half-written
+    # .mp4 isn't left behind (ConfirmExitModal W2 の文言が前提とする残置とは別に、
+    # CLI/正常失敗経路では掃除する)。
+    output.unlink(missing_ok=True)
+```
+
+> cancel 経路 (L221-222、L252-253) と最終失敗経路 (L263-268、L271-276) の raise 直前に挿入。成功時 (returncode==0 return) は unlink しない。libx264 retry が成功する経路でも 1st attempt の partial は `-y` で上書きされるため unlink 不要 (retry 前に消すと retry が書けない)。**retry の前では unlink しない** ことに注意。
+
+- [ ] **Step 3:** PASS + Commit。
+
+> I-5 は cancel/失敗経路が複数あり注意が要る。複雑化したら I-5 のみ (B) handoff に切り出す (PR 本文明記)。
+
+## Task J: docs — cli-spec / output-spec の exit code 同期 (P2-7/10/11)
+
+**Files:** Modify `docs/cli-spec.md` / `docs/output-spec.md`
+
+- [ ] **Step 1:** 現記述を確認:
+
+```bash
+grep -nE "export|debug-brightness|exit|interval|output" docs/cli-spec.md | grep -iE "exit|export|interval" | head -40
+grep -nE "export|exit code|exit 2|exit 5|interval" docs/output-spec.md | head -40
+```
+
+- [ ] **Step 2:** 実態に訂正 (W1 が変えた挙動のみ):
+  - export: AllaganEyeError は exit code マッピング (例 ffmpeg/IO → 3、設定不正 → 5)、`AllaganEyeError` 未捕捉 exit 1 / output_dir 不在 exit 2 という旧記述を削除・訂正。output_dir は mkdir されるため「`-o` 不在で exit 2」記述は除去。
+  - debug-brightness: `--interval <= 0` は exit 5 (ConfigValidationError)。
+  - P2-20 で命名が H-MM-SS になる旨、`{start}` トークン説明があれば更新。
+- [ ] **Step 3:** markdownlint:
+
+```bash
+bash scripts/check-markdownlint.sh 2>&1 | tail -15
+```
+
+Expected: 0 violation (W1 で触れた .md のみ。違反は `docs/markdownlint-guide.md` の recipe で fix)
+
+- [ ] **Step 4: Commit** (`doc: export/debug-brightness の exit code を実態に同期 (Refs #840)`)。
+
+## Task K: Pre-flight + PR (controller)
+
+- [ ] **Step 0 (hard-gate):** `gh pr list --search "840" --state open --repo Idios/kobutachan-allaganeye` → W1 PR 0 件
+- [ ] **Step 1-3:** `git fetch origin develop-0.3.0` → `git log HEAD..origin/develop-0.3.0 --oneline` (取り込み未済確認) → touched files (export.py / cli.py 参照のみ / pool.py / ffmpeg_runner.py / debug_brightness.py / detector.py / 各 test / cli-spec / output-spec) が develop-0.3.0 新規 commit と交差しないか
+- [ ] **Step 4:** `gh pr list --search "840" --state all --repo Idios/kobutachan-allaganeye` → 重複なし
+- [ ] **Step 5:** codex `adversarial-review` (memory `project_codex_adversarial_review_direct_invocation`: companion script `C:/Users/idios/.claude/plugins/cache/openai-codex/codex/1.0.4/scripts/codex-companion.mjs` の `adversarial-review` subcommand を `--wait --base origin/develop-0.3.0 --scope branch "<focus ASCII>"` で Bash run_in_background 直接呼出、final marker `# Codex Adversarial Review` を待つ)。focus ASCII 候補:
+  `P2-7 export wraps body in except AllaganEyeError but the cancelled/failure typer.Exit is re-raised inside the try and swallowed by except Exception turning exit 130 into 1 / json error path still emits a summary somewhere masking the error in start_export which prioritizes summary over exit code / P2-8 stdout reconfigure called but a prior write already happened so encoding switch is too late / stdin buffer read breaks the existing file-path metadata load / P2-9 skipped counted but double counts a match that is both excluded and skip-override / P2-11 generate_timestamps guard breaks detect Pass1 callers that pass a valid interval / P2-20 negative or non-finite seconds not clamped identically to the GUI / P2-40 reader thread leaks or the queue get timeout busy-spins CPU or proc.wait timeout kills a still-finishing encode / partial file unlink removes the output before a successful libx264 retry can write it / include exclude out-of-range warning fires on valid 1-based indexes`
+  不可なら CLAUDE.md §C6 fallback (`superpowers:requesting-code-review` subagent) + PR 本文に **Codex fallback notice 必須**
+- [ ] **Step 6 (machine verify、全 pass、各コマンド個別行):**
+
+```bash
+ruff check .
+ruff format --check .
+pyright
+python -m pytest -q
+```
+
+(lint と他コマンドを `&&`/`;` で同一行連結しない)
+
+- [ ] **Step 7 (実機 trigger):** CLI subprocess / encoding / cancel ロジック変更のため **`AskUserQuestion` で Idios に実機検証を依頼**:
+  - (a) **P2-8/P2-7**: 非 ASCII (日本語) path を含む metadata で `allaganeye export --json --stdin` を cp932 console から実行 → output_path/エラーが文字化けしない + ffmpeg 不在等の hard error が clean な exit code で終わる (traceback でない)
+  - (b) **P2-40**: 実 export 中に Ctrl+C → 数秒以内に中断する (無出力 stall を作りにくければ通常 export の cancel 応答で可)
+  - (c) **P2-10**: 存在しない `-o` 先を指定 → ディレクトリが作られ export が成功する
+  - (d) **P2-20**: 1 時間超の start を持つ match の出力ファイル名が GUI プレビュー (`H-MM-SS`) と一致する
+  - (e) **P2-11**: `allaganeye debug-brightness <video> --interval 0` → exit 5 + 明確なエラー (hang しない)
+  - 回答まで PR を merge 可能と扱わない
+- [ ] **Step 8:** push + PR (base `develop-0.3.0`, **Refs #840 / Closes 禁止**)。session-id `audit-w2-w1-20260622`。PR 本文は日本語のため `gh api repos/.../pulls --input <json>` (Python で ASCII JSON 構築) か `printf | gh pr create --body-file -`。Self-Test Report: machine-verified (ruff/format/pyright/pytest) は `[x]`、実機 (a)-(e) は plain bullet `-` (Idios 依頼中)。AC 10 項目を逐条 + diff/test 引用。3 層 encoding audit 結論 (P2-8 = Python 側のみ touch、Rust 側 #657/#662 で対応済、OS code page 対象外) を明記。
+
+## Task L: /iterate-review (controller)
+
+- [ ] **Step 1:** `/iterate-review <PR#>` 自走 (1 round = 1 commit `fix(round-N): ... (Refs #840)`、divergence cap Round 5、controller から scope 拡大選択肢を足さない — subagent recommendation 第一)
+- [ ] **Step 2:** Step 5b 表が全ゼロ or Round 5 / 発散検知で収束 → summary コメント 1 個。P2-40 の (B) handoff 判断や I-5 切り出しが発生したら明記
+
+## マージ後 (Idios merge 後、controller)
+
+- iterate-review 収束後の最終状態で実機検証 (Task K Step 7) → Idios merge → `/close-issue 840` を呼び、AC 10 項目を merge 後 base ブランチで実測再検証 (実機分は Idios 検証結果を引用)。未消化チェックボックス / handoff 分を (B)/(C) トリアージしてからユーザー承認で `gh issue close 840`
+- 次サイクル候補 = W4 (core 堅牢化、実動画 gate 重) / W5 (test 配線) / W6 (N3 #818 待ち)
+
+---
+
+## Self-Review (writing-plans 自己点検)
+
+- **Spec coverage**: issue #840 AC 10 項目 → AC1(P2-7)=Task G / AC2(P2-8)=Task F / AC3(P2-9)=Task E / AC4(P2-10)=Task D + Task J / AC5(P2-11)=Task C / AC6(P2-20)=Task B / AC7(P2-40)=Task H / AC8(P3)=Task I / AC9(machine)=Task K Step 6 / AC10(実機)=Task K Step 7。spec §W1 骨子 7 点すべてに task 対応。✓
+- **Placeholder scan**: 各 step に実コード / 実コマンド / 期待出力あり。test の起動ヘルパ (CliRunner / metadata fixture / json stdout parse の正確形) は「test file を Read して合わせる」と明記 (実装依存の正確値は subagent が確定、W2 plan と同方針)。TBD・「適切に」等なし。✓
+- **Type consistency**: `_format_start_for_filename(float)->str` (B) / `_generate_timestamps(float,float)->list[float]` に guard 追加で signature 不変 (C) / `_format_filename(m, pattern)` (I-1 で codec 除去、call site も更新) / `_run_single_attempt(args, duration_s, progress_cb, cancel_event)->_AttemptOutcome` signature 不変 (H) / `summary.skipped: int` 代入 (E) / `_report_app_error(exc, *, verbose, quiet, show_hint)` / `_report_unexpected_error(*, verbose, quiet, show_hint)` を export.py から再利用 (G)。✓
+- **TDD gate**: B/C/D/E/F/G/H/I-2/I-3/I-4/I-5 すべて RED→GREEN。J (docs) は test 不要 (markdownlint で検証)。I-1 (dead param) は既存 test green で非回帰確認。✓
+- **保護機構の発火側 red 実証** (memory `feedback_protective_mechanism_red_verification`): C は `_generate_timestamps(.,0)` の ValueError 発火を観測 (RED は無限ループ回避のため一時 guard 法を明記)。H は無出力 stall + cancel で kill 発火 + 有界時間を観測。P2-11 debug-brightness は exit 5 を観測。✓
+- **detection flag cache key** (memory `feedback_detection_flag_cache_key`): W1 は検出 param を増やさない (export/CLI のみ、detector は `_generate_timestamps` guard のみで検出出力不変) → cache key 変更不要。✓
+- **encoding boundary audit** (CLAUDE.md #656/#657/#662 checklist): P2-8 は **Python 側のみ** touch (stdout reconfigure / stdin buffer)。Rust 側は #657/#662 で対応済 (start_export は PYTHONIOENCODING 注入)、OS code page は対象外。PR 本文に 3 層の touch 範囲を明示。✓
+- **Iron Law 6 実機検証** (CLI subprocess / encoding / cancel = mock 不可): Task K Step 7 で AskUserQuestion 必須、回答まで merge 不可。✓
+- **scope 非拡大** (Iron Law 3): released `start_detect` (#838) / detect json encoding / GUI・Rust / W6 doc は OUT 明記。P2-40 と I-5 は膨張時 (B) handoff の判断点を task 内に明記。✓
+- **gh 日本語** (memory `feedback_gh_command_ja_heredoc`): commit は `git commit -F - <<'EOF'` (HEREDOC)。PR 本文 / issue close コメントは file 経由 (gh api --input ASCII JSON or --body-file -)。✓

--- a/tests/test_debug_brightness.py
+++ b/tests/test_debug_brightness.py
@@ -8,12 +8,13 @@ import numpy as np
 import pytest
 
 from allaganeye.commands.debug_brightness import run_debug_brightness
-from allaganeye.exceptions import VideoProcessingError
+from allaganeye.exceptions import ConfigValidationError, VideoProcessingError
 from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
     _SCOREBAR_ROI_X_END,
     _SCOREBAR_ROI_X_START,
     _SCOREBAR_ROI_Y_END,
+    _generate_timestamps,
 )
 
 MODULE = "allaganeye.commands.debug_brightness"
@@ -377,3 +378,33 @@ def test_scorebar_detail_mode_exception_fallback(
     # t=1.0 should have normal values
     parts_1 = lines[2].split(",")
     assert float(parts_1[1]) > 0.0
+
+
+# --- P2-11: interval non-positive guard tests ---
+
+
+def test_generate_timestamps_rejects_nonpositive_interval():
+    # P2-11: interval<=0 causes `while t < duration: t += interval` to infinite-loop;
+    # _generate_timestamps must guard against it (protects all callers at the root).
+    with pytest.raises(ValueError):
+        _generate_timestamps(100.0, 0.0)
+    with pytest.raises(ValueError):
+        _generate_timestamps(100.0, -1.0)
+
+
+def test_generate_timestamps_positive_interval_unchanged():
+    # Positive intervals must continue to work exactly as before (existing callers
+    # e.g. detect Pass 1 always pass a config-validated > 0 interval).
+    assert _generate_timestamps(5.0, 2.0) == [0.0, 2.0, 4.0]
+
+
+def test_run_debug_brightness_rejects_nonpositive_interval(tmp_path):
+    # P2-11: debug-brightness bypasses config validation and calls _generate_timestamps
+    # directly, so interval<=0 must be caught at the command level as
+    # ConfigValidationError (exit 5) BEFORE any video probe is attempted.
+    video = tmp_path / "dummy.mp4"
+    video.write_bytes(b"\x00")
+    with pytest.raises(ConfigValidationError):
+        run_debug_brightness(video, interval=0.0)
+    with pytest.raises(ConfigValidationError):
+        run_debug_brightness(video, interval=-2.0)

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -646,10 +646,14 @@ def test_export_warns_on_filename_collision(app: typer.Typer, tmp_path: Path):
         )
     # warning goes to stderr; command can still succeed
     assert result.exit_code == 0
-    assert "warning" in result.output.lower() or "warning" in (result.stderr or "").lower()
+    assert (
+        "warning" in result.output.lower() or "warning" in (result.stderr or "").lower()
+    )
 
 
-def test_export_no_collision_warning_when_pattern_has_idx(app: typer.Typer, tmp_path: Path):
+def test_export_no_collision_warning_when_pattern_has_idx(
+    app: typer.Typer, tmp_path: Path
+):
     # P3 I-3: no warning when the pattern contains {idx} (all names are distinct).
     metadata_path = _make_metadata(tmp_path)
     with patch(

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -402,3 +402,58 @@ def test_export_creates_missing_output_dir(app: typer.Typer, tmp_path: Path):
         )
     assert result.exit_code == 0, result.output
     assert captured["exists"] is True  # output_dir already existed when called
+
+
+@patch("allaganeye.commands.export.export_matches")
+def test_export_counts_skipped(
+    mock_export: MagicMock, app: typer.Typer, tmp_path: Path
+):
+    # P2-9: ExportSummary.skipped was never incremented and stayed 0 regardless
+    # of include/exclude/type_override=skip filtering. Verify the --json summary
+    # reports the real filtered-out count.
+    mock_export.return_value = ExportSummary(success=1, failure=0)
+    payload = {
+        "schema_version": "1",
+        "source": str(tmp_path / "in.mp4"),
+        "matches": [
+            {"index": 0, "start_time": 0.0, "end_time": 10.0, "type": "match"},
+            {"index": 1, "start_time": 10.0, "end_time": 20.0, "type": "match"},
+            {
+                "index": 2,
+                "start_time": 20.0,
+                "end_time": 30.0,
+                "type": "match",
+                "type_override": "skip",
+            },
+        ],
+        "system_info": {
+            "gpu_vendors_available": [],
+            "vendor_preference": ["nvidia"],
+            "gpu": [],
+        },
+    }
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            str(metadata_path),
+            "--output-dir",
+            str(tmp_path),
+            "--codec",
+            "h264",
+            "--exclude",
+            "1",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # export target is index 0 only (index 1 excluded, index 2 skip-override)
+    _, kwargs = mock_export.call_args
+    assert [m.index for m in kwargs.get("matches")] == [0]
+    # summary.skipped reflects the 2 filtered-out matches
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    last = json.loads(lines[-1])
+    assert last["type"] == "summary"
+    assert last["skipped"] == 2

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -368,3 +368,37 @@ def test_export_copy_mode_uses_single_slot(
     assert result.exit_code == 0
     _, kwargs = mock_export.call_args
     assert len(kwargs.get("slots")) == 1
+
+
+def test_export_creates_missing_output_dir(app: typer.Typer, tmp_path: Path):
+    # P2-10: export did not mkdir output_dir (split/detect do), so a missing
+    # -o dir made every match's ffmpeg fail to write and the run exited 1.
+    out = tmp_path / "nested" / "out"  # does not exist yet
+    captured: dict[str, object] = {}
+
+    def fake_export_matches(**kwargs: object) -> ExportSummary:
+        out_dir = kwargs["output_dir"]
+        assert isinstance(out_dir, Path)
+        captured["output_dir"] = out_dir
+        captured["exists"] = out_dir.exists()
+        return ExportSummary(success=1)
+
+    metadata_path = _make_metadata(tmp_path)
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        side_effect=fake_export_matches,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(out),
+                "--codec",
+                "h264",
+                "--quiet",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert captured["exists"] is True  # output_dir already existed when called

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -608,6 +608,74 @@ def test_export_json_does_not_emit_summary_on_error(app: typer.Typer, tmp_path: 
     assert '"type":"summary"' not in result.stdout
 
 
+def test_export_warns_on_filename_collision(app: typer.Typer, tmp_path: Path):
+    # P3 I-3: a name pattern without {idx}/{idx:03} maps every match to the same
+    # filename, silently overwriting. export should warn on stderr.
+    payload = {
+        "schema_version": "1",
+        "source": str(tmp_path / "in.mp4"),
+        "matches": [
+            {"index": 0, "start_time": 0.0, "end_time": 10.0, "type": "match"},
+            {"index": 1, "start_time": 10.0, "end_time": 20.0, "type": "match"},
+        ],
+        "system_info": {
+            "gpu_vendors_available": [],
+            "vendor_preference": ["nvidia"],
+            "gpu": [],
+        },
+    }
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(json.dumps(payload), encoding="utf-8")
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        return_value=ExportSummary(success=2),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "copy",
+                "--name-pattern",
+                "{type}.mp4",  # no {idx}: both matches → "match.mp4" (collision)
+                "--quiet",
+            ],
+        )
+    # warning goes to stderr; command can still succeed
+    assert result.exit_code == 0
+    assert "warning" in result.output.lower() or "warning" in (result.stderr or "").lower()
+
+
+def test_export_no_collision_warning_when_pattern_has_idx(app: typer.Typer, tmp_path: Path):
+    # P3 I-3: no warning when the pattern contains {idx} (all names are distinct).
+    metadata_path = _make_metadata(tmp_path)
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        return_value=ExportSummary(success=2),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "copy",
+                "--name-pattern",
+                "{idx:03}_{type}.mp4",
+                "--quiet",
+            ],
+        )
+    assert result.exit_code == 0
+    # no collision warning
+    full_output = result.output + (result.stderr or "")
+    assert "duplicate" not in full_output.lower()
+
+
 def test_export_concurrency_zero_is_rejected(app: typer.Typer, tmp_path: Path):
     # P3 I-2: --concurrency 0 must be rejected with BadParameter (exit 2) before
     # any ffmpeg is launched. Negative values must be rejected too.

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -606,3 +606,27 @@ def test_export_json_does_not_emit_summary_on_error(app: typer.Typer, tmp_path: 
     # no summary line on stdout (stderr carries the error)
     assert '"type": "summary"' not in result.stdout
     assert '"type":"summary"' not in result.stdout
+
+
+def test_export_concurrency_zero_is_rejected(app: typer.Typer, tmp_path: Path):
+    # P3 I-2: --concurrency 0 must be rejected with BadParameter (exit 2) before
+    # any ffmpeg is launched. Negative values must be rejected too.
+    metadata_path = _make_metadata(tmp_path)
+    for bad_val in ("0", "-1", "-99"):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "h264",
+                "--concurrency",
+                bad_val,
+                "--quiet",
+            ],
+        )
+        assert result.exit_code == 2, (
+            f"--concurrency {bad_val} should exit 2 (BadParameter), got {result.exit_code}"
+        )

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -608,9 +608,8 @@ def test_export_json_does_not_emit_summary_on_error(app: typer.Typer, tmp_path: 
     assert '"type":"summary"' not in result.stdout
 
 
-def test_export_warns_on_filename_collision(app: typer.Typer, tmp_path: Path):
-    # P3 I-3: a name pattern without {idx}/{idx:03} maps every match to the same
-    # filename, silently overwriting. export should warn on stderr.
+def _make_colliding_metadata(tmp_path: Path) -> Path:
+    """metadata.json whose 2 matches collide under a pattern without {idx}."""
     payload = {
         "schema_version": "1",
         "source": str(tmp_path / "in.mp4"),
@@ -626,10 +625,19 @@ def test_export_warns_on_filename_collision(app: typer.Typer, tmp_path: Path):
     }
     metadata_path = tmp_path / "metadata.json"
     metadata_path.write_text(json.dumps(payload), encoding="utf-8")
+    return metadata_path
+
+
+def test_export_collision_is_hard_error_exit5(app: typer.Typer, tmp_path: Path):
+    # Finding 3: a name pattern without {idx}/{idx:03} maps every match to the
+    # same filename (overwrite / parallel race / misleading success summary).
+    # This is now a hard preflight error (ConfigValidationError -> exit 5)
+    # raised BEFORE any ffmpeg work, not a warning.
+    metadata_path = _make_colliding_metadata(tmp_path)
     with patch(
         "allaganeye.commands.export.export_matches",
         return_value=ExportSummary(success=2),
-    ):
+    ) as mock_export:
         result = runner.invoke(
             app,
             [
@@ -644,11 +652,39 @@ def test_export_warns_on_filename_collision(app: typer.Typer, tmp_path: Path):
                 "--quiet",
             ],
         )
-    # warning goes to stderr; command can still succeed
-    assert result.exit_code == 0
-    assert (
-        "warning" in result.output.lower() or "warning" in (result.stderr or "").lower()
-    )
+    assert result.exit_code == 5  # ConfigValidationError.exit_code
+    # export must NOT run (the error is raised before any ffmpeg work)
+    mock_export.assert_not_called()
+    assert "Traceback" not in result.output
+
+
+def test_export_collision_json_emits_no_summary(app: typer.Typer, tmp_path: Path):
+    # Finding 3 + P2-7: in --json mode the hard collision error must NOT emit a
+    # summary line (start_export treats any summary line as success in lib.rs).
+    metadata_path = _make_colliding_metadata(tmp_path)
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        return_value=ExportSummary(success=2),
+    ) as mock_export:
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "copy",
+                "--name-pattern",
+                "{type}.mp4",  # collision
+                "--json",
+            ],
+        )
+    assert result.exit_code == 5
+    mock_export.assert_not_called()
+    # no summary line on stdout (the error is the only wire signal)
+    assert '"type": "summary"' not in result.stdout
+    assert '"type":"summary"' not in result.stdout
 
 
 def test_export_no_collision_warning_when_pattern_has_idx(

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -640,7 +640,7 @@ def test_export_warns_on_filename_collision(app: typer.Typer, tmp_path: Path):
                 "--codec",
                 "copy",
                 "--name-pattern",
-                "{type}.mp4",  # no {idx}: both matches → "match.mp4" (collision)
+                "{type}.mp4",  # no {idx}: both matches -> "match.mp4" (collision)
                 "--quiet",
             ],
         )

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -475,9 +475,7 @@ def test_export_json_reconfigures_stdout_utf8(app: typer.Typer, tmp_path: Path):
 
     metadata_path = _make_metadata(tmp_path)
     with (
-        patch.object(
-            click_testing._NamedTextIOWrapper, "reconfigure", spy_reconfigure
-        ),
+        patch.object(click_testing._NamedTextIOWrapper, "reconfigure", spy_reconfigure),
         patch(
             "allaganeye.commands.export.export_matches",
             return_value=ExportSummary(success=1),
@@ -551,3 +549,60 @@ def test_export_stdin_reads_utf8_buffer(app: typer.Typer, tmp_path: Path):
         )
     assert result.exit_code == 0, result.output
     assert str(captured["source_video"]) == non_ascii_source
+
+
+def test_export_maps_allagan_error_to_exit_code(app: typer.Typer, tmp_path: Path):
+    # P2-7: export alone did not catch AllaganEyeError -> raw traceback + exit 1.
+    # It must map to the error's exit code with a clean stderr (no traceback),
+    # like split/detect/debug-brightness.
+    from allaganeye.exceptions import VideoProcessingError
+
+    metadata_path = _make_metadata(tmp_path)
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        side_effect=VideoProcessingError("ffmpeg boom"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "h264",
+                "--quiet",
+            ],
+        )
+    assert result.exit_code == 3  # VideoProcessingError.exit_code
+    assert "Error: ffmpeg boom" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_export_json_does_not_emit_summary_on_error(app: typer.Typer, tmp_path: Path):
+    # P2-7: in --json mode a hard error must NOT emit a summary line. start_export
+    # treats any summary line as success (lib.rs) and would mask the error in the
+    # GUI. The terminal signal is a non-zero exit + stderr, never a summary.
+    from allaganeye.exceptions import VideoProcessingError
+
+    metadata_path = _make_metadata(tmp_path)
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        side_effect=VideoProcessingError("ffmpeg boom"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "h264",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 3
+    # no summary line on stdout (stderr carries the error)
+    assert '"type": "summary"' not in result.stdout
+    assert '"type":"summary"' not in result.stdout

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -698,3 +698,64 @@ def test_export_concurrency_zero_is_rejected(app: typer.Typer, tmp_path: Path):
         assert result.exit_code == 2, (
             f"--concurrency {bad_val} should exit 2 (BadParameter), got {result.exit_code}"
         )
+
+
+def test_export_include_help_mentions_1_based(app: typer.Typer):
+    # P3 I-4 (a): --include/--exclude help text must mention 1-based indexes so
+    # users don't confuse them with 0-based array positions.
+    result = runner.invoke(app, ["export", "--help"])
+    assert result.exit_code == 0
+    help_text = result.output
+    assert "1-based" in help_text
+
+
+def test_export_include_out_of_range_warns(app: typer.Typer, tmp_path: Path):
+    # P3 I-4 (b): --include 99 (no such match in metadata) should warn on stderr.
+    metadata_path = _make_metadata(tmp_path)  # matches: index 0, 1
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        return_value=ExportSummary(success=0),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "copy",
+                "--include",
+                "99",  # no match has index 99
+                "--quiet",
+            ],
+        )
+    assert result.exit_code == 0  # warning only, not an error
+    assert "warning" in result.output.lower()
+    assert "99" in result.output
+
+
+def test_export_exclude_out_of_range_warns(app: typer.Typer, tmp_path: Path):
+    # P3 I-4 (b): --exclude 99 (no such match) should warn on stderr.
+    metadata_path = _make_metadata(tmp_path)  # matches: index 0, 1
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        return_value=ExportSummary(success=2),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "copy",
+                "--exclude",
+                "99",  # no match has index 99
+                "--quiet",
+            ],
+        )
+    assert result.exit_code == 0  # warning only
+    assert "warning" in result.output.lower()
+    assert "99" in result.output

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -457,3 +458,96 @@ def test_export_counts_skipped(
     last = json.loads(lines[-1])
     assert last["type"] == "summary"
     assert last["skipped"] == 2
+
+
+def test_export_json_reconfigures_stdout_utf8(app: typer.Typer, tmp_path: Path):
+    # P2-8: --json emits non-ASCII (output_path / error_message) with
+    # ensure_ascii=False but never reconfigured stdout to UTF-8, relying on the
+    # Rust caller's PYTHONIOENCODING. On a cp932 console CLI-only this corrupts
+    # output. Verify the command reconfigures stdout to utf-8.
+    import click.testing as click_testing
+
+    calls: list[dict[str, object]] = []
+
+    def spy_reconfigure(self: io.TextIOWrapper, **kw: object) -> None:
+        calls.append(kw)
+        io.TextIOWrapper.reconfigure(self, **kw)  # type: ignore[arg-type]
+
+    metadata_path = _make_metadata(tmp_path)
+    with (
+        patch.object(
+            click_testing._NamedTextIOWrapper, "reconfigure", spy_reconfigure
+        ),
+        patch(
+            "allaganeye.commands.export.export_matches",
+            return_value=ExportSummary(success=1),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export",
+                str(metadata_path),
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "h264",
+                "--json",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert any(c.get("encoding") == "utf-8" for c in calls), calls
+
+
+def test_export_stdin_reads_utf8_buffer(app: typer.Typer, tmp_path: Path):
+    # P2-8: --stdin must read sys.stdin.buffer as bytes and decode UTF-8 so a
+    # cp932 default stdin encoding (Windows console) can't corrupt a non-ASCII
+    # source path. We model that by giving CliRunner a cp932 text layer over
+    # UTF-8 bytes: the old json.load(sys.stdin) text path mis-decodes, the new
+    # buffer path round-trips.
+    cp932_runner = CliRunner(charset="cp932")
+    non_ascii_source = str(tmp_path / "録画" / "試合.mp4")
+    # ensure_ascii=False so the wire carries raw UTF-8 multibyte bytes. With the
+    # old json.load(sys.stdin) cp932 text path those bytes mis-decode (mojibake);
+    # only sys.stdin.buffer + UTF-8 decode round-trips. (ASCII-escaped JSON would
+    # decode identically under any charset and would not discriminate.)
+    payload = json.dumps(
+        {
+            "source": non_ascii_source,
+            "matches": [
+                {"index": 0, "start_time": 0.0, "end_time": 5.0, "type": "match"}
+            ],
+            "system_info": {
+                "gpu_vendors_available": [],
+                "vendor_preference": ["nvidia"],
+                "gpu": [],
+            },
+        },
+        ensure_ascii=False,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_export_matches(**kwargs: object) -> ExportSummary:
+        captured["source_video"] = kwargs["source_video"]
+        return ExportSummary(success=1)
+
+    with patch(
+        "allaganeye.commands.export.export_matches",
+        side_effect=fake_export_matches,
+    ):
+        result = cp932_runner.invoke(
+            app,
+            [
+                "export",
+                "--stdin",
+                "--output-dir",
+                str(tmp_path),
+                "--codec",
+                "copy",
+                "--quiet",
+            ],
+            input=payload.encode("utf-8"),
+        )
+    assert result.exit_code == 0, result.output
+    assert str(captured["source_video"]) == non_ascii_source

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -799,3 +799,117 @@ def test_export_exclude_out_of_range_warns(app: typer.Typer, tmp_path: Path):
     assert result.exit_code == 0  # warning only
     assert "warning" in result.output.lower()
     assert "99" in result.output
+
+
+def test_load_metadata_stdin_invalid_utf8_raises_unicode_decode_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Round 1 FIX 1 (a): _load_metadata(--stdin) reads sys.stdin.buffer as bytes
+    # and decodes UTF-8. Invalid bytes must raise UnicodeDecodeError (a ValueError
+    # subclass, NOT OSError/JSONDecodeError) so the command can map it to exit 2.
+    from allaganeye.commands.export import _load_metadata
+
+    bad_bytes = b"\xff\xfe\x00\x80not utf-8"
+
+    class _FakeStdin:
+        buffer = io.BytesIO(bad_bytes)
+
+    monkeypatch.setattr("allaganeye.commands.export.sys.stdin", _FakeStdin())
+    with pytest.raises(UnicodeDecodeError):
+        _load_metadata(None, use_stdin=True)
+
+
+def test_export_stdin_invalid_utf8_exits_2(app: typer.Typer, tmp_path: Path):
+    # Round 1 FIX 1 (a): the --stdin decode failure (UnicodeDecodeError) must map
+    # to exit 2 with a clean stderr, NOT escape as a raw traceback / exit 1.
+    bad_bytes = b"\xff\xfe\x00\x80not utf-8"
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            "--stdin",
+            "--output-dir",
+            str(tmp_path),
+            "--codec",
+            "copy",
+            "--quiet",
+        ],
+        input=bad_bytes,
+    )
+    assert result.exit_code == 2, result.output
+    assert "Traceback" not in result.output
+
+
+def test_export_metadata_missing_index_exits_2(app: typer.Typer, tmp_path: Path):
+    # Round 1 FIX 1 (b): a match missing the required "index" key raises KeyError
+    # in the filter loop (which runs BEFORE the P2-7 frame). It must map to exit 2
+    # with a clean stderr, not escape as a raw traceback / exit 1.
+    payload = {
+        "schema_version": "1",
+        "source": str(tmp_path / "in.mp4"),
+        "matches": [
+            {"start_time": 0.0, "end_time": 10.0, "type": "match"},  # no "index"
+        ],
+        "system_info": {
+            "gpu_vendors_available": [],
+            "vendor_preference": ["nvidia"],
+            "gpu": [],
+        },
+    }
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            str(metadata_path),
+            "--output-dir",
+            str(tmp_path),
+            "--codec",
+            "copy",
+            "--quiet",
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    assert "Traceback" not in result.output
+
+
+def test_export_metadata_non_numeric_start_time_exits_2(
+    app: typer.Typer, tmp_path: Path
+):
+    # Round 1 FIX 1 (b): a non-numeric "start_time" raises ValueError in the
+    # filter loop (before the P2-7 frame). It must map to exit 2 with a clean
+    # stderr, not escape as a raw traceback / exit 1.
+    payload = {
+        "schema_version": "1",
+        "source": str(tmp_path / "in.mp4"),
+        "matches": [
+            {
+                "index": 0,
+                "start_time": "not-a-number",
+                "end_time": 10.0,
+                "type": "match",
+            },
+        ],
+        "system_info": {
+            "gpu_vendors_available": [],
+            "vendor_preference": ["nvidia"],
+            "gpu": [],
+        },
+    }
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "export",
+            str(metadata_path),
+            "--output-dir",
+            str(tmp_path),
+            "--codec",
+            "copy",
+            "--quiet",
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    assert "Traceback" not in result.output

--- a/tests/test_export_ffmpeg_runner.py
+++ b/tests/test_export_ffmpeg_runner.py
@@ -816,3 +816,76 @@ def test_partial_cleanup_cancel_output_deleted(mock_popen: MagicMock, tmp_path: 
         )
     assert exc_info.value.kind == "cancelled"
     assert not output.exists(), "partial output MUST be deleted on cancel"
+
+
+# --- run_export_attempt: ownership-safe cleanup (Finding 1) ---
+# The I-5 cleanup must only remove files THIS attempt created. A pre-existing
+# valid output (left by a prior run, or a path that already held content) must
+# survive a failure/cancel where ffmpeg never rewrote it -- otherwise a transient
+# failure silently destroys a good file the attempt did not own.
+
+
+@patch("allaganeye.export.ffmpeg_runner.subprocess.Popen")
+def test_preexisting_output_preserved_on_failure(mock_popen: MagicMock, tmp_path: Path):
+    """Finding 1: a PRE-EXISTING output is NOT deleted when the attempt fails
+    without rewriting it (ownership-safe). The fake proc fails (returncode 1)
+    and never touches the file, so output_pre_existed is True and the unlink
+    must be skipped.
+    """
+    output = tmp_path / "out.mp4"
+    output.write_bytes(b"good prior output")  # exists BEFORE the attempt
+
+    def popen_side(*args, **kwargs):  # type: ignore[no-untyped-def]
+        # Note: does NOT write output -- ffmpeg failed before truncating it.
+        return _make_proc(1, [b"Error opening codec\n"])
+
+    mock_popen.side_effect = popen_side
+
+    with pytest.raises(ExportError) as exc_info:
+        run_export_attempt(
+            video=tmp_path / "in.mp4",
+            start=0.0,
+            end=10.0,
+            output=output,
+            codec="h264",
+            encoder=H264Encoder.LIBX264,  # avoid the fallback path
+            progress_cb=lambda p, s: None,
+            fallback_cb=None,
+            cancel_event=threading.Event(),
+        )
+    assert exc_info.value.kind == "ffmpeg.exit_failed"
+    assert output.exists(), "pre-existing output MUST NOT be deleted on failure"
+    assert output.read_bytes() == b"good prior output", "bytes must be unchanged"
+
+
+@patch("allaganeye.export.ffmpeg_runner.subprocess.Popen")
+def test_preexisting_output_preserved_on_cancel(mock_popen: MagicMock, tmp_path: Path):
+    """Finding 1: a PRE-EXISTING output is NOT deleted on cancel when the
+    attempt did not rewrite it.
+    """
+    output = tmp_path / "out.mp4"
+    output.write_bytes(b"good prior output")  # exists BEFORE the attempt
+    cancel = threading.Event()
+    cancel.set()  # cancel immediately
+
+    def popen_side(*args, **kwargs):  # type: ignore[no-untyped-def]
+        # Does NOT write output.
+        return _make_proc(-9, [])
+
+    mock_popen.side_effect = popen_side
+
+    with pytest.raises(ExportError) as exc_info:
+        run_export_attempt(
+            video=tmp_path / "in.mp4",
+            start=0.0,
+            end=10.0,
+            output=output,
+            codec="h264",
+            encoder=H264Encoder.LIBX264,
+            progress_cb=lambda p, s: None,
+            fallback_cb=None,
+            cancel_event=cancel,
+        )
+    assert exc_info.value.kind == "cancelled"
+    assert output.exists(), "pre-existing output MUST NOT be deleted on cancel"
+    assert output.read_bytes() == b"good prior output", "bytes must be unchanged"

--- a/tests/test_export_ffmpeg_runner.py
+++ b/tests/test_export_ffmpeg_runner.py
@@ -618,7 +618,7 @@ def _make_proc(returncode: int, stderr_lines: list[bytes]) -> MagicMock:
     """Build a fake subprocess.Popen return value."""
     proc = MagicMock()
     proc.stderr = MagicMock()
-    proc.stderr.readline = MagicMock(side_effect=stderr_lines + [b""])
+    proc.stderr.readline = MagicMock(side_effect=[*stderr_lines, b""])
     proc.wait = MagicMock(return_value=returncode)
     proc.returncode = returncode
     return proc
@@ -666,7 +666,9 @@ def test_partial_cleanup_gpu_fail_retry_success_output_kept(
         if call_count == 1:
             # 1st attempt (NVENC): writes partial then fails
             output.write_bytes(b"partial")
-            return _make_proc(1, [b"[h264_nvenc @ 0xfff] No NVENC capable devices found\n"])
+            return _make_proc(
+                1, [b"[h264_nvenc @ 0xfff] No NVENC capable devices found\n"]
+            )
         # 2nd attempt (libx264): rewrites and succeeds
         output.write_bytes(b"real output")
         return _make_proc(0, [b"out_time_ms=1000000\n", b"progress=end\n"])
@@ -701,7 +703,9 @@ def test_partial_cleanup_final_failure_output_deleted(
         call_count += 1
         output.write_bytes(b"partial")  # simulate partial write on each attempt
         if call_count == 1:
-            return _make_proc(1, [b"[h264_nvenc @ 0xfff] No NVENC capable devices found\n"])
+            return _make_proc(
+                1, [b"[h264_nvenc @ 0xfff] No NVENC capable devices found\n"]
+            )
         return _make_proc(1, [b"Error opening codec\n"])
 
     mock_popen.side_effect = popen_side

--- a/tests/test_export_ffmpeg_runner.py
+++ b/tests/test_export_ffmpeg_runner.py
@@ -7,6 +7,7 @@ is_gpu_encoder_failure coverage, see #591/#761). Heavy mocking around subprocess
 from __future__ import annotations
 
 import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -221,6 +222,66 @@ def test_run_export_attempt_cancel_event_kills_ffmpeg(
             cancel_event=cancel,
         )
     assert exc_info.value.kind == "cancelled"
+    proc.kill.assert_called()
+
+
+# --- _run_single_attempt: cancel responsiveness on no-output stall (P2-40) ---
+
+
+def test_run_single_attempt_responds_to_cancel_when_no_output():
+    """P2-40: cancel must respond on a bounded cadence even when ffmpeg emits
+    nothing to stderr.
+
+    The old implementation blocked directly on ``proc.stderr.readline()`` and
+    only re-checked ``cancel_event`` after a line returned, so a stalled ffmpeg
+    (no output) ignored cancel until the next line or EOF. The reader-thread +
+    queue rearchitecture polls cancel every ~100ms via ``queue.get(timeout=...)``.
+
+    RED design (pytest-timeout is NOT installed, so the fake readline must not
+    block forever): ``readline`` blocks for a *bounded* 4s then returns b"" (EOF),
+    while ``cancel_event`` is set at ~0.3s.
+      - NEW code: the main loop sees cancel at ~0.3s -> ``proc.kill()`` -> returns
+        promptly (elapsed < 2.0, kill called).
+      - OLD code: first iteration checks cancel (not set yet) -> blocks in
+        ``readline`` for the full 4s (never re-checks cancel) -> gets b"" -> breaks
+        WITHOUT calling kill (elapsed ~4s, kill NOT called).
+    Assertions ``elapsed < 2.0`` + ``proc.kill.assert_called()`` therefore FAIL on
+    OLD and PASS on NEW, without ever hanging.
+    """
+    from allaganeye.export.ffmpeg_runner import _run_single_attempt
+
+    readline_released = threading.Event()
+
+    class BlockingStderr:
+        def readline(self) -> bytes:
+            # Bounded block: returns EOF after 4s so the OLD code terminates
+            # (slowly, wrong behavior) rather than hanging forever.
+            readline_released.wait(timeout=4.0)
+            return b""
+
+    proc = MagicMock()
+    proc.stderr = BlockingStderr()
+    proc.kill = MagicMock()
+    proc.wait = MagicMock(return_value=-9)
+
+    cancel_event = threading.Event()
+    timer = threading.Timer(0.3, cancel_event.set)
+    timer.start()
+
+    start = time.monotonic()
+    with patch("allaganeye.export.ffmpeg_runner.subprocess.Popen", return_value=proc):
+        _run_single_attempt(
+            ["ffmpeg"],
+            duration_s=100.0,
+            progress_cb=lambda *a: None,
+            cancel_event=cancel_event,
+        )
+    elapsed = time.monotonic() - start
+
+    timer.cancel()
+    readline_released.set()  # release the (daemon) reader thread for cleanup
+
+    assert elapsed < 2.0, f"cancel should be bounded, took {elapsed:.1f}s"
     proc.kill.assert_called()
 
 

--- a/tests/test_export_ffmpeg_runner.py
+++ b/tests/test_export_ffmpeg_runner.py
@@ -603,3 +603,149 @@ def test_run_export_attempt_nvdec_decode_failure_triggers_libx264_retry(
     # libx264 retry argv lacks -hwaccel
     second_argv = mock_popen.call_args_list[1].args[0]
     assert "-hwaccel" not in second_argv
+
+
+# --- run_export_attempt: partial file cleanup (P3 I-5) ---
+# Protective tests ensure the unlink logic fires on exactly the right paths.
+# Safety contract:
+#   (1) successful 1st attempt -> output NOT deleted (it's the real result)
+#   (2) GPU fail -> successful libx264 retry -> output NOT deleted
+#   (3) final failure (both attempts fail) -> partial IS deleted
+#   (4) cancel -> partial IS deleted
+
+
+def _make_proc(returncode: int, stderr_lines: list[bytes]) -> MagicMock:
+    """Build a fake subprocess.Popen return value."""
+    proc = MagicMock()
+    proc.stderr = MagicMock()
+    proc.stderr.readline = MagicMock(side_effect=stderr_lines + [b""])
+    proc.wait = MagicMock(return_value=returncode)
+    proc.returncode = returncode
+    return proc
+
+
+@patch("allaganeye.export.ffmpeg_runner.subprocess.Popen")
+def test_partial_cleanup_success_1st_attempt_output_kept(
+    mock_popen: MagicMock, tmp_path: Path
+):
+    """I-5 safety (1): successful 1st attempt MUST NOT delete the output."""
+    output = tmp_path / "out.mp4"
+
+    def popen_side(*args, **kwargs):  # type: ignore[no-untyped-def]
+        output.write_bytes(b"real output")  # simulate ffmpeg writing the file
+        return _make_proc(0, [b"out_time_ms=1000000\n", b"progress=end\n"])
+
+    mock_popen.side_effect = popen_side
+
+    result = run_export_attempt(
+        video=tmp_path / "in.mp4",
+        start=0.0,
+        end=10.0,
+        output=output,
+        codec="h264",
+        encoder=H264Encoder.LIBX264,
+        progress_cb=lambda p, s: None,
+        fallback_cb=None,
+        cancel_event=threading.Event(),
+    )
+    assert result.encoder_used == H264Encoder.LIBX264.value
+    assert output.exists(), "output must NOT be deleted on success"
+
+
+@patch("allaganeye.export.ffmpeg_runner.subprocess.Popen")
+def test_partial_cleanup_gpu_fail_retry_success_output_kept(
+    mock_popen: MagicMock, tmp_path: Path
+):
+    """I-5 safety (2): GPU fail -> libx264 retry success -> output MUST NOT be deleted."""
+    output = tmp_path / "out.mp4"
+    call_count = 0
+
+    def popen_side(*args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # 1st attempt (NVENC): writes partial then fails
+            output.write_bytes(b"partial")
+            return _make_proc(1, [b"[h264_nvenc @ 0xfff] No NVENC capable devices found\n"])
+        # 2nd attempt (libx264): rewrites and succeeds
+        output.write_bytes(b"real output")
+        return _make_proc(0, [b"out_time_ms=1000000\n", b"progress=end\n"])
+
+    mock_popen.side_effect = popen_side
+
+    result = run_export_attempt(
+        video=tmp_path / "in.mp4",
+        start=0.0,
+        end=10.0,
+        output=output,
+        codec="h264",
+        encoder=H264Encoder.NVENC,
+        progress_cb=lambda p, s: None,
+        fallback_cb=lambda f, t, m: None,
+        cancel_event=threading.Event(),
+    )
+    assert result.encoder_used == H264Encoder.LIBX264.value
+    assert output.exists(), "output must NOT be deleted after successful retry"
+
+
+@patch("allaganeye.export.ffmpeg_runner.subprocess.Popen")
+def test_partial_cleanup_final_failure_output_deleted(
+    mock_popen: MagicMock, tmp_path: Path
+):
+    """I-5 safety (3): both attempts fail -> partial output MUST be deleted."""
+    output = tmp_path / "out.mp4"
+    call_count = 0
+
+    def popen_side(*args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal call_count
+        call_count += 1
+        output.write_bytes(b"partial")  # simulate partial write on each attempt
+        if call_count == 1:
+            return _make_proc(1, [b"[h264_nvenc @ 0xfff] No NVENC capable devices found\n"])
+        return _make_proc(1, [b"Error opening codec\n"])
+
+    mock_popen.side_effect = popen_side
+
+    with pytest.raises(ExportError) as exc_info:
+        run_export_attempt(
+            video=tmp_path / "in.mp4",
+            start=0.0,
+            end=10.0,
+            output=output,
+            codec="h264",
+            encoder=H264Encoder.NVENC,
+            progress_cb=lambda p, s: None,
+            fallback_cb=lambda f, t, m: None,
+            cancel_event=threading.Event(),
+        )
+    assert exc_info.value.kind == "ffmpeg.exit_failed"
+    assert not output.exists(), "partial output MUST be deleted on final failure"
+
+
+@patch("allaganeye.export.ffmpeg_runner.subprocess.Popen")
+def test_partial_cleanup_cancel_output_deleted(mock_popen: MagicMock, tmp_path: Path):
+    """I-5 safety (4): cancel -> partial output MUST be deleted."""
+    output = tmp_path / "out.mp4"
+    cancel = threading.Event()
+    cancel.set()  # cancel immediately
+
+    def popen_side(*args, **kwargs):  # type: ignore[no-untyped-def]
+        output.write_bytes(b"partial")  # simulate partial write
+        return _make_proc(-9, [])
+
+    mock_popen.side_effect = popen_side
+
+    with pytest.raises(ExportError) as exc_info:
+        run_export_attempt(
+            video=tmp_path / "in.mp4",
+            start=0.0,
+            end=10.0,
+            output=output,
+            codec="h264",
+            encoder=H264Encoder.LIBX264,
+            progress_cb=lambda p, s: None,
+            fallback_cb=None,
+            cancel_event=cancel,
+        )
+    assert exc_info.value.kind == "cancelled"
+    assert not output.exists(), "partial output MUST be deleted on cancel"

--- a/tests/test_export_ffmpeg_runner.py
+++ b/tests/test_export_ffmpeg_runner.py
@@ -201,7 +201,11 @@ def test_run_export_attempt_cancel_event_kills_ffmpeg(
     """cancel_event が set されたら ffmpeg を kill して ExportError(kind='cancelled') raise."""
     proc = MagicMock()
     proc.stderr = MagicMock()
-    proc.stderr.readline = MagicMock(return_value=b"out_time_ms=1000000\n")
+    # Finite side_effect ending in b"" -- a real ffmpeg's stderr reaches EOF
+    # after kill(). A constant return_value (never b"") would make the reader
+    # thread's `iter(readline, b"")` spin forever and fill the queue (suite OOM);
+    # see test_reader_thread_stops_after_attempt_with_continuous_stderr.
+    proc.stderr.readline = MagicMock(side_effect=[b"out_time_ms=1000000\n", b""])
     proc.wait = MagicMock(return_value=-9)  # SIGKILL
     proc.returncode = -9
     mock_popen.return_value = proc
@@ -283,6 +287,65 @@ def test_run_single_attempt_responds_to_cancel_when_no_output():
 
     assert elapsed < 2.0, f"cancel should be bounded, took {elapsed:.1f}s"
     proc.kill.assert_called()
+
+
+# --- _run_single_attempt: reader thread must not outlive the attempt (P2-40 OOM) ---
+
+
+def test_reader_thread_stops_after_attempt_with_continuous_stderr():
+    """Regression: a stderr that never returns b"" (a stalled or continuously
+    chatty producer) must not leave the daemon reader thread spinning and
+    filling the queue after the attempt finishes -- that leaked unbounded memory
+    and OOM-crashed the whole test suite. A stop flag ends the pump.
+
+    Cleanup releases the fake reader unconditionally so that, even if the fix
+    regresses, this test only fails (thread still alive) instead of OOM-ing the
+    rest of the suite.
+    """
+    from allaganeye.export.ffmpeg_runner import _run_single_attempt
+
+    keep_emitting = threading.Event()
+    keep_emitting.set()
+
+    def fake_readline() -> bytes:
+        # Emit forever until cleanup clears the flag, then EOF (b"").
+        return b"noise\n" if keep_emitting.is_set() else b""
+
+    proc = MagicMock()
+    proc.stderr = MagicMock()
+    proc.stderr.readline = MagicMock(side_effect=fake_readline)
+    proc.kill = MagicMock()
+    proc.wait = MagicMock(return_value=-9)
+
+    cancel = threading.Event()
+    cancel.set()  # finish the attempt immediately
+
+    try:
+        with patch(
+            "allaganeye.export.ffmpeg_runner.subprocess.Popen", return_value=proc
+        ):
+            _run_single_attempt(
+                ["ffmpeg"],
+                duration_s=10.0,
+                progress_cb=lambda p, s: None,
+                cancel_event=cancel,
+            )
+        # With the stop flag, the reader winds down even though readline never
+        # returned b"" during the attempt. Poll briefly for it to exit.
+        deadline = time.monotonic() + 2.0
+        alive = True
+        while time.monotonic() < deadline:
+            alive = any(
+                t.name == "ffmpeg-stderr" and t.is_alive()
+                for t in threading.enumerate()
+            )
+            if not alive:
+                break
+            time.sleep(0.02)
+        assert not alive, "reader thread leaked after attempt (P2-40 OOM regression)"
+    finally:
+        keep_emitting.clear()  # release the fake reader so a regression can't OOM
+        time.sleep(0.05)
 
 
 # --- run_export_attempt: libx264 retry also fails ---

--- a/tests/test_export_pool.py
+++ b/tests/test_export_pool.py
@@ -16,8 +16,31 @@ from unittest.mock import patch
 import pytest
 
 from allaganeye.export.encoder import EncoderSlot, H264Encoder
-from allaganeye.export.pool import ExportMatch, export_matches
+from allaganeye.export.pool import (
+    ExportMatch,
+    _format_start_for_filename,
+    export_matches,
+)
 from allaganeye.export.schema import ExportError, ExportResult
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0.0, "00-00"),
+        (5.0, "00-05"),
+        (65.0, "01-05"),
+        (915.5, "15-15"),  # 15m15s
+        (3599.0, "59-59"),
+        (3600.0, "1-00-00"),  # 1h ちょうど
+        (5021.5, "1-23-41"),  # 1h23m41s -- GUI formatStartForFilename と一致
+        (-10.0, "00-00"),  # 負値は 0 clamp (GUI と同じ)
+    ],
+)
+def test_format_start_matches_gui_h_mm_ss(seconds: float, expected: str):
+    # P2-20: GUI ExportScreen.tsx formatStartForFilename と bit-identical。
+    # 旧実装は通算分 (5021.5 -> "83-41") で 1h 以降に GUI プレビューと乖離した。
+    assert _format_start_for_filename(seconds) == expected
 
 
 def _slots(n: int) -> list[EncoderSlot]:


### PR DESCRIPTION
監査 remediation Wave 2 **W1** ([#840](https://github.com/Idios/kobutachan-allaganeye/issues/840))。`allaganeye export` (#761) と `debug-brightness` の CLI / wire 契約の品質を split/detect 水準に揃える。spec `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` §W1 / audit `docs/audits/2026-06-10-full-audit.md` P2-7/8/9/10/11/20/40 + export 系 P3 を消化。

base: `develop-0.3.0` / **Refs #840 (Closes は使わない、手動 close)**。session-id: `audit-w2-w1-20260622`。plan: `docs/superpowers/plans/2026-06-22-audit-w2-w1.md`。

## 対応 finding

### P2 (audit)

- **P2-7** export を cli.py のエラー枠組みに収める (`except AllaganEyeError → exit code` / 予期せぬ例外 → exit 1)。`--json` の hard error 時は summary を **emit しない** (Rust start_export は summary を exit code より優先し error を mask するため、非ゼロ exit + stderr が正)。`typer.Exit` (cancelled 130 / failure 1) は try の外で握り潰し回避 (bb6d6b0)
- **P2-8** `--json` の Python 層 encoding 自衛 (`sys.stdout.reconfigure(utf-8)` + `--stdin` を `sys.stdin.buffer` で UTF-8 decode)。Rust の PYTHONIOENCODING 注入に依存しない (1ec9125)
- **P2-9** `ExportSummary.skipped` を実数化 (include/exclude/skip-override で除外した件数を反映、常に 0 を解消) (a4298f3)
- **P2-10** export 開始前に output_dir を mkdir (`-o` 先不在でも失敗しない) (8d3d71a)
- **P2-11** `debug-brightness --interval 0`/負値の無限ループ防止。`_generate_timestamps` に非正値 guard + debug-brightness で exit 5 (ConfigValidationError) (bba464a)
- **P2-20** `{start}` 命名を GUI `formatStartForFilename` と同一 H-MM-SS に統一 (5021.5→`1-23-41`、負/非有限は 0 clamp) (b77dfa7)
- **P2-40** export cancel を ffmpeg 無出力 stall でも応答化 (stderr を reader thread + queue でポンプし worker は cancel を有界 cadence でポーリング、`proc.wait` に timeout+kill) (9b72aa9)

### export P3

- 未使用 `codec` 引数除去 (fdf64e4) / `--concurrency ≤0` を BadParameter で弾く (10856b8) / `{idx}` 欠落の命名衝突を **hard-fail (exit 5)** で弾く (e5f5dd3→4b48cf9) / `--include`・`--exclude` help に 1-based 基数明記 + 範囲外 index 警告 (ad3676c) / ffmpeg 失敗・cancel 時の partial 出力掃除を **ownership-safe** に (83d0a4a→f354e38)

### docs

- cli-spec.md の export/debug-brightness exit code を実態に同期 (c8b9548)

## 実装中に発見・修正した問題

### OOM リーク (full-suite 検証で発見、6cb1a0a + 76ccec5)

P2-40 で追加した stderr reader thread が、テストの定数 readline mock (never EOF) と組み合わさり無制限 queue を埋め、フルスイートを ~80% で **OOM クラッシュ**させていた (subagent の per-task targeted test では緑、フルスイートでのみ顕在化)。stop flag で reader を attempt 寿命に束縛 + 有限 mock + 回帰テスト。後に bounded queue + `is_alive` 終了に再構成 (#838 と同じ bounded-drain 思想)。memory `feedback_reader_thread_eof_leak` に記録。

### Codex adversarial-review round 1 の 3 finding (Idios 承認方針で修正)

- **[high] finding 1**: I-5 partial 掃除の `output.unlink()` が、ffmpeg が出力を開く前に失敗した場合等に既存の valid ファイルを削除しうる (#805 と同型の「不可逆削除×弱い信号」) → attempt 開始前の存在を記録し**新規作成分のみ unlink** (ownership-safe) (f354e38)
- **[high] finding 2**: reader queue が unbounded + None sentinel 依存 (full queue で sentinel drop → hang) → **bounded queue + put_nowait drop + `reader.is_alive()` 終了**に再構成 (76ccec5)
- **[medium] finding 3**: 命名衝突を warn のみで継続 → 上書き/並列レース/JSON success に隠れる → P2-7 try 内で **hard-fail (exit 5)** に昇格 (4b48cf9)

> **Codex fallback notice**: codex round 2 は環境 read-only でリポジトリ diff を検査できず実行失敗 (私のコードへの finding ではない)。CLAUDE.md §C6 に従い superpowers requesting-code-review subagent で **fallback 独立レビュー** → **APPROVE (no defects)**、3 fix + P2-7 invariant の正当性を実コード精読で確認。

## 3 層 encoding audit (#656/#657/#662 checklist)

P2-8 は **Python 側のみ** touch (`sys.stdout.reconfigure` / `sys.stdin.buffer`)。Rust 側は #657/#662 で対応済 (start_export の PYTHONIOENCODING 注入)。OS code page は対象外。

## Self-Test Report

machine-verified:

- [x] `python -m ruff check .` — All checks passed
- [x] `python -m ruff format --check .` — 131 files already formatted
- [x] `python -m pyright allaganeye tests` — 0 errors (bare `pyright` の 64 errors は local の stale `.claude/worktrees/*` noise、CI の fresh checkout では非該当)
- [x] `python -m pytest` — **1491 passed, 1 skipped** (OOM 解消、フルスイート完走)
- [x] `bash scripts/check-markdownlint.sh` (CI 同 version, 全 .md) — 0 errors

実機検証 (Idios、iterate-review 収束後の最終状態で AskUserQuestion 依頼予定。subprocess/encoding/cancel は mock 不可):

- `allaganeye export --json --stdin` の非 ASCII (日本語) path / cp932 console で output_path・error が文字化けしない
- export 中 Ctrl+C で数秒以内に中断 (cancel 応答)
- 存在しない `-o` 先 → 自動作成して成功
- 1 時間超の start を持つ match のファイル名が GUI プレビュー (H-MM-SS) と一致
- `allaganeye debug-brightness <video> --interval 0` → exit 5 (hang しない)

## 受け入れ条件 (issue #840 AC 逐条)

- [x] **P2-7** error→exit code マッピング / json hard error で no-summary (bb6d6b0、`test_export_maps_allagan_error_to_exit_code` / `test_export_json_does_not_emit_summary_on_error`)
- [x] **P2-8** json stdout utf-8 reconfigure / stdin buffer (1ec9125、reconfigure・stdin utf-8 test)
- [x] **P2-9** skipped 実数化 (a4298f3、`test_export_counts_skipped`)
- [x] **P2-10** output_dir mkdir + doc 訂正 (8d3d71a + c8b9548、`test_export_creates_missing_output_dir`)
- [x] **P2-11** interval≤0 exit 5 + 根本 guard (bba464a、`test_generate_timestamps_rejects_nonpositive_interval` / `test_run_debug_brightness_rejects_nonpositive_interval`)
- [x] **P2-20** GUI parity (b77dfa7、`test_format_start_matches_gui_h_mm_ss`)
- [x] **P2-40** cancel 応答 + 無出力 stall (9b72aa9 + 6cb1a0a + 76ccec5、`test_run_single_attempt_responds_to_cancel_when_no_output` / `test_reader_thread_stops_after_attempt_with_continuous_stderr`)
- [x] **export P3** concurrency / partial (ownership-safe) / dead param / `{idx}` hard-fail / 基数+範囲外警告 を消化
- [x] Python path 全チェック green (上記 Self-Test Report)
- 実機検証 (Idios) — **pending** (iterate-review 収束後に依頼、回答まで merge 不可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
