### PR TITLE
fix(detector): W4 core 堅牢化 (P2-3/4/6 + core P3) (Refs #842)

### DIFF
--- a/allaganeye/commands/split_matches.py
+++ b/allaganeye/commands/split_matches.py
@@ -7,7 +7,6 @@ import shutil
 import sys
 import time
 from collections.abc import Callable
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import TypedDict, cast
 
@@ -16,6 +15,11 @@ from click._termui_impl import ProgressBar as _ClickProgressBar  # subclass 用 
 
 from allaganeye.audio.matcher import BgmHit
 from allaganeye.config import SplitConfig
+from allaganeye.detection.format import (
+    format_duration as _format_duration,
+    format_timestamp as _format_timestamp,
+    iso_utc_now as _iso_utc_now,
+)
 from allaganeye.detection.metadata_writer import (
     read_metadata,
     write_metadata_atomic,
@@ -1729,15 +1733,6 @@ def _print_detection_stats(stats: DetectionStats) -> None:
         typer.echo(f"  + {unknown_count} unknown {label} (録画途中試合)")
 
 
-def _format_timestamp(seconds: float) -> str:
-    """Format seconds as MM:SS or H:MM:SS."""
-    m, s = divmod(int(seconds), 60)
-    h, m = divmod(m, 60)
-    if h:
-        return f"{h}:{m:02d}:{s:02d}"
-    return f"{m:02d}:{s:02d}"
-
-
 def _format_eta(seconds: float) -> str:
     """Format an ETA for in-label display (compact, e.g. '45s' or '3m20s').
 
@@ -1754,16 +1749,6 @@ def _format_eta(seconds: float) -> str:
     return f"{h}h{m:02d}m"
 
 
-def _format_duration(seconds: float) -> str:
-    """Format duration as e.g. '14m02s' or '1h05m'."""
-    total = int(seconds)
-    m, s = divmod(total, 60)
-    h, m = divmod(m, 60)
-    if h:
-        return f"{h}h{m:02d}m"
-    return f"{m}m{s:02d}s"
-
-
 def _emit_total_time(total_start: float, verbose: bool, show: bool) -> None:
     """Print ``Total: HH:MM:SS`` wall-clock for the split pipeline (#381).
 
@@ -1773,15 +1758,6 @@ def _emit_total_time(total_start: float, verbose: bool, show: bool) -> None:
     """
     if verbose and show:
         typer.echo(f"Total: {_format_duration(time.monotonic() - total_start)}")
-
-
-def _iso_utc_now() -> str:
-    """UTC timestamp in ISO 8601 with 'Z' suffix, e.g. '2026-04-19T12:34:56Z'.
-
-    Used for metadata.json `detected_at` (#370).  Second precision keeps the
-    string human-readable without losing practical reproducibility.
-    """
-    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 def _auto_sample_interval(duration: float, configured_interval: float) -> float:

--- a/allaganeye/video/capture_region.py
+++ b/allaganeye/video/capture_region.py
@@ -238,49 +238,13 @@ def _scorebar_saturated_runs(band: np.ndarray, cv2) -> list[tuple[int, int]]:
     `_SCOREBAR_SCAN_MIN_WIDTH_PX`..`_SCOREBAR_SCAN_MAX_WIDTH_PX` の幅のもののみ。
     """
     from allaganeye.video.detector import (
-        _SCOREBAR_SCAN_COL_RATIO,
-        _SCOREBAR_SCAN_MAX_GAP_PX,
         _SCOREBAR_SCAN_MAX_WIDTH_PX,
         _SCOREBAR_SCAN_MIN_WIDTH_PX,
-        _SCOREBAR_SCAN_SAT_THRESHOLD,
-        _SCOREBAR_SCAN_VAL_THRESHOLD,
+        _saturated_column_runs,
     )
-
-    bgr = cv2.cvtColor(band, cv2.COLOR_RGB2BGR)
-    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
-    sat = hsv[:, :, 1].astype(np.float32)
-    val = hsv[:, :, 2].astype(np.float32)
-    pixel_mask = (sat > _SCOREBAR_SCAN_SAT_THRESHOLD) & (
-        val > _SCOREBAR_SCAN_VAL_THRESHOLD
-    )
-    col_saturated = pixel_mask.mean(axis=0) >= _SCOREBAR_SCAN_COL_RATIO
-
-    width = band.shape[1]
-    raw_runs: list[tuple[int, int]] = []
-    i = 0
-    while i < width:
-        if col_saturated[i]:
-            j = i
-            while j < width and col_saturated[j]:
-                j += 1
-            raw_runs.append((i, j - 1))
-            i = j
-        else:
-            i += 1
-
-    if not raw_runs:
-        return []
-
-    merged: list[tuple[int, int]] = [raw_runs[0]]
-    for start, end in raw_runs[1:]:
-        prev_start, prev_end = merged[-1]
-        if start - prev_end - 1 <= _SCOREBAR_SCAN_MAX_GAP_PX:
-            merged[-1] = (prev_start, end)
-        else:
-            merged.append((start, end))
 
     runs: list[tuple[int, int]] = []
-    for start, end in merged:
+    for start, end in _saturated_column_runs(band, cv2):
         span_width = end - start + 1
         if _SCOREBAR_SCAN_MIN_WIDTH_PX <= span_width <= _SCOREBAR_SCAN_MAX_WIDTH_PX:
             runs.append((start, end))
@@ -300,6 +264,7 @@ def _emblem_and_margin(
     from allaganeye.video.detector import (
         _EMBLEM_EDGE_THRESHOLD,
         _EMBLEM_SAT_THRESHOLD,
+        _emblem_metrics,
     )
 
     min_ratio: float | None = None
@@ -307,22 +272,7 @@ def _emblem_and_margin(
         region = frame[y1:y2, x1:x2, :]
         if region.size == 0:
             return None
-        bgr = cv2.cvtColor(region, cv2.COLOR_RGB2BGR)
-        hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
-        gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
-
-        val = hsv[:, :, 2].astype(np.float32)
-        sat = hsv[:, :, 1].astype(np.float32)
-        bright_mask = val > 30
-        if bright_mask.sum() > 5:
-            mean_sat = float(sat[bright_mask].mean())
-        else:
-            mean_sat = 0.0
-
-        sobel_x = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
-        sobel_y = cv2.Sobel(gray, cv2.CV_64F, 0, 1, ksize=3)
-        edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
-
+        mean_sat, edge_density = _emblem_metrics(region, cv2)
         if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
             return None
         ratio = min(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1,10 +1,12 @@
 """Match boundary detection using parallel ffmpeg frame probing."""
 
+import contextlib
 import logging
 import math
 import os
 import subprocess
 import tempfile
+import threading
 import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -202,6 +204,28 @@ def _sample_chunk_frames(
             raise VideoProcessingError(msg)
 
     return results
+
+
+@contextlib.contextmanager
+def _proc_deadline_watchdog(proc: subprocess.Popen[bytes], deadline_s: float):
+    """Force-kill ``proc`` if it outlives ``deadline_s`` (#842 P2-3).
+
+    The v2 streaming decode reads ``proc.stdout`` via ``_sample_chunk_frames``
+    with a blocking ``stream.read`` that never returns while ffmpeg stalls
+    (no output, no EOF), so the post-read ``proc.wait(timeout=)`` is never
+    reached.  This watchdog kills the process at the deadline; the blocked
+    read then sees EOF, ``proc.wait`` returns immediately, and the existing
+    ``proc.returncode != 0`` handling (CPU: 255.0 fallback / GPU: raise ->
+    CPU fallback) fires.  On a healthy decode the timer is cancelled before
+    firing -> no behaviour change (bit-exact).
+    """
+    timer = threading.Timer(deadline_s, proc.kill)
+    timer.daemon = True
+    timer.start()
+    try:
+        yield
+    finally:
+        timer.cancel()
 
 
 def _resolve_workers(workers: int | None) -> int:
@@ -975,18 +999,22 @@ def _decode_chunk_cpu_v2(
             stdout=subprocess.PIPE,
             stderr=stderr_buf,
         ) as proc:
+            deadline = max(300, int(chunk_duration * 2))
             try:
-                results = _sample_chunk_frames(
-                    stream=proc.stdout,
-                    chunk_start=chunk_start,
-                    chunk_timestamps=chunk_timestamps,
-                    fps_num=fps_num,
-                    fps_den=fps_den,
-                    expected_frames=expected_frames,
-                    is_tail_chunk=is_tail_chunk,
-                    region=region,
-                )
-                proc.wait(timeout=max(300, int(chunk_duration * 2)))
+                with _proc_deadline_watchdog(proc, deadline):
+                    results = _sample_chunk_frames(
+                        stream=proc.stdout,
+                        chunk_start=chunk_start,
+                        chunk_timestamps=chunk_timestamps,
+                        fps_num=fps_num,
+                        fps_den=fps_den,
+                        expected_frames=expected_frames,
+                        is_tail_chunk=is_tail_chunk,
+                        region=region,
+                    )
+                    # Defense-in-depth: watchdog covers stream.read stall;
+                    # this wait covers proc-exit lag after the stream closes.
+                    proc.wait(timeout=deadline)
                 # Read stderr from temp file (no pipe backpressure issue)
                 stderr_buf.seek(0)
                 stderr_text = stderr_buf.read().decode(errors="replace")

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1892,6 +1892,17 @@ Pass 1 samples spaced 3s apart.  Pass 2's own +-_REFINE_WINDOW (5s)
 further extends the probe window, so effective coverage is +-8s.
 """
 
+_BORDERLINE_SPAN_CAP_FRACTION = 1.5
+"""borderline pseudo-region (#576 A5) 合計長の上限 (total_duration 比、#842 P2-4)。
+
+健全な OBS 録画でも brightness 15-55 の borderline frame は多く、実測 (2026-06-24)
+で raw_span は duration の 15-50% に達する (obs-20260118: 50.1%)。一方 brightness
+15-55 の待機画面が支配的な pathological 録画では raw_frac が ~200% に達し Pass 2
+probe が非有界に増える。cap = この値 × total_duration。1.5 は実測最大 50% の 3x
+margin で、未検証の長尺/暗め録画も clip せず pathological のみ捕捉する。超過分は
+drop + warning、本体 blackout 抽出 (``< blackout_threshold``) は不変。
+"""
+
 _REFINE_INTERVAL = 0.25
 """Fine interval for 2nd-pass re-probing of blackout candidates."""
 
@@ -1988,11 +1999,35 @@ def _borderline_pseudo_regions(
     """
     radius = _BORDERLINE_REFINE_RADIUS
     upper = _TRANSITION_THRESHOLD
-    return [
+    regions = [
         (max(0.0, t - radius), min(total_duration, t + radius))
         for t, b in results.items()
         if blackout_threshold <= b < upper
     ]
+    # #842 P2-4: total-length cap (fraction of duration). Prevents Pass 2 probe
+    # blow-up on recordings where borderline (15-55) wait screens dominate.
+    # Accumulate in start order, drop the overflow. Healthy recordings
+    # (raw_frac <= 50% measured) never hit the cap -> bit-exact.
+    cap_span = _BORDERLINE_SPAN_CAP_FRACTION * total_duration
+    regions.sort()
+    capped: list[tuple[float, float]] = []
+    running = 0.0
+    for start, end in regions:
+        span = end - start
+        if running + span > cap_span:
+            logger.warning(
+                "borderline pseudo-region 合計長が cap (%.0fs = %.1f×duration) を"
+                "超過: %d 領域中 %d を drop (待機画面が支配的な録画の Pass 2 probe "
+                "を有界化)。",
+                cap_span,
+                _BORDERLINE_SPAN_CAP_FRACTION,
+                len(regions),
+                len(regions) - len(capped),
+            )
+            break
+        capped.append((start, end))
+        running += span
+    return capped
 
 
 def _merge_regions(

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1463,6 +1463,75 @@ def _probe_frame_rgb_hires(video_path: Path, timestamp: float) -> bytes | None:
     return result.stdout[:rgb_size]
 
 
+def _saturated_column_runs(band: np.ndarray, cv2_module) -> list[tuple[int, int]]:
+    """Gap-merged saturated column runs of a (Hb, W, 3) RGB band.
+
+    Shared V2 scorebar geometry core: per-pixel HSV sat/val mask -> per-column
+    saturated fraction >= ``_SCOREBAR_SCAN_COL_RATIO`` -> contiguous runs bridged
+    across gaps <= ``_SCOREBAR_SCAN_MAX_GAP_PX``.  Returns merged ``(x_left,
+    x_right)`` inclusive runs ascending, BEFORE any width-gate / center-straddle
+    selection, so ``_find_scorebar_horizontal_range`` and
+    ``capture_region._scorebar_saturated_runs`` apply their own post-selection
+    on identical input (single source of truth, #842 P2-6).
+    """
+    bgr = cv2_module.cvtColor(band, cv2_module.COLOR_RGB2BGR)
+    hsv = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2HSV)
+    sat = hsv[:, :, 1].astype(np.float32)
+    val = hsv[:, :, 2].astype(np.float32)
+    pixel_mask = (sat > _SCOREBAR_SCAN_SAT_THRESHOLD) & (
+        val > _SCOREBAR_SCAN_VAL_THRESHOLD
+    )
+    col_saturated = pixel_mask.mean(axis=0) >= _SCOREBAR_SCAN_COL_RATIO
+
+    width = band.shape[1]
+    raw_runs: list[tuple[int, int]] = []
+    i = 0
+    while i < width:
+        if col_saturated[i]:
+            j = i
+            while j < width and col_saturated[j]:
+                j += 1
+            raw_runs.append((i, j - 1))
+            i = j
+        else:
+            i += 1
+    if not raw_runs:
+        return []
+
+    merged: list[tuple[int, int]] = [raw_runs[0]]
+    for start, end in raw_runs[1:]:
+        prev_start, prev_end = merged[-1]
+        if start - prev_end - 1 <= _SCOREBAR_SCAN_MAX_GAP_PX:
+            merged[-1] = (prev_start, end)
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _emblem_metrics(region: np.ndarray, cv2_module) -> tuple[float, float]:
+    """(mean_sat_of_bright_pixels, sobel_edge_density) for one emblem region.
+
+    Shared core of the 3-point emblem AND (#842 P2-6).  ``region`` must be a
+    non-empty (h, w, 3) RGB uint8 array.  Bright pixels = HSV value > 30; mean
+    saturation over them (0.0 if <= 5 bright pixels).  Edge density = mean Sobel
+    magnitude (CV_64F, ksize=3) of the grayscale region.
+    """
+    bgr = cv2_module.cvtColor(region, cv2_module.COLOR_RGB2BGR)
+    hsv = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2HSV)
+    gray = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2GRAY)
+    val = hsv[:, :, 2].astype(np.float32)
+    sat = hsv[:, :, 1].astype(np.float32)
+    bright_mask = val > 30
+    if bright_mask.sum() > 5:
+        mean_sat = float(sat[bright_mask].mean())
+    else:
+        mean_sat = 0.0
+    sobel_x = cv2_module.Sobel(gray, cv2_module.CV_64F, 1, 0, ksize=3)
+    sobel_y = cv2_module.Sobel(gray, cv2_module.CV_64F, 0, 1, ksize=3)
+    edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
+    return mean_sat, edge_density
+
+
 def _find_scorebar_horizontal_range(raw_rgb: bytes) -> tuple[int, int] | None:
     """Detect horizontal extent [x_left, x_right] of the FL scorebar.
 
@@ -1499,39 +1568,9 @@ def _find_scorebar_horizontal_range(raw_rgb: bytes) -> tuple[int, int] | None:
     frame = np.frombuffer(raw_rgb, dtype=np.uint8).reshape(height, width, 3)
 
     top = frame[_SCOREBAR_SCAN_Y_START:_SCOREBAR_SCAN_Y_END, :, :]
-    bgr = cv2.cvtColor(top, cv2.COLOR_RGB2BGR)
-    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
-    sat = hsv[:, :, 1].astype(np.float32)
-    val = hsv[:, :, 2].astype(np.float32)
-
-    pixel_mask = (sat > _SCOREBAR_SCAN_SAT_THRESHOLD) & (
-        val > _SCOREBAR_SCAN_VAL_THRESHOLD
-    )
-    col_fraction = pixel_mask.mean(axis=0)
-    col_saturated = col_fraction >= _SCOREBAR_SCAN_COL_RATIO
-
-    raw_runs: list[tuple[int, int]] = []
-    i = 0
-    while i < width:
-        if col_saturated[i]:
-            j = i
-            while j < width and col_saturated[j]:
-                j += 1
-            raw_runs.append((i, j - 1))
-            i = j
-        else:
-            i += 1
-
-    if not raw_runs:
+    merged = _saturated_column_runs(top, cv2)
+    if not merged:
         return None
-
-    merged: list[tuple[int, int]] = [raw_runs[0]]
-    for start, end in raw_runs[1:]:
-        prev_start, prev_end = merged[-1]
-        if start - prev_end - 1 <= _SCOREBAR_SCAN_MAX_GAP_PX:
-            merged[-1] = (prev_start, end)
-        else:
-            merged.append((start, end))
 
     # The FL scorebar is horizontally centered, so the candidate is the run
     # straddling screen center -- NOT merely the longest run.  Selecting the
@@ -1572,24 +1611,7 @@ def _emblem_and_check(
     """
     for name, x1, y1, x2, y2 in positions:
         region = frame[y1:y2, x1:x2, :]
-        bgr = cv2_module.cvtColor(region, cv2_module.COLOR_RGB2BGR)
-        hsv = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2HSV)
-        gray = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2GRAY)
-
-        # Saturation of bright pixels (exclude very dark pixels)
-        val = hsv[:, :, 2].astype(np.float32)
-        sat = hsv[:, :, 1].astype(np.float32)
-        bright_mask = val > 30
-        if bright_mask.sum() > 5:
-            mean_sat = float(sat[bright_mask].mean())
-        else:
-            mean_sat = 0.0
-
-        # Edge density (Sobel magnitude)
-        sobel_x = cv2_module.Sobel(gray, cv2_module.CV_64F, 1, 0, ksize=3)
-        sobel_y = cv2_module.Sobel(gray, cv2_module.CV_64F, 0, 1, ksize=3)
-        edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
-
+        mean_sat, edge_density = _emblem_metrics(region, cv2_module)
         if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
             logger.debug(
                 "scorebar_v2 (%s): %s x=%d..%d sat=%.1f edge=%.1f -> fail",

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -206,6 +206,20 @@ def _sample_chunk_frames(
     return results
 
 
+class _WatchdogState:
+    """Shared flag telling the caller whether the deadline watchdog fired (#842).
+
+    ``fired`` is set in the timer thread just before the kill, then read by the
+    decode caller so a stalled-then-killed chunk is handled as a decode failure
+    (graceful fallback) rather than a hard error.
+    """
+
+    __slots__ = ("fired",)
+
+    def __init__(self) -> None:
+        self.fired = False
+
+
 @contextlib.contextmanager
 def _proc_deadline_watchdog(proc: subprocess.Popen[bytes], deadline_s: float):
     """Force-kill ``proc`` if it outlives ``deadline_s`` (#842 P2-3).
@@ -213,17 +227,25 @@ def _proc_deadline_watchdog(proc: subprocess.Popen[bytes], deadline_s: float):
     The v2 streaming decode reads ``proc.stdout`` via ``_sample_chunk_frames``
     with a blocking ``stream.read`` that never returns while ffmpeg stalls
     (no output, no EOF), so the post-read ``proc.wait(timeout=)`` is never
-    reached.  This watchdog kills the process at the deadline; the blocked
-    read then sees EOF, ``proc.wait`` returns immediately, and the existing
-    ``proc.returncode != 0`` handling (CPU: 255.0 fallback / GPU: raise ->
-    CPU fallback) fires.  On a healthy decode the timer is cancelled before
-    firing -> no behaviour change (bit-exact).
+    reached.  This watchdog kills the process at the deadline; the blocked read
+    then sees EOF.  Yields a ``_WatchdogState`` whose ``fired`` flag lets the
+    caller route a watchdog-killed (and therefore truncated) decode into its
+    decode-failed fallback (CPU: 255.0 / GPU: raise -> CPU fallback) instead of
+    propagating the resulting frame-count ``VideoProcessingError`` as a hard
+    detection failure (#842 codex).  On a healthy decode the timer is cancelled
+    before firing -> no behaviour change (bit-exact).
     """
-    timer = threading.Timer(deadline_s, proc.kill)
+    state = _WatchdogState()
+
+    def _on_deadline() -> None:
+        state.fired = True
+        proc.kill()
+
+    timer = threading.Timer(deadline_s, _on_deadline)
     timer.daemon = True
     timer.start()
     try:
-        yield
+        yield state
     finally:
         timer.cancel()
 
@@ -1000,8 +1022,9 @@ def _decode_chunk_cpu_v2(
             stderr=stderr_buf,
         ) as proc:
             deadline = max(300, int(chunk_duration * 2))
+            watchdog: _WatchdogState | None = None
             try:
-                with _proc_deadline_watchdog(proc, deadline):
+                with _proc_deadline_watchdog(proc, deadline) as watchdog:
                     results = _sample_chunk_frames(
                         stream=proc.stdout,
                         chunk_start=chunk_start,
@@ -1026,6 +1049,18 @@ def _decode_chunk_cpu_v2(
                     stderr_text = stderr_buf.read().decode(errors="replace")
                 except Exception:
                     logger.debug("Failed to read stderr from temp file", exc_info=True)
+                if watchdog is not None and watchdog.fired:
+                    # ffmpeg stalled and the watchdog killed it; the truncated
+                    # read tripped the dynamic frame-count guard. Treat as a
+                    # decode failure (graceful 255.0 fallback) rather than
+                    # failing the whole detect (#842 codex).
+                    logger.warning(
+                        "CPU chunk v2 decode watchdog fired [%.1f-%.1f]; "
+                        "treating as decode failure",
+                        chunk_start,
+                        chunk_end,
+                    )
+                    return {t: 255.0 for t in chunk_timestamps}
                 raise
             except subprocess.TimeoutExpired:
                 proc.kill()

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1898,7 +1898,7 @@ _BORDERLINE_SPAN_CAP_FRACTION = 1.5
 健全な OBS 録画でも brightness 15-55 の borderline frame は多く、実測 (2026-06-24)
 で raw_span は duration の 15-50% に達する (obs-20260118: 50.1%)。一方 brightness
 15-55 の待機画面が支配的な pathological 録画では raw_frac が ~200% に達し Pass 2
-probe が非有界に増える。cap = この値 × total_duration。1.5 は実測最大 50% の 3x
+probe が非有界に増える。cap = この値 x total_duration。1.5 は実測最大 50% の 3x
 margin で、未検証の長尺/暗め録画も clip せず pathological のみ捕捉する。超過分は
 drop + warning、本体 blackout 抽出 (``< blackout_threshold``) は不変。
 """
@@ -2016,7 +2016,7 @@ def _borderline_pseudo_regions(
         span = end - start
         if running + span > cap_span:
             logger.warning(
-                "borderline pseudo-region 合計長が cap (%.0fs = %.1f×duration) を"
+                "borderline pseudo-region 合計長が cap (%.0fs = %.1fx duration) を"
                 "超過: %d 領域中 %d を drop (待機画面が支配的な録画の Pass 2 probe "
                 "を有界化)。",
                 cap_span,

--- a/allaganeye/video/detector.py
+++ b/allaganeye/video/detector.py
@@ -1931,7 +1931,7 @@ _BORDERLINE_SPAN_CAP_FRACTION = 1.5
 """borderline pseudo-region (#576 A5) 合計長の上限 (total_duration 比、#842 P2-4)。
 
 健全な OBS 録画でも brightness 15-55 の borderline frame は多く、実測 (2026-06-24)
-で raw_span は duration の 15-50% に達する (obs-20260118: 50.1%)。一方 brightness
+で raw_span は duration の 13-50% に達する (5 baseline 実測、最大 obs-20260118: 50.1%)。一方 brightness
 15-55 の待機画面が支配的な pathological 録画では raw_frac が ~200% に達し Pass 2
 probe が非有界に増える。cap = この値 x total_duration。1.5 は実測最大 50% の 3x
 margin で、未検証の長尺/暗め録画も clip せず pathological のみ捕捉する。超過分は

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -346,16 +346,39 @@ def scan_gpu(
 def _check_gpu_usage(
     stderr_text: str, codec: str | None, cuvid_decoder: str | None
 ) -> None:
-    """Log GPU decode status based on ffmpeg stderr output."""
+    """Log GPU decode status based on ffmpeg stderr output.
+
+    cuvid の実 decoder 名 (h264_cuvid 等) が stderr に出ていれば実 decode を
+    確認できるため "active"。d3d11va/qsv/auto は **要求した hwaccel 名が
+    コマンドエコーに必ず出る**ため、その substring 一致だけでは実 decode を
+    確認できない (#842 P3): CPU fallback でも真になる。over-claim を避け
+    "requested (decode path unconfirmed)" と honest に記す。全 marker 不在は
+    CPU fallback の warning。vendor 固有の init 成否 marker による完全判定は
+    実機 stderr が前提で別 issue。
+    """
     lowered = stderr_text.lower()
     if cuvid_decoder and cuvid_decoder in stderr_text:
         logger.info("GPU decode active: %s", cuvid_decoder)
-    elif "d3d11va" in lowered:
-        logger.info("GPU decode active (d3d11va)")
-    elif "qsv" in lowered:
-        logger.info("GPU decode active (qsv)")
-    elif "hwaccel" in lowered or "cuda" in lowered:
-        logger.info("GPU decode active (hwaccel auto)")
+    elif (
+        "d3d11va" in lowered
+        or "qsv" in lowered
+        or "cuda" in lowered
+        or "hwaccel" in lowered
+    ):
+        if "d3d11va" in lowered:
+            requested = "d3d11va"
+        elif "qsv" in lowered:
+            requested = "qsv"
+        elif "cuda" in lowered:
+            requested = "cuda"
+        else:
+            requested = "hwaccel auto"
+        logger.info(
+            "GPU hwaccel '%s' requested for codec '%s' (decode path unconfirmed "
+            "from stderr; CPU fallback not distinguishable here)",
+            requested,
+            codec or "unknown",
+        )
     else:
         logger.warning(
             "GPU acceleration not active for codec '%s', falling back to CPU decode",

--- a/allaganeye/video/gpu_detector.py
+++ b/allaganeye/video/gpu_detector.py
@@ -22,6 +22,7 @@ from allaganeye.video.detector import (
     _SAMPLE_WIDTH,
     _frame_brightness,
     _generate_timestamps,
+    _proc_deadline_watchdog,
     _resolve_fps_rational,
     _sample_chunk_frames,
     _use_legacy_fps_filter,
@@ -676,18 +677,22 @@ def _decode_chunk_v2(
             stdout=subprocess.PIPE,
             stderr=stderr_buf,
         ) as proc:
+            deadline = max(300, int(chunk_duration * 2))
             try:
-                results = _sample_chunk_frames(
-                    stream=proc.stdout,
-                    chunk_start=chunk_start,
-                    chunk_timestamps=chunk_timestamps or [],
-                    fps_num=fps_num,
-                    fps_den=fps_den,
-                    expected_frames=expected_frames,
-                    is_tail_chunk=is_tail_chunk,
-                    region=region,
-                )
-                proc.wait(timeout=max(300, int(chunk_duration * 2)))
+                with _proc_deadline_watchdog(proc, deadline):
+                    results = _sample_chunk_frames(
+                        stream=proc.stdout,
+                        chunk_start=chunk_start,
+                        chunk_timestamps=chunk_timestamps or [],
+                        fps_num=fps_num,
+                        fps_den=fps_den,
+                        expected_frames=expected_frames,
+                        is_tail_chunk=is_tail_chunk,
+                        region=region,
+                    )
+                    # Defense-in-depth: watchdog covers stream.read stall;
+                    # this wait covers proc-exit lag after the stream closes.
+                    proc.wait(timeout=deadline)
                 # Read stderr from temp file (no pipe backpressure issue)
                 stderr_buf.seek(0)
                 stderr_text = stderr_buf.read().decode(errors="replace")

--- a/allaganeye/video/probe.py
+++ b/allaganeye/video/probe.py
@@ -150,14 +150,25 @@ def probe_video(video_path: Path) -> ProbeResult:
                 diff_ratio * 100,
             )
 
-    duration = float(data.get("format", {}).get("duration", 0))
+    raw_duration = data.get("format", {}).get("duration", 0)
+    try:
+        duration = float(raw_duration)
+    except (TypeError, ValueError) as e:
+        raise VideoProcessingError(
+            f"Cannot parse video duration from ffprobe output: {raw_duration!r}"
+        ) from e
     if duration <= 0:
         raise VideoProcessingError(
             "Cannot determine video duration from ffprobe output"
         )
 
-    width = int(video_stream.get("width", 0))
-    height = int(video_stream.get("height", 0))
+    try:
+        width = int(video_stream.get("width", 0))
+        height = int(video_stream.get("height", 0))
+    except (TypeError, ValueError) as e:
+        raise VideoProcessingError(
+            "Cannot parse video resolution from ffprobe output"
+        ) from e
     if width <= 0 or height <= 0:
         raise VideoProcessingError(
             "Cannot determine video resolution from ffprobe output"

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -357,14 +357,24 @@ def _classify_blackout_localize(
         ]
         if pre_re_ts:
             _, _, pre_re_loc = _probe_scorebar_context(
-                video_path, pre_re_ts, height, workers, with_localize=True
+                video_path,
+                pre_re_ts,
+                height,
+                workers,
+                with_localize=True,
+                with_lowres=False,
             )
             pre_re = _majority_scorebar(pre_re_loc)
             if pre_re is not None:
                 pre_has = pre_re
         if post_re_ts:
             _, _, post_re_loc = _probe_scorebar_context(
-                video_path, post_re_ts, height, workers, with_localize=True
+                video_path,
+                post_re_ts,
+                height,
+                workers,
+                with_localize=True,
+                with_lowres=False,
             )
             post_re = _majority_scorebar(post_re_loc)
             if post_re is not None:

--- a/allaganeye/video/scorebar.py
+++ b/allaganeye/video/scorebar.py
@@ -59,6 +59,7 @@ def _probe_scorebar_context(
     workers: int | None,
     *,
     with_localize: bool = False,
+    with_lowres: bool = True,
 ) -> tuple[list[bool | None], list[bytes | None], list[bool | None]]:
     """Probe multiple timestamps and return has_scorebar + raw frames.
 
@@ -76,18 +77,29 @@ def _probe_scorebar_context(
     and downstream merge logic handle isolated false negatives.
 
     Duplicate timestamps are probed only once; results are shared.
+
+    ``with_lowres=False``: callers that discard the returned raw frames
+    (merge-probe / re-probe) skip the always-on low-res probe in V2 mode.
+    Low-res is still needed for the V1 fallback when V2 returns None (no
+    opencv), so it is probed lazily for just those timestamps -> bit-exact.
     """
     max_workers = _resolve_workers(workers)
     use_v2 = _SCOREBAR_METHOD == "v2"
     unique_ts = sorted(set(timestamps))
     scorebar_results: dict[float, bool | None] = {}
-    raw_frames: dict[float, bytes | None] = {}
+    raw_frames: dict[float, bytes | None] = {t: None for t in unique_ts}
+
+    # V2 + with_lowres=False: skip upfront low-res (callers discard it).
+    # V1 fallback path lazily probes below only if V2 returns None.
+    probe_lowres_upfront = with_lowres or not use_v2
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        # Always probe low-res for static screen detection (classify_blackout)
-        lo_futures = {
-            pool.submit(_probe_frame_rgb, video_path, t, height): t for t in unique_ts
-        }
+        lo_futures: dict[Future[bytes | None], float] = {}
+        if probe_lowres_upfront:
+            lo_futures = {
+                pool.submit(_probe_frame_rgb, video_path, t, height): t
+                for t in unique_ts
+            }
         # V2: also probe high-res for emblem detection
         hi_futures: dict[Future[bytes | None], float] = {}
         if use_v2:
@@ -99,10 +111,10 @@ def _probe_scorebar_context(
         for future in as_completed(lo_futures):
             t = lo_futures[future]
             try:
-                raw = future.result()
-            except VideoProcessingError:
-                raw = None
-            raw_frames[t] = raw
+                raw_frames[t] = future.result()
+            except VideoProcessingError as exc:
+                logger.debug("scorebar probe failed at t=%.2f: %s", t, exc)
+                raw_frames[t] = None
 
         # Collect high-res results and run V2 detection
         hi_raws: dict[float, bytes | None] = {}
@@ -110,10 +122,10 @@ def _probe_scorebar_context(
             for future in as_completed(hi_futures):
                 t = hi_futures[future]
                 try:
-                    raw = future.result()
-                except VideoProcessingError:
-                    raw = None
-                hi_raws[t] = raw
+                    hi_raws[t] = future.result()
+                except VideoProcessingError as exc:
+                    logger.debug("scorebar probe failed at t=%.2f: %s", t, exc)
+                    hi_raws[t] = None
 
         # Determine scorebar results.
         # V2 True -> True (high specificity, eliminates lobby FP).
@@ -123,16 +135,27 @@ def _probe_scorebar_context(
         #   because classify_blackout's 3-frame majority vote and
         #   downstream merge logic handle isolated FN).
         # V2 None -> V1 (opencv not installed).
+        need_v1: list[float] = []
         for t in unique_ts:
             if use_v2:
                 v2_result = _has_scorebar_v2(hi_raws.get(t))
                 if v2_result is not None:
                     scorebar_results[t] = v2_result
                 else:
-                    # V2 failed (e.g. no opencv) -> use V1
-                    scorebar_results[t] = _has_scorebar(raw_frames[t], height)
+                    need_v1.append(t)
             else:
                 scorebar_results[t] = _has_scorebar(raw_frames[t], height)
+
+        # V1 fallback: lazily probe low-res for timestamps where V2 returned
+        # None (opencv absent) and we skipped the upfront low-res probe.
+        for t in need_v1:
+            if not probe_lowres_upfront and raw_frames.get(t) is None:
+                try:
+                    raw_frames[t] = _probe_frame_rgb(video_path, t, height)
+                except VideoProcessingError as exc:
+                    logger.debug("lazy scorebar probe failed at t=%.2f: %s", t, exc)
+                    raw_frames[t] = None
+            scorebar_results[t] = _has_scorebar(raw_frames[t], height)
 
         # localize-present from the hi-res frames already decoded for v2
         # (additive; OBS production passes with_localize=False -> all None,
@@ -474,11 +497,11 @@ def classify_blackout(
         post_re_results: list[bool | None] = []
         if pre_re_timestamps:
             pre_re_results, _, _ = _probe_scorebar_context(
-                video_path, pre_re_timestamps, height, workers
+                video_path, pre_re_timestamps, height, workers, with_lowres=False
             )
         if post_re_timestamps:
             post_re_results, _, _ = _probe_scorebar_context(
-                video_path, post_re_timestamps, height, workers
+                video_path, post_re_timestamps, height, workers, with_lowres=False
             )
         pre_has_re = _majority_scorebar(pre_re_results)
         post_has_re = _majority_scorebar(post_re_results)
@@ -745,6 +768,7 @@ def _merge_boundary_pairs(
                         height,
                         workers,
                         with_localize=True,
+                        with_lowres=False,
                     )
                 else:
                     probe_signal, _, _ = _probe_scorebar_context(
@@ -752,6 +776,7 @@ def _merge_boundary_pairs(
                         probe_points,
                         height,
                         workers,
+                        with_lowres=False,
                     )
                 all_valid = all(r is not None for r in probe_signal)
                 any_scorebar = any(r is True for r in probe_signal)

--- a/docs/superpowers/plans/2026-06-24-audit-w2-w4.md
+++ b/docs/superpowers/plans/2026-06-24-audit-w2-w4.md
@@ -1,0 +1,1019 @@
+# Audit Remediation Wave 2 — W4 (#842 core 堅牢化) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development` (fresh subagent per task + spec/quality 2-stage review). TDD HARD-GATE (`superpowers:test-driven-development`): NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST. Steps use checkbox (`- [ ]`).
+
+**Goal:** detect パイプラインの堅牢性 regression と複製構造を解消する — (P2-3) v2 streaming decode の stall watchdog、(P2-4) borderline pseudo-region 合計長 cap、(P2-6) saturated-run / emblem 計算の共有ヘルパ抽出、+ core P3 5 件 (GPU 診断ログ honesty 化 / lo-probe skip / probe duration parse / scorebar logger / format.py dead module 整理)。**全変更は実動画 baseline に対し bit-exact** (防御機構は通常録画で不発、純粋 refactor、log/error 整備のみ)。
+
+**Architecture:**
+
+- **P2-6 (`detector.py` + `capture_region.py`)**: 共有ヘルパ 2 つを detector.py に新設 — `_saturated_column_runs(band, cv2)` (per-pixel sat/val mask → col-ratio → run → gap-merge、width-gate/center-select 前の merged runs) と `_emblem_metrics(region, cv2)` ((mean_sat, edge_density))。detector の `_find_scorebar_horizontal_range` / `_emblem_and_check` と capture_region の `_scorebar_saturated_runs` / `_emblem_and_margin` を repoint。capture_region は既存同様 lazy import (`from allaganeye.video.detector import ...`)。純粋抽出で各 caller の出力不変 = bit-exact。
+- **P2-3 (`detector.py` + `gpu_detector.py`)**: 共有 context manager `_proc_deadline_watchdog(proc, deadline_s)` を detector.py に新設。`threading.Timer(deadline_s, proc.kill)` (daemon) を start し `finally` で必ず cancel。`_decode_chunk_cpu_v2` / `_decode_chunk_v2` の `_sample_chunk_frames(stream=proc.stdout, ...)` + `proc.wait` を watchdog で包む。ffmpeg stall 時に Timer が proc.kill → `stream.read` が EOF で抜け → `proc.wait` 即返り → 既存の `proc.returncode != 0` 処理 (CPU=255.0 fallback / GPU=`VideoProcessingError` raise) に自然合流。healthy decode では Timer cancel → 不発 → bit-exact。
+- **P2-4 (`detector.py`)**: module 定数 `_BORDERLINE_TOTAL_SPAN_CAP` を新設。`_borderline_pseudo_regions` 内で生成 region を start 昇順に accumulate し、合計長が cap を超えたら以降を drop + 1 回 warning。`< blackout_threshold` の本体抽出 (Pass 2 strict 判定) は不変、additive coverage (#576 A5) のみ縮退。**cap 値は baseline 実測 (`_measure_borderline.py`、detached 実行中) で確定** (T3 Step 0 ゲート)。
+- **P3 GPU log (`gpu_detector.py`)**: `_check_gpu_usage` の d3d11va/qsv branch が**要求 hwaccel の substring 一致だけ**で「decode active」と over-claim するのを honesty 化 (「requested、decode 経路は stderr から未確認」表記)。cuvid (実 decoder 名一致) と「全 marker 不在 → CPU fallback」branch は据置。log-only。vendor 固有 marker の完全 active 判定は実機 AMD/Intel stderr が前提で **scope 外 (follow-up)**。
+- **P3 lo-probe (`scorebar.py`)**: `_probe_scorebar_context(..., with_lowres=True)` 追加。frames を捨てる site (re-probe `classify_blackout` / merge-probe `_merge_boundary_pairs`) で `with_lowres=False` 指定 → v2 経路の low-res probe を skip (ffmpeg 起動削減)。v2 が None (opencv 不在) の ts のみ low-res を**遅延 probe** して V1 fallback 維持 → 全経路 bit-exact。frames を使う site (primary `classify_blackout` / `_classify_blackout_localize`) は default True 据置。
+- **P3 probe dur (`probe.py`)**: `format.duration` / video stream `width`/`height` の numeric parse を try/except で堅牢化し非数値/型不正で `VideoProcessingError` (exit 3) を送出 (現状 `float()`/`int()` の uncaught ValueError → exit 1)。duration が監査明示対象、width/height は同クラス横展開 (CLAUDE.md 根本原因方針)。
+- **P3 logger (`scorebar.py`)**: `_probe_scorebar_context` の `except VideoProcessingError` 2 箇所に `logger.debug` を追加 (ffmpeg 不在等の probe 失敗の silent swallow を `-v` で可視化)。
+- **P3 format.py (`split_matches.py`)**: `commands/split_matches.py` の private `_format_timestamp` / `_format_duration` / `_iso_utc_now` 定義 (バイト等価を実測確認) を `from allaganeye.detection.format import format_timestamp as _format_timestamp, format_duration as _format_duration, iso_utc_now as _iso_utc_now` に置換 → `detection/format.py` を canonical 化 (#463 共有意図回復)、重複定義消滅。全 internal call site / `commands/detect.py` import / tests は名前不変で動作。`disabled_emitter()` は intent 確認後 keep+注記 (削除はしない、後述)。
+
+**Tech Stack:** Python 3.12 (pytest, unittest.mock, numpy, opencv-python-headless) / ruff / pyright。
+
+**元 issue:** [#842](https://github.com/Idios/kobutachan-allaganeye/issues/842) (bug, P2-medium)。受け入れ条件 (issue 本文の正式 AC、逐条検証する):
+
+- **P2-3**: 両 v2 decode に deadline watchdog、stall でも `max(300, int(chunk_duration*2))` 秒で kill → 既存 fallback/error。watchdog は healthy で不発 + `finally` cancel。**発火側 RED 実証** + full pytest で leak/OOM 無し。
+- **P2-4**: `_borderline_pseudo_regions` に合計長 cap、超過時 warning + 縮退、本体抽出不変。cap 値は baseline 実測 + margin、5 baseline で不発 (`slow_detect` bit-exact)。**発火側 RED 実証**。
+- **P2-6**: saturated-run / emblem 計算を共有ヘルパに抽出し detector / capture_region が同一実装を呼ぶ。**bit-exact** (`slow_detect` PASS + capture_region localize test PASS)。
+- **P3**: GPU log over-claim 是正 / lo-probe skip (通常経路 bit-exact、no-opencv 維持) / probe duration 非数値で exit 3 (pin test) / scorebar probe 失敗の log / format.py 重複解消 (単一 source)。
+- 共通: `ruff check .` / `ruff format --check .` / `python -m pyright allaganeye tests` / `pytest` 全 PASS。`pytest -m slow_detect` bit-exact PASS (timestamp churn 除外)。Idios 実機検証 (GPU detect / 長時間動画 / stall watchdog)。
+
+---
+
+## 前提条件 / 事実 (2026-06-24 実測、#841 W1 merge 後 = develop-0.3.0 @ e63bf56)
+
+- main worktree、branch `claude/audit-w2-w4` (origin/develop-0.3.0 起点、作成済)。session-id: `audit-w2-w4-20260623`。working tree clean。
+- サンプル動画ローカル存在: `E:/royalstraightflesh/videos/{20260116,20260118,20260119,20260127}/...mkv` (baseline source と一致確認済)。`ALLAGANEYE_SAMPLE_VIDEO_DIR` は session で unset → gate/測定は明示 set で実行。
+- ffmpeg = Gyan.FFmpeg 8.1 (GPL build、libx264 在)。
+
+### P2-6 重複構造 (バイト等価を実測確認)
+
+- **`detector.py`** ([detector.py](../../../allaganeye/video/detector.py)):
+  - `_find_scorebar_horizontal_range(raw_rgb)` (L1466-1559): reshape → `top = frame[_SCOREBAR_SCAN_Y_START:_SCOREBAR_SCAN_Y_END, :, :]` → cvtColor RGB2BGR→BGR2HSV → sat/val mask (`> _SCOREBAR_SCAN_SAT_THRESHOLD` & `> _SCOREBAR_SCAN_VAL_THRESHOLD`) → `col_fraction = pixel_mask.mean(axis=0)`; `col_saturated = col_fraction >= _SCOREBAR_SCAN_COL_RATIO` → raw_runs (while ループ) → merged (gap `<= _SCOREBAR_SCAN_MAX_GAP_PX`) → **center-straddle 選択** (`center_x = _SCOREBAR_V2_PROBE_WIDTH // 2`) + width-gate (`_SCOREBAR_SCAN_MIN_WIDTH_PX`..`_SCOREBAR_SCAN_MAX_WIDTH_PX`)。`width = _SCOREBAR_V2_PROBE_WIDTH` (= `top.shape[1]`)。
+  - `_emblem_and_check(frame, positions, path_label, cv2_module)` (L1562-1605): position 毎に `region = frame[y1:y2, x1:x2, :]` → cvtColor RGB2BGR / BGR2HSV / BGR2GRAY → `bright_mask = val > 30`; `mean_sat = sat[bright_mask].mean() if bright_mask.sum() > 5 else 0.0` → Sobel x/y `CV_64F ksize=3` → `edge_density = sqrt(sx**2+sy**2).mean()` → `if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD: debug + return False` → all pass debug + `return True`。
+- **`capture_region.py`** ([capture_region.py](../../../allaganeye/video/capture_region.py)):
+  - `_scorebar_saturated_runs(band, cv2)` (L233-287): detector と**同一の** mask→col-ratio→raw_runs→merged を計算後 (docstring 明記)、width-gate **全件** 返す (center-select なし)。`width = band.shape[1]`。
+  - `_emblem_and_margin(frame, positions, cv2)` (L290-333): detector と**同一の** sat/edge 計算。`region.size == 0 → None` guard あり。pass で `ratio = min(mean_sat/SAT, edge/EDGE)`、最弱 `min_ratio` 返す。fail で None。
+- 等価性: mask/run/merge ブロックは detector(L1504-1534) ≡ capture_region(L249-280)、emblem 計算は detector(L1574-1591) ≡ capture_region(L310-324)。`top.shape[1] == _SCOREBAR_V2_PROBE_WIDTH` のため detector の `width` 定数と capture_region の `band.shape[1]` は一致。
+- 定数は detector.py に定義: `_SCOREBAR_SCAN_SAT_THRESHOLD` / `_VAL_THRESHOLD` / `_COL_RATIO` / `_MAX_GAP_PX` / `_MIN_WIDTH_PX` / `_MAX_WIDTH_PX` / `_SCOREBAR_V2_PROBE_WIDTH` / `_EMBLEM_SAT_THRESHOLD` / `_EMBLEM_EDGE_THRESHOLD`。capture_region は lazy import 済。
+- test: [test_scorebar_v2.py](../../../tests/test_scorebar_v2.py) / [test_capture_region.py](../../../tests/test_capture_region.py) / localize 系 (実装前に Read)。
+
+### P2-3 v2 decode stall (read timeout 欠如)
+
+- **`detector.py`** `_sample_chunk_frames(stream, ...)` (L116-202): `while True: raw = stream.read(_FRAME_SIZE); if len(raw) < _FRAME_SIZE: break; ...`。`stream` = `proc.stdout`。ffmpeg stall (no output, no EOF) で **`stream.read` が無期限ブロック**。
+- `_decode_chunk_cpu_v2` (L885-1026): `with subprocess.Popen(cmd, stdout=PIPE, stderr=stderr_buf) as proc:` → `try: results = _sample_chunk_frames(stream=proc.stdout, ...); proc.wait(timeout=max(300, int(chunk_duration*2)))` / `except VideoProcessingError: kill; raise` / `except TimeoutExpired: kill; warning; return {t:255.0}`。`finally: stderr_buf.close()`。post-with: `if proc.returncode != 0: warning; return {t:255.0}`; `return results`。← **timeout 保護は read 完了後の wait のみで stall に到達不能**。
+- `gpu_detector.py` `_decode_chunk_v2` (L573-720): 同構造。post-with: `if proc.returncode != 0: raise VideoProcessingError("GPU decode v2 failed", ...)` (CPU は 255.0 fallback、GPU は raise → 上位で CPU fallback)。
+- gpu_detector は detector から既に `_FRAME_SIZE` 等を import (gpu_detector.py:20 付近)。`_proc_deadline_watchdog` も同経路で import。
+- legacy `subprocess.run(timeout=)` 経路 (detector L846 `_decode_chunk_cpu_legacy` / gpu L516) は保護あり (regression は v2 path のみ)。
+- test: [test_detector.py](../../../tests/test_detector.py) / [test_gpu_detector.py](../../../tests/test_gpu_detector.py)。
+
+### P2-4 borderline cap
+
+- `_borderline_pseudo_regions(results, blackout_threshold, total_duration)` (detector.py L1915-1945): `radius = _BORDERLINE_REFINE_RADIUS` (=3.0); `upper = _TRANSITION_THRESHOLD` (=55); `return [(max(0, t-radius), min(total_duration, t+radius)) for t,b in results.items() if blackout_threshold <= b < upper]`。call: L539 (CPU) / L709 (GPU)。
+- cost: borderline frame 毎に ±3s 窓 → Pass 2 が merged span を 0.25s 間隔で再 probe (1h sustained で ~14,400 起動)。
+- 測定: `_measure_borderline.py` (repo root TEMP) が brightness_callback で Pass 1 を捕捉し raw_span/merged_span を baseline 毎に出力。detached 実行中 (`_measure_borderline.out.log`)。
+- test: [test_detector.py](../../../tests/test_detector.py)。
+
+### core P3
+
+- `gpu_detector.py` `_check_gpu_usage(stderr_text, codec, cuvid_decoder)` (L345-362): `if cuvid_decoder and cuvid_decoder in stderr_text: info "active: {decoder}"` / `elif "d3d11va" in lowered: info "active (d3d11va)"` / `elif "qsv": info "active (qsv)"` / `elif "hwaccel"/"cuda": info "active (hwaccel auto)"` / `else: warning "not active ... CPU"`。← d3d11va/qsv/hwaccel branch は**要求文字列の stderr echo**で常に真。
+- `scorebar.py` `_probe_scorebar_context` (L55-152): `except VideoProcessingError: raw = None` が L103-104 (lo) / L114-115 (hi) で**log なし**。lo_futures は use_v2 でも常時 submit (L88-90)、hi_futures は use_v2 のみ (L93-96)。frames 消費: `_classify_blackout_localize` L302/305 → `_band_mad_min` L352/353、`classify_blackout` primary L438/441 → `_is_static_from_frames` L517/525。frames 破棄: `classify_blackout` re-probe L476/480、`_merge_boundary_pairs` L742/750。
+- `probe.py` (L153): `duration = float(data.get("format", {}).get("duration", 0))`。L159-160: `width = int(video_stream.get("width", 0))` / `height = int(...)`。非数値文字列 (`"N/A"` 等) で uncaught ValueError → exit 1 (`VideoProcessingError` 経由の exit 3 にならない)。
+- `detection/format.py`: `format_timestamp`/`format_duration`/`iso_utc_now`。`detection/__init__.py` が re-export するのみで production import 0。
+- `commands/split_matches.py`: `_format_timestamp` (L1732-1738) / `_format_duration` (L1757-1764) / `_iso_utc_now` (L1778-1784) — `detection/format.py` の public 版と**バイト等価** (実測確認)。`commands/detect.py` (L28-34) が `_format_duration` / `_iso_utc_now` を split_matches から import。tests も `_format_timestamp`/`_format_duration`/`_format_eta` を split_matches から import (名前依存)。`_format_eta` は public 版なし → 据置。
+- `detection/progress_emitter.py` `disabled_emitter()` (L120): production 未使用 (tests のみ)。
+
+### スコープ判断 (Iron Law 3 整合)
+
+- **IN**: P2-3 / P2-4 / P2-6 + core P3 5 件 (GPU 診断ログ honesty / lo-probe skip / probe duration parse / scorebar logger / format.py consolidate-alias)。各 TDD。probe.py の width/height は duration と同クラス横展開として同時修正 (review で creep 判定を仰ぐ)。
+- **OUT (本 PR では触らない)**:
+  - P2-1 / P2-2 / P2-5 (trailing drop 多重防御 / opt-out gate / audio scan チャンク化) は #805 / 別 finding。
+  - P3 のうち metadata_writer fsync / min_match_duration 結合 / rescue bar_width 1px / `_largest_component_region` cv2 guard / GPU chunk fallback join 待ち / `metadata_types` 型劣化 は spec §W4 骨子外 (follow-up)。
+  - GPU 診断ログの **vendor 固有 stderr marker による完全 active 判定** (実機 AMD/Intel stderr 前提、honesty 化のみ IN)。
+  - `disabled_emitter()` の**削除** (tested + intended opt-out API の可能性 → keep + 注記。削除は別判断)。
+  - W6 範囲の doc 一括再同期。
+
+---
+
+## File Structure
+
+| 区分 | path | 責務 |
+| --- | --- | --- |
+| Create | `docs/superpowers/plans/2026-06-24-audit-w2-w4.md` | 本 plan |
+| Modify | `allaganeye/video/detector.py` | `_saturated_column_runs`/`_emblem_metrics` 新設 + 2 関数 repoint (P2-6) / `_proc_deadline_watchdog` 新設 + `_decode_chunk_cpu_v2` 適用 (P2-3) / `_BORDERLINE_TOTAL_SPAN_CAP` + `_borderline_pseudo_regions` cap (P2-4) |
+| Modify | `allaganeye/video/capture_region.py` | `_scorebar_saturated_runs`/`_emblem_and_margin` を共有ヘルパ呼出に (P2-6) |
+| Modify | `allaganeye/video/gpu_detector.py` | `_decode_chunk_v2` に watchdog 適用 (P2-3) / `_check_gpu_usage` honesty 化 (P3) |
+| Modify | `allaganeye/video/scorebar.py` | `_probe_scorebar_context` `with_lowres` + lazy fallback (P3) / probe 失敗 log (P3) / re-probe・merge site `with_lowres=False` |
+| Modify | `allaganeye/video/probe.py` | duration/width/height の robust parse → exit 3 (P3) |
+| Modify | `allaganeye/commands/split_matches.py` | private `_format_*`/`_iso_utc_now` を detection.format import alias に (P3) |
+| Modify | `tests/test_detector.py` | `_saturated_column_runs`/`_emblem_metrics` unit (P2-6) / `_proc_deadline_watchdog` 発火・不発 unit (P2-3) / `_borderline_pseudo_regions` cap 発火・不発 unit (P2-4) |
+| Modify | `tests/test_capture_region.py` | 共有ヘルパ repoint の非回帰 (P2-6) |
+| Modify | `tests/test_gpu_detector.py` | `_check_gpu_usage` honesty unit (P3) |
+| Modify | `tests/test_scorebar.py` | `with_lowres` skip / lazy fallback / probe 失敗 log unit (P3) |
+| Modify | `tests/test_probe.py` | duration/width/height 非数値 → VideoProcessingError unit (P3) |
+| Modify | `tests/test_split_matches.py` | format alias の非回帰 (既存 import 名で値一致) (P3) |
+
+> detector.py は T1→T2→T3 で順次編集。各 task は実装前に現在の detector.py を Read して surgical edit する (commit 進行で行ずれ)。
+
+---
+
+## Task A: plan commit (controller)
+
+- [ ] **Step 1:** branch = `claude/audit-w2-w4` (作成済)。plan + TEMP 測定スクリプトを確認 (測定 log/動画は stage しない):
+
+```bash
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" branch --show-current   # claude/audit-w2-w4
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" add docs/superpowers/plans/2026-06-24-audit-w2-w4.md
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" commit -F - <<'EOF'
+doc: W4 (#842 core 堅牢化) の実装 plan を追加 (Refs #842)
+
+audit remediation Wave 2 W4。spec §W4 の just-in-time plan。
+P2-6 共有ヘルパ抽出 / P2-3 v2 decode watchdog / P2-4 borderline cap +
+core P3 5 件 (GPU log honesty / lo-probe skip / probe dur parse /
+scorebar logger / format.py consolidate-alias) を実測 + 確定。
+全変更 bit-exact 前提、保護機構は発火側 red 実証。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+> `_measure_borderline.py` / `_measure_borderline.*.log` / `_smoke.mkv` は TEMP。`.gitignore` 外なので **add しない** (PR 前に削除)。
+
+---
+
+## Task T1: P2-6 — saturated-run / emblem 共有ヘルパ抽出 (TDD, pure refactor, bit-exact)
+
+**Files:** Modify `allaganeye/video/detector.py` / `allaganeye/video/capture_region.py` / Test `tests/test_detector.py` / `tests/test_capture_region.py`
+
+- [ ] **Step 1: 新ヘルパの failing test を書く** (`tests/test_detector.py`)
+
+```python
+def test_saturated_column_runs_gap_merge_and_empty():
+    import numpy as np
+    import cv2
+    from allaganeye.video.detector import (
+        _saturated_column_runs,
+        _SCOREBAR_SCAN_MAX_GAP_PX,
+    )
+    # saturated band (high S, high V) の 2 group を gap <= MAX_GAP で配置 → 1 run に merge
+    h, w = 20, 200
+    band = np.zeros((h, w, 3), dtype=np.uint8)
+    # RGB pure red 系 (high saturation, high value)
+    band[:, 10:40] = (255, 0, 0)
+    band[:, 40 + _SCOREBAR_SCAN_MAX_GAP_PX : 80] = (255, 0, 0)  # gap <= MAX_GAP
+    runs = _saturated_column_runs(band, cv2)
+    assert len(runs) == 1
+    assert runs[0][0] <= 10 and runs[0][1] >= 79
+    # 全黒 band → []
+    assert _saturated_column_runs(np.zeros((h, w, 3), dtype=np.uint8), cv2) == []
+
+
+def test_emblem_metrics_bright_vs_dark():
+    import numpy as np
+    import cv2
+    from allaganeye.video.detector import _emblem_metrics
+    # 明るい彩度高 + 高周波テクスチャ → sat>0, edge>0
+    region = np.random.default_rng(0).integers(0, 256, (40, 40, 3), dtype=np.uint8)
+    region[:, :, 0] = 220  # bias toward saturated bright
+    sat, edge = _emblem_metrics(region, cv2)
+    assert sat > 0.0 and edge > 0.0
+    # 全黒 region → bright_mask.sum() <= 5 → mean_sat 0.0
+    dark = np.zeros((40, 40, 3), dtype=np.uint8)
+    d_sat, d_edge = _emblem_metrics(dark, cv2)
+    assert d_sat == 0.0
+```
+
+- [ ] **Step 2: fail 確認** — Run `python -m pytest tests/test_detector.py::test_saturated_column_runs_gap_merge_and_empty tests/test_detector.py::test_emblem_metrics_bright_vs_dark -v` / Expected: FAIL (`ImportError: cannot import name '_saturated_column_runs'`)
+
+- [ ] **Step 3: detector.py に共有ヘルパを新設** (`_find_scorebar_horizontal_range` の直前に追加)
+
+```python
+def _saturated_column_runs(band: "np.ndarray", cv2_module) -> list[tuple[int, int]]:
+    """Gap-merged saturated column runs of a (Hb, W, 3) RGB band.
+
+    Shared V2 scorebar geometry core: per-pixel HSV sat/val mask -> per-column
+    saturated fraction >= ``_SCOREBAR_SCAN_COL_RATIO`` -> contiguous runs bridged
+    across gaps <= ``_SCOREBAR_SCAN_MAX_GAP_PX``.  Returns merged ``(x_left,
+    x_right)`` inclusive runs ascending, BEFORE any width-gate / center-straddle
+    selection, so ``_find_scorebar_horizontal_range`` and
+    ``capture_region._scorebar_saturated_runs`` apply their own post-selection
+    on identical input (single source of truth, #842 P2-6).
+    """
+    bgr = cv2_module.cvtColor(band, cv2_module.COLOR_RGB2BGR)
+    hsv = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2HSV)
+    sat = hsv[:, :, 1].astype(np.float32)
+    val = hsv[:, :, 2].astype(np.float32)
+    pixel_mask = (sat > _SCOREBAR_SCAN_SAT_THRESHOLD) & (
+        val > _SCOREBAR_SCAN_VAL_THRESHOLD
+    )
+    col_saturated = pixel_mask.mean(axis=0) >= _SCOREBAR_SCAN_COL_RATIO
+
+    width = band.shape[1]
+    raw_runs: list[tuple[int, int]] = []
+    i = 0
+    while i < width:
+        if col_saturated[i]:
+            j = i
+            while j < width and col_saturated[j]:
+                j += 1
+            raw_runs.append((i, j - 1))
+            i = j
+        else:
+            i += 1
+    if not raw_runs:
+        return []
+
+    merged: list[tuple[int, int]] = [raw_runs[0]]
+    for start, end in raw_runs[1:]:
+        prev_start, prev_end = merged[-1]
+        if start - prev_end - 1 <= _SCOREBAR_SCAN_MAX_GAP_PX:
+            merged[-1] = (prev_start, end)
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _emblem_metrics(region: "np.ndarray", cv2_module) -> tuple[float, float]:
+    """(mean_sat_of_bright_pixels, sobel_edge_density) for one emblem region.
+
+    Shared core of the 3-point emblem AND (#842 P2-6).  ``region`` must be a
+    non-empty (h, w, 3) RGB uint8 array.  Bright pixels = HSV value > 30; mean
+    saturation over them (0.0 if <= 5 bright pixels).  Edge density = mean Sobel
+    magnitude (CV_64F, ksize=3) of the grayscale region.
+    """
+    bgr = cv2_module.cvtColor(region, cv2_module.COLOR_RGB2BGR)
+    hsv = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2HSV)
+    gray = cv2_module.cvtColor(bgr, cv2_module.COLOR_BGR2GRAY)
+    val = hsv[:, :, 2].astype(np.float32)
+    sat = hsv[:, :, 1].astype(np.float32)
+    bright_mask = val > 30
+    if bright_mask.sum() > 5:
+        mean_sat = float(sat[bright_mask].mean())
+    else:
+        mean_sat = 0.0
+    sobel_x = cv2_module.Sobel(gray, cv2_module.CV_64F, 1, 0, ksize=3)
+    sobel_y = cv2_module.Sobel(gray, cv2_module.CV_64F, 0, 1, ksize=3)
+    edge_density = float(np.sqrt(sobel_x**2 + sobel_y**2).mean())
+    return mean_sat, edge_density
+```
+
+- [ ] **Step 4: pass 確認** — Run the Step 2 command / Expected: PASS
+
+- [ ] **Step 5: `_find_scorebar_horizontal_range` を repoint** (mask/run/merge ブロック L1497-1534 を helper 呼出に置換、center-straddle + width-gate は据置)
+
+```python
+    try:
+        import cv2
+    except ImportError:
+        return None
+
+    width = _SCOREBAR_V2_PROBE_WIDTH
+    height = _SCOREBAR_V2_PROBE_HEIGHT
+    frame = np.frombuffer(raw_rgb, dtype=np.uint8).reshape(height, width, 3)
+    top = frame[_SCOREBAR_SCAN_Y_START:_SCOREBAR_SCAN_Y_END, :, :]
+
+    merged = _saturated_column_runs(top, cv2)
+    if not merged:
+        return None
+
+    # (center-straddle 選択 + width-gate は既存どおり — L1536-1559 を維持)
+    center_x = _SCOREBAR_V2_PROBE_WIDTH // 2
+    center_run = next((run for run in merged if run[0] <= center_x <= run[1]), None)
+    if center_run is None:
+        return None
+    span_width = center_run[1] - center_run[0] + 1
+    if span_width < _SCOREBAR_SCAN_MIN_WIDTH_PX:
+        return None
+    if span_width > _SCOREBAR_SCAN_MAX_WIDTH_PX:
+        return None
+    return center_run
+```
+
+- [ ] **Step 6: `_emblem_and_check` を repoint** (per-position の sat/edge 計算 L1574-1591 を helper 呼出に置換、threshold + debug log は据置)
+
+```python
+    for name, x1, y1, x2, y2 in positions:
+        region = frame[y1:y2, x1:x2, :]
+        mean_sat, edge_density = _emblem_metrics(region, cv2_module)
+        if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
+            logger.debug(
+                "scorebar_v2 (%s): %s x=%d..%d sat=%.1f edge=%.1f -> fail",
+                path_label, name, x1, x2, mean_sat, edge_density,
+            )
+            return False
+    logger.debug("scorebar_v2 (%s): all 3 positions passed -> True", path_label)
+    return True
+```
+
+- [ ] **Step 7: capture_region.py を repoint** (`_scorebar_saturated_runs` L249-280 / `_emblem_and_margin` L310-324 の重複ブロックを helper 呼出に)
+
+```python
+def _scorebar_saturated_runs(band: np.ndarray, cv2) -> list[tuple[int, int]]:
+    """band (Hb,W,3 uint8 RGB) の saturated column run を width-gate して全件返す。"""
+    from allaganeye.video.detector import (
+        _SCOREBAR_SCAN_MAX_WIDTH_PX,
+        _SCOREBAR_SCAN_MIN_WIDTH_PX,
+        _saturated_column_runs,
+    )
+
+    runs: list[tuple[int, int]] = []
+    for start, end in _saturated_column_runs(band, cv2):
+        span_width = end - start + 1
+        if _SCOREBAR_SCAN_MIN_WIDTH_PX <= span_width <= _SCOREBAR_SCAN_MAX_WIDTH_PX:
+            runs.append((start, end))
+    return runs
+
+
+def _emblem_and_margin(frame: np.ndarray, positions, cv2) -> float | None:
+    """3点 emblem AND。全通過なら最弱 margin (min ratio>1.0)、不通過なら None。"""
+    from allaganeye.video.detector import (
+        _EMBLEM_EDGE_THRESHOLD,
+        _EMBLEM_SAT_THRESHOLD,
+        _emblem_metrics,
+    )
+
+    min_ratio: float | None = None
+    for _name, x1, y1, x2, y2 in positions:
+        region = frame[y1:y2, x1:x2, :]
+        if region.size == 0:
+            return None
+        mean_sat, edge_density = _emblem_metrics(region, cv2)
+        if mean_sat <= _EMBLEM_SAT_THRESHOLD or edge_density <= _EMBLEM_EDGE_THRESHOLD:
+            return None
+        ratio = min(
+            mean_sat / _EMBLEM_SAT_THRESHOLD,
+            edge_density / _EMBLEM_EDGE_THRESHOLD,
+        )
+        min_ratio = ratio if min_ratio is None else min(min_ratio, ratio)
+    return min_ratio
+```
+
+- [ ] **Step 8: 既存 scorebar/capture_region test の非回帰確認** — Run `python -m pytest tests/test_detector.py tests/test_scorebar_v2.py tests/test_capture_region.py -q` / Expected: PASS (repoint 後も既存挙動不変)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" add allaganeye/video/detector.py allaganeye/video/capture_region.py tests/test_detector.py tests/test_capture_region.py
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" commit -F - <<'EOF'
+refactor(detector): saturated-run/emblem 計算を共有ヘルパに抽出 (Refs #842)
+
+P2-6。detector._find_scorebar_horizontal_range / _emblem_and_check と
+capture_region._scorebar_saturated_runs / _emblem_and_margin の重複を
+_saturated_column_runs / _emblem_metrics に集約。片側修正で OBS parity が
+silent に壊れる構造を解消。純粋抽出で各 caller の出力不変 (bit-exact)。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task T2: P2-3 — v2 decode stall watchdog (TDD, 発火側 red 実証)
+
+**Files:** Modify `allaganeye/video/detector.py` / `allaganeye/video/gpu_detector.py` / Test `tests/test_detector.py`
+
+- [ ] **Step 1: watchdog の failing test を書く** (`tests/test_detector.py`、発火 + 不発の両側)
+
+```python
+def test_proc_deadline_watchdog_kills_when_block_exceeds_deadline():
+    import time
+    from unittest.mock import Mock
+    from allaganeye.video.detector import _proc_deadline_watchdog
+    proc = Mock()
+    with _proc_deadline_watchdog(proc, 0.05):
+        time.sleep(0.25)  # deadline を超過 (stall を模す)
+    proc.kill.assert_called_once()  # 発火側 red 実証
+
+
+def test_proc_deadline_watchdog_no_kill_when_fast():
+    from unittest.mock import Mock
+    from allaganeye.video.detector import _proc_deadline_watchdog
+    proc = Mock()
+    with _proc_deadline_watchdog(proc, 5.0):
+        pass  # 即完了 (healthy decode)
+    proc.kill.assert_not_called()  # 不発 (bit-exact 保証)
+```
+
+- [ ] **Step 2: fail 確認** — Run `python -m pytest tests/test_detector.py::test_proc_deadline_watchdog_kills_when_block_exceeds_deadline tests/test_detector.py::test_proc_deadline_watchdog_no_kill_when_fast -v` / Expected: FAIL (`ImportError: ... _proc_deadline_watchdog`)
+
+- [ ] **Step 3: detector.py に watchdog context manager を新設** (module 冒頭 import に `import contextlib` / `import threading` を確認の上、`_sample_chunk_frames` の近傍に追加)
+
+```python
+@contextlib.contextmanager
+def _proc_deadline_watchdog(proc, deadline_s: float):
+    """Force-kill ``proc`` if it outlives ``deadline_s`` (#842 P2-3).
+
+    The v2 streaming decode reads ``proc.stdout`` via ``_sample_chunk_frames``
+    with a blocking ``stream.read`` that never returns while ffmpeg stalls
+    (no output, no EOF), so the post-read ``proc.wait(timeout=)`` is never
+    reached.  This watchdog kills the process at the deadline; the blocked
+    read then sees EOF, ``proc.wait`` returns immediately, and the existing
+    ``proc.returncode != 0`` handling (CPU: 255.0 fallback / GPU: raise ->
+    CPU fallback) fires.  On a healthy decode the timer is cancelled before
+    firing -> no behaviour change (bit-exact).
+    """
+    timer = threading.Timer(deadline_s, proc.kill)
+    timer.daemon = True
+    timer.start()
+    try:
+        yield
+    finally:
+        timer.cancel()
+```
+
+- [ ] **Step 4: pass 確認** — Run the Step 2 command / Expected: PASS
+
+- [ ] **Step 5: `_decode_chunk_cpu_v2` に watchdog 適用** (detector.py、`_sample_chunk_frames` + `proc.wait` を包む。deadline は既存 `proc.wait` と同値)
+
+```python
+        with subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=stderr_buf,
+        ) as proc:
+            deadline = max(300, int(chunk_duration * 2))
+            try:
+                with _proc_deadline_watchdog(proc, deadline):
+                    results = _sample_chunk_frames(
+                        stream=proc.stdout,
+                        chunk_start=chunk_start,
+                        chunk_timestamps=chunk_timestamps,
+                        fps_num=fps_num,
+                        fps_den=fps_den,
+                        expected_frames=expected_frames,
+                        is_tail_chunk=is_tail_chunk,
+                        region=region,
+                    )
+                    proc.wait(timeout=deadline)
+                # (stderr 読みは既存どおり watchdog 外で)
+                stderr_buf.seek(0)
+                stderr_text = stderr_buf.read().decode(errors="replace")
+            except VideoProcessingError:
+                proc.kill()
+                ...  # 既存 except 群は据置
+```
+
+> watchdog kill → `stream.read` EOF → `_sample_chunk_frames` 返り → `proc.wait` 即返り → post-with `if proc.returncode != 0: return {t:255.0}` (既存) に合流。stderr 読みは watchdog 外 (kill 後も temp file から読める)。
+
+- [ ] **Step 6: `_decode_chunk_v2` に watchdog 適用** (gpu_detector.py、同型。gpu_detector の detector import に `_proc_deadline_watchdog` を追加)
+
+```python
+# gpu_detector.py の import (detector から _FRAME_SIZE 等を import している箇所) に追加:
+from allaganeye.video.detector import _proc_deadline_watchdog  # 既存 import 群に合流
+```
+
+```python
+        with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=stderr_buf) as proc:
+            deadline = max(300, int(chunk_duration * 2))
+            try:
+                with _proc_deadline_watchdog(proc, deadline):
+                    results = _sample_chunk_frames(stream=proc.stdout, ...)  # 既存引数
+                    proc.wait(timeout=deadline)
+                stderr_buf.seek(0)
+                stderr_text = stderr_buf.read().decode(errors="replace")
+            except VideoProcessingError:
+                proc.kill()
+                raise
+            except subprocess.TimeoutExpired as e:
+                proc.kill()
+                raise VideoProcessingError(...) from e  # 既存
+```
+
+> kill → post-with `if proc.returncode != 0: raise VideoProcessingError("GPU decode v2 failed", ...)` (既存) に合流 → 上位 CPU fallback。
+
+- [ ] **Step 7: 非回帰 + full suite** — Run `python -m pytest tests/test_detector.py tests/test_gpu_detector.py -q` then **必ず full** `python -m pytest -q` / Expected: PASS。concurrency 変更のため full suite で reader/watchdog thread の leak/OOM が無いことを確認 (memory feedback_reader_thread_eof_leak)。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" add allaganeye/video/detector.py allaganeye/video/gpu_detector.py tests/test_detector.py
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" commit -F - <<'EOF'
+fix(detector): v2 decode stall に deadline watchdog を追加 (Refs #842)
+
+P2-3。_decode_chunk_cpu_v2 / _decode_chunk_v2 の _sample_chunk_frames は
+stream.read が EOF まで無期限ブロックし、後続 proc.wait(timeout) に到達
+しない (ffmpeg stall で detect 全体ハング)。_proc_deadline_watchdog で
+deadline 超過時に proc.kill → 既存 returncode 処理に合流。healthy decode
+では timer cancel で不発 (bit-exact)。発火側を red 実証。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task T3: P2-4 — borderline pseudo-region 合計長 cap (TDD, 発火側 red 実証)
+
+**Files:** Modify `allaganeye/video/detector.py` / Test `tests/test_detector.py`
+
+- [ ] **Step 0 (controller measurement gate):** detached 測定 `_measure_borderline.out.log` 完了を確認し、4 baseline の `raw_span` 最大値を読む。cap 値 = `max(600.0, ceil(max_raw_span * 2 / 60) * 60)` (最大の 2x 以上、かつ最低 600s)。確定値を Step 3 の `_BORDERLINE_TOTAL_SPAN_CAP` に反映 + PR 本文に実測値 + margin を記録。**baseline raw_span は cap を下回る = 不発 = bit-exact** が前提 (slow_detect gate で再確認)。
+
+- [ ] **Step 1: cap の failing test を書く** (`tests/test_detector.py`、発火 + 不発)
+
+```python
+def test_borderline_pseudo_regions_capped_with_warning(caplog):
+    import logging
+    from allaganeye.video.detector import (
+        _borderline_pseudo_regions,
+        _BORDERLINE_TOTAL_SPAN_CAP,
+        _BORDERLINE_REFINE_RADIUS,
+    )
+    # cap を確実に超える borderline frame 列 (b=40 ∈ [15,55)、互いに非重複)
+    step = int(_BORDERLINE_REFINE_RADIUS * 2) + 2
+    n = int(_BORDERLINE_TOTAL_SPAN_CAP / (_BORDERLINE_REFINE_RADIUS * 2)) + 50
+    results = {float(i * step): 40.0 for i in range(n)}
+    total_dur = float(n * step + 100)
+    with caplog.at_level(logging.WARNING):
+        regions = _borderline_pseudo_regions(results, 15.0, total_dur)
+    total = sum(e - s for s, e in regions)
+    assert total <= _BORDERLINE_TOTAL_SPAN_CAP + (_BORDERLINE_REFINE_RADIUS * 2)
+    assert any("borderline" in r.message.lower() for r in caplog.records)  # 発火 red 実証
+
+
+def test_borderline_pseudo_regions_not_capped_under_threshold(caplog):
+    import logging
+    from allaganeye.video.detector import _borderline_pseudo_regions
+    results = {0.0: 40.0, 100.0: 42.0}  # 2 frame、span « cap
+    with caplog.at_level(logging.WARNING):
+        regions = _borderline_pseudo_regions(results, 15.0, 1000.0)
+    assert len(regions) == 2  # 全件保持 (不発 = bit-exact)
+    assert not any("borderline" in r.message.lower() for r in caplog.records)
+```
+
+- [ ] **Step 2: fail 確認** — Run `python -m pytest tests/test_detector.py::test_borderline_pseudo_regions_capped_with_warning tests/test_detector.py::test_borderline_pseudo_regions_not_capped_under_threshold -v` / Expected: FAIL (`ImportError: ... _BORDERLINE_TOTAL_SPAN_CAP` / cap 未実装で span 超過)
+
+- [ ] **Step 3: cap 定数 + cap ロジックを実装** (Step 0 の確定値。下記は default 600.0、Step 0 で bump 可)
+
+```python
+_BORDERLINE_TOTAL_SPAN_CAP = 600.0
+"""borderline pseudo-region (#576 A5) の合計長上限 (秒)。健全な OBS 録画は
+試合境界の短い fade のみで borderline span が極小だが、brightness 15-55 の
+待機画面が長時間続く録画では Pass 2 probe が非有界に増える (#842 P2-4)。
+合計長がこの値を超えたら additive coverage を縮退する (本体 blackout 抽出は
+不変)。値は baseline 実測 (max raw_span) の 2x 以上 + 最低 600s で決定。"""
+```
+
+`_borderline_pseudo_regions` の return を cap 適用に変更:
+
+```python
+    radius = _BORDERLINE_REFINE_RADIUS
+    upper = _TRANSITION_THRESHOLD
+    regions = [
+        (max(0.0, t - radius), min(total_duration, t + radius))
+        for t, b in results.items()
+        if blackout_threshold <= b < upper
+    ]
+    # #842 P2-4: 合計長 cap。待機画面が長い録画で Pass 2 probe が非有界に
+    # 増えるのを防ぐ。start 昇順に accumulate し cap 超過分を drop。
+    regions.sort()
+    capped: list[tuple[float, float]] = []
+    running = 0.0
+    for start, end in regions:
+        span = end - start
+        if running + span > _BORDERLINE_TOTAL_SPAN_CAP:
+            dropped = len(regions) - len(capped)
+            logger.warning(
+                "borderline pseudo-region 合計長が cap (%.0fs) を超過: "
+                "%d 領域中 %d を drop (待機画面が長い録画の Pass 2 probe を有界化)。",
+                _BORDERLINE_TOTAL_SPAN_CAP,
+                len(regions),
+                dropped,
+            )
+            break
+        capped.append((start, end))
+        running += span
+    return capped
+```
+
+- [ ] **Step 4: pass 確認** — Run the Step 2 command / Expected: PASS
+
+- [ ] **Step 5: 非回帰** — Run `python -m pytest tests/test_detector.py -q` / Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" add allaganeye/video/detector.py tests/test_detector.py
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" commit -F - <<'EOF'
+fix(detector): borderline pseudo-region に合計長 cap を追加 (Refs #842)
+
+P2-4。_borderline_pseudo_regions (#576 A5) は brightness 15-55 の待機画面が
+長時間続く録画で Pass 2 probe を非有界に増やす。_BORDERLINE_TOTAL_SPAN_CAP
+(baseline 実測 + margin) で合計長を有界化、超過分を drop + warning。本体の
+blackout 抽出は不変、5 baseline で不発 (bit-exact)。発火側を red 実証。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task T4: P3 — probe.py duration/width/height robust parse (TDD, pin test)
+
+**Files:** Modify `allaganeye/video/probe.py` / Test `tests/test_probe.py`
+
+- [ ] **Step 1: failing test** (`tests/test_probe.py`、ffprobe duration="N/A" → VideoProcessingError、exit 3 系)
+
+```python
+def test_probe_nonnumeric_duration_raises_video_processing_error(monkeypatch):
+    import json
+    from allaganeye.exceptions import VideoProcessingError
+    from allaganeye.video import probe as probe_mod
+    fake = {
+        "format": {"duration": "N/A"},
+        "streams": [{"codec_type": "video", "width": 1920, "height": 1080,
+                     "r_frame_rate": "60/1", "avg_frame_rate": "60/1",
+                     "codec_name": "h264"}],
+    }
+    monkeypatch.setattr(probe_mod, "_run_ffprobe", lambda *a, **k: json.dumps(fake))
+    import pytest
+    with pytest.raises(VideoProcessingError):
+        probe_mod.probe_video(__import__("pathlib").Path("dummy.mkv"))
+```
+
+> 実装前に `tests/test_probe.py` と `probe.py` の ffprobe 呼出名 (`_run_ffprobe` 等) を Read し、monkeypatch 対象を正す。
+
+- [ ] **Step 2: fail 確認** — Run `python -m pytest tests/test_probe.py::test_probe_nonnumeric_duration_raises_video_processing_error -v` / Expected: FAIL (uncaught `ValueError`、`VideoProcessingError` でない)
+
+- [ ] **Step 3: probe.py の numeric parse を堅牢化** (duration L153 + width/height L159-160)
+
+```python
+    raw_duration = data.get("format", {}).get("duration", 0)
+    try:
+        duration = float(raw_duration)
+    except (TypeError, ValueError) as e:
+        raise VideoProcessingError(
+            f"Cannot parse video duration from ffprobe output: {raw_duration!r}"
+        ) from e
+    if duration <= 0:
+        raise VideoProcessingError("Cannot determine video duration from ffprobe output")
+
+    try:
+        width = int(video_stream.get("width", 0))
+        height = int(video_stream.get("height", 0))
+    except (TypeError, ValueError) as e:
+        raise VideoProcessingError(
+            "Cannot parse video resolution from ffprobe output"
+        ) from e
+    if width <= 0 or height <= 0:
+        raise VideoProcessingError("Cannot determine video resolution from ffprobe output")
+```
+
+- [ ] **Step 4: pass + 非回帰** — Run `python -m pytest tests/test_probe.py -q` / Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" add allaganeye/video/probe.py tests/test_probe.py
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" commit -F - <<'EOF'
+fix(probe): duration/resolution の非数値で VideoProcessingError (Refs #842)
+
+P3。ffprobe の duration が "N/A" 等の非数値文字列のとき float()/int() の
+uncaught ValueError で exit 1 になっていた (VideoProcessingError 経由の
+exit 3 が正)。duration (監査明示) + width/height (同クラス横展開) を
+try/except で堅牢化。pin test 同梱。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task T5: P3 — scorebar probe 失敗の logging (TDD)
+
+**Files:** Modify `allaganeye/video/scorebar.py` / Test `tests/test_scorebar.py`
+
+- [ ] **Step 1: failing test** — `_probe_scorebar_context` が probe 失敗 (VideoProcessingError) を logger.debug で記録することを検証 (probe fn を VideoProcessingError raise に mock、caplog で debug 出力確認)。実装前に `tests/test_scorebar.py` の既存 mock helper を Read。
+
+```python
+def test_probe_scorebar_context_logs_probe_failure(monkeypatch, caplog):
+    import logging
+    from allaganeye.exceptions import VideoProcessingError
+    from allaganeye.video import scorebar as sb
+    def boom(*a, **k):
+        raise VideoProcessingError("ffmpeg not found")
+    monkeypatch.setattr(sb, "_probe_frame_rgb", boom)
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", boom)
+    with caplog.at_level(logging.DEBUG, logger="allaganeye.video.scorebar"):
+        sb._probe_scorebar_context(__import__("pathlib").Path("x.mkv"), [1.0], 180, 1)
+    assert any("probe" in r.message.lower() for r in caplog.records)
+```
+
+- [ ] **Step 2: fail 確認** — Run `python -m pytest tests/test_scorebar.py::test_probe_scorebar_context_logs_probe_failure -v` / Expected: FAIL (log なし)
+
+- [ ] **Step 3: 実装** (`_probe_scorebar_context` の `except VideoProcessingError` 2 箇所 L103-104 / L114-115)
+
+```python
+            except VideoProcessingError as exc:
+                logger.debug("scorebar probe failed at t=%.2f: %s", t, exc)
+                raw = None
+```
+
+- [ ] **Step 4: pass + 非回帰** — Run `python -m pytest tests/test_scorebar.py -q` / Expected: PASS
+
+- [ ] **Step 5: Commit** (`fix(scorebar): probe 失敗を log に記録 (Refs #842)` + Co-Authored-By trailer)
+
+---
+
+## Task T6: P3 — lo-probe skip + lazy fallback (TDD, bit-exact)
+
+**Files:** Modify `allaganeye/video/scorebar.py` / Test `tests/test_scorebar.py`
+
+- [ ] **Step 1: failing test** — `with_lowres=False` + v2 + opencv 在で low-res probe (`_probe_frame_rgb`) が呼ばれないこと、かつ scorebar 判定が `with_lowres=True` と一致すること (bit-exact)。さらに v2 None (opencv 不在を模す) で lazy に low-res が呼ばれ V1 fallback が効くこと。実装前に既存 mock helper を Read。
+
+```python
+def test_probe_scorebar_context_with_lowres_false_skips_lowres(monkeypatch):
+    from unittest.mock import MagicMock
+    from allaganeye.video import scorebar as sb
+    lo = MagicMock(return_value=b"\x00" * 10)
+    hi = MagicMock(return_value=b"\x00" * 10)
+    monkeypatch.setattr(sb, "_probe_frame_rgb", lo)
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", hi)
+    monkeypatch.setattr(sb, "_has_scorebar_v2", lambda raw: True)  # opencv 在
+    monkeypatch.setattr(sb, "_SCOREBAR_METHOD", "v2")
+    res, frames, _ = sb._probe_scorebar_context(
+        __import__("pathlib").Path("x.mkv"), [1.0, 2.0], 180, 2, with_lowres=False
+    )
+    lo.assert_not_called()         # low-res skip (通常経路)
+    assert res == [True, True]     # hi-res で判定 (bit-exact)
+
+
+def test_probe_scorebar_context_lazy_lowres_when_v2_none(monkeypatch):
+    from unittest.mock import MagicMock
+    from allaganeye.video import scorebar as sb
+    lo = MagicMock(return_value=b"\x00" * 10)
+    monkeypatch.setattr(sb, "_probe_frame_rgb", lo)
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", MagicMock(return_value=b""))
+    monkeypatch.setattr(sb, "_has_scorebar_v2", lambda raw: None)   # opencv 不在を模す
+    monkeypatch.setattr(sb, "_has_scorebar", lambda raw, h: False)  # V1 fallback
+    monkeypatch.setattr(sb, "_SCOREBAR_METHOD", "v2")
+    res, _, _ = sb._probe_scorebar_context(
+        __import__("pathlib").Path("x.mkv"), [1.0], 180, 1, with_lowres=False
+    )
+    lo.assert_called()             # lazy に low-res を probe (no-opencv 維持)
+    assert res == [False]
+```
+
+- [ ] **Step 2: fail 確認** — Run the two tests / Expected: FAIL (`with_lowres` 引数なし)
+
+- [ ] **Step 3: `_probe_scorebar_context` に `with_lowres` + lazy fallback を実装**
+
+```python
+def _probe_scorebar_context(
+    video_path: Path,
+    timestamps: list[float],
+    height: int,
+    workers: int | None,
+    *,
+    with_localize: bool = False,
+    with_lowres: bool = True,
+) -> tuple[list[bool | None], list[bytes | None], list[bool | None]]:
+    """... (既存 docstring に with_lowres 追記) ...
+
+    ``with_lowres=False``: callers that discard the returned raw frames
+    (merge-probe / re-probe) skip the always-on low-res probe in V2 mode.
+    Low-res is still needed for the V1 fallback when V2 returns None (no
+    opencv), so it is probed lazily for just those timestamps -> bit-exact.
+    """
+    max_workers = _resolve_workers(workers)
+    use_v2 = _SCOREBAR_METHOD == "v2"
+    unique_ts = sorted(set(timestamps))
+    scorebar_results: dict[float, bool | None] = {}
+    raw_frames: dict[float, bytes | None] = {t: None for t in unique_ts}
+
+    # V2 + with_lowres=False の通常経路では low-res を upfront に probe しない。
+    probe_lowres_upfront = with_lowres or not use_v2
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        lo_futures = {}
+        if probe_lowres_upfront:
+            lo_futures = {
+                pool.submit(_probe_frame_rgb, video_path, t, height): t
+                for t in unique_ts
+            }
+        hi_futures: dict[Future[bytes | None], float] = {}
+        if use_v2:
+            hi_futures = {
+                pool.submit(_probe_frame_rgb_hires, video_path, t): t for t in unique_ts
+            }
+
+        for future in as_completed(lo_futures):
+            t = lo_futures[future]
+            try:
+                raw_frames[t] = future.result()
+            except VideoProcessingError as exc:
+                logger.debug("scorebar probe failed at t=%.2f: %s", t, exc)
+                raw_frames[t] = None
+
+        hi_raws: dict[float, bytes | None] = {}
+        if use_v2:
+            for future in as_completed(hi_futures):
+                t = hi_futures[future]
+                try:
+                    hi_raws[t] = future.result()
+                except VideoProcessingError as exc:
+                    logger.debug("scorebar probe failed at t=%.2f: %s", t, exc)
+                    hi_raws[t] = None
+
+        # V2 結果。V2 None (opencv 不在) の ts は V1 fallback のため low-res が必要。
+        # with_lowres=False で upfront skip した場合のみ lazy に probe。
+        need_v1: list[float] = []
+        for t in unique_ts:
+            if use_v2:
+                v2_result = _has_scorebar_v2(hi_raws.get(t))
+                if v2_result is not None:
+                    scorebar_results[t] = v2_result
+                else:
+                    need_v1.append(t)
+            else:
+                scorebar_results[t] = _has_scorebar(raw_frames[t], height)
+
+        if need_v1:
+            for t in need_v1:
+                if not probe_lowres_upfront and raw_frames.get(t) is None:
+                    try:
+                        raw_frames[t] = _probe_frame_rgb(video_path, t, height)
+                    except VideoProcessingError as exc:
+                        logger.debug("lazy scorebar probe failed at t=%.2f: %s", t, exc)
+                        raw_frames[t] = None
+                scorebar_results[t] = _has_scorebar(raw_frames[t], height)
+
+        localize_results: dict[float, bool | None] = {}
+        if with_localize and use_v2:
+            for t in unique_ts:
+                localize_results[t] = _localize_present_from_raw(hi_raws.get(t))
+        else:
+            for t in unique_ts:
+                localize_results[t] = None
+
+    return (
+        [scorebar_results[t] for t in timestamps],
+        [raw_frames[t] for t in timestamps],
+        [localize_results[t] for t in timestamps],
+    )
+```
+
+> 既存の lo-probe except の log は T5 と整合 (同 message)。T5 を先に commit している場合は重複させず統一。
+
+- [ ] **Step 4: pass 確認** — Run the Step 2 tests / Expected: PASS
+
+- [ ] **Step 5: re-probe / merge-probe site で `with_lowres=False` を指定** (frames を破棄する 4 site のみ)
+
+```python
+# classify_blackout re-probe (L476 / L480): _, _, _ = ... → with_lowres=False 追加
+            pre_re_results, _, _ = _probe_scorebar_context(
+                video_path, pre_re_timestamps, height, workers, with_lowres=False
+            )
+            post_re_results, _, _ = _probe_scorebar_context(
+                video_path, post_re_timestamps, height, workers, with_lowres=False
+            )
+# _merge_boundary_pairs (L742 / L750): probe_signal のみ使用 → with_lowres=False 追加
+```
+
+> primary `classify_blackout` (L438/441 → `_is_static_from_frames`) と `_classify_blackout_localize` (L302/305 → `_band_mad_min`) は frames を使うため **default True 据置** (変更しない)。
+
+- [ ] **Step 6: 非回帰** — Run `python -m pytest tests/test_scorebar.py -q` / Expected: PASS
+
+- [ ] **Step 7: Commit** (`perf(scorebar): merge/re-probe で不要な low-res probe を skip (Refs #842)` + Co-Authored-By trailer)
+
+---
+
+## Task T7: P3 — GPU 診断ログ honesty 化 (TDD)
+
+**Files:** Modify `allaganeye/video/gpu_detector.py` / Test `tests/test_gpu_detector.py`
+
+- [ ] **Step 1: failing test** — d3d11va を要求した stderr (但し実 decode 未確認) で「active」と断定 info を出さない (over-claim しない) ことを検証。cuvid 実 decoder 名一致時の active と、全 marker 不在の CPU fallback warning は据置。
+
+```python
+def test_check_gpu_usage_d3d11va_does_not_overclaim(caplog):
+    import logging
+    from allaganeye.video.gpu_detector import _check_gpu_usage
+    # ffmpeg のコマンドエコーに -hwaccel d3d11va が出るだけの stderr
+    stderr = "ffmpeg ... -hwaccel d3d11va -c:v ... \nframe= 100 ..."
+    with caplog.at_level(logging.INFO):
+        _check_gpu_usage(stderr, "h264", None)
+    text = " ".join(r.message for r in caplog.records).lower()
+    assert "active (d3d11va)" not in text  # over-claim しない
+    assert "requested" in text or "unconfirmed" in text  # honest 表記
+
+
+def test_check_gpu_usage_cuvid_confirms_active(caplog):
+    import logging
+    from allaganeye.video.gpu_detector import _check_gpu_usage
+    with caplog.at_level(logging.INFO):
+        _check_gpu_usage("Using h264_cuvid decoder ...", "h264", "h264_cuvid")
+    assert any("active" in r.message.lower() for r in caplog.records)
+
+
+def test_check_gpu_usage_no_marker_warns_cpu(caplog):
+    import logging
+    from allaganeye.video.gpu_detector import _check_gpu_usage
+    with caplog.at_level(logging.WARNING):
+        _check_gpu_usage("plain software decode log", "h264", None)
+    assert any("CPU" in r.message or "not active" in r.message.lower()
+               for r in caplog.records)
+```
+
+- [ ] **Step 2: fail 確認** — Run the 3 tests / Expected: 1 つ目 FAIL (現状 "active (d3d11va)" を出す)
+
+- [ ] **Step 3: `_check_gpu_usage` を honesty 化**
+
+```python
+def _check_gpu_usage(
+    stderr_text: str, codec: str | None, cuvid_decoder: str | None
+) -> None:
+    """Log GPU decode status based on ffmpeg stderr output.
+
+    cuvid の実 decoder 名 (h264_cuvid 等) が stderr に出ていれば実 decode を
+    確認できるため "active"。d3d11va/qsv/auto は **要求した hwaccel 名が
+    コマンドエコーに必ず出る**ため、その substring 一致だけでは実 decode を
+    確認できない (#842 P3): CPU fallback でも真になる。over-claim を避け
+    "requested (decode path unconfirmed)" と honest に記す。全 marker 不在は
+    従来どおり CPU fallback の warning。vendor 固有の init 成否 marker による
+    完全判定は実機 stderr が前提で別 issue。
+    """
+    lowered = stderr_text.lower()
+    if cuvid_decoder and cuvid_decoder in stderr_text:
+        logger.info("GPU decode active: %s", cuvid_decoder)
+    elif "d3d11va" in lowered or "qsv" in lowered or "cuda" in lowered or "hwaccel" in lowered:
+        requested = (
+            "d3d11va" if "d3d11va" in lowered
+            else "qsv" if "qsv" in lowered
+            else "cuda" if "cuda" in lowered
+            else "hwaccel auto"
+        )
+        logger.info(
+            "GPU hwaccel '%s' requested for codec '%s' (decode path unconfirmed "
+            "from stderr; CPU fallback not distinguishable here)",
+            requested,
+            codec or "unknown",
+        )
+    else:
+        logger.warning(
+            "GPU acceleration not active for codec '%s', falling back to CPU decode",
+            codec or "unknown",
+        )
+```
+
+- [ ] **Step 4: pass + 非回帰** — Run `python -m pytest tests/test_gpu_detector.py -q` / Expected: PASS (既存 test が "active (d3d11va)" 文字列に依存していれば honest 文言に更新)
+
+- [ ] **Step 5: Commit** (`fix(gpu): GPU 診断ログの over-claim を honesty 化 (Refs #842)` + Co-Authored-By trailer)
+
+---
+
+## Task T8: P3 — format.py consolidate-alias (TDD, bit-exact)
+
+**Files:** Modify `allaganeye/commands/split_matches.py` / Test `tests/test_split_matches.py`
+
+- [ ] **Step 1: failing test** — split_matches の `_format_timestamp`/`_format_duration`/`_iso_utc_now` が `detection.format` の public 版と同一オブジェクト (alias) であることを検証 (consolidate の証明)。
+
+```python
+def test_split_matches_format_helpers_are_detection_format_aliases():
+    from allaganeye.commands import split_matches as sm
+    from allaganeye.detection import format as fmt
+    assert sm._format_timestamp is fmt.format_timestamp
+    assert sm._format_duration is fmt.format_duration
+    assert sm._iso_utc_now is fmt.iso_utc_now
+```
+
+- [ ] **Step 2: fail 確認** — Run `python -m pytest tests/test_split_matches.py::test_split_matches_format_helpers_are_detection_format_aliases -v` / Expected: FAIL (別 def なので `is` not True)
+
+- [ ] **Step 3: split_matches.py の private def を import alias に置換** (L1732-1738 / L1757-1764 / L1778-1784 を削除し、module top の import 群に追加)
+
+```python
+# split_matches.py の import 群 (datetime import の近傍) に追加:
+from allaganeye.detection.format import (
+    format_duration as _format_duration,
+    format_timestamp as _format_timestamp,
+    iso_utc_now as _iso_utc_now,
+)
+```
+
+> 旧 `def _format_timestamp` / `def _format_duration` / `def _iso_utc_now` (本体 + docstring) を削除。`_format_eta` (public 版なし) は据置。`from datetime import UTC, datetime` が他で使われていなければ lint が unused を検出 → 削除 (ruff に従う)。`commands/detect.py` の `from ...split_matches import _format_duration, _iso_utc_now` は alias 経由で動作 (変更不要)。
+
+- [ ] **Step 4: disabled_emitter 確認** — `git log -1 --format=%H -- allaganeye/detection/progress_emitter.py` 等で intent を確認。tested + opt-out API の体裁のため **削除しない**。本 task では touch せず、PR 本文に「intended opt-out API として retain、production caller は将来追加余地」と注記するに留める。
+
+- [ ] **Step 5: pass + 非回帰** — Run `python -m pytest tests/test_split_matches.py tests/test_detect.py -q` / Expected: PASS (alias で値・名前不変)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" add allaganeye/commands/split_matches.py tests/test_split_matches.py
+git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" commit -F - <<'EOF'
+refactor(detection): split_matches の format helper を detection.format に統合 (Refs #842)
+
+P3。detection/format.py (#463 で共有用に作成、public 版) が production から
+未 import の dead module になり、split_matches に byte 等価の private
+_format_timestamp/_format_duration/_iso_utc_now が live していた。private 版を
+detection.format の import alias に置換し canonical 化、重複定義を解消。全 call
+site / detect.py import / tests は名前不変で動作 (bit-exact)。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## 検証 (controller、Subagent-Driven 完了後)
+
+1. **fast gate** (touch root のみ): `python -m ruff check allaganeye tests` / `python -m ruff format --check allaganeye tests` / `python -m pyright allaganeye tests` / `python -m pytest -q` (concurrency 変更のため full、leak/OOM 確認)。
+2. **cap 実測確定** (T3 Step 0): `_measure_borderline.out.log` の 4 baseline raw_span から cap を確定し T3 に反映済を確認。実測値 + margin を PR 本文に記録。
+3. **bit-exact baseline gate** (代理、detached): `ALLAGANEYE_SAMPLE_VIDEO_DIR=E:\royalstraightflesh\videos`、`ALLAGANEYE_INTEGRITY_SKIP=1`、`python -m pytest -m slow_detect -q` を Start-Process Hidden で実行 (memory feedback_long_gpu_job_detached_execution)。PASS = released 出力 bit-exact。timestamp churn (detected_at/generated_at) が差分原因なら grep 除外で output-neutral 判定 (memory feedback_worktree_bash_cwd_drift)。
+4. **Pre-flight Step 0-5** (Iron Law 6): Step 5 codex adversarial-review (focus ASCII、`--scope branch`、env fail 時 §C6 fallback + notice)。
+5. **Idios 実機検証** (AskUserQuestion、Pre-flight): 実 GPU detect (NVIDIA/AMD) / 長時間動画 / stall watchdog 発火。iterate-review 収束後の最終状態で。
+6. TEMP ファイル削除 (`_measure_borderline.py` / `*.log` / `_smoke.mkv`)。
+
+---
+
+## Self-Review (writing-plans)
+
+- **Spec coverage**: P2-3 (T2) / P2-4 (T3) / P2-6 (T1) / GPU log (T7) / lo-probe (T6) / probe dur (T4) / scorebar logger (T5) / format.py (T8) — issue #842 AC 全項目に task 対応。
+- **Placeholder scan**: cap 値は default 600.0 + T3 Step 0 measurement gate で確定 (placeholder でなく確定手順)。他は実コード提示済。
+- **Type consistency**: `_saturated_column_runs` / `_emblem_metrics` / `_proc_deadline_watchdog` / `_BORDERLINE_TOTAL_SPAN_CAP` / `with_lowres` は全 task で名称一貫。
+- **bit-exact**: T1 (純粋抽出) / T2 (timer 不発) / T3 (cap 不発) / T6 (opencv 在で同判定) は baseline gate で実証。T4/T5/T7/T8 は出力非影響 (parse error path / log / alias)。

--- a/docs/superpowers/plans/2026-06-24-audit-w2-w4.md
+++ b/docs/superpowers/plans/2026-06-24-audit-w2-w4.md
@@ -538,7 +538,7 @@ _BORDERLINE_SPAN_CAP_FRACTION = 1.5
 健全な OBS 録画でも brightness 15-55 の borderline frame は多く、実測 (2026-06-24)
 で raw_span は duration の 15-50% に達する (obs-20260118: 50.1%)。一方 brightness
 15-55 の待機画面が支配的な pathological 録画では raw_frac が ~200% に達し Pass 2
-probe が非有界に増える。cap = この値 × total_duration。1.5 は実測最大 50% の 3x
+probe が非有界に増える。cap = この値 x total_duration。1.5 は実測最大 50% の 3x
 margin で、未検証の長尺/暗め録画も clip せず pathological のみ捕捉する。超過分は
 drop + warning、本体 blackout 抽出 (`< blackout_threshold`) は不変。"""
 ```
@@ -564,7 +564,7 @@ drop + warning、本体 blackout 抽出 (`< blackout_threshold`) は不変。"""
         span = end - start
         if running + span > cap_span:
             logger.warning(
-                "borderline pseudo-region 合計長が cap (%.0fs = %.1f×duration) を"
+                "borderline pseudo-region 合計長が cap (%.0fs = %.1fx duration) を"
                 "超過: %d 領域中 %d を drop (待機画面が支配的な録画の Pass 2 probe "
                 "を有界化)。",
                 cap_span,

--- a/docs/superpowers/plans/2026-06-24-audit-w2-w4.md
+++ b/docs/superpowers/plans/2026-06-24-audit-w2-w4.md
@@ -8,7 +8,7 @@
 
 - **P2-6 (`detector.py` + `capture_region.py`)**: 共有ヘルパ 2 つを detector.py に新設 — `_saturated_column_runs(band, cv2)` (per-pixel sat/val mask → col-ratio → run → gap-merge、width-gate/center-select 前の merged runs) と `_emblem_metrics(region, cv2)` ((mean_sat, edge_density))。detector の `_find_scorebar_horizontal_range` / `_emblem_and_check` と capture_region の `_scorebar_saturated_runs` / `_emblem_and_margin` を repoint。capture_region は既存同様 lazy import (`from allaganeye.video.detector import ...`)。純粋抽出で各 caller の出力不変 = bit-exact。
 - **P2-3 (`detector.py` + `gpu_detector.py`)**: 共有 context manager `_proc_deadline_watchdog(proc, deadline_s)` を detector.py に新設。`threading.Timer(deadline_s, proc.kill)` (daemon) を start し `finally` で必ず cancel。`_decode_chunk_cpu_v2` / `_decode_chunk_v2` の `_sample_chunk_frames(stream=proc.stdout, ...)` + `proc.wait` を watchdog で包む。ffmpeg stall 時に Timer が proc.kill → `stream.read` が EOF で抜け → `proc.wait` 即返り → 既存の `proc.returncode != 0` 処理 (CPU=255.0 fallback / GPU=`VideoProcessingError` raise) に自然合流。healthy decode では Timer cancel → 不発 → bit-exact。
-- **P2-4 (`detector.py`)**: module 定数 `_BORDERLINE_TOTAL_SPAN_CAP` を新設。`_borderline_pseudo_regions` 内で生成 region を start 昇順に accumulate し、合計長が cap を超えたら以降を drop + 1 回 warning。`< blackout_threshold` の本体抽出 (Pass 2 strict 判定) は不変、additive coverage (#576 A5) のみ縮退。**cap 値は baseline 実測 (`_measure_borderline.py`、detached 実行中) で確定** (T3 Step 0 ゲート)。
+- **P2-4 (`detector.py`)**: module 定数 `_BORDERLINE_SPAN_CAP_FRACTION` (=1.5) を新設。`_borderline_pseudo_regions` 内で生成 region を start 昇順に accumulate し、合計長が `fraction × total_duration` を超えたら以降を drop + 1 回 warning。`< blackout_threshold` の本体抽出 (Pass 2 strict 判定) は不変、additive coverage (#576 A5) のみ縮退。**cap は duration 比** (実測で健全録画の raw_frac が最大 50% = obs-20260118 と判明、絶対値 cap では未検証の長尺録画を clip し bit-exact を破綻させるため、Idios 判断 (AskUserQuestion) で duration 比を採用、T3 Step 0)。
 - **P3 GPU log (`gpu_detector.py`)**: `_check_gpu_usage` の d3d11va/qsv branch が**要求 hwaccel の substring 一致だけ**で「decode active」と over-claim するのを honesty 化 (「requested、decode 経路は stderr から未確認」表記)。cuvid (実 decoder 名一致) と「全 marker 不在 → CPU fallback」branch は据置。log-only。vendor 固有 marker の完全 active 判定は実機 AMD/Intel stderr が前提で **scope 外 (follow-up)**。
 - **P3 lo-probe (`scorebar.py`)**: `_probe_scorebar_context(..., with_lowres=True)` 追加。frames を捨てる site (re-probe `classify_blackout` / merge-probe `_merge_boundary_pairs`) で `with_lowres=False` 指定 → v2 経路の low-res probe を skip (ffmpeg 起動削減)。v2 が None (opencv 不在) の ts のみ low-res を**遅延 probe** して V1 fallback 維持 → 全経路 bit-exact。frames を使う site (primary `classify_blackout` / `_classify_blackout_localize`) は default True 据置。
 - **P3 probe dur (`probe.py`)**: `format.duration` / video stream `width`/`height` の numeric parse を try/except で堅牢化し非数値/型不正で `VideoProcessingError` (exit 3) を送出 (現状 `float()`/`int()` の uncaught ValueError → exit 1)。duration が監査明示対象、width/height は同クラス横展開 (CLAUDE.md 根本原因方針)。
@@ -87,7 +87,7 @@
 | 区分 | path | 責務 |
 | --- | --- | --- |
 | Create | `docs/superpowers/plans/2026-06-24-audit-w2-w4.md` | 本 plan |
-| Modify | `allaganeye/video/detector.py` | `_saturated_column_runs`/`_emblem_metrics` 新設 + 2 関数 repoint (P2-6) / `_proc_deadline_watchdog` 新設 + `_decode_chunk_cpu_v2` 適用 (P2-3) / `_BORDERLINE_TOTAL_SPAN_CAP` + `_borderline_pseudo_regions` cap (P2-4) |
+| Modify | `allaganeye/video/detector.py` | `_saturated_column_runs`/`_emblem_metrics` 新設 + 2 関数 repoint (P2-6) / `_proc_deadline_watchdog` 新設 + `_decode_chunk_cpu_v2` 適用 (P2-3) / `_BORDERLINE_SPAN_CAP_FRACTION` + `_borderline_pseudo_regions` cap (P2-4) |
 | Modify | `allaganeye/video/capture_region.py` | `_scorebar_saturated_runs`/`_emblem_and_margin` を共有ヘルパ呼出に (P2-6) |
 | Modify | `allaganeye/video/gpu_detector.py` | `_decode_chunk_v2` に watchdog 適用 (P2-3) / `_check_gpu_usage` honesty 化 (P3) |
 | Modify | `allaganeye/video/scorebar.py` | `_probe_scorebar_context` `with_lowres` + lazy fallback (P3) / probe 失敗 log (P3) / re-probe・merge site `with_lowres=False` |
@@ -493,7 +493,7 @@ EOF
 
 **Files:** Modify `allaganeye/video/detector.py` / Test `tests/test_detector.py`
 
-- [ ] **Step 0 (controller measurement gate):** detached 測定 `_measure_borderline.out.log` 完了を確認し、4 baseline の `raw_span` 最大値を読む。cap 値 = `max(600.0, ceil(max_raw_span * 2 / 60) * 60)` (最大の 2x 以上、かつ最低 600s)。確定値を Step 3 の `_BORDERLINE_TOTAL_SPAN_CAP` に反映 + PR 本文に実測値 + margin を記録。**baseline raw_span は cap を下回る = 不発 = bit-exact** が前提 (slow_detect gate で再確認)。
+- [ ] **Step 0 (controller measurement gate — DONE 2026-06-24):** detached 測定 `_measure_borderline.py` で 4 baseline の raw_span を実測。**結果**: obs-20260116 raw_frac 28.8% / obs-20260118 **50.1% (最大、4124.7s)** / obs-20260119 16.9% / obs-20260127 15.4%。健全録画でも borderline raw_span は大きい (最大 duration の 50.1%)。**Idios 判断 (AskUserQuestion)**: 絶対値 cap ではなく **duration 比 cap** を採用。`_BORDERLINE_SPAN_CAP_FRACTION = 1.5` (cap = 1.5 × total_duration = 実測最大 50% の 3x margin)。pathological な待機画面支配録画は raw_frac ~200% に達し cap 発火、健全録画 (≤50%) は不発 = bit-exact。slow_detect gate で再確認。
 
 - [ ] **Step 1: cap の failing test を書く** (`tests/test_detector.py`、発火 + 不発)
 
@@ -502,42 +502,45 @@ def test_borderline_pseudo_regions_capped_with_warning(caplog):
     import logging
     from allaganeye.video.detector import (
         _borderline_pseudo_regions,
-        _BORDERLINE_TOTAL_SPAN_CAP,
-        _BORDERLINE_REFINE_RADIUS,
+        _BORDERLINE_SPAN_CAP_FRACTION,
     )
-    # cap を確実に超える borderline frame 列 (b=40 ∈ [15,55)、互いに非重複)
-    step = int(_BORDERLINE_REFINE_RADIUS * 2) + 2
-    n = int(_BORDERLINE_TOTAL_SPAN_CAP / (_BORDERLINE_REFINE_RADIUS * 2)) + 50
-    results = {float(i * step): 40.0 for i in range(n)}
-    total_dur = float(n * step + 100)
+    # 高密度の borderline frame (b=40 ∈ [15,55)) を全域に敷き、raw_span が
+    # fraction×duration を超える pathological を模す (interval≈3, radius=3 で
+    # raw_span ≈ 2×duration ≈ 200% > 150% cap)。
+    total_dur = 1000.0
+    results = {float(t): 40.0 for t in range(0, int(total_dur), 3)}
     with caplog.at_level(logging.WARNING):
         regions = _borderline_pseudo_regions(results, 15.0, total_dur)
     total = sum(e - s for s, e in regions)
-    assert total <= _BORDERLINE_TOTAL_SPAN_CAP + (_BORDERLINE_REFINE_RADIUS * 2)
+    cap = _BORDERLINE_SPAN_CAP_FRACTION * total_dur
+    assert total <= cap + 6.0  # +1 region 分の許容
     assert any("borderline" in r.message.lower() for r in caplog.records)  # 発火 red 実証
 
 
 def test_borderline_pseudo_regions_not_capped_under_threshold(caplog):
     import logging
     from allaganeye.video.detector import _borderline_pseudo_regions
-    results = {0.0: 40.0, 100.0: 42.0}  # 2 frame、span « cap
+    results = {0.0: 40.0, 100.0: 42.0}  # 疎、raw_span « cap
     with caplog.at_level(logging.WARNING):
         regions = _borderline_pseudo_regions(results, 15.0, 1000.0)
     assert len(regions) == 2  # 全件保持 (不発 = bit-exact)
     assert not any("borderline" in r.message.lower() for r in caplog.records)
 ```
 
-- [ ] **Step 2: fail 確認** — Run `python -m pytest tests/test_detector.py::test_borderline_pseudo_regions_capped_with_warning tests/test_detector.py::test_borderline_pseudo_regions_not_capped_under_threshold -v` / Expected: FAIL (`ImportError: ... _BORDERLINE_TOTAL_SPAN_CAP` / cap 未実装で span 超過)
+- [ ] **Step 2: fail 確認** — Run `python -m pytest tests/test_detector.py::test_borderline_pseudo_regions_capped_with_warning tests/test_detector.py::test_borderline_pseudo_regions_not_capped_under_threshold -v` / Expected: FAIL (`ImportError: ... _BORDERLINE_SPAN_CAP_FRACTION` / cap 未実装で span 超過)
 
-- [ ] **Step 3: cap 定数 + cap ロジックを実装** (Step 0 の確定値。下記は default 600.0、Step 0 で bump 可)
+- [ ] **Step 3: cap 定数 + cap ロジックを実装**
 
 ```python
-_BORDERLINE_TOTAL_SPAN_CAP = 600.0
-"""borderline pseudo-region (#576 A5) の合計長上限 (秒)。健全な OBS 録画は
-試合境界の短い fade のみで borderline span が極小だが、brightness 15-55 の
-待機画面が長時間続く録画では Pass 2 probe が非有界に増える (#842 P2-4)。
-合計長がこの値を超えたら additive coverage を縮退する (本体 blackout 抽出は
-不変)。値は baseline 実測 (max raw_span) の 2x 以上 + 最低 600s で決定。"""
+_BORDERLINE_SPAN_CAP_FRACTION = 1.5
+"""borderline pseudo-region (#576 A5) 合計長の上限 (total_duration 比、#842 P2-4)。
+
+健全な OBS 録画でも brightness 15-55 の borderline frame は多く、実測 (2026-06-24)
+で raw_span は duration の 15-50% に達する (obs-20260118: 50.1%)。一方 brightness
+15-55 の待機画面が支配的な pathological 録画では raw_frac が ~200% に達し Pass 2
+probe が非有界に増える。cap = この値 × total_duration。1.5 は実測最大 50% の 3x
+margin で、未検証の長尺/暗め録画も clip せず pathological のみ捕捉する。超過分は
+drop + warning、本体 blackout 抽出 (`< blackout_threshold`) は不変。"""
 ```
 
 `_borderline_pseudo_regions` の return を cap 適用に変更:
@@ -550,21 +553,24 @@ _BORDERLINE_TOTAL_SPAN_CAP = 600.0
         for t, b in results.items()
         if blackout_threshold <= b < upper
     ]
-    # #842 P2-4: 合計長 cap。待機画面が長い録画で Pass 2 probe が非有界に
-    # 増えるのを防ぐ。start 昇順に accumulate し cap 超過分を drop。
+    # #842 P2-4: 合計長 cap (total_duration 比)。borderline が支配的な待機画面
+    # 録画で Pass 2 probe が非有界に増えるのを防ぐ。start 昇順に accumulate し
+    # cap 超過分を drop。健全録画 (raw_frac <= 50% 実測) では不発 = bit-exact。
+    cap_span = _BORDERLINE_SPAN_CAP_FRACTION * total_duration
     regions.sort()
     capped: list[tuple[float, float]] = []
     running = 0.0
     for start, end in regions:
         span = end - start
-        if running + span > _BORDERLINE_TOTAL_SPAN_CAP:
-            dropped = len(regions) - len(capped)
+        if running + span > cap_span:
             logger.warning(
-                "borderline pseudo-region 合計長が cap (%.0fs) を超過: "
-                "%d 領域中 %d を drop (待機画面が長い録画の Pass 2 probe を有界化)。",
-                _BORDERLINE_TOTAL_SPAN_CAP,
+                "borderline pseudo-region 合計長が cap (%.0fs = %.1f×duration) を"
+                "超過: %d 領域中 %d を drop (待機画面が支配的な録画の Pass 2 probe "
+                "を有界化)。",
+                cap_span,
+                _BORDERLINE_SPAN_CAP_FRACTION,
                 len(regions),
-                dropped,
+                len(regions) - len(capped),
             )
             break
         capped.append((start, end))
@@ -584,9 +590,10 @@ git -C "E:/projects/kobutachan-tools/kobutachan-allaganeye" commit -F - <<'EOF'
 fix(detector): borderline pseudo-region に合計長 cap を追加 (Refs #842)
 
 P2-4。_borderline_pseudo_regions (#576 A5) は brightness 15-55 の待機画面が
-長時間続く録画で Pass 2 probe を非有界に増やす。_BORDERLINE_TOTAL_SPAN_CAP
-(baseline 実測 + margin) で合計長を有界化、超過分を drop + warning。本体の
-blackout 抽出は不変、5 baseline で不発 (bit-exact)。発火側を red 実証。
+支配的な録画で Pass 2 probe を非有界に増やす。_BORDERLINE_SPAN_CAP_FRACTION
+(=1.5、実測最大 raw_frac 50% の 3x margin) で合計長を duration 比で有界化、
+超過分を drop + warning。本体 blackout 抽出は不変、4 baseline で不発
+(bit-exact)。発火側を red 実証。
 
 Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
 EOF
@@ -1015,5 +1022,5 @@ EOF
 
 - **Spec coverage**: P2-3 (T2) / P2-4 (T3) / P2-6 (T1) / GPU log (T7) / lo-probe (T6) / probe dur (T4) / scorebar logger (T5) / format.py (T8) — issue #842 AC 全項目に task 対応。
 - **Placeholder scan**: cap 値は default 600.0 + T3 Step 0 measurement gate で確定 (placeholder でなく確定手順)。他は実コード提示済。
-- **Type consistency**: `_saturated_column_runs` / `_emblem_metrics` / `_proc_deadline_watchdog` / `_BORDERLINE_TOTAL_SPAN_CAP` / `with_lowres` は全 task で名称一貫。
+- **Type consistency**: `_saturated_column_runs` / `_emblem_metrics` / `_proc_deadline_watchdog` / `_BORDERLINE_SPAN_CAP_FRACTION` / `with_lowres` は全 task で名称一貫。
 - **bit-exact**: T1 (純粋抽出) / T2 (timer 不発) / T3 (cap 不発) / T6 (opencv 在で同判定) は baseline gate で実証。T4/T5/T7/T8 は出力非影響 (parse error path / log / alias)。

--- a/docs/superpowers/plans/2026-06-24-audit-w2-w4.md
+++ b/docs/superpowers/plans/2026-06-24-audit-w2-w4.md
@@ -493,7 +493,7 @@ EOF
 
 **Files:** Modify `allaganeye/video/detector.py` / Test `tests/test_detector.py`
 
-- [ ] **Step 0 (controller measurement gate — DONE 2026-06-24):** detached 測定 `_measure_borderline.py` で 4 baseline の raw_span を実測。**結果**: obs-20260116 raw_frac 28.8% / obs-20260118 **50.1% (最大、4124.7s)** / obs-20260119 16.9% / obs-20260127 15.4%。健全録画でも borderline raw_span は大きい (最大 duration の 50.1%)。**Idios 判断 (AskUserQuestion)**: 絶対値 cap ではなく **duration 比 cap** を採用。`_BORDERLINE_SPAN_CAP_FRACTION = 1.5` (cap = 1.5 × total_duration = 実測最大 50% の 3x margin)。pathological な待機画面支配録画は raw_frac ~200% に達し cap 発火、健全録画 (≤50%) は不発 = bit-exact。slow_detect gate で再確認。
+- [ ] **Step 0 (controller measurement gate — DONE 2026-06-24):** detached 測定 `_measure_borderline.py` で 5 baseline の raw_span を実測 (Round 1 #4 で obs-20260209 を追加実測)。**結果**: obs-20260116 raw_frac 28.8% / obs-20260118 **50.1% (最大、4124.7s)** / obs-20260119 16.9% / obs-20260127 15.4% / obs-20260209 13.1%。健全録画でも borderline raw_span は大きい (最大 duration の 50.1%)。**Idios 判断 (AskUserQuestion)**: 絶対値 cap ではなく **duration 比 cap** を採用。`_BORDERLINE_SPAN_CAP_FRACTION = 1.5` (cap = 1.5 × total_duration = 実測最大 50% の 3x margin)。pathological な待機画面支配録画は raw_frac ~200% に達し cap 発火、健全録画 (≤50%) は不発 = bit-exact。slow_detect gate で再確認。
 
 - [ ] **Step 1: cap の failing test を書く** (`tests/test_detector.py`、発火 + 不発)
 
@@ -592,7 +592,7 @@ fix(detector): borderline pseudo-region に合計長 cap を追加 (Refs #842)
 P2-4。_borderline_pseudo_regions (#576 A5) は brightness 15-55 の待機画面が
 支配的な録画で Pass 2 probe を非有界に増やす。_BORDERLINE_SPAN_CAP_FRACTION
 (=1.5、実測最大 raw_frac 50% の 3x margin) で合計長を duration 比で有界化、
-超過分を drop + warning。本体 blackout 抽出は不変、4 baseline で不発
+超過分を drop + warning。本体 blackout 抽出は不変、5 baseline で不発
 (bit-exact)。発火側を red 実証。
 
 Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
@@ -1010,7 +1010,7 @@ EOF
 ## 検証 (controller、Subagent-Driven 完了後)
 
 1. **fast gate** (touch root のみ): `python -m ruff check allaganeye tests` / `python -m ruff format --check allaganeye tests` / `python -m pyright allaganeye tests` / `python -m pytest -q` (concurrency 変更のため full、leak/OOM 確認)。
-2. **cap 実測確定** (T3 Step 0): `_measure_borderline.out.log` の 4 baseline raw_span から cap を確定し T3 に反映済を確認。実測値 + margin を PR 本文に記録。
+2. **cap 実測確定** (T3 Step 0): `_measure_borderline.out.log` の 5 baseline raw_span (obs-20260209 含む) から cap を確定し T3 に反映済を確認。実測値 + margin を PR 本文に記録。
 3. **bit-exact baseline gate** (代理、detached): `ALLAGANEYE_SAMPLE_VIDEO_DIR=E:\royalstraightflesh\videos`、`ALLAGANEYE_INTEGRITY_SKIP=1`、`python -m pytest -m slow_detect -q` を Start-Process Hidden で実行 (memory feedback_long_gpu_job_detached_execution)。PASS = released 出力 bit-exact。timestamp churn (detected_at/generated_at) が差分原因なら grep 除外で output-neutral 判定 (memory feedback_worktree_bash_cwd_drift)。
 4. **Pre-flight Step 0-5** (Iron Law 6): Step 5 codex adversarial-review (focus ASCII、`--scope branch`、env fail 時 §C6 fallback + notice)。
 5. **Idios 実機検証** (AskUserQuestion、Pre-flight): 実 GPU detect (NVIDIA/AMD) / 長時間動画 / stall watchdog 発火。iterate-review 収束後の最終状態で。

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -3316,3 +3316,24 @@ def test_emblem_metrics_bright_vs_dark():
     dark = np.zeros((40, 40, 3), dtype=np.uint8)
     d_sat, _d_edge = _emblem_metrics(dark, cv2)
     assert d_sat == 0.0
+
+
+def test_proc_deadline_watchdog_kills_when_block_exceeds_deadline():
+    import time
+    from unittest.mock import Mock
+    from allaganeye.video.detector import _proc_deadline_watchdog
+
+    proc = Mock()
+    with _proc_deadline_watchdog(proc, 0.05):
+        time.sleep(0.25)  # outlive deadline (simulates stall)
+    proc.kill.assert_called_once()  # fire-side red proof
+
+
+def test_proc_deadline_watchdog_no_kill_when_fast():
+    from unittest.mock import Mock
+    from allaganeye.video.detector import _proc_deadline_watchdog
+
+    proc = Mock()
+    with _proc_deadline_watchdog(proc, 5.0):
+        pass  # completes immediately (healthy decode)
+    proc.kill.assert_not_called()  # no fire (bit-exact guarantee)

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -3260,3 +3260,59 @@ def test_detect_masked_fallback_threads_brightness_hint(monkeypatch):
     )
     assert out is None
     assert seen["hint"] == {1.0: 5.0, 2.0: 200.0}
+
+
+def test_saturated_column_runs_gap_merge_and_empty():
+    import numpy as np
+    import cv2
+    from allaganeye.video.detector import (
+        _saturated_column_runs,
+        _SCOREBAR_SCAN_MAX_GAP_PX,
+    )
+
+    # Build a synthetic band with two saturated (high S, high V) regions.
+    # Using pure blue (BGR 255,0,0 = RGB 0,0,255) -> HSV S=255, V=255 (fully
+    # saturated, well above SAT_THRESHOLD=80 and VAL_THRESHOLD=60).
+    h, w = 20, 200
+    band = np.zeros((h, w, 3), dtype=np.uint8)
+    # Region A: columns 10..39 (inclusive) = 30 px
+    band[:, 10:40, 2] = 255  # RGB blue
+    # Region B: starts at 40 + _SCOREBAR_SCAN_MAX_GAP_PX (gap exactly MAX_GAP px
+    # apart from region A end at 39, so gap = (40 + MAX_GAP) - 39 - 1 = MAX_GAP)
+    # -> should merge into a single run.
+    b_start = 40 + _SCOREBAR_SCAN_MAX_GAP_PX
+    band[:, b_start : b_start + 40, 2] = 255  # RGB blue
+    runs = _saturated_column_runs(band, cv2)
+    assert len(runs) == 1
+    assert runs[0][0] <= 10 and runs[0][1] >= b_start + 39
+
+    # Gap of MAX_GAP+1 px -> NOT merged (exclusive boundary): two separate
+    # runs.  Teeth on the gap-merge condition: a regression widening the bound
+    # would wrongly merge these and fail this assertion.
+    w2 = 60 + 2 * _SCOREBAR_SCAN_MAX_GAP_PX
+    band2 = np.zeros((h, w2, 3), dtype=np.uint8)
+    band2[:, 10:40, 2] = 255  # region A: cols 10..39
+    c_start = 40 + _SCOREBAR_SCAN_MAX_GAP_PX + 1  # gap = MAX_GAP+1 (> MAX_GAP)
+    band2[:, c_start : c_start + 15, 2] = 255  # region C
+    runs2 = _saturated_column_runs(band2, cv2)
+    assert len(runs2) == 2
+
+    # All-black band -> no saturated runs
+    assert _saturated_column_runs(np.zeros((h, w, 3), dtype=np.uint8), cv2) == []
+
+
+def test_emblem_metrics_bright_vs_dark():
+    import numpy as np
+    import cv2
+    from allaganeye.video.detector import _emblem_metrics
+
+    # Bright saturated region: high R channel -> high sat in HSV
+    region = np.random.default_rng(0).integers(0, 256, (40, 40, 3), dtype=np.uint8)
+    region[:, :, 0] = 220  # raise R channel -> ensure some saturation and brightness
+    sat, edge = _emblem_metrics(region, cv2)
+    assert sat > 0.0 and edge > 0.0
+
+    # All-black -> no bright pixels -> mean_sat == 0.0
+    dark = np.zeros((40, 40, 3), dtype=np.uint8)
+    d_sat, _d_edge = _emblem_metrics(dark, cv2)
+    assert d_sat == 0.0

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -3370,3 +3370,53 @@ def test_proc_deadline_watchdog_no_kill_when_fast():
     with _proc_deadline_watchdog(proc, 5.0):
         pass  # completes immediately (healthy decode)
     proc.kill.assert_not_called()  # no fire (bit-exact guarantee)
+
+
+def test_decode_chunk_cpu_v2_watchdog_fire_returns_fallback(monkeypatch):
+    """A watchdog-killed stall degrades to the 255.0 decode-failed fallback,
+    not a propagated VideoProcessingError that fails the whole detect (#842 codex).
+
+    When the watchdog kills a stalled ffmpeg, the blocked read in
+    ``_sample_chunk_frames`` resumes at EOF with too few frames and (for a
+    non-tail chunk) trips the dynamic frame-count guard, raising
+    ``VideoProcessingError``.  That must be treated as a decode failure (graceful
+    255.0 fallback), NOT re-raised to fail the whole detection.
+    """
+    import contextlib
+    from pathlib import Path
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from allaganeye.exceptions import VideoProcessingError
+    from allaganeye.video import detector as det
+
+    @contextlib.contextmanager
+    def _fired_watchdog(_proc, _deadline_s):
+        yield SimpleNamespace(fired=True)
+
+    def _raise_vfr(**_kwargs):
+        raise VideoProcessingError("Dynamic VFR detection: chunk emitted 0 frames")
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = -9
+    fake_cm = MagicMock()
+    fake_cm.__enter__.return_value = fake_proc
+    fake_cm.__exit__.return_value = False
+
+    monkeypatch.setattr(det, "_proc_deadline_watchdog", _fired_watchdog)
+    monkeypatch.setattr(det, "_sample_chunk_frames", _raise_vfr)
+    monkeypatch.setattr(det, "find_ffmpeg", lambda: "ffmpeg")
+    monkeypatch.setattr(det.subprocess, "Popen", MagicMock(return_value=fake_cm))
+
+    chunk_ts = [0.0, 3.0, 6.0]
+    result = det._decode_chunk_cpu_v2(
+        video_path=Path("x.mkv"),
+        chunk_timestamps=chunk_ts,
+        chunk_start=0.0,
+        chunk_end=9.0,
+        sample_interval=3.0,
+        fps_num=60,
+        fps_den=1,
+        is_tail_chunk=False,
+    )
+    assert result == {t: 255.0 for t in chunk_ts}

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1642,6 +1642,39 @@ class TestBorderlinePseudoRegions:
         regions = _borderline_pseudo_regions(results, 15.0, 1000.0)
         assert len(regions) == 1
 
+    def test_borderline_pseudo_regions_capped_with_warning(self, caplog):
+        import logging
+
+        from allaganeye.video.detector import (
+            _BORDERLINE_SPAN_CAP_FRACTION,
+            _borderline_pseudo_regions,
+        )
+
+        # Dense borderline frames (b=40 in [15,55)) across the whole video, so
+        # raw_span exceeds fraction*duration (interval~3, radius=3 -> raw_span
+        # ~2*duration ~200% > 150% cap).
+        total_dur = 1000.0
+        results = {float(t): 40.0 for t in range(0, int(total_dur), 3)}
+        with caplog.at_level(logging.WARNING):
+            regions = _borderline_pseudo_regions(results, 15.0, total_dur)
+        total = sum(e - s for s, e in regions)
+        cap = _BORDERLINE_SPAN_CAP_FRACTION * total_dur
+        assert total <= cap + 6.0  # allow one region's worth
+        assert any(
+            "borderline" in r.message.lower() for r in caplog.records
+        )  # fire-side red proof
+
+    def test_borderline_pseudo_regions_not_capped_under_threshold(self, caplog):
+        import logging
+
+        from allaganeye.video.detector import _borderline_pseudo_regions
+
+        results = {0.0: 40.0, 100.0: 42.0}  # sparse, raw_span << cap
+        with caplog.at_level(logging.WARNING):
+            regions = _borderline_pseudo_regions(results, 15.0, 1000.0)
+        assert len(regions) == 2  # all kept (no fire = bit-exact)
+        assert not any("borderline" in r.message.lower() for r in caplog.records)
+
 
 class TestMergeRegions:
     """Unit tests for _merge_regions (A3 helper, #361)."""

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -1025,3 +1025,42 @@ class TestGpuBrightnessParity:
         sig = inspect.signature(gpu.scan_gpu)
         assert "region" in sig.parameters
         assert sig.parameters["region"].default is FULL_FRAME
+
+
+class TestCheckGpuUsage:
+    """_check_gpu_usage は honesty 原則: cuvid 実 decoder 名一致のみ "active" と
+    断言し、hwaccel コマンドエコーによる substring 一致は "requested (unconfirmed)"
+    と正直に記す (#842 P3)。"""
+
+    def test_check_gpu_usage_d3d11va_does_not_overclaim(self, caplog):
+        import logging
+
+        from allaganeye.video.gpu_detector import _check_gpu_usage
+
+        stderr = "ffmpeg ... -hwaccel d3d11va -c:v ... \nframe= 100 ..."
+        with caplog.at_level(logging.INFO):
+            _check_gpu_usage(stderr, "h264", None)
+        text = " ".join(r.message for r in caplog.records).lower()
+        assert "active (d3d11va)" not in text  # no over-claim
+        assert "requested" in text or "unconfirmed" in text  # honest wording
+
+    def test_check_gpu_usage_cuvid_confirms_active(self, caplog):
+        import logging
+
+        from allaganeye.video.gpu_detector import _check_gpu_usage
+
+        with caplog.at_level(logging.INFO):
+            _check_gpu_usage("Using h264_cuvid decoder ...", "h264", "h264_cuvid")
+        assert any("active" in r.message.lower() for r in caplog.records)
+
+    def test_check_gpu_usage_no_marker_warns_cpu(self, caplog):
+        import logging
+
+        from allaganeye.video.gpu_detector import _check_gpu_usage
+
+        with caplog.at_level(logging.WARNING):
+            _check_gpu_usage("plain software decode log", "h264", None)
+        assert any(
+            "cpu" in r.message.lower() or "not active" in r.message.lower()
+            for r in caplog.records
+        )

--- a/tests/test_gpu_detector.py
+++ b/tests/test_gpu_detector.py
@@ -979,6 +979,53 @@ class TestDecodeChunkV2Cmd:
         assert ss_positions[0] < i_idx, "first -ss should be input seek (before -i)"
         assert ss_positions[1] > i_idx, "second -ss should be output seek (after -i)"
 
+    def test_decode_chunk_v2_watchdog_fire_raises_for_cpu_fallback(self, monkeypatch):
+        """GPU watchdog-fire (stall) raises VideoProcessingError so scan_gpu falls
+        back to CPU, not silently swallow the stalled chunk (#842 codex, GPU side).
+
+        Symmetric to the CPU test
+        ``test_decode_chunk_cpu_v2_watchdog_fire_returns_fallback``: the CPU path
+        degrades to 255.0, the GPU path re-raises (its decode-failed contract ->
+        upstream CPU fallback). Both must surface the stall, never hang/swallow.
+        """
+        import contextlib
+        from types import SimpleNamespace
+
+        from allaganeye.exceptions import VideoProcessingError
+        from allaganeye.video import gpu_detector as gd
+
+        @contextlib.contextmanager
+        def _fired_watchdog(_proc, _deadline_s):
+            yield SimpleNamespace(fired=True)
+
+        def _raise_vfr(**_kwargs):
+            raise VideoProcessingError("Dynamic VFR detection: chunk emitted 0 frames")
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = -9
+        fake_cm = MagicMock()
+        fake_cm.__enter__.return_value = fake_proc
+        fake_cm.__exit__.return_value = False
+
+        monkeypatch.setattr(gd, "_proc_deadline_watchdog", _fired_watchdog)
+        monkeypatch.setattr(gd, "_sample_chunk_frames", _raise_vfr)
+        monkeypatch.setattr(gd, "find_ffmpeg", lambda: "ffmpeg")
+        monkeypatch.setattr(gd.subprocess, "Popen", MagicMock(return_value=fake_cm))
+
+        with pytest.raises(VideoProcessingError):
+            gd._decode_chunk_v2(
+                Path("x.mkv"),
+                chunk_start=0.0,
+                chunk_end=9.0,
+                sample_interval=3.0,
+                codec="h264",
+                chunk_timestamps=[0.0, 3.0, 6.0],
+                vendor=None,
+                fps_num=60,
+                fps_den=1,
+                is_tail_chunk=False,
+            )
+
 
 class TestGpuFallbackIntegration:
     @patch("allaganeye.video.detector._scan_cpu")

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -561,3 +561,84 @@ class TestProbeStaticVfrWarn:
 
         warns = [r for r in caplog.records if "VFR" in r.getMessage()]
         assert warns == []
+
+
+# --- P3 pin tests: non-numeric duration / resolution ---
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+@patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe")
+def test_probe_nonnumeric_duration_raises_video_processing_error(
+    _mock_ffprobe, mock_run, tmp_path
+):
+    """ffprobe duration='N/A' must raise VideoProcessingError, not bare ValueError."""
+    video = tmp_path / "test.mkv"
+    video.touch()
+    data = {
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "r_frame_rate": "60/1",
+                "avg_frame_rate": "60/1",
+            }
+        ],
+        "format": {"duration": "N/A"},
+    }
+    mock_run.return_value = _mock_result(stdout=json.dumps(data))
+    with pytest.raises(VideoProcessingError):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+@patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe")
+def test_probe_nonnumeric_width_raises_video_processing_error(
+    _mock_ffprobe, mock_run, tmp_path
+):
+    """ffprobe width='N/A' must raise VideoProcessingError, not bare ValueError."""
+    video = tmp_path / "test.mkv"
+    video.touch()
+    data = {
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": "N/A",
+                "height": 1080,
+                "r_frame_rate": "60/1",
+                "avg_frame_rate": "60/1",
+            }
+        ],
+        "format": {"duration": "600.0"},
+    }
+    mock_run.return_value = _mock_result(stdout=json.dumps(data))
+    with pytest.raises(VideoProcessingError):
+        probe_video(video)
+
+
+@patch("allaganeye.video.probe.subprocess.run")
+@patch("allaganeye.video.probe.find_ffprobe", return_value="ffprobe")
+def test_probe_nonnumeric_height_raises_video_processing_error(
+    _mock_ffprobe, mock_run, tmp_path
+):
+    """ffprobe height='N/A' must raise VideoProcessingError, not bare ValueError."""
+    video = tmp_path / "test.mkv"
+    video.touch()
+    data = {
+        "streams": [
+            {
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": "N/A",
+                "r_frame_rate": "60/1",
+                "avg_frame_rate": "60/1",
+            }
+        ],
+        "format": {"duration": "600.0"},
+    }
+    mock_run.return_value = _mock_result(stdout=json.dumps(data))
+    with pytest.raises(VideoProcessingError):
+        probe_video(video)

--- a/tests/test_scorebar.py
+++ b/tests/test_scorebar.py
@@ -1405,7 +1405,9 @@ def test_classify_localize_truth_table(monkeypatch):
 
     calls = {"n": 0}
 
-    def fake_probe(video, ts, height, workers, *, with_localize=False):
+    def fake_probe(
+        video, ts, height, workers, *, with_localize=False, with_lowres=True
+    ):
         # pre call first, post call second (region_width re-probe not triggered
         # unless both not-True).
         calls["n"] += 1
@@ -1426,7 +1428,7 @@ def test_classify_localize_both_present_is_in_match(monkeypatch):
     monkeypatch.setattr(
         sb,
         "_probe_scorebar_context",
-        lambda v, ts, h, w, *, with_localize=False: (
+        lambda v, ts, h, w, *, with_localize=False, with_lowres=True: (
             [None] * len(ts),
             [b"f"] * len(ts),
             [True] * len(ts),
@@ -1445,7 +1447,7 @@ def test_classify_localize_both_absent_is_non_fl(monkeypatch):
     monkeypatch.setattr(
         sb,
         "_probe_scorebar_context",
-        lambda v, ts, h, w, *, with_localize=False: (
+        lambda v, ts, h, w, *, with_localize=False, with_lowres=True: (
             [None] * len(ts),
             [b"f"] * len(ts),
             [False] * len(ts),
@@ -1470,7 +1472,9 @@ def test_classify_localize_reprobe_rescues_to_boundary(monkeypatch):
     # call 1 pre absent, call 2 post absent, call 3 pre_re present, call 4 post_re absent
     per_call_present = {1: False, 2: False, 3: True, 4: False}
 
-    def fake_probe(video, ts, height, workers, *, with_localize=False):
+    def fake_probe(
+        video, ts, height, workers, *, with_localize=False, with_lowres=True
+    ):
         calls["n"] += 1
         present = per_call_present[calls["n"]]
         return ([None] * len(ts), [b"f"] * len(ts), [present] * len(ts))
@@ -1494,7 +1498,7 @@ def test_classify_localize_all_none_is_unknown(monkeypatch):
     monkeypatch.setattr(
         sb,
         "_probe_scorebar_context",
-        lambda v, ts, h, w, *, with_localize=False: (
+        lambda v, ts, h, w, *, with_localize=False, with_lowres=True: (
             [None] * len(ts),
             [b"f"] * len(ts),
             [None] * len(ts),
@@ -1543,7 +1547,7 @@ def test_classify_blackout_obs_does_not_call_localize(monkeypatch):
     monkeypatch.setattr(
         sb,
         "_probe_scorebar_context",
-        lambda v, ts, h, w, *, with_localize=False: (
+        lambda v, ts, h, w, *, with_localize=False, with_lowres=True: (
             [False] * len(ts),
             [b"f"] * len(ts),
             [None] * len(ts),
@@ -1580,7 +1584,9 @@ def test_merge_gap_probe_uses_localize_path(monkeypatch):
 
     captured = {}
 
-    def fake_probe(video, points, height, workers, *, with_localize=False):
+    def fake_probe(
+        video, points, height, workers, *, with_localize=False, with_lowres=True
+    ):
         captured["with_localize"] = with_localize
         # gap shows no scorebar by either signal -> eligible to merge.
         return ([None] * len(points), [b"f"] * len(points), [False] * len(points))
@@ -1615,3 +1621,61 @@ def test_classify_blackout_localize_selector_routes(monkeypatch):
         sb.classify_blackout(Path("x.mp4"), (10.0, 12.0), 100.0, 180, localize=False)
         != "LOCALIZED"
     )
+
+
+# --- T5/T6: _probe_scorebar_context with_lowres + logger ---
+
+
+def test_probe_scorebar_context_with_lowres_false_skips_lowres(monkeypatch):
+    """with_lowres=False in v2 mode: low-res probe not called, result from hi-res."""
+    from unittest.mock import MagicMock
+    from pathlib import Path
+    from allaganeye.video import scorebar as sb
+
+    lo = MagicMock(return_value=b"\x00" * 10)
+    hi = MagicMock(return_value=b"\x00" * 10)
+    monkeypatch.setattr(sb, "_probe_frame_rgb", lo)
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", hi)
+    monkeypatch.setattr(sb, "_has_scorebar_v2", lambda raw: True)  # opencv present
+    monkeypatch.setattr(sb, "_SCOREBAR_METHOD", "v2")
+    res, _frames, _ = sb._probe_scorebar_context(
+        Path("x.mkv"), [1.0, 2.0], 180, 2, with_lowres=False
+    )
+    lo.assert_not_called()  # low-res skipped (normal path, opencv present)
+    assert res == [True, True]  # decided by hi-res (bit-exact)
+
+
+def test_probe_scorebar_context_lazy_lowres_when_v2_none(monkeypatch):
+    """with_lowres=False + V2 returns None (no opencv): lazy low-res probe fires."""
+    from unittest.mock import MagicMock
+    from pathlib import Path
+    from allaganeye.video import scorebar as sb
+
+    lo = MagicMock(return_value=b"\x00" * 10)
+    monkeypatch.setattr(sb, "_probe_frame_rgb", lo)
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", MagicMock(return_value=b""))
+    monkeypatch.setattr(sb, "_has_scorebar_v2", lambda raw: None)  # opencv absent
+    monkeypatch.setattr(sb, "_has_scorebar", lambda raw, h: False)  # V1 fallback
+    monkeypatch.setattr(sb, "_SCOREBAR_METHOD", "v2")
+    res, _, _ = sb._probe_scorebar_context(
+        Path("x.mkv"), [1.0], 180, 1, with_lowres=False
+    )
+    lo.assert_called()  # lazily probed for V1 fallback (no-opencv preserved)
+    assert res == [False]
+
+
+def test_probe_scorebar_context_logs_probe_failure(monkeypatch, caplog):
+    """VideoProcessingError in probe -> debug-logged (not silently swallowed)."""
+    import logging
+    from pathlib import Path
+    from allaganeye.exceptions import VideoProcessingError
+    from allaganeye.video import scorebar as sb
+
+    def boom(*a, **k):
+        raise VideoProcessingError("ffmpeg not found")
+
+    monkeypatch.setattr(sb, "_probe_frame_rgb", boom)
+    monkeypatch.setattr(sb, "_probe_frame_rgb_hires", boom)
+    with caplog.at_level(logging.DEBUG, logger="allaganeye.video.scorebar"):
+        sb._probe_scorebar_context(Path("x.mkv"), [1.0], 180, 1)
+    assert any("probe" in r.message.lower() for r in caplog.records)

--- a/tests/test_split_matches.py
+++ b/tests/test_split_matches.py
@@ -4791,3 +4791,12 @@ def test_build_metadata_payload_round_trips_warnings(tmp_path):
     payload = _build_metadata_payload(**common, warnings=warned)  # type: ignore[arg-type]
     # _build_metadata_payload forwards the list verbatim (not rebuilt).
     assert payload.get("warnings") == warned
+
+
+def test_split_matches_format_helpers_are_detection_format_aliases():
+    from allaganeye.commands import split_matches as sm
+    from allaganeye.detection import format as fmt
+
+    assert sm._format_timestamp is fmt.format_timestamp
+    assert sm._format_duration is fmt.format_duration
+    assert sm._iso_utc_now is fmt.iso_utc_now


### PR DESCRIPTION
本 PR は監査 remediation **Wave 2 / W4 (core 堅牢化)** を実装する。

- 元 issue: #842 (bug, P2-medium)
- 設計 SSoT: `docs/superpowers/specs/2026-06-10-audit-remediation-design.md` §「W4: core 堅牢化」
- 実装 plan: `docs/superpowers/plans/2026-06-24-audit-w2-w4.md` (本 PR 先頭 commit)
- 対応 finding: **P2-3 / P2-4 / P2-6 + core P3 5 件**
- base: `develop-0.3.0` / 先行: W1 #840 / W2 #837 / W3 #834
- 設計原則: 全変更は実動画 baseline に対し **bit-exact** (防御機構は通常録画で不発 / 純粋 refactor / log・error 整備)

## 変更概要 (task 別)

| task | finding | 変更 | bit-exact 根拠 |
| --- | --- | --- | --- |
| T1 | P2-6 | saturated-run/emblem 計算を共有ヘルパ `_saturated_column_runs`/`_emblem_metrics` に抽出し detector↔capture_region の複製を解消 | 純粋抽出 (baseline gate + 既存 scorebar/capture_region test) |
| T2 | P2-3 | v2 decode に `_proc_deadline_watchdog` (threading.Timer + finally cancel) を追加。stall した ffmpeg を deadline で kill し既存 returncode fallback に合流 | healthy decode では timer cancel = 不発 |
| T3 | P2-4 | `_BORDERLINE_SPAN_CAP_FRACTION = 1.5` で borderline pseudo-region 合計長を duration 比 cap | 実測 raw_frac ≤ 50% << 150% cap で不発 |
| T4 | P3 | `probe.py` の duration/resolution 非数値で `VideoProcessingError` (exit 3) | valid 数値入力は不変 |
| T5+T6 | P3 | `_probe_scorebar_context` に `with_lowres` skip + lazy V1 fallback + probe 失敗の debug log | opencv 在 (production) で byte-identical |
| T7 | P3 | `_check_gpu_usage` の d3d11va/qsv over-claim を honesty 化 ("requested, decode path unconfirmed") | log-only |
| T8 | P3 | `split_matches` の private `_format_*`/`_iso_utc_now` を `detection.format` の import alias に統合 | byte 等価 alias |

## 受け入れ条件 ↔ 対応 (逐条)

- **P2-3 watchdog**: `_decode_chunk_cpu_v2` / `_decode_chunk_v2` に deadline watchdog (T2、cccf7cf→0d9974b)。healthy 不発 + `finally` cancel。**発火側 RED 実証** (`test_proc_deadline_watchdog_kills_when_block_exceeds_deadline`)。並行/subprocess 変更のため **full `pytest` で leak/OOM 無し**を確認 (1511 passed)。
- **P2-4 cap**: `_borderline_pseudo_regions` に合計長 cap (T3、3cb95d3)。超過時 warning + 縮退、本体抽出不変。cap 値は **5 baseline 実測 (max raw_frac 50.1%) + 3x margin = duration 比 1.5**。**発火側 RED 実証** (`test_borderline_pseudo_regions_capped_with_warning`)。
- **P2-6 helper**: saturated-run / emblem を共有ヘルパに抽出 (T1、d7844d6)。**bit-exact** (baseline gate + capture_region localize test)。
- **P3**: GPU log over-claim 是正 (T7) / lo-probe skip + lazy fallback (T5+T6) / probe duration 非数値 exit 3 + pin test (T4) / scorebar probe 失敗 log (T5+T6) / format.py 重複解消・単一 source (T8)。
- **共通**: ruff / pyright / pytest 全 PASS。slow_detect bit-exact baseline gate (下記)。Idios 実機検証 (下記)。

## P2-4 cap の実測根拠 (設計判断の記録)

`_measure_borderline.py` で 5 baseline の Pass 1 borderline span を実測 (obs-20260209 は /iterate-review Round 1 #4 で追加実測):

| baseline | dur | raw_span | raw_frac | merged_frac |
| --- | --- | --- | --- | --- |
| obs-20260116 | 7303s | 2101.5s | 28.8% | 16.7% |
| obs-20260118 | 8235s | 4124.7s | **50.1%** | 31.6% |
| obs-20260119 | 9234s | 1560.0s | 16.9% | 10.6% |
| obs-20260127 | 3671s | 566.3s | 15.4% | 8.8% |
| obs-20260209 | 3427s | 450.0s | 13.1% | 9.8% |

健全な OBS 録画でも borderline (brightness 15-55) frame は多く raw_span は duration の最大 50.1% に達する。**絶対値 cap は未検証の長尺録画を clip し bit-exact を破綻させる**ため、Idios 判断 (AskUserQuestion) で **duration 比 cap (fraction 1.5 = 観測最大の 3x margin)** を採用。pathological な待機画面支配録画 (raw_frac ~200%) のみ cap 発火、健全録画 (≤50%) は不発。

## encoding boundary audit (#656/#657/#662 教訓)

T3 の cap docstring/warning が U+00D7 (`×`) を含み `test_ascii_guard` の production-code 禁止文字 check で fail → ASCII `x` に修正 (9c6fc37)。Python 層のみ (Rust/OS code page は本変更で touch せず)。

## Self-Test Report

machine-verified:

- [x] `python -m ruff check` (touched scope) → All checks passed
- [x] `python -m ruff format --check` (touched scope) → 6 files already formatted
- [x] `python -m pyright allaganeye tests` → 0 errors, 0 warnings
- [x] `python -m pytest` (full) → **1512 passed, 1 skipped, 60 deselected** (codex 回帰テスト含む)
- [x] `test_ascii_guard` (production non-ASCII) → PASS (U+00D7 修正後)
- [x] 発火側 RED 実証: watchdog Timer 発火 (`proc.kill` 呼出) / watchdog 発火→255.0 fallback / cap overflow + warning — いずれも RED→GREEN test 同梱
- [x] 実動画 bit-exact baseline gate: `test_class_a_bit_exact` (4 Class A baseline obs-20260116/0119/0127/0209 で `detect --no-cache` → `compare-baseline.py` で matches+gaps を bit-exact 比較、timestamp churn は projection で除外) → **4 passed (33:48、detached)**。cap / watchdog いずれも不発 = released 出力 byte-identical。codex 修正 (77802fc) は stall-path-only = baseline-neutral のため本 gate (pre-fix code で取得) は post-fix でも有効。

machine-unverifiable (Idios 実機検証を依頼):

- 実 GPU detect (NVIDIA / AMD) で watchdog 不発 + 検出出力不変
- 長時間動画 (2h+) での detect 正常完了 + cap 不発
- (任意) ffmpeg stall 時の watchdog 発火 → fallback 経路

## codex adversarial-review (Iron Law 6 Pre-flight Step 5)

codex companion script (`adversarial-review --scope branch`) が **HIGH 1 件** を摘出:

- **[high]** watchdog 発火した**非 tail chunk** は、kill 後の short read が `_sample_chunk_frames` の dynamic frame-count guard を踏み `VideoProcessingError` を raise → `_decode_chunk_cpu_v2` が再 raise し **detect 全体が失敗**しうる (約束した 255.0 fallback に未到達)。T2 quality reviewer が "pre-existing" と判定した点を codex が No-ship と正しく指摘。

→ **当 PR 内で修正** (77802fc、(A) PR 内修正優先): `_proc_deadline_watchdog` が `_WatchdogState.fired` を yield し、CPU path は watchdog 発火時に decode 失敗として `255.0` を返す。真の VFR error (watchdog 不発) は raise 維持。GPU path は raise→CPU fallback が decode-failed 契約のため変更不要。発火→fallback を回帰テスト (`test_decode_chunk_cpu_v2_watchdog_fire_returns_fallback`) で実証。

## スコープ外 (follow-up 候補)

- GPU 診断ログの vendor 固有 stderr marker による完全 active 判定 (実機 AMD/Intel stderr 採取が前提)
- `disabled_emitter()` は tested + intended opt-out API として retain (削除せず)
- P2-1/2/5 (trailing drop 多重防御 / opt-out gate / audio scan チャンク化) は #805 / 別 finding

作成: audit-w2-w4-20260623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

