### PR TITLE
fix(gui): start_detect stderr drain を bounded helper に委譲 + 回帰 guard (Refs #838)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-838-detect-drain.md
+++ b/docs/superpowers/plans/2026-06-25-838-detect-drain.md
@@ -1,0 +1,230 @@
+# #838 start_detect stderr drain bounded 化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `start_detect` の inline `read_until(b'\n')` stderr drain loop を、#837 で導入済の bounded helper `drain_to_bounded_tail` への委譲に置換し、newline-free / CR-only ストリームでも tail が有界になるようにする。
+
+**Architecture:** released な `start_detect` (`gui/src-tauri/src/lib.rs`) の stderr drain を、sibling `start_export` (#837) と同型に `drain_to_bounded_tail(stderr, 2048)` 呼び出しへ収束させる。`drain_to_bounded_tail` の boundedness は既存の `drain_to_bounded_tail_bounds_newline_free_stream` / `_cr_only_progress` test で red 実証済 (#837 codex review)。本 PR は配線変更 + anti-regression source guard (gate 戦略 B、Idios 承認 2026-06-25) のみ。`start_export` は既に helper を使うため触らない (scope 限定、Iron Law 3)。
+
+**Tech Stack:** Rust (tokio async / `tauri::command`), `cargo test --lib`。
+
+---
+
+## 背景と正 (SSoT)
+
+- issue: #838 (`[bug] start_detect の stderr drain が改行なしストリームで非有界`、独立 issue = W ではない。priority P2-medium)
+- 親 finding: #837 (W2) の codex adversarial review。`start_export` 側は #837 で `drain_to_bounded_tail` 導入済、`start_detect` を #838 に handoff
+- 設計判断 (Idios 承認 2026-06-25 brainstorming):
+  - gate 戦略 = **B** (minimal 配線 + anti-regression source guard、配線前 RED → 配線後 GREEN を self-verify)
+  - 実機検証 = **不要** (cargo test で十分。boundedness は helper unit test で deterministic、通常 detect の tail consumption は byte 等価で不変)
+
+## 該当 symbol (実測済、行番号は drift しうるので symbol で照合)
+
+- `start_detect` (`async fn start_detect(` から次の `async fn` = `dev_force_panic` まで) 内の stderr drain task
+  (`let stderr_handle = tokio::spawn(async move { ... reader.read_until(b'\n', &mut buf) ... tail.drain(0..drop) ... });`)
+- 委譲先 helper: `async fn drain_to_bounded_tail<R>(reader: R, max_tail: usize) -> Vec<u8>` (固定長 chunk read)
+- sibling 参照 (触らない): `start_export` 内 `tokio::spawn(async move { drain_to_bounded_tail(stderr, 2048).await })`
+- 既存 helper test (触らない、boundedness の red 実証済): `append_bounded_tail_caps_to_about_max` /
+  `drain_to_bounded_tail_bounds_newline_free_stream` / `drain_to_bounded_tail_bounds_cr_only_progress`
+- consumption (不変、`Vec<u8>` 互換): `let stderr_tail = stderr_handle.await.unwrap_or_default();` →
+  `String::from_utf8_lossy(&stderr_tail).trim()`
+
+## File Structure
+
+- Modify: `gui/src-tauri/src/lib.rs`
+  - `start_detect` の stderr drain task: inline loop → `drain_to_bounded_tail(stderr, 2048)` 委譲 (production)
+  - `#[cfg(test)] mod tests`: anti-regression guard `#[test]` を helper test 群の近くに追加 (test)
+
+---
+
+## Task 1: anti-regression guard を RED-first で追加し、start_detect を helper に配線して GREEN にする
+
+stderr drain は `#[tauri::command]` 内で実 subprocess を spawn するため unit 単体テスト不可。boundedness 自体は
+`drain_to_bounded_tail_bounds_*` が担保する。本 task は「start_detect が helper に委譲し、inline 有界化を再導入しない」
+契約を source span 走査で gate する (RED → GREEN を実証)。
+
+**Files:**
+
+- Modify: `gui/src-tauri/src/lib.rs` (`mod tests` に guard test 追加 → `start_detect` の stderr drain を委譲化)
+
+- [ ] **Step 1: guard test を追加 (RED-first、production code は未変更)**
+
+`gui/src-tauri/src/lib.rs` の `#[cfg(test)] mod tests` 内、`drain_to_bounded_tail_bounds_cr_only_progress`
+test の直後に以下を追加する (helper test 群の近くにまとめる)。
+
+```rust
+    // #838 anti-regression guard -- start_detect must delegate its stderr drain
+    // to the bounded helper `drain_to_bounded_tail` (same as start_export, #837),
+    // not re-introduce an inline `read_until`-based accumulator that only bounds
+    // after a whole line and so grows without limit on newline-free / CR-only
+    // streams. The drain runs inside a `#[tauri::command]` that spawns a real
+    // subprocess and is not unit-testable in isolation; the boundedness behavior
+    // itself is covered by `drain_to_bounded_tail_bounds_*` above. This guard
+    // scans the start_detect source span and fires (RED) if the inline pattern
+    // returns. Scoped strictly to start_detect (ends at the next `async fn`, well
+    // before start_export's helper call) so it never matches start_export.
+    #[test]
+    fn start_detect_delegates_stderr_drain_to_bounded_helper() {
+        let src = include_str!("lib.rs");
+        let start = src
+            .find("async fn start_detect(")
+            .expect("start_detect must exist");
+        let rest = &src[start + "async fn start_detect(".len()..];
+        let end = rest
+            .find("\nasync fn ")
+            .expect("a function must follow start_detect");
+        let body = &rest[..end];
+
+        assert!(
+            body.contains("drain_to_bounded_tail"),
+            "start_detect must delegate stderr draining to drain_to_bounded_tail \
+             (bounded helper, #838); an inline read_until accumulator grows \
+             unbounded on newline-free / CR-only streams"
+        );
+        assert!(
+            !body.contains("tail.drain(0..drop)"),
+            "start_detect must not re-introduce an inline tail-bounding loop \
+             (#838); delegate to drain_to_bounded_tail instead"
+        );
+    }
+```
+
+- [ ] **Step 2: guard が RED であることを実証 (発火側の red 検証)**
+
+Run: `cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml start_detect_delegates_stderr_drain_to_bounded_helper -- --nocapture`
+
+Expected: **FAIL**。現状 start_detect は inline loop なので `body.contains("drain_to_bounded_tail")` が false
+(positive assertion 失敗) かつ `tail.drain(0..drop)` を含む (negative assertion 失敗)。
+panic message に上記 assert メッセージが出ることを確認 (no-op gate でないことの実証)。
+
+- [ ] **Step 3: start_detect の stderr drain を helper 委譲に置換 (production)**
+
+`start_detect` 内の stderr drain task ブロック全体 (コメント `// Stderr drains in parallel ...` から
+`let stderr_handle = tokio::spawn(async move { ... tail });` の閉じまで) を以下で置換する。
+
+置換前 (削除対象、symbol で照合):
+
+```rust
+    // Stderr drains in parallel into a bounded tail buffer so the OS
+    // pipe doesn't fill up if the CLI is chatty under -v / verbose.
+    // #656 -- avoid `lines()` for the same UTF-8 強制 reason as stdout
+    // above. The tail is exposed only when the child exits non-zero, so
+    // line semantics are not load-bearing -- we just need the trailing
+    // bytes intact for the GUI error display.
+    let stderr_handle = tokio::spawn(async move {
+        let max_tail = 2048usize;
+        let mut tail: Vec<u8> = Vec::with_capacity(4096);
+        let mut reader = BufReader::new(stderr);
+        let mut buf: Vec<u8> = Vec::with_capacity(1024);
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf).await {
+                Ok(0) => break,
+                Ok(_) => {
+                    tail.extend_from_slice(&buf);
+                    if tail.len() > max_tail * 2 {
+                        let drop = tail.len() - max_tail;
+                        tail.drain(0..drop);
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        tail
+    });
+```
+
+置換後:
+
+```rust
+    // Stderr drains in parallel into a bounded tail buffer so the OS
+    // pipe doesn't fill up if the CLI is chatty under -v / verbose.
+    // #656 -- avoid `lines()` for the same UTF-8 強制 reason as stdout
+    // above. The tail is exposed only when the child exits non-zero, so
+    // line semantics are not load-bearing -- we just need the trailing
+    // bytes intact for the GUI error display.
+    // #838 -- drain in fixed-size chunks via the shared bounded helper
+    // (not a newline-delimited accumulator) so the tail stays bounded even
+    // for newline-free / CR-only child output (e.g. ffmpeg progress). The
+    // earlier inline read_until loop only bounded after a whole line, so a
+    // newline-free run could grow without limit before EOF. This converges
+    // start_detect with start_export (#837) on drain_to_bounded_tail.
+    let stderr_handle =
+        tokio::spawn(async move { drain_to_bounded_tail(stderr, 2048).await });
+```
+
+注意:
+
+- 置換後コメントに文字列 `tail.drain(0..drop)` を**書かない** (guard の negative assertion を壊すため)。上記コメントは
+  `newline-delimited accumulator` / `inline read_until loop` と表現し回避済。
+- stdout 側 reader (`let mut reader = BufReader::new(stdout);` + `read_until`) は残るので `BufReader` /
+  `AsyncBufReadExt` の import は引き続き使用される (unused import 警告は出ない)。`drain_to_bounded_tail` は内部で
+  自前の `AsyncReadExt` を use するため start_detect 側に新規 import 不要。
+- consumption (`stderr_handle.await.unwrap_or_default()`) は `JoinHandle<Vec<u8>>` のままで不変。
+
+- [ ] **Step 4: guard が GREEN になったことを確認**
+
+Run: `cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml start_detect_delegates_stderr_drain_to_bounded_helper -- --nocapture`
+
+Expected: **PASS** (start_detect が `drain_to_bounded_tail` を含み、`tail.drain(0..drop)` を含まない)。
+
+- [ ] **Step 5: lib test 全体の非回帰を確認**
+
+Run: `cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml`
+
+Expected: 全 PASS (既存 helper test 群 + 新 guard 含む)。失敗ゼロ。
+
+- [ ] **Step 6: format / lint hygiene**
+
+Run: `cargo fmt --manifest-path gui/src-tauri/Cargo.toml -- --check`
+
+Expected: PASS。flag されるのが**自分の追加行のみ**なら fmt して修正。pre-existing な無関係 format noise は scope 外
+(出たら報告のみ、触らない)。任意で `cargo clippy --manifest-path gui/src-tauri/Cargo.toml --no-default-features --lib`
+を回し、新規コードに warning がないことを確認。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gui/src-tauri/src/lib.rs
+git commit -m "$(cat <<'EOF'
+fix(gui): start_detect の stderr drain を bounded helper 委譲化 (Refs #838)
+
+inline read_until accumulator は改行を見るまで bounded tail に切り詰めない
+ため、newline-free / CR-only (ffmpeg progress) ストリームで buffer が EOF まで
+非有界に伸びていた。#837 で start_export 用に導入した drain_to_bounded_tail
+(固定長 chunk read) へ委譲し、両者を真に同型・有界に収束させる。
+
+anti-regression guard (start_detect_delegates_stderr_drain_to_bounded_helper)
+を追加し、inline 有界化の再導入を source span 走査で gate (配線前 RED → 配線後
+GREEN を実証)。
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## 検証方針 (本サイクルの gate)
+
+- **CI 等価**: `cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml` (gui-rust job と同一)
+- **gate B 実証**: guard test を pre-fix で RED、post-fix で GREEN にすることで「発火する側」を実証
+  (memory feedback_protective_mechanism_red_verification / feedback_false_green_gate_completeness)
+- **boundedness**: 既存 `drain_to_bounded_tail_bounds_newline_free_stream` / `_cr_only_progress` が担保
+  (本 PR で start_detect がこの helper を使うようになるため、start_detect の drain も同じ boundedness を継承)
+- **Pre-flight (controller)**: Iron Law 6 Step 0-5。GUI area PR なので cargo (test/fmt) に加え npm suite
+  (lint/typecheck/test/build) も baseline 確認のため回す (TS は未 touch なので no-op だが Red Flag 回避)。
+  Step 5 = codex adversarial-review (focus ASCII: stderr drain bounded delegation, regression guard completeness,
+  scope leakage into start_export)
+- **実機検証**: 不要 (Idios 承認)。stderr drain の boundedness は unit test で deterministic、通常 detect の tail
+  consumption は byte 等価で不変
+
+## Self-Review (writing-plans gate)
+
+- **Spec coverage**: #838 修正方針 (inline drain → drain_to_bounded_tail 委譲、両者同型収束) を Task 1 Step 3 が実装。
+  検証 (cargo test 非回帰 + helper test) を Step 4/5 が、gate B (新 guard) を Step 1/2/4 がカバー
+- **Placeholder scan**: なし (全 step に実コード / 実コマンド / expected を記載)
+- **Type consistency**: `drain_to_bounded_tail(reader, max_tail) -> Vec<u8>` / `JoinHandle<Vec<u8>>` /
+  `stderr_handle.await.unwrap_or_default()` は既存 signature と一致。guard の marker 文字列
+  (`drain_to_bounded_tail` / `tail.drain(0..drop)`) は production diff と整合
+- **Scope check**: 単一ファイル (lib.rs) の配線 + 1 guard test。start_export は触らない。Phase 分割不要

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2391,8 +2391,7 @@ async fn start_detect(
     // earlier inline read_until loop only bounded after a whole line, so a
     // newline-free run could grow without limit before EOF. This converges
     // start_detect with start_export (#837) on drain_to_bounded_tail.
-    let stderr_handle =
-        tokio::spawn(async move { drain_to_bounded_tail(stderr, 2048).await });
+    let stderr_handle = tokio::spawn(async move { drain_to_bounded_tail(stderr, 2048).await });
 
     let mut metadata_path: Option<String> = None;
     let mut total_matches: u64 = 0;

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -4804,10 +4804,18 @@ mod tests {
     // after a whole line and so grows without limit on newline-free / CR-only
     // streams. The drain runs inside a `#[tauri::command]` that spawns a real
     // subprocess and is not unit-testable in isolation; the boundedness behavior
-    // itself is covered by `drain_to_bounded_tail_bounds_*` above. This guard
-    // scans the start_detect source span and fires (RED) if the inline pattern
-    // returns. Scoped strictly to start_detect (ends at the next `async fn`, well
-    // before start_export's helper call) so it never matches start_export.
+    // itself is covered by `drain_to_bounded_tail_bounds_*` above. This guard pins
+    // the wiring and fires (RED) if the delegation is removed.
+    //
+    // codex #838 adversarial review (rounds 1-2): scope the assertion to the
+    // `let stderr_handle =` initializer LINE (code only -- any trailing `//`
+    // comment is stripped), not the whole start_detect body. A whole-body scan
+    // false-greens when the helper name appears in a comment/string while the
+    // stderr task regresses to an inline read_until drain (including via an
+    // aliased pipe such as `let p = stderr; BufReader::new(p)`, which dodges a
+    // `BufReader::new(stderr)` substring check). The initializer line must BE the
+    // bounded delegation expression. (Idios-approved approach A; a syn AST check
+    // was the considered-heavier alternative.)
     #[test]
     fn start_detect_delegates_stderr_drain_to_bounded_helper() {
         let src = include_str!("lib.rs");
@@ -4820,16 +4828,40 @@ mod tests {
             .expect("a function must follow start_detect");
         let body = &rest[..end];
 
+        // The `let stderr_handle = ...;` initializer, code portion only: drop any
+        // trailing `// comment` so a crafted comment on this line cannot satisfy
+        // the check. start_detect's stdout reader is a separate `let mut reader`
+        // binding, so scoping to `let stderr_handle` isolates the stderr drain.
+        let init_start = body
+            .find("let stderr_handle")
+            .expect("start_detect must bind stderr_handle");
+        let init_line_end = body[init_start..]
+            .find('\n')
+            .map(|i| init_start + i)
+            .unwrap_or(body.len());
+        let init_code = body[init_start..init_line_end]
+            .split("//")
+            .next()
+            .unwrap_or("");
+
+        // Positive: the initializer IS the bounded-helper delegation expression
+        // (the full `(stderr, 2048).await` call cannot be produced by prose, and
+        // a regressed inline drain pushes the spawn body onto later lines so this
+        // single-line check no longer matches).
         assert!(
-            body.contains("drain_to_bounded_tail"),
-            "start_detect must delegate stderr draining to drain_to_bounded_tail \
-             (bounded helper, #838); an inline read_until accumulator grows \
-             unbounded on newline-free / CR-only streams"
+            init_code.contains("drain_to_bounded_tail(stderr, 2048).await"),
+            "start_detect's stderr_handle must be the bounded delegation \
+             tokio::spawn(async move {{ drain_to_bounded_tail(stderr, 2048).await }}) \
+             (#838); a regressed inline read_until drain grows unbounded on \
+             newline-free / CR-only streams. Got: {init_code:?}"
         );
+        // Negative: the bounded delegation needs no read_until; its presence on
+        // the stderr_handle initializer line means an inline accumulator returned.
         assert!(
-            !body.contains("tail.drain(0..drop)"),
-            "start_detect must not re-introduce an inline tail-bounding loop \
-             (#838); delegate to drain_to_bounded_tail instead"
+            !init_code.contains("read_until"),
+            "start_detect's stderr_handle initializer must not use read_until \
+             (#838 inline drain regression); delegate to drain_to_bounded_tail. \
+             Got: {init_code:?}"
         );
     }
 

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -2385,27 +2385,14 @@ async fn start_detect(
     // above. The tail is exposed only when the child exits non-zero, so
     // line semantics are not load-bearing -- we just need the trailing
     // bytes intact for the GUI error display.
-    let stderr_handle = tokio::spawn(async move {
-        let max_tail = 2048usize;
-        let mut tail: Vec<u8> = Vec::with_capacity(4096);
-        let mut reader = BufReader::new(stderr);
-        let mut buf: Vec<u8> = Vec::with_capacity(1024);
-        loop {
-            buf.clear();
-            match reader.read_until(b'\n', &mut buf).await {
-                Ok(0) => break,
-                Ok(_) => {
-                    tail.extend_from_slice(&buf);
-                    if tail.len() > max_tail * 2 {
-                        let drop = tail.len() - max_tail;
-                        tail.drain(0..drop);
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-        tail
-    });
+    // #838 -- drain in fixed-size chunks via the shared bounded helper
+    // (not a newline-delimited accumulator) so the tail stays bounded even
+    // for newline-free / CR-only child output (e.g. ffmpeg progress). The
+    // earlier inline read_until loop only bounded after a whole line, so a
+    // newline-free run could grow without limit before EOF. This converges
+    // start_detect with start_export (#837) on drain_to_bounded_tail.
+    let stderr_handle =
+        tokio::spawn(async move { drain_to_bounded_tail(stderr, 2048).await });
 
     let mut metadata_path: Option<String> = None;
     let mut total_matches: u64 = 0;
@@ -4810,6 +4797,41 @@ mod tests {
         let tail = drain_to_bounded_tail(&data[..], 2048).await;
         assert!(tail.len() <= 4096, "tail must stay bounded, got {}", tail.len());
         assert!(tail.ends_with(b"frame=4999\r"), "most recent progress retained");
+    }
+
+    // #838 anti-regression guard -- start_detect must delegate its stderr drain
+    // to the bounded helper `drain_to_bounded_tail` (same as start_export, #837),
+    // not re-introduce an inline `read_until`-based accumulator that only bounds
+    // after a whole line and so grows without limit on newline-free / CR-only
+    // streams. The drain runs inside a `#[tauri::command]` that spawns a real
+    // subprocess and is not unit-testable in isolation; the boundedness behavior
+    // itself is covered by `drain_to_bounded_tail_bounds_*` above. This guard
+    // scans the start_detect source span and fires (RED) if the inline pattern
+    // returns. Scoped strictly to start_detect (ends at the next `async fn`, well
+    // before start_export's helper call) so it never matches start_export.
+    #[test]
+    fn start_detect_delegates_stderr_drain_to_bounded_helper() {
+        let src = include_str!("lib.rs");
+        let start = src
+            .find("async fn start_detect(")
+            .expect("start_detect must exist");
+        let rest = &src[start + "async fn start_detect(".len()..];
+        let end = rest
+            .find("\nasync fn ")
+            .expect("a function must follow start_detect");
+        let body = &rest[..end];
+
+        assert!(
+            body.contains("drain_to_bounded_tail"),
+            "start_detect must delegate stderr draining to drain_to_bounded_tail \
+             (bounded helper, #838); an inline read_until accumulator grows \
+             unbounded on newline-free / CR-only streams"
+        );
+        assert!(
+            !body.contains("tail.drain(0..drop)"),
+            "start_detect must not re-introduce an inline tail-bounding loop \
+             (#838); delegate to drain_to_bounded_tail instead"
+        );
     }
 
     // -- #813 run-id stamping (越境イベント遮断) ---------------------------

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -1891,11 +1891,11 @@ fn tail_string(buf: &[u8], max_bytes: usize) -> String {
 }
 
 /// Append `chunk` to a rolling `tail` buffer, keeping at most ~`max_tail`
-/// trailing bytes. Used by start_export's stderr drain so a chatty child can't
-/// grow the buffer without bound while still preserving the most recent output
-/// for the error message (audit P2-15). Drains only when the buffer exceeds
-/// `max_tail * 2`, amortising the shift cost (same shape as start_detect's
-/// inline drain loop).
+/// trailing bytes. Used by `drain_to_bounded_tail` (the start_detect /
+/// start_export stderr drains) so a chatty child can't grow the buffer without
+/// bound while still preserving the most recent output for the error message
+/// (audit P2-15). Drains only when the buffer exceeds `max_tail * 2`, amortising
+/// the shift cost.
 fn append_bounded_tail(tail: &mut Vec<u8>, chunk: &[u8], max_tail: usize) {
     tail.extend_from_slice(chunk);
     if tail.len() > max_tail * 2 {


### PR DESCRIPTION
## 概要

`start_detect` (`gui/src-tauri/src/lib.rs`) の stderr drain は inline な `read_until(b'\n')` loop で「1 行」を蓄積してから bounded tail に切り詰めていたため、改行なし / CR-only (ffmpeg progress 等) ストリームでは buffer が EOF まで非有界に伸びていた。#837 で sibling `start_export` 用に導入済の bounded helper `drain_to_bounded_tail` (固定長 chunk read) へ委譲し、両者を真に同型・有界に収束させる。

派生 finding #838 (W2 #837 の codex adversarial review が摘出。独立 issue = W ではない、P2-medium)。

## 変更内容

- **production**: `start_detect` の stderr drain task を 21 行の inline `read_until` loop から `let stderr_handle = tokio::spawn(async move { drain_to_bounded_tail(stderr, 2048).await });` 1 行に置換 (`start_export` と同型)。consumption (`stderr_handle.await.unwrap_or_default()` → `String::from_utf8_lossy().trim()`) と `JoinHandle<Vec<u8>>` 型は不変 (挙動等価)
- **test (gate B)**: anti-regression guard `start_detect_delegates_stderr_drain_to_bounded_helper` を追加。`let stderr_handle =` initializer 行 (trailing comment strip 済) が full delegation 式 `drain_to_bounded_tail(stderr, 2048).await` を含み `read_until` を含まないことを assert。inline regression で RED
- **docstring**: `append_bounded_tail` の「same shape as start_detect's inline drain loop」を委譲後の事実に更新 (code-quality review (A) fold-in)

## scope (Iron Law 3)

- `start_export` / helper 本体 (`drain_to_bounded_tail` / `append_bounded_tail`) / 既存 helper test は不変。`start_export` は既に helper 使用のため「両者同型収束」は start_detect 変更のみで達成
- production touch は単一ファイル (`gui/src-tauri/src/lib.rs`) + plan doc

## 設計判断 (brainstorming + codex、Idios 承認)

- gate 戦略 = **B** (配線 + anti-regression source guard、self-verify RED→GREEN)
- guard robustness = **approach A** (`let stderr_handle =` initializer 行に scope)。Pre-flight codex adversarial review が source-text guard の false-green を 2 round 摘出 (bare-name token は production comment にも含まれる / whole-body の call-form scan は aliased pipe `let p = stderr; BufReader::new(p)` で evade 可) したため、whack-a-mole 化を受けて Idios が approach A を選択 (syn AST は重め判断で見送り)
- 実機検証 = **不要** (boundedness は helper unit test で deterministic、通常 detect の tail consumption は byte 等価で不変。codex も production delegation を correct / scope leak なし / 挙動不変と確認)

## Self-Test Report

machine-verified:

- [x] `cargo test --lib --no-default-features --manifest-path gui/src-tauri/Cargo.toml` — 198 passed / 0 failed (新 guard 含む)
- [x] guard RED 実証: production を inline `read_until` drain (codex round-2 の aliased pipe 形) に一時 mutate → guard が positive assertion で RED (`Got: "let stderr_handle = tokio::spawn(async move {"`) → restore で GREEN
- [x] `cargo fmt --check` — 追加/変更行 clean (crate 全体の pre-existing fmt 差分は gui-rust CI 非 gate のため不変)
- [x] `npm run lint` / `npm run typecheck` — PASS
- [x] `npm test` (vitest) — 757 passed (48 files)
- [x] `npm run build` (vite) — PASS
- [x] markdownlint (plan doc) — 0 errors
- [x] Pre-flight Step 0/4 (`gh pr list --search 838`) open PR なし / Step 1-3 base 同期 (`HEAD..origin/develop-0.3.0` 空)

machine-unverifiable:

- Pre-flight Step 5 codex adversarial-review: 2 round 実行。production delegation は correct / scope leak なし / 挙動不変と確認。anti-regression guard の false-green を 2 round 摘出 → Idios approach A (initializer-line scope) で対応。whack-a-mole discipline に従い同 class の codex loop を停止 (Idios 決定が stopping rule)。codex fallback は未使用 (env 正常)
- boundedness の本質保証は helper behavior test (`drain_to_bounded_tail_bounds_newline_free_stream` / `_cr_only_progress`、#837)。本 PR で start_detect が helper を経由するため drain も同じ有界性を継承

Refs #838

作成: 838-drain-20260625
