### PR TITLE
docs(roadmap): v0.3.0 (L3) 残タスク再計画 + triage snapshot

### DIFF
--- a/docs/superpowers/specs/2026-06-29-v030-l3-roadmap.md
+++ b/docs/superpowers/specs/2026-06-29-v030-l3-roadmap.md
@@ -1,0 +1,100 @@
+# v0.3.0 (L3) roadmap 再計画 (2026-06-29)
+
+> **Status**: roadmap (triage 完了、各 issue は着手時に個別 brainstorming → writing-plans)
+> **作成**: 2026-06-29 / session `l3-vtuber-replan`
+> **目的**: #805 段階2 Phase 1 merge 済 (PR #848) を起点に、open 48 件を triage し v0.3.0 (L3) の残タスクを再計画する。スコープ線引き・着手順序・グルーピング・各 issue の skill dispatch 方針を SSoT 化する
+> **由来**: 本 roadmap の決定は session `l3-vtuber-replan` の brainstorming で Idios が確定 (スコープ線引き / 着手順序 / ラベル整合の 3 AskUserQuestion)
+
+## 1. 背景 (triage snapshot 2026-06-29)
+
+open 48 件を 4 バケットに分類した。
+
+- **A) v0.3.0 (L3) 対応**: #753 (parent) / #810 / #809 / #480 / #822 / #824 / #805 Phase2 / #818
+- **B) quick-win (非 deferred 小 bug/task/運用)**: #804 / #827 / #828 / #795
+- **C) deferred roadmap (v0.4.0+)**: L4 (#125-130 task + #128/129/150/151/152 risk) / L5 (#131/132/134 + #133) / L6 (#135/136/137) / L7 (#28/63) / 横断 (#139/140)
+- **D) その他 deferred (据え置き、close 候補なし)**: #32/326/372/373/376/412/432/479/518/652/658/671/742/765
+
+### triage 上の重要な発見
+
+1. **#373 は close しない** — `2026-06-26-issue-805-post-match-nondestructive-design.md` §9 で確認済。#373 (`< min_match_duration` の余り = Match にならない span を `dropped:{leading,trailing}` に記録) と #805 `post_match` flag (`>= min_match_duration` = Match になりうる segment) は **別機構で補完関係**。重複ではないため deferred 据え置きが妥当。
+2. **#809 受け入れ条件の moot 化** — audit P1-8 由来の「region != FULL_FRAME 時は `_drop_post_match_trailing` を無効化する gate」は、#805 Phase 1 (PR #848) で不可逆削除が非破壊フラグ方式に置換され **moot 化**。VTuber wiring × trailing drop の複合事故リスクは構造的に解消済 (#809 にコメント注記済)。
+3. **明確な close 候補・完了済 issue は無し**。stale 重複も未検出。
+
+## 2. 採用方針 (brainstorming で確定)
+
+| 論点 | 選択肢 | 採用 | 根拠 |
+| --- | --- | --- | --- |
+| v0.3.0 スコープ線引き | (A) VTuberコア+#805Ph2+doc に絞る / (B) L3 全部入り / (C) VTuberコアのみ最小 | **(A)** | release gate (release-process.md L111) の headline = VTuber baseline 検知 GT 一致 + export 並列 + Portable ZIP 起動回帰 と整合。minimap/responsiveness を切り出しリリース粒度を小さく保つ |
+| 着手順序 | (A) quick-win 先行 / (B) VTuberコア最優先 / (C) doc SSoT 先行 | **(A)** | #827 は現 squash-merge 済 branch cleanup に直結、#828 は worktree の pyright ノイズ除去で L3 開発の足場が整う。安価で開発体験が改善 |
+| ラベル整合 | 全 8 件一括 / 個別 / しない | **全 8 件一括** | sequencing とラベル状態を一致させる (下記 §5) |
+
+## 3. v0.3.0 スコープ (確定)
+
+**IN (v0.3.0)**:
+
+- VTuber 検出コア: #810 / #809 / #480 / #822 / #824
+- #805 Phase 2 (GUI 視覚 UX)
+- #818 (doc SSoT 規約 + release gate)
+
+**OUT (v0.3.x patch か v0.4.0 へ切り出し)**:
+
+- #481 (minimap 切抜き) / #670 (GUI HTTP server responsiveness)
+- capture 領域基盤 (#810) 完成後に再評価する
+
+## 4. sequencing + grouping + dispatch 方針
+
+### Phase 0 — quick-win 整備バッチ (先行、相互独立 → 並行 worktree 可)
+
+| # | 種別 | dispatch 方針 |
+| --- | --- | --- |
+| #827 | bug | squash-merge 判定 fix。現 branch cleanup に直結 → 最初に。systematic-debugging → TDD → 小 PR |
+| #828 | task | pyright `.claude/worktrees/**` 恒久除外。config のみ小 PR |
+| #804 | bug | validate-fps-retirement.py PTS extraction 常時 0.021 調査+fix (PR #793 blocker)。systematic-debugging → TDD |
+| #795 | doc | Pre-flight Step 5 Codex 運用整理。doc 単独 PR |
+
+### Phase 1 — doc SSoT gate (#818) ※実装着地の前に
+
+- release gate / doc SSoT 規約を **実装 merge より先に** 明文化し、L3 で増える doc drift を予防。doc 単独 PR。
+
+### Phase 2 — VTuber 検出コア (v0.3.0 中核)
+
+```text
+#810 (metadata capture領域 schema) ──基盤──┐
+                                            ▼
+#809 (Pass1 wiring) ⟷ #480 (scorebar localize consumer)  ← audit P1-8 で coupling、同時/先行
+                                            ▼
+#822 (localize 分類器精緻化 = masked 過分割解消)  ← 品質 follow-up
+                                            ▼
+#824 (probe 失敗縮退 semantics 統一契約)  ← 診断基盤、Phase 3 cutover と統合判断
+```
+
+- dispatch: 設計重め (#809 / #480 / #824) は brainstorming → writing-plans → subagent-driven-development → /review-pr + `/codex:adversarial-review`。
+- **gate (必須)**: OBS bit-exact gate + 実機検証 (7h 動画 ~50min 級 GPU detect)。`feedback_position_independent_detector_not_a_discriminator` / `feedback_long_gpu_job_detached_execution` 遵守。
+- **#809 着手時**: 受け入れ条件の moot gate (§1-2) を削除/読替。`_CACHE_SENSITIVE_FILES` への `capture_region.py` 追加 (`feedback_detection_flag_cache_key`) は引き続き有効。
+- **#824**: 設計 spec 先行 (brainstorming → spec)。detection-map §5.4 Phase 3 cutover と統合するか独立かは着手時判断。
+
+### Phase 3 — #805 Phase 2 (GUI 視覚 UX) ※Phase 2 と並行可
+
+- CompleteScreen/PreviewScreen の `post_match:true` 視覚区別 (badge/dimming) + ExportScreen 非選択 row + vitest。検出 backend と別層なので並行可。
+- 完了後に #805 を close 可能 (Iron Law 4: 受け入れ条件実測 + Idios 承認後)。
+
+### Release — v0.3.0
+
+- version bump + CHANGELOG (直列・最後)。
+- gate (release-process.md L111): VTuber baseline 検知 GT 一致 / export 並列 encoder 出力 visual spot check / Portable ZIP 起動回帰。
+
+## 5. ラベル整合 (2026-06-29 実施済)
+
+| 操作 | issue | 理由 |
+| --- | --- | --- |
+| `deferred` 除去 | #753 / #480 / #809 / #810 | v0.3.0 active 化 |
+| `deferred` 付与 | #481 / #670 | v0.3.0 外へ切り出し |
+| `P2-medium` 付与 | #822 / #824 | priority 未付与 → active 明示 |
+
+## 6. 参照
+
+- #805 Phase 1: PR #848 (squash c7040d6) / spec `2026-06-26-issue-805-post-match-nondestructive-design.md`
+- L3 設計: `docs/detection-map.md` / `2026-05-31-l3-detection-rearchitecture-two-signal-design.md` / `2026-06-01-l3-phase2-localize-classify.md`
+- VTuber capture region: `2026-05-26-vtuber-capture-region-detection-design.md` (Phase 2a PR #807)
+- audit P1-8: `docs/audits/2026-06-10-full-audit.md`
+- release: `docs/release-process.md` (v0.3.0 gate L111、Track 構造)

--- a/docs/superpowers/specs/2026-06-29-v030-l3-roadmap.md
+++ b/docs/superpowers/specs/2026-06-29-v030-l3-roadmap.md
@@ -94,7 +94,7 @@ open 48 件を 4 バケットに分類した。
 ## 6. 参照
 
 - #805 Phase 1: PR #848 (squash c7040d6) / spec `2026-06-26-issue-805-post-match-nondestructive-design.md`
-- L3 設計: `docs/detection-map.md` / `2026-05-31-l3-detection-rearchitecture-two-signal-design.md` / `2026-06-01-l3-phase2-localize-classify.md`
+- L3 設計: `docs/detection-map.md` / `2026-05-31-l3-detection-rearchitecture-two-signal-design.md` / `docs/superpowers/plans/2026-06-01-l3-phase2-localize-classify.md`
 - VTuber capture region: `2026-05-26-vtuber-capture-region-detection-design.md` (Phase 2a PR #807)
 - audit P1-8: `docs/audits/2026-06-10-full-audit.md`
 - release: `docs/release-process.md` (v0.3.0 gate L111、Track 構造)


### PR DESCRIPTION
## 概要

open 48 件を triage し、v0.3.0 (L3) の残タスクを再計画する roadmap doc を追加する。session `l3-vtuber-replan` の brainstorming で Idios が確定したスコープ線引き・着手順序・グルーピング・skill dispatch 方針を SSoT 化する。

**実装変更なし** (doc 単独追加)。各 issue は着手時に個別 brainstorming → writing-plans サイクルを回す。

## 確定事項

### v0.3.0 スコープ
- **IN**: VTuber 検出コア (#810/#809/#480/#822/#824) + #805 Phase2 (GUI 視覚 UX) + #818 (doc SSoT)
- **OUT** (v0.3.x/v0.4.0 へ切り出し): #481 (minimap) / #670 (GUI responsiveness)

### 着手順序
Phase 0 quick-win (#827/#828/#804/#795) 先行 → Phase 1 doc gate (#818) → Phase 2 VTuber コア → Phase 3 #805 GUI (並行可)

### triage 判断
- #373 は #805 `post_match` と補完関係 (spec §9) → close せず据え置き
- 明確な close 候補・完了済・stale 重複は無し
- #809 受け入れ条件の trailing-drop 無効化 gate は #805 Phase1 (PR #848) で moot 化

### 本 PR と併せて実施済 (リポジトリ反映)
- ラベル整合 8 件 (deferred 除去 #753/#480/#809/#810、付与 #481/#670、P2-medium 付与 #822/#824)
- #809 への注記コメント (moot gate 読替指示)

## Self-Test Report

- [x] `bash scripts/check-markdownlint.sh <doc>` → 0 error(s)
- doc 単独 PR のため Python/GUI 自動チェック・実機検証は非該当 (logic 変更なし)
- `/codex:adversarial-review` 非実行: 内容は Idios が brainstorming で承認済の計画記録で、code/encoding/GPU surface を持たないため focus 対象外

## 関連

Refs #753, #805, #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)
