### PR TITLE
fix(scripts): cleanup-claude-branches が squash merge を OID 同一性で検出 (Refs #827)

### DIFF
--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -679,14 +679,14 @@ Claude Code のセッション用 worktree はセッション終了時に `git w
 
 `scripts/cleanup-claude-branches.sh --apply` が `git branch -D` で削除する条件 (#708):
 
-- **AND 1 (merged)**: 最新 (`sort -V`) の `origin/develop-*` または `origin/main` の祖先 (`git merge-base --is-ancestor`。#816 で develop-0.2.0 固定から一般化。stale な旧 develop ref を merge 根拠にしないため最新のみを採用)
+- **AND 1 (merged)**: 最新 (`sort -V`) の `origin/develop-*` または `origin/main` の祖先 (`git merge-base --is-ancestor`。#816 で develop-0.2.0 固定から一般化。stale な旧 develop ref を merge 根拠にしないため最新のみを採用)、**または** `gh pr list --state merged` の head ref 集合に含まれる (#827)。本 repo の PR は `--squash` マージのため branch tip が base の祖先にならず is-ancestor では永遠に not-merged 扱いになる。この構造的不整合を gh の merged 状態 (GitHub の ground truth) で OR 補完する。gh 不在 / 非ゼロ exit / timeout 時は集合を空に倒し is-ancestor のみに fallback する (安全側、false-positive を導入しない)
 - **AND 2 (active 参照なし)**: `git worktree list --porcelain` の `branch refs/heads/...` 集合に含まれない
 - **AND 3 (24h cooldown)**: 最終 commit (`git log -1 --format=%ct`) が 24h 以上前
 - **prefix 限定**: `claude/` のみ (= `feature/xxx` 等の手動 branch は対象外)
 
-**評価順序**: AND 2 → AND 1 → AND 3 (cost-efficient: AND 2 は local hash lookup で安価、AND 1 / AND 3 は git subprocess を spawn するため後回し)。最初に fail した条件が `kept <branch> (reason: not-merged | active | cooldown)` の reason として記録される。
+**評価順序**: AND 2 → AND 1 → AND 3 (cost-efficient: AND 2 は local hash lookup で安価、AND 1 / AND 3 は git subprocess を spawn するため後回し)。最初に fail した条件が `kept <branch> (reason: not-merged | active | cooldown)` の reason として記録される。gh merged 判定 (#827) は `command -v gh` + `command -v timeout` guard 下でループ前に 1 回だけ `gh pr list` を呼ぶ (network 依存)。判定経路は start event の `gh_merged_lookup` (`ok` / `unavailable` / `error`) と deleted / would_delete event の `merged_via` (`ancestor` / `gh`) で可視化される。
 
-最新の `origin/develop-*` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。`git fetch` は hook 内で実行せず、user の通常運用 (`git pull`) を前提とする。
+最新の `origin/develop-*` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。`git fetch` は hook 内で実行せず、user の通常運用 (`git pull`) を前提とする。gh merged 判定も同様に、gh 未認証 / network 不通なら fallback して is-ancestor のみで判定するため、オフライン環境でも安全に動作する。残余 false-positive (PR merge 後に同名 branch を再作成し新 commit を積むケース) は本 repo の session 固有 slug 運用では実質非発生 + AND2/AND3 が追加 guard (#827 で受容確定)。
 
 ### 手動実行
 

--- a/docs/l2-workflow.md
+++ b/docs/l2-workflow.md
@@ -679,14 +679,14 @@ Claude Code のセッション用 worktree はセッション終了時に `git w
 
 `scripts/cleanup-claude-branches.sh --apply` が `git branch -D` で削除する条件 (#708):
 
-- **AND 1 (merged)**: 最新 (`sort -V`) の `origin/develop-*` または `origin/main` の祖先 (`git merge-base --is-ancestor`。#816 で develop-0.2.0 固定から一般化。stale な旧 develop ref を merge 根拠にしないため最新のみを採用)、**または** `gh pr list --state merged` の head ref 集合に含まれる (#827)。本 repo の PR は `--squash` マージのため branch tip が base の祖先にならず is-ancestor では永遠に not-merged 扱いになる。この構造的不整合を gh の merged 状態 (GitHub の ground truth) で OR 補完する。gh 不在 / 非ゼロ exit / timeout 時は集合を空に倒し is-ancestor のみに fallback する (安全側、false-positive を導入しない)
+- **AND 1 (merged)**: 最新 (`sort -V`) の `origin/develop-*` または `origin/main` の祖先 (`git merge-base --is-ancestor`。#816 で develop-0.2.0 固定から一般化。stale な旧 develop ref を merge 根拠にしないため最新のみを採用)、**または** local branch tip の OID が `gh pr list --state merged` の head commit OID (`headRefOid`) 集合に一致する (#827)。本 repo の PR は `--squash` マージのため branch tip が base の祖先にならず is-ancestor では永遠に not-merged 扱いになる。この構造的不整合を gh の merged head OID で OR 補完する。**OID 同一性で照合する**ため、PR merge 後に同名 branch を再作成し未 merge の新 commit を積んでも local tip OID が一致せず kept になり、不可逆 data-loss を構造的に防ぐ (codex HIGH)。gh または `timeout` が不在 / 非ゼロ exit / timeout 発火時は集合を空に倒し is-ancestor のみに fallback する (安全側)
 - **AND 2 (active 参照なし)**: `git worktree list --porcelain` の `branch refs/heads/...` 集合に含まれない
 - **AND 3 (24h cooldown)**: 最終 commit (`git log -1 --format=%ct`) が 24h 以上前
 - **prefix 限定**: `claude/` のみ (= `feature/xxx` 等の手動 branch は対象外)
 
-**評価順序**: AND 2 → AND 1 → AND 3 (cost-efficient: AND 2 は local hash lookup で安価、AND 1 / AND 3 は git subprocess を spawn するため後回し)。最初に fail した条件が `kept <branch> (reason: not-merged | active | cooldown)` の reason として記録される。gh merged 判定 (#827) は `command -v gh` + `command -v timeout` guard 下でループ前に 1 回だけ `gh pr list` を呼ぶ (network 依存)。判定経路は start event の `gh_merged_lookup` (`ok` / `unavailable` / `error`) と deleted / would_delete event の `merged_via` (`ancestor` / `gh`) で可視化される。
+**評価順序**: AND 2 → AND 1 → AND 3 (cost-efficient: AND 2 は local hash lookup で安価、AND 1 / AND 3 は git subprocess を spawn するため後回し)。最初に fail した条件が `kept <branch> (reason: not-merged | active | cooldown)` の reason として記録される。gh merged 判定 (#827) は `command -v gh` + `command -v timeout` の両方が揃うときのみループ前に 1 回だけ `timeout 10 gh pr list` を呼ぶ (network 依存だが必ず bound される)。判定経路は start event の `gh_merged_lookup` (`ok` / `unavailable` / `error`) と deleted / would_delete event の `merged_via` (`ancestor` / `gh`) で可視化される。
 
-最新の `origin/develop-*` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。`git fetch` は hook 内で実行せず、user の通常運用 (`git pull`) を前提とする。gh merged 判定も同様に、gh 未認証 / network 不通なら fallback して is-ancestor のみで判定するため、オフライン環境でも安全に動作する。残余 false-positive (PR merge 後に同名 branch を再作成し新 commit を積むケース) は本 repo の session 固有 slug 運用では実質非発生 + AND2/AND3 が追加 guard (#827 で受容確定)。
+最新の `origin/develop-*` / `origin/main` が未 fetch だと `merge-base --is-ancestor` が false に倒れて keep される = 安全側。`git fetch` は hook 内で実行せず、user の通常運用 (`git pull`) を前提とする。gh merged 判定も同様に、gh 未認証 / network 不通 / `timeout` 不在なら fallback して is-ancestor のみで判定するため、オフライン環境でも安全に (かつ実行時間を bound して) 動作する。OID 同一性照合により、gh が報告する merged head と local branch tip が同一 commit のときのみ削除するため、名前衝突による誤削除は発生しない (#827 codex HIGH 対応)。
 
 ### 手動実行
 

--- a/schemas/cleanup-output.schema.json
+++ b/schemas/cleanup-output.schema.json
@@ -11,7 +11,8 @@
         "event": {"const": "start"},
         "script": {"enum": ["cleanup-worktrees", "cleanup-claude-branches"]},
         "apply": {"type": "boolean"},
-        "repo_root": {"type": "string"}
+        "repo_root": {"type": "string"},
+        "gh_merged_lookup": {"enum": ["ok", "unavailable", "error"]}
       },
       "additionalProperties": false
     },
@@ -21,7 +22,8 @@
       "properties": {
         "event": {"enum": ["removed", "deleted", "would_remove", "would_delete"]},
         "script": {"enum": ["cleanup-worktrees", "cleanup-claude-branches"]},
-        "name": {"type": "string"}
+        "name": {"type": "string"},
+        "merged_via": {"enum": ["ancestor", "gh"]}
       },
       "additionalProperties": false
     },

--- a/scripts/cleanup-claude-branches.sh
+++ b/scripts/cleanup-claude-branches.sh
@@ -5,8 +5,10 @@
 #
 # Safety AND conditions (3-condition structure unchanged from pre-#710; AND 1 bases generalized in #816):
 #   1. merged: ancestor of the latest (sort -V) origin/develop-* or origin/main,
-#      OR listed by `gh pr list --state merged` head refs (#827: --squash merges
-#      are not ancestors of base; gh absent/error/timeout -> ancestor-only fallback)
+#      OR the branch tip OID equals a `gh pr list --state merged` head OID (#827:
+#      --squash merges are not ancestors of base; OID identity match avoids
+#      deleting a recreated same-name branch; gh/timeout absent or error ->
+#      ancestor-only fallback)
 #   2. active 不在: not referenced by any active worktree
 #   3. cooldown: last commit ≥ 24h ago
 #   (prefix filter: claude/* only is listed)
@@ -96,29 +98,25 @@ MERGE_BASES+=("origin/main")
 
 # AND 1 augmentation (#827): --squash マージ済み branch は tip が base の祖先に
 # ならない (squash は新規 commit を base に作る) ため is-ancestor では永遠に
-# not-merged 扱いになる。gh pr list --state merged の headRefName 集合を 1 回だけ
-# 取得し、is-ancestor と OR して merged 判定する。gh 不在 / 非ゼロ exit / timeout
-# の場合は集合を空に倒し is-ancestor のみ (= 現行の安全側挙動) に fallback する。
-# merged 状態は GitHub の ground truth なので false-positive を導入しない。
-# 残余リスク (PR merge 後に同名 branch を再作成) は本 repo の session 固有 slug
-# 運用では実質非発生 + AND2/AND3 が追加 guard (2026-06 #827 で受容確定)。
-declare -A MERGED_PR_HEADS=()
+# not-merged 扱いになる。gh pr list --state merged の head commit OID 集合を 1 回だけ
+# 取得し、local branch tip の OID が一致するとき merged と判定する (is-ancestor と OR)。
+# **OID 同一性で照合する** (headRefName ではない): これにより「PR merge 後に同名
+# branch を再作成し未 merge の新 commit を積んだ」ケースでも local tip OID が merged
+# head OID と一致しないため kept になり、不可逆 data-loss を構造的に防ぐ (codex HIGH)。
+# gh または timeout が不在 / 非ゼロ exit / timeout 発火の場合は集合を空に倒し
+# is-ancestor のみ (= 現行の安全側挙動) に fallback する。network lookup は必ず
+# timeout で bound する (timeout 不在プラットフォームでは gh を呼ばず skip、codex MEDIUM)。
+declare -A MERGED_HEAD_OIDS=()
 GH_LOOKUP_STATUS=""
 if (( ${#BRANCHES[@]} > 0 )); then
-  if command -v gh >/dev/null 2>&1; then
-    if command -v timeout >/dev/null 2>&1; then
-      _gh_out=$(timeout 10 gh pr list --state merged --limit 200 \
-                  --json headRefName --jq '.[].headRefName' 2>/dev/null)
-      _gh_rc=$?
-    else
-      _gh_out=$(gh pr list --state merged --limit 200 \
-                  --json headRefName --jq '.[].headRefName' 2>/dev/null)
-      _gh_rc=$?
-    fi
+  if command -v gh >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+    _gh_out=$(timeout 10 gh pr list --state merged --limit 200 \
+                --json headRefOid --jq '.[].headRefOid' 2>/dev/null)
+    _gh_rc=$?
     if (( _gh_rc == 0 )); then
       GH_LOOKUP_STATUS="ok"
-      while IFS= read -r _ref; do
-        [[ -n "$_ref" ]] && MERGED_PR_HEADS["$_ref"]=1
+      while IFS= read -r _oid; do
+        [[ -n "$_oid" ]] && MERGED_HEAD_OIDS["$_oid"]=1
       done <<< "$_gh_out"
     else
       GH_LOOKUP_STATUS="error"
@@ -154,9 +152,12 @@ for branch in "${BRANCHES[@]}"; do
       break
     fi
   done
-  if [[ "$merged" -eq 0 ]] && [[ -n "${MERGED_PR_HEADS[$branch]:-}" ]]; then
-    merged=1
-    merged_via="gh"
+  if [[ "$merged" -eq 0 ]] && (( ${#MERGED_HEAD_OIDS[@]} > 0 )); then
+    branch_oid=$(git -C "$REPO_ROOT" rev-parse --verify "${branch}^{commit}" 2>/dev/null || echo "")
+    if [[ -n "$branch_oid" ]] && [[ -n "${MERGED_HEAD_OIDS[$branch_oid]:-}" ]]; then
+      merged=1
+      merged_via="gh"
+    fi
   fi
   if [[ "$merged" -eq 0 ]]; then
     _emit kept name="$branch" reason=not-merged

--- a/scripts/cleanup-claude-branches.sh
+++ b/scripts/cleanup-claude-branches.sh
@@ -4,7 +4,9 @@
 # Output: stdout NDJSON (one JSON object per line). Schema: schemas/cleanup-output.schema.json.
 #
 # Safety AND conditions (3-condition structure unchanged from pre-#710; AND 1 bases generalized in #816):
-#   1. merged: ancestor of the latest (sort -V) origin/develop-* or origin/main
+#   1. merged: ancestor of the latest (sort -V) origin/develop-* or origin/main,
+#      OR listed by `gh pr list --state merged` head refs (#827: --squash merges
+#      are not ancestors of base; gh absent/error/timeout -> ancestor-only fallback)
 #   2. active 不在: not referenced by any active worktree
 #   3. cooldown: last commit ≥ 24h ago
 #   (prefix filter: claude/* only is listed)
@@ -61,12 +63,6 @@ while (( $# > 0 )); do
   shift
 done
 
-if (( APPLY )); then
-  _emit start apply=true repo_root="$REPO_ROOT"
-else
-  _emit start apply=false repo_root="$REPO_ROOT"
-fi
-
 mapfile -t BRANCHES < <(git -C "$REPO_ROOT" branch --list 'claude/*' --format='%(refname:short)')
 
 deleted=0
@@ -98,6 +94,48 @@ if (( ${#DEVELOP_REFS[@]} > 0 )); then
 fi
 MERGE_BASES+=("origin/main")
 
+# AND 1 augmentation (#827): --squash マージ済み branch は tip が base の祖先に
+# ならない (squash は新規 commit を base に作る) ため is-ancestor では永遠に
+# not-merged 扱いになる。gh pr list --state merged の headRefName 集合を 1 回だけ
+# 取得し、is-ancestor と OR して merged 判定する。gh 不在 / 非ゼロ exit / timeout
+# の場合は集合を空に倒し is-ancestor のみ (= 現行の安全側挙動) に fallback する。
+# merged 状態は GitHub の ground truth なので false-positive を導入しない。
+# 残余リスク (PR merge 後に同名 branch を再作成) は本 repo の session 固有 slug
+# 運用では実質非発生 + AND2/AND3 が追加 guard (2026-06 #827 で受容確定)。
+declare -A MERGED_PR_HEADS=()
+GH_LOOKUP_STATUS=""
+if (( ${#BRANCHES[@]} > 0 )); then
+  if command -v gh >/dev/null 2>&1; then
+    if command -v timeout >/dev/null 2>&1; then
+      _gh_out=$(timeout 10 gh pr list --state merged --limit 200 \
+                  --json headRefName --jq '.[].headRefName' 2>/dev/null)
+      _gh_rc=$?
+    else
+      _gh_out=$(gh pr list --state merged --limit 200 \
+                  --json headRefName --jq '.[].headRefName' 2>/dev/null)
+      _gh_rc=$?
+    fi
+    if (( _gh_rc == 0 )); then
+      GH_LOOKUP_STATUS="ok"
+      while IFS= read -r _ref; do
+        [[ -n "$_ref" ]] && MERGED_PR_HEADS["$_ref"]=1
+      done <<< "$_gh_out"
+    else
+      GH_LOOKUP_STATUS="error"
+    fi
+  else
+    GH_LOOKUP_STATUS="unavailable"
+  fi
+fi
+
+if [[ -n "$GH_LOOKUP_STATUS" ]]; then
+  _emit start apply="$([[ $APPLY -eq 1 ]] && echo true || echo false)" \
+              repo_root="$REPO_ROOT" gh_merged_lookup="$GH_LOOKUP_STATUS"
+else
+  _emit start apply="$([[ $APPLY -eq 1 ]] && echo true || echo false)" \
+              repo_root="$REPO_ROOT"
+fi
+
 for branch in "${BRANCHES[@]}"; do
   # AND 2: active 不在判定
   if [[ -n "${ACTIVE_BRANCHES[$branch]:-}" ]]; then
@@ -106,14 +144,20 @@ for branch in "${BRANCHES[@]}"; do
     continue
   fi
 
-  # AND 1: merged 判定 (sort -V 最新の origin/develop-* or origin/main の祖先)
+  # AND 1: merged 判定 (is-ancestor OR gh merged PR head、#827)
   merged=0
+  merged_via=""
   for base in "${MERGE_BASES[@]}"; do
     if git -C "$REPO_ROOT" merge-base --is-ancestor "$branch" "$base" 2>/dev/null; then
       merged=1
+      merged_via="ancestor"
       break
     fi
   done
+  if [[ "$merged" -eq 0 ]] && [[ -n "${MERGED_PR_HEADS[$branch]:-}" ]]; then
+    merged=1
+    merged_via="gh"
+  fi
   if [[ "$merged" -eq 0 ]]; then
     _emit kept name="$branch" reason=not-merged
     kept=$((kept + 1))
@@ -133,14 +177,14 @@ for branch in "${BRANCHES[@]}"; do
     git -C "$REPO_ROOT" branch -D "$branch" >/dev/null 2>&1
     rc=$?
     if [[ "$rc" -eq 0 ]]; then
-      _emit deleted name="$branch"
+      _emit deleted name="$branch" merged_via="$merged_via"
       deleted=$((deleted + 1))
     else
       _emit delete_failed name="$branch" exit_code="$rc"
       kept=$((kept + 1))
     fi
   else
-    _emit would_delete name="$branch"
+    _emit would_delete name="$branch" merged_via="$merged_via"
     deleted=$((deleted + 1))
   fi
 done

--- a/tests/hooks/_gh_stub.sh
+++ b/tests/hooks/_gh_stub.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# gh stub for session-start.sh tests. Reads the canned response from
-# $GH_STUB_RESPONSE env var (literal string passed through).
+# gh stub for session-start.sh / cleanup-claude-branches.sh tests. Reads the
+# canned response from $GH_STUB_RESPONSE (literal string passed through) and an
+# optional exit code from $GH_STUB_EXIT (default 0, used to simulate gh failure
+# / network error for cleanup-claude-branches.sh #827 fallback tests).
 # Usage in tests: configure PATH to put this file's parent first, name it `gh`.
 echo "${GH_STUB_RESPONSE:-[]}"
+exit "${GH_STUB_EXIT:-0}"

--- a/tests/hooks/conftest.py
+++ b/tests/hooks/conftest.py
@@ -262,18 +262,21 @@ def with_gh_stub(tmp_repo: Path, monkeypatch):
 
     Args of the returned callable:
       response: literal string the stub will print on stdout.
+      exit_code: exit status the stub returns (default 0). Non-zero simulates a
+        gh failure / network error (cleanup-claude-branches.sh #827 fallback).
 
     Returns: None (callable side-effect).
     """
     stub_src = PROJECT_ROOT / "tests" / "hooks" / "_gh_stub.sh"
 
-    def _install(response: str) -> None:
+    def _install(response: str, exit_code: int = 0) -> None:
         bin_dir = tmp_repo / "bin"
         bin_dir.mkdir(exist_ok=True)
         gh_target = bin_dir / "gh"
         shutil.copy2(stub_src, gh_target)
         gh_target.chmod(0o755)
         monkeypatch.setenv("GH_STUB_RESPONSE", response)
+        monkeypatch.setenv("GH_STUB_EXIT", str(exit_code))
         monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
 
     return _install

--- a/tests/hooks/test_cleanup_claude_branches.py
+++ b/tests/hooks/test_cleanup_claude_branches.py
@@ -506,3 +506,50 @@ def test_gh_oid_mismatch_recreated_branch_kept(
     assert any(
         e["name"] == "claude/scenario16" and e["reason"] == "not-merged" for e in kept
     ), result.stdout
+
+
+# ---------- Scenario 17: gh 不在 -> gh_merged_lookup=unavailable + is-ancestor fallback ----------
+
+
+def test_gh_absent_reports_unavailable_and_falls_back(
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+    monkeypatch,
+) -> None:
+    """gh が PATH に無いとき gh_merged_lookup=unavailable + is-ancestor のみで判定 (#827 codex MEDIUM).
+
+    `command -v gh` が false になるよう、gh executable を含む PATH ディレクトリを
+    すべて除去して実行する。gh も timeout も無い環境の fallback を pin する。
+    gh/timeout を git/timeout と分離できない PATH レイアウト (両者同一 dir) では skip。
+    """
+    import os
+    import shutil
+
+    sep = os.pathsep
+
+    def _has_gh(d: str) -> bool:
+        for name in ("gh", "gh.exe", "gh.cmd", "gh.bat"):
+            p = os.path.join(d, name)
+            if os.path.isfile(p) and os.access(p, os.X_OK):
+                return True
+        return False
+
+    reduced = sep.join(
+        d for d in os.environ.get("PATH", "").split(sep) if d and not _has_gh(d)
+    )
+    monkeypatch.setenv("PATH", reduced)
+    if shutil.which("git") is None or shutil.which("timeout") is None:
+        import pytest
+
+        pytest.skip("gh を git/timeout と分離できない PATH レイアウトのため skip")
+
+    make_claude_branch("scenario17", merged=False, age_seconds=86400 * 2)
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    start = _of_event(result.ndjson, "start")
+    assert start and start[0].get("gh_merged_lookup") == "unavailable", result.stdout
+    kept = _of_event(result.ndjson, "kept")
+    assert any(
+        e["name"] == "claude/scenario17" and e["reason"] == "not-merged" for e in kept
+    ), result.stdout

--- a/tests/hooks/test_cleanup_claude_branches.py
+++ b/tests/hooks/test_cleanup_claude_branches.py
@@ -365,3 +365,99 @@ def test_latest_develop_uses_version_sort_for_double_digits(
     assert_valid_ndjson(result.ndjson)
     deleted = _of_event(result.ndjson, "deleted")
     assert any(e["name"] == "claude/scenario11" for e in deleted), result.stdout
+
+
+# ---------- Scenario 12: squash-merged (is-ancestor=false) + gh merged -> deleted (#827) ----------
+
+
+def test_squash_merged_via_gh_deleted(
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+    with_gh_stub,
+) -> None:
+    """squash マージ済み branch は is-ancestor=false だが gh が merged と報告 -> deleted (#827).
+
+    本 repo の PR は --squash マージのため branch tip が base の祖先にならず、
+    旧実装では永遠に not-merged 扱いだった。gh pr list --state merged の
+    headRefName 集合に含まれれば merged と判定して削除する。
+    """
+    branch = make_claude_branch("scenario12", merged=False, age_seconds=86400 * 2)
+    # gh stub は `gh pr list ... --jq '.[].headRefName'` の出力 (改行区切り ref) を模す。
+    with_gh_stub("claude/scenario12")
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    deleted = _of_event(result.ndjson, "deleted")
+    assert any(e["name"] == branch and e.get("merged_via") == "gh" for e in deleted), (
+        result.stdout
+    )
+    # start event records the gh augmentation succeeded.
+    start = _of_event(result.ndjson, "start")
+    assert start and start[0].get("gh_merged_lookup") == "ok", result.stdout
+
+
+# ---------- Scenario 13: gh が空 [] -> is-ancestor=false は kept (OR が過剰削除しない) ----------
+
+
+def test_gh_empty_does_not_over_delete(
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+    with_gh_stub,
+) -> None:
+    """gh が merged PR を 1 件も返さないとき、is-ancestor=false branch は kept (安全側)."""
+    make_claude_branch("scenario13", merged=False, age_seconds=86400 * 2)
+    with_gh_stub("")  # 空 = merged PR head なし
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    kept = _of_event(result.ndjson, "kept")
+    assert any(
+        e["name"] == "claude/scenario13" and e["reason"] == "not-merged" for e in kept
+    ), result.stdout
+
+
+# ---------- Scenario 14: gh 非ゼロ exit -> is-ancestor fallback で kept + status=error ----------
+
+
+def test_gh_failure_falls_back_to_ancestor(
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+    with_gh_stub,
+) -> None:
+    """gh が失敗 (非ゼロ exit) したら集合を空に倒し is-ancestor のみで判定 (安全側 kept).
+
+    gh が「全 branch を merged」と誤って報告する状況を防ぐ: 失敗時は削除根拠に
+    しない。start.gh_merged_lookup=error で fallback を可視化する。
+    """
+    make_claude_branch("scenario14", merged=False, age_seconds=86400 * 2)
+    # response があっても exit!=0 なら無視されねばならない。
+    with_gh_stub("claude/scenario14", exit_code=1)
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    kept = _of_event(result.ndjson, "kept")
+    assert any(
+        e["name"] == "claude/scenario14" and e["reason"] == "not-merged" for e in kept
+    ), result.stdout
+    start = _of_event(result.ndjson, "start")
+    assert start and start[0].get("gh_merged_lookup") == "error", result.stdout
+
+
+# ---------- Scenario 15: gh merged だが cooldown 内 -> kept cooldown (gh が AND3 を bypass しない) ----------
+
+
+def test_gh_merged_still_respects_cooldown(
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+    with_gh_stub,
+) -> None:
+    """gh が merged と報告しても 24h cooldown 内なら削除しない (AND3 を bypass しない)."""
+    make_claude_branch("scenario15", merged=False, age_seconds=600)
+    with_gh_stub("claude/scenario15")
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    kept = _of_event(result.ndjson, "kept")
+    assert any(
+        e["name"] == "claude/scenario15" and e["reason"] == "cooldown" for e in kept
+    ), result.stdout

--- a/tests/hooks/test_cleanup_claude_branches.py
+++ b/tests/hooks/test_cleanup_claude_branches.py
@@ -367,24 +367,39 @@ def test_latest_develop_uses_version_sort_for_double_digits(
     assert any(e["name"] == "claude/scenario11" for e in deleted), result.stdout
 
 
-# ---------- Scenario 12: squash-merged (is-ancestor=false) + gh merged -> deleted (#827) ----------
+def _rev_parse(repo: Path, ref: str) -> str:
+    """Return the commit OID of ref in repo."""
+    import subprocess
+
+    return subprocess.run(
+        ["git", "rev-parse", ref],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+# ---------- Scenario 12: squash-merged (is-ancestor=false) + gh OID 一致 -> deleted (#827) ----------
 
 
 def test_squash_merged_via_gh_deleted(
+    tmp_repo: Path,
     make_claude_branch,
     run_hook,
     assert_valid_ndjson,
     with_gh_stub,
 ) -> None:
-    """squash マージ済み branch は is-ancestor=false だが gh が merged と報告 -> deleted (#827).
+    """squash マージ済み branch は is-ancestor=false だが gh が merged head OID を報告 -> deleted (#827).
 
     本 repo の PR は --squash マージのため branch tip が base の祖先にならず、
     旧実装では永遠に not-merged 扱いだった。gh pr list --state merged の
-    headRefName 集合に含まれれば merged と判定して削除する。
+    headRefOid 集合に local branch tip の OID が一致すれば merged と判定して削除する。
+    OID 同一性で照合するため headRefName 衝突による誤削除は起こらない (#827 codex HIGH)。
     """
     branch = make_claude_branch("scenario12", merged=False, age_seconds=86400 * 2)
-    # gh stub は `gh pr list ... --jq '.[].headRefName'` の出力 (改行区切り ref) を模す。
-    with_gh_stub("claude/scenario12")
+    # gh stub は `gh pr list ... --jq '.[].headRefOid'` の出力 (改行区切り OID) を模す。
+    with_gh_stub(_rev_parse(tmp_repo, branch))
     result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
     assert_valid_ndjson(result.ndjson)
     deleted = _of_event(result.ndjson, "deleted")
@@ -407,7 +422,7 @@ def test_gh_empty_does_not_over_delete(
 ) -> None:
     """gh が merged PR を 1 件も返さないとき、is-ancestor=false branch は kept (安全側)."""
     make_claude_branch("scenario13", merged=False, age_seconds=86400 * 2)
-    with_gh_stub("")  # 空 = merged PR head なし
+    with_gh_stub("")  # 空 = merged PR head OID なし
     result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
     assert_valid_ndjson(result.ndjson)
     kept = _of_event(result.ndjson, "kept")
@@ -420,6 +435,7 @@ def test_gh_empty_does_not_over_delete(
 
 
 def test_gh_failure_falls_back_to_ancestor(
+    tmp_repo: Path,
     make_claude_branch,
     run_hook,
     assert_valid_ndjson,
@@ -430,9 +446,9 @@ def test_gh_failure_falls_back_to_ancestor(
     gh が「全 branch を merged」と誤って報告する状況を防ぐ: 失敗時は削除根拠に
     しない。start.gh_merged_lookup=error で fallback を可視化する。
     """
-    make_claude_branch("scenario14", merged=False, age_seconds=86400 * 2)
-    # response があっても exit!=0 なら無視されねばならない。
-    with_gh_stub("claude/scenario14", exit_code=1)
+    branch = make_claude_branch("scenario14", merged=False, age_seconds=86400 * 2)
+    # 一致する OID を返しても exit!=0 なら無視されねばならない。
+    with_gh_stub(_rev_parse(tmp_repo, branch), exit_code=1)
     result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
     assert_valid_ndjson(result.ndjson)
     kept = _of_event(result.ndjson, "kept")
@@ -447,17 +463,46 @@ def test_gh_failure_falls_back_to_ancestor(
 
 
 def test_gh_merged_still_respects_cooldown(
+    tmp_repo: Path,
     make_claude_branch,
     run_hook,
     assert_valid_ndjson,
     with_gh_stub,
 ) -> None:
     """gh が merged と報告しても 24h cooldown 内なら削除しない (AND3 を bypass しない)."""
-    make_claude_branch("scenario15", merged=False, age_seconds=600)
-    with_gh_stub("claude/scenario15")
+    branch = make_claude_branch("scenario15", merged=False, age_seconds=600)
+    with_gh_stub(_rev_parse(tmp_repo, branch))
     result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
     assert_valid_ndjson(result.ndjson)
     kept = _of_event(result.ndjson, "kept")
     assert any(
         e["name"] == "claude/scenario15" and e["reason"] == "cooldown" for e in kept
+    ), result.stdout
+
+
+# ---------- Scenario 16: 同名 branch 再作成で OID 不一致 -> kept (data-loss 防止, codex HIGH) ----------
+
+
+def test_gh_oid_mismatch_recreated_branch_kept(
+    tmp_repo: Path,
+    make_claude_branch,
+    run_hook,
+    assert_valid_ndjson,
+    with_gh_stub,
+) -> None:
+    """merged PR の head 名と同名だが local tip OID が異なる branch は削除しない (#827 codex HIGH).
+
+    claude/foo が squash-merged 後に同名で再作成され未 merge の新 commit を積んだ
+    ケースを再現する。gh が返す merged head OID (= 別 commit) と local branch tip が
+    一致しないため、headRefName が衝突しても kept になる (不可逆 data-loss を防止)。
+    """
+    make_claude_branch("scenario16", merged=False, age_seconds=86400 * 2)
+    # gh は当該 branch tip とは異なる OID (base develop-0.2.0 の commit) を merged head として返す。
+    # 旧 name-match 実装ではここで誤削除された (codex HIGH)。OID 一致必須なら kept。
+    with_gh_stub(_rev_parse(tmp_repo, "develop-0.2.0"))
+    result = run_hook("scripts/cleanup-claude-branches.sh", "--apply")
+    assert_valid_ndjson(result.ndjson)
+    kept = _of_event(result.ndjson, "kept")
+    assert any(
+        e["name"] == "claude/scenario16" and e["reason"] == "not-merged" for e in kept
     ), result.stdout


### PR DESCRIPTION
## 概要

`scripts/cleanup-claude-branches.sh` の AND 1 (merged 判定) は `git merge-base --is-ancestor` を使うが、本 repo の PR は `--squash` マージのため branch tip が base の祖先にならず、merged 済みの `claude/*` branch が永遠に `not-merged` 扱いで自動掃除されなかった (実測: 157 本中 deleted=0)。

## 修正 (案1: gh PR 状態ベース + OID 同一性照合)

- ループ前に 1 回 `timeout 10 gh pr list --state merged --limit 200 --json headRefOid` で merged head commit OID 集合を取得
- AND 1 を「is-ancestor **OR** local branch tip OID が merged head OID 集合に一致」で判定
- **OID 同一性照合** (headRefName ではない): PR merge 後に同名 branch を再作成し未 merge の新 commit を積んでも tip OID が一致せず kept になり、不可逆 data-loss を構造的に防ぐ
- gh または `timeout` が不在 / 非ゼロ exit / timeout 発火時は集合を空に倒し is-ancestor のみに fallback (現行の安全側挙動を保持、全プラットフォームで実行時間を bound)
- 観測性: `start` に `gh_merged_lookup` (ok/unavailable/error)、`deleted`/`would_delete` に `merged_via` (ancestor/gh) を追加 (schema 更新)

## 受け入れ条件 (#827) との対応

- [x] 3 案から方針確定 → 案1 (gh PR 状態ベース、Idios 承認、brainstorming)
- [x] no-network 設計 (#708) との整合 → gh/timeout guard + 失敗時 is-ancestor fallback。session-start.sh の gh+timeout precedent を踏襲
- [x] 採用案実装 + pin test 追加 (squash→gh deleted / gh 空→kept / gh 失敗→fallback / cooldown bypass せず / **再作成 branch OID 不一致→kept**)
- [x] `docs/l2-workflow.md` の安全条件記述を更新

## codex adversarial-review (Pre-flight Step 5)

2 findings を **(A) PR 内対応**:

- **[HIGH]** name-match による data-loss → **OID 同一性照合**に変更 (scenario16 で回帰 pin)
- **[MEDIUM]** no-timeout の unbounded gh → `timeout` 必須化 (不在なら gh skip)

## Self-Test Report

- [x] `pytest tests/hooks/` → 51 passed (scenario12 OID 化 + scenario16 追加 + 既存 11 回帰なし)
- [x] `ruff check` / `ruff format --check` / `pyright` → all clean
- [x] `markdownlint` (docs/l2-workflow.md) → 0 errors
- [x] 実機 dry-run: gh merged head OID 200 件中、local claude tip と OID 一致する squash-merged branch 3 本を正しく検出 (いずれも active worktree のため AND2 で kept = 安全側)
- shellcheck: ローカル未インストール (CI で検証)。変更は session-start.sh の既存 gh+timeout パターンを踏襲

## 関連

Refs #827, #708 (no-network 設計), #816 (AND 1 base 一般化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
