### PR TITLE
task(config): pyright の解析対象から .claude/worktrees を恒久除外 (Refs #828)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,4 +72,4 @@ ignore = [
 [tool.pyright]
 pythonVersion = "3.11"
 typeCheckingMode = "standard"
-exclude = ["tmp", ".venv", "build", "dist"]
+exclude = ["tmp", ".venv", "build", "dist", ".claude/worktrees"]


### PR DESCRIPTION
## 概要

素の `python -m pyright` が park 中 worktree (`.claude/worktrees/**`) 配下の旧コードを解析対象に含め、本体 tree と無関係な型エラーを大量に出す (実測 red: **69 errors**、issue 起票時 132。worktree 構成で変動)。`pyproject.toml` `[tool.pyright]` の `exclude` に `.claude/worktrees` を 1 行追加して恒久除外する。

## 受け入れ条件 (#828) との対応

- [x] **既存設定の所在確認 + exclude 追加**: `pyrightconfig.json` は不在、`pyproject.toml` L72-75 に既存 `[tool.pyright]` あり → そこへ追記 (新規ファイル不要)
- [x] **素の `python -m pyright` が 0 errors**: 実測 red 69 errors → fix 後 **0 errors, 0 warnings** (`protective_mechanism_red_verification` 準拠で red を先に観測)
- [x] **CLAUDE.md / docs のコマンド記述反映**: sweep の結果、CLAUDE.md (§コマンド) と CI (`.github/workflows/ci.yml:87`) は既に素の `pyright` 表記のため**変更不要**。scope 指定 (`pyright allaganeye gui tests scripts`) の記述は `docs/superpowers/plans/*.md` の歴史的実行記録のみで、living doc には存在しない
- [x] **markdownlint の glob 規約との整合確認**: markdownlint (`.markdownlint-cli2.yaml`) は `**` glob 形式だが、pyright 側は既存 exclude エントリ (`"tmp"`, `".venv"` 等 bare dir 形式) とのスタイル統一を優先。pyright はディレクトリ指定で配下全体を除外する (公式 docs 確認済、ツールごとの規約差は意図的)

## codex adversarial-review (Pre-flight Step 5)

verdict: **approve** (material findings なし)。確認観点: false-green リスク (対象は gitignore 済 worktree cache path で正当な source ではない) / pyright の dir 指定 semantics (公式 docs で valid) / `[tool.pyright]` を解決する他ツール (CI は素の pyright、executionEnvironments 不使用)。

## Self-Test Report

- [x] `python -m pyright` → **0 errors** (fix 前 69 errors で red 実証)
- [x] `python -m ruff check .` / `ruff format --check .` → clean
- [x] `python -m pytest` → 1544 passed, 1 skipped
- config 1 行変更のため GUI / 実機検証は非該当

## 関連

Refs #828, #816 (worktree 掃除で本ノイズが顕在化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
