### PR TITLE
fix(scripts): validate-fps-retirement の PTS extraction を放出フレーム基準に修正 (Refs #804)

### DIFF
--- a/scripts/validate-fps-retirement.py
+++ b/scripts/validate-fps-retirement.py
@@ -52,9 +52,13 @@ from allaganeye.video.probe import probe_video  # noqa: E402
 
 import numpy as np  # noqa: E402
 
-# Matches the first showinfo line for frame n=0, capturing pts_time value.
-# Pattern: n: 0 pts: <int> pts_time:<float>
-_PTS_RE = re.compile(r"n:\s*0\s+pts:\s*\d+\s+pts_time:([\d.]+)")
+# Matches every showinfo line, capturing its pts_time value.
+# Pattern: n: <int> pts: <int> pts_time:<float>
+_PTS_RE = re.compile(r"n:\s*\d+\s+pts:\s*-?\d+\s+pts_time:(-?[\d.]+)")
+
+# Printed pts_time has finite decimal precision; a frame exactly at chunk_start
+# can print a hair below it.  0.1 ms is far under any real frame period (#804).
+_PTS_EPSILON = 1e-4
 
 
 def _classify_chunk(chunk_start: float, duration: float) -> str:
@@ -86,12 +90,21 @@ def _validate_duration_against_chunks(duration: float, chunks: list[float]) -> N
         sys.exit(2)
 
 
-def _parse_first_pts_time(stderr_text: str) -> float | None:
-    """Extract pts_time of the first showinfo frame (n: 0). Returns None if absent."""
-    m = _PTS_RE.search(stderr_text)
-    if not m:
-        return None
-    return float(m.group(1))
+def _parse_first_emitted_pts_time(stderr_text: str, chunk_start: float) -> float | None:
+    """Extract pts_time of the first *emitted* showinfo frame. None if absent.
+
+    Output seek (``-ss`` after ``-i``) trims at the muxer stage AFTER the
+    filter graph, so showinfo logs every decoded frame from t=0 and the
+    ``n: 0`` line is always the video's first frame (= container start_time,
+    the constant 0.021 that #804 reported).  The first frame the muxer
+    actually emits is the first showinfo line with
+    ``pts_time >= chunk_start`` (within printing-precision epsilon).
+    """
+    for m in _PTS_RE.finditer(stderr_text):
+        pts = float(m.group(1))
+        if pts >= chunk_start - _PTS_EPSILON:
+            return pts
+    return None
 
 
 def _build_ffmpeg_cmd(
@@ -150,7 +163,7 @@ def _run_chunk(
     cmd = _build_ffmpeg_cmd(video, chunk_start, vendor, codec)
     proc = subprocess.run(cmd, capture_output=True, timeout=60)
     stderr_text = proc.stderr.decode(errors="replace")
-    emit_pts = _parse_first_pts_time(stderr_text)
+    emit_pts = _parse_first_emitted_pts_time(stderr_text, chunk_start)
 
     if proc.returncode != 0 or len(proc.stdout) < _FRAME_SIZE:
         emit_brightness: float | None = None

--- a/scripts/validate-fps-retirement.py
+++ b/scripts/validate-fps-retirement.py
@@ -56,10 +56,6 @@ import numpy as np  # noqa: E402
 # Pattern: n: <int> pts: <int> pts_time:<float>
 _PTS_RE = re.compile(r"n:\s*\d+\s+pts:\s*-?\d+\s+pts_time:(-?[\d.]+)")
 
-# Printed pts_time has finite decimal precision; a frame exactly at chunk_start
-# can print a hair below it.  0.1 ms is far under any real frame period (#804).
-_PTS_EPSILON = 1e-4
-
 
 def _classify_chunk(chunk_start: float, duration: float) -> str:
     """Return 'skip_tail' if chunk_start + 0.5 > duration, else 'run'."""
@@ -98,11 +94,15 @@ def _parse_first_emitted_pts_time(stderr_text: str, chunk_start: float) -> float
     ``n: 0`` line is always the video's first frame (= container start_time,
     the constant 0.021 that #804 reported).  The first frame the muxer
     actually emits is the first showinfo line with
-    ``pts_time >= chunk_start`` (within printing-precision epsilon).
+    ``pts_time >= chunk_start`` (strict: no negative tolerance -- a printed
+    value just below chunk_start belongs to a frame the muxer dropped, and
+    selecting it would pair its PTS with the brightness of the NEXT frame,
+    forging PASS evidence; showinfo's %.6g rounding never prints a >=
+    chunk_start frame below it at these magnitudes).
     """
     for m in _PTS_RE.finditer(stderr_text):
         pts = float(m.group(1))
-        if pts >= chunk_start - _PTS_EPSILON:
+        if pts >= chunk_start:
             return pts
     return None
 
@@ -159,9 +159,23 @@ def _run_chunk(
     codec: str,
     source_fps: float,
 ) -> tuple[float | None, float | None, float]:
-    """Run ffmpeg and return (emit_pts, emit_brightness, probe_brightness)."""
+    """Run ffmpeg and return (emit_pts, emit_brightness, probe_brightness).
+
+    Output seek decodes from t=0, so the decode budget grows with chunk_start
+    (codex #804): timeout scales as ``60 + chunk_start`` (decode is normally
+    faster than realtime; this is a generous cap, not an estimate).  On
+    timeout the chunk degrades to a FAIL row instead of crashing the run.
+    """
     cmd = _build_ffmpeg_cmd(video, chunk_start, vendor, codec)
-    proc = subprocess.run(cmd, capture_output=True, timeout=60)
+    try:
+        proc = subprocess.run(cmd, capture_output=True, timeout=60.0 + chunk_start)
+    except subprocess.TimeoutExpired:
+        print(
+            f"WARN: ffmpeg timed out for chunk_start {chunk_start} "
+            f"(decode-from-0 exceeded {60.0 + chunk_start:.0f}s)",
+            file=sys.stderr,
+        )
+        return None, None, _probe_single_frame(video, chunk_start)
     stderr_text = proc.stderr.decode(errors="replace")
     emit_pts = _parse_first_emitted_pts_time(stderr_text, chunk_start)
 

--- a/tests/test_validate_fps_retirement.py
+++ b/tests/test_validate_fps_retirement.py
@@ -71,23 +71,57 @@ class TestEdgeCaseShortClip:
 
 
 class TestParsePtsTime:
-    """ffmpeg showinfo stderr frame 0 pts_time extraction (#576 S4.4)."""
+    """ffmpeg showinfo stderr first *emitted* frame pts_time extraction (#804).
 
-    def test_parse_first_frame_pts(self):
+    Output seek (``-ss`` after ``-i``) trims at the muxer stage AFTER the
+    filter graph, so showinfo logs every decoded frame from t=0.  The first
+    emitted frame is therefore the first showinfo line with
+    ``pts_time >= chunk_start``, NOT the ``n: 0`` line (which is always the
+    video's first frame = container start_time, e.g. the constant 0.021 of
+    OBS MKV recordings that #804 reported).
+    """
+
+    def test_parse_first_emitted_pts_skips_pre_seek_frames(self):
+        """#804 regression: n:0 is the video head (0.021), not the emitted frame."""
         mod = _load_module()
         stderr = (
-            "[Parsed_showinfo_0 @ 0x1234] n: 0 pts: 0 pts_time:10.5 "
+            "[Parsed_showinfo_0 @ 0x1234] n:   0 pts:     21 pts_time:0.021 "
             "duration: 0 duration_time: 0 ...\n"
-            "[Parsed_showinfo_0 @ 0x1234] n: 1 pts: 60 pts_time:10.516667 ...\n"
+            "[Parsed_showinfo_0 @ 0x1234] n:   1 pts:    533 pts_time:0.0543333 ...\n"
+            "[Parsed_showinfo_0 @ 0x1234] n: 899 pts: 460288 pts_time:29.966667 ...\n"
+            "[Parsed_showinfo_0 @ 0x1234] n: 900 pts: 460800 pts_time:30 ...\n"
+            "[Parsed_showinfo_0 @ 0x1234] n: 901 pts: 461312 pts_time:30.033333 ...\n"
         )
-        assert mod._parse_first_pts_time(stderr) == pytest.approx(10.5)
+        assert mod._parse_first_emitted_pts_time(stderr, 30.0) == pytest.approx(30.0)
 
     def test_no_match_returns_none(self):
         mod = _load_module()
-        assert mod._parse_first_pts_time("no showinfo output here") is None
+        assert (
+            mod._parse_first_emitted_pts_time("no showinfo output here", 30.0) is None
+        )
 
-    def test_second_frame_not_extracted(self):
+    def test_all_frames_before_chunk_start_returns_none(self):
+        """Stream that ends before chunk_start (e.g. ffmpeg died early) -> None."""
         mod = _load_module()
-        # Only n:0 should match; a stream starting at n:1 has no n:0
-        stderr = "[Parsed_showinfo_0 @ 0x5678] n: 1 pts: 60 pts_time:10.516667 ...\n"
-        assert mod._parse_first_pts_time(stderr) is None
+        stderr = (
+            "[Parsed_showinfo_0 @ 0x5678] n: 0 pts: 21 pts_time:0.021 ...\n"
+            "[Parsed_showinfo_0 @ 0x5678] n: 1 pts: 533 pts_time:0.0543333 ...\n"
+        )
+        assert mod._parse_first_emitted_pts_time(stderr, 30.0) is None
+
+    def test_epsilon_tolerates_printed_rounding_just_below_boundary(self):
+        """pts_time printed a hair below chunk_start (decimal rounding) still matches."""
+        mod = _load_module()
+        stderr = (
+            "[Parsed_showinfo_0 @ 0x9abc] n: 0 pts: 0 pts_time:0 ...\n"
+            "[Parsed_showinfo_0 @ 0x9abc] n: 900 pts: 460799 pts_time:29.99995 ...\n"
+        )
+        assert mod._parse_first_emitted_pts_time(stderr, 30.0) == pytest.approx(
+            29.99995
+        )
+
+    def test_chunk_start_zero_returns_first_frame(self):
+        """chunk_start=0: the video's first frame IS the emitted frame."""
+        mod = _load_module()
+        stderr = "[Parsed_showinfo_0 @ 0x1234] n: 0 pts: 21 pts_time:0.021 ...\n"
+        assert mod._parse_first_emitted_pts_time(stderr, 0.0) == pytest.approx(0.021)

--- a/tests/test_validate_fps_retirement.py
+++ b/tests/test_validate_fps_retirement.py
@@ -109,19 +109,78 @@ class TestParsePtsTime:
         )
         assert mod._parse_first_emitted_pts_time(stderr, 30.0) is None
 
-    def test_epsilon_tolerates_printed_rounding_just_below_boundary(self):
-        """pts_time printed a hair below chunk_start (decimal rounding) still matches."""
+    def test_just_below_boundary_frame_is_not_selected(self):
+        """codex #804: a dropped frame printed a hair below chunk_start must be
+        skipped -- selecting it would pair its PTS with the brightness of the
+        NEXT frame (the actually emitted one) and forge PASS evidence."""
         mod = _load_module()
         stderr = (
             "[Parsed_showinfo_0 @ 0x9abc] n: 0 pts: 0 pts_time:0 ...\n"
             "[Parsed_showinfo_0 @ 0x9abc] n: 900 pts: 460799 pts_time:29.99995 ...\n"
+            "[Parsed_showinfo_0 @ 0x9abc] n: 901 pts: 461312 pts_time:30.016667 ...\n"
         )
         assert mod._parse_first_emitted_pts_time(stderr, 30.0) == pytest.approx(
-            29.99995
+            30.016667
         )
+
+    def test_stream_ending_just_below_boundary_returns_none(self):
+        """Strict >= boundary: only pre-boundary frames -> None (no forged PTS)."""
+        mod = _load_module()
+        stderr = (
+            "[Parsed_showinfo_0 @ 0x9abc] n: 900 pts: 460799 pts_time:29.99995 ...\n"
+        )
+        assert mod._parse_first_emitted_pts_time(stderr, 30.0) is None
 
     def test_chunk_start_zero_returns_first_frame(self):
         """chunk_start=0: the video's first frame IS the emitted frame."""
         mod = _load_module()
         stderr = "[Parsed_showinfo_0 @ 0x1234] n: 0 pts: 21 pts_time:0.021 ...\n"
         assert mod._parse_first_emitted_pts_time(stderr, 0.0) == pytest.approx(0.021)
+
+
+class TestRunChunkTimeout:
+    """long chunk_start decode-from-0 timeout handling (codex #804)."""
+
+    def _fake_completed(self, mod, stderr_text: str):
+        import subprocess
+
+        return subprocess.CompletedProcess(
+            args=["ffmpeg"],
+            returncode=0,
+            stdout=b"\x40" * mod._FRAME_SIZE,
+            stderr=stderr_text.encode(),
+        )
+
+    def test_timeout_expired_degrades_to_fail_row_not_crash(self, monkeypatch):
+        """TimeoutExpired -> (None, None, probe) so the caller prints a FAIL row."""
+        import subprocess
+
+        mod = _load_module()
+
+        def _raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=["ffmpeg"], timeout=kwargs["timeout"])
+
+        monkeypatch.setattr(mod.subprocess, "run", _raise_timeout)
+        monkeypatch.setattr(mod, "_probe_single_frame", lambda *a, **k: 42.0)
+        emit_pts, emit_brightness, probe_brightness = mod._run_chunk(
+            Path("dummy.mkv"), 7200.0, "cpu", "h264", 60.0
+        )
+        assert emit_pts is None
+        assert emit_brightness is None
+        assert probe_brightness == 42.0
+
+    def test_timeout_scales_with_chunk_start(self, monkeypatch):
+        """decode-from-0 needs ~chunk_start seconds of decode budget, not fixed 60s."""
+        mod = _load_module()
+        captured: dict = {}
+
+        def _capture(cmd, **kwargs):
+            captured.update(kwargs)
+            return self._fake_completed(
+                mod, "[Parsed_showinfo_0 @ 0x1] n: 0 pts: 0 pts_time:7200 ...\n"
+            )
+
+        monkeypatch.setattr(mod.subprocess, "run", _capture)
+        monkeypatch.setattr(mod, "_probe_single_frame", lambda *a, **k: 42.0)
+        mod._run_chunk(Path("dummy.mkv"), 7200.0, "cpu", "h264", 60.0)
+        assert captured["timeout"] >= 7200.0


### PR DESCRIPTION
## Root cause (systematic-debugging Phase 1-3 で実証)

`_PTS_RE` が showinfo の `n: 0` 行 (filtergraph に入る最初のフレーム) を match していたが、output seek (`-i` の後の `-ss`) の trim は **filtergraph の後 (muxer 段)** で行われるため、showinfo は t=0 から全フレームを log する。よって `n: 0` は常に**動画先頭フレーム** = container start_time であり、OBS MKV の video stream `start_time = 0.021000` (ffprobe 実証) が chunk_start に無関係に返っていた。brightness は stdout (trim 後の rawvideo) 由来のため正常 — issue の symptom と完全一致。

再現実証: `-ss 30` 実行時、showinfo は `n:0 pts_time:0` から log し、放出初フレームは `pts_time >= 30` の最初の行 (`n:900 pts_time:30`) と正確に一致。

## Fix

- parse を「`pts_time >= chunk_start` (strict) の最初の showinfo 行」に変更 (`_parse_first_emitted_pts_time`)。ffmpeg コマンドは不変 (本 script の測定意図 = output seek 検証のまま)
- **codex finding 対応 1 (medium)**: 当初案の ε 許容 (`- 1e-4`) は muxer が drop した boundary 直下フレームを掴み「PTS と brightness が別フレーム由来」の偽 PASS evidence を生みうる → strict `>=` に硬化 (showinfo の `%.6g` は丸めであり真値 >= boundary が下に印字されることはない)。回帰 pin 2 件
- **codex finding 対応 2 (medium)**: usage 例 (3600/7200) の長 offset で decode-from-0 + timeout=60 固定が unhandled `TimeoutExpired` crash → timeout を `60 + chunk_start` にスケール + catch して WARN + FAIL 行に縮退

## 調査範囲 (#804) との対応

- [x] **1. root cause 特定**: 上記 (output parsing の `n: 0` anchor が誤り。format string ではなく parse 対象の選択ミス)
- [x] **2. 修正実装 + unit test 追加**: `_parse_first_emitted_pts_time` + TestParsePtsTime 6 件 (0.021 再発 pin / None 系 / boundary 直下 / chunk_start=0) + TestRunChunkTimeout 2 件 = **14 passed**
- 3. evidence 再収集 (任意、v0.3.x scope): 本 PR では未実施。script が使用可能になったため必要時に実行可

## Self-Test Report

- [x] `pytest tests/test_validate_fps_retirement.py` → 14 passed (RED→GREEN を各段で確認)
- [x] `pytest` full → 1546 passed, 1 skipped
- [x] `ruff check` / `ruff format --check` / `pyright` → clean
- [x] e2e 実動画 (30fps MP4): chunks 0/30/100.5 → emit_pts が chunk_start に追従、pts_diff **0.0000** x3 PASS
- [x] e2e OBS MKV (60fps、start_time=0.021 = bug の元シナリオ): chunks 5/45 → emit_pts 5.004/45.004、pts_diff 0.004 < 1/60 PASS (常時 0.021 は消滅)
- 同種 sweep: `n:\s*0` PTS parse は本 script のみ (repo grep、他 site なし)
- GPU vendor path (nvidia/amd/intel) は cmd 構築のみで parse 共通 → cpu e2e で parse 検証は完結。GPU での evidence 再収集は調査範囲 3 (任意) の際に実施

## codex adversarial-review (Pre-flight Step 5)

Round 1: needs-attention (medium x2、上記) → 両方 (A) PR 内対応済。

## 関連

Refs #804, #576 (fps filter retirement)、PR #793 (script 導入元)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
